### PR TITLE
chore: add env default for proxy host port

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+# docker-compose defaults
+#
+# Host port for the public reverse proxy (container listens on 8787)
+PROXY_HOST_PORT=8787


### PR DESCRIPTION
## Summary\n- commit .env with default proxy host port\n\n## Testing\n- not needed (config only)