### PR TITLE
refactor(dashboard): migrate dashboard to NgRx Signal Store (#96)

### DIFF
--- a/web/src/app/stats/shell/dashboard.store.ts
+++ b/web/src/app/stats/shell/dashboard.store.ts
@@ -1,0 +1,362 @@
+import { computed, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+import {
+  PushupLiveService,
+  StatsApiService,
+  UserConfigApiService,
+} from '@pu-stats/data-access';
+import {
+  PushupRecord,
+  StatsGranularity,
+  StatsResponse,
+  StatsSeriesEntry,
+} from '@pu-stats/models';
+import { UserContextService } from '../../user-context.service';
+import { createWeekRange } from '../../util/date/create-week-range';
+import { inferRangeMode } from '../../util/date/infer-range-mode';
+import { RangeModes } from '../../util/date/range-modes.type';
+import { toLocalIsoDate } from '../../util/date/to-local-iso-date';
+
+const EMPTY_STATS: StatsResponse = {
+  meta: {
+    from: null,
+    to: null,
+    entries: 0,
+    days: 0,
+    total: 0,
+    granularity: 'daily',
+  },
+  series: [],
+};
+
+const PERIOD_TITLE_MAP: Record<RangeModes | 'today', string> = {
+  today: $localize`:@@period.today:Heute`,
+  day: $localize`:@@period.day:Tag`,
+  week: $localize`:@@period.week:Woche`,
+  month: $localize`:@@period.month:Monat`,
+  year: $localize`:@@period.year:Jahr`,
+  custom: $localize`:@@period.range:Zeitraum`,
+};
+
+type DashboardState = {
+  from: string;
+  to: string;
+  rangeMode: RangeModes;
+  busyAction: 'create' | 'update' | 'delete' | null;
+  busyId: string | null;
+  stats: StatsResponse;
+  allTimeStats: StatsResponse;
+  entryRows: PushupRecord[];
+  dailyGoal: number;
+  dayChartMode: '24h' | '14h';
+  savingDayChartMode: boolean;
+  loading: boolean;
+  errorMessage: string;
+};
+
+const defaultRange = createWeekRange();
+
+const initialState: DashboardState = {
+  from: defaultRange.from,
+  to: defaultRange.to,
+  rangeMode: inferRangeMode(defaultRange.from, defaultRange.to),
+  busyAction: null,
+  busyId: null,
+  stats: EMPTY_STATS,
+  allTimeStats: EMPTY_STATS,
+  entryRows: [],
+  dailyGoal: 100,
+  dayChartMode: '14h',
+  savingDayChartMode: false,
+  loading: false,
+  errorMessage: '',
+};
+
+export const DashboardStore = signalStore(
+  { providedIn: 'root' },
+  withState(initialState),
+  withComputed((store) => {
+    const live = inject(PushupLiveService);
+
+    return {
+      total: computed(() => store.stats().meta.total),
+      days: computed(() => store.stats().meta.days),
+      entries: computed(() => store.stats().meta.entries),
+      avg: computed(() => {
+        const days = store.stats().meta.days;
+        const total = store.stats().meta.total;
+        return days ? (total / days).toFixed(1) : '0';
+      }),
+
+      allTimeTotal: computed(() => store.allTimeStats().meta.total),
+      allTimeDays: computed(() => store.allTimeStats().meta.days),
+      allTimeEntries: computed(() => store.allTimeStats().meta.entries),
+      allTimeAvg: computed(() => {
+        const days = store.allTimeStats().meta.days;
+        const total = store.allTimeStats().meta.total;
+        return days ? (total / days).toFixed(1) : '0';
+      }),
+
+      granularity: computed<StatsGranularity>(
+        () => store.stats().meta.granularity
+      ),
+      rows: computed<StatsSeriesEntry[]>(() => store.stats().series),
+
+      selectedDayTotal: computed(() => {
+        const day = store.from() || toLocalIsoDate(new Date());
+        return store
+          .entryRows()
+          .filter((entry) => entry.timestamp.slice(0, 10) === day)
+          .reduce((sum, entry) => sum + entry.reps, 0);
+      }),
+
+      periodTotal: computed(() => {
+        if (store.rangeMode() === 'day') {
+          const day = store.from() || toLocalIsoDate(new Date());
+          return store
+            .entryRows()
+            .filter((entry) => entry.timestamp.slice(0, 10) === day)
+            .reduce((sum, entry) => sum + entry.reps, 0);
+        }
+        return store.stats().meta.total;
+      }),
+
+      periodGoal: computed(() => {
+        const multiplier =
+          store.rangeMode() === 'day'
+            ? 1
+            : Math.max(1, store.stats().meta.days);
+        return store.dailyGoal() * multiplier;
+      }),
+
+      goalProgressPercent: computed(() => {
+        const periodTotal =
+          store.rangeMode() === 'day'
+            ? store
+                .entryRows()
+                .filter(
+                  (entry) =>
+                    entry.timestamp.slice(0, 10) ===
+                    (store.from() || toLocalIsoDate(new Date()))
+                )
+                .reduce((sum, entry) => sum + entry.reps, 0)
+            : store.stats().meta.total;
+        const periodGoal =
+          store.dailyGoal() *
+          (store.rangeMode() === 'day'
+            ? 1
+            : Math.max(1, store.stats().meta.days));
+
+        return periodGoal
+          ? Math.min(100, Math.round((periodTotal / periodGoal) * 100))
+          : 0;
+      }),
+
+      periodTitle: computed(() => {
+        if (
+          store.rangeMode() === 'day' &&
+          toLocalIsoDate(new Date()) === store.from()
+        ) {
+          return PERIOD_TITLE_MAP.today;
+        }
+        return PERIOD_TITLE_MAP[store.rangeMode()];
+      }),
+
+      lastEntry: computed<PushupRecord | null>(() => {
+        const rows = store.entryRows();
+        if (!rows.length) return null;
+        return (
+          [...rows].sort(
+            (a, b) =>
+              new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+          )[0] ?? null
+        );
+      }),
+
+      latestEntries: computed<PushupRecord[]>(() =>
+        [...store.entryRows()]
+          .sort(
+            (a, b) =>
+              new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+          )
+          .slice(0, 10)
+      ),
+
+      liveConnected: computed(() => live.connected()),
+    };
+  }),
+  withMethods((store) => {
+    const api = inject(StatsApiService);
+    const user = inject(UserContextService);
+    const userConfigApi = inject(UserConfigApiService);
+
+    const loadCurrentStats = async () => {
+      const from = store.from();
+      const to = store.to();
+      const stats = await firstValueFrom(
+        api.load({ from: from || undefined, to: to || undefined })
+      );
+      patchState(store, { stats: stats ?? EMPTY_STATS });
+    };
+
+    const loadEntries = async () => {
+      const from = store.from();
+      const to = store.to();
+      const rows = await firstValueFrom(
+        api.listPushups({ from: from || undefined, to: to || undefined })
+      );
+      patchState(store, { entryRows: rows ?? [] });
+    };
+
+    const loadAllTime = async () => {
+      const allTimeStats = await firstValueFrom(api.load({}));
+      patchState(store, { allTimeStats: allTimeStats ?? EMPTY_STATS });
+    };
+
+    return {
+      setFrom(from: string) {
+        patchState(store, {
+          from,
+          rangeMode: inferRangeMode(from, store.to()),
+        });
+        void this.refreshAll();
+      },
+
+      setTo(to: string) {
+        patchState(store, {
+          to,
+          rangeMode: inferRangeMode(store.from(), to),
+        });
+        void this.refreshAll();
+      },
+
+      setRangeMode(mode: RangeModes) {
+        patchState(store, { rangeMode: mode });
+      },
+
+      async initFromUrl(search: string) {
+        const params = new URLSearchParams(search);
+        const from = params.get('from') ?? defaultRange.from;
+        const to = params.get('to') ?? defaultRange.to;
+        patchState(store, {
+          from,
+          to,
+          rangeMode: inferRangeMode(from, to),
+        });
+        await this.loadUserConfig();
+        await this.refreshAll();
+      },
+
+      async refreshAll() {
+        patchState(store, { loading: true, errorMessage: '' });
+        try {
+          await Promise.all([loadCurrentStats(), loadEntries(), loadAllTime()]);
+        } catch {
+          patchState(store, {
+            errorMessage:
+              'Daten konnten nicht geladen werden. Bitte Zeitraum prüfen oder die Seite neu laden.',
+          });
+        } finally {
+          patchState(store, { loading: false });
+        }
+      },
+
+      async loadUserConfig() {
+        const cfg = await firstValueFrom(
+          userConfigApi.getConfig(user.userIdSafe())
+        );
+        patchState(store, {
+          dailyGoal: cfg.dailyGoal ?? 100,
+          dayChartMode: cfg.ui?.dayChartMode === '24h' ? '24h' : '14h',
+        });
+      },
+
+      async onCreateEntry(payload: {
+        timestamp: string;
+        reps: number;
+        source?: string;
+        type?: string;
+      }) {
+        patchState(store, { busyAction: 'create', busyId: null });
+        try {
+          await firstValueFrom(api.createPushup(payload));
+          await this.refreshAll();
+        } finally {
+          patchState(store, { busyAction: null, busyId: null });
+        }
+      },
+
+      async onUpdateEntry(payload: {
+        id: string;
+        timestamp: string;
+        reps: number;
+        source?: string;
+        type?: string;
+      }) {
+        patchState(store, { busyAction: 'update', busyId: payload.id });
+        try {
+          await firstValueFrom(
+            api.updatePushup(payload.id, {
+              timestamp: payload.timestamp,
+              reps: payload.reps,
+              source: payload.source,
+              type: payload.type,
+            })
+          );
+          await this.refreshAll();
+        } finally {
+          patchState(store, { busyAction: null, busyId: null });
+        }
+      },
+
+      async onDeleteEntry(id: string) {
+        patchState(store, { busyAction: 'delete', busyId: id });
+        try {
+          await firstValueFrom(api.deletePushup(id));
+          await this.refreshAll();
+        } finally {
+          patchState(store, { busyAction: null, busyId: null });
+        }
+      },
+
+      async onDayChartModeChange(mode: '24h' | '14h') {
+        if (!mode || mode === store.dayChartMode()) return;
+        patchState(store, { dayChartMode: mode, savingDayChartMode: true });
+        try {
+          await firstValueFrom(
+            userConfigApi.updateConfig(user.userIdSafe(), {
+              ui: { dayChartMode: mode },
+            })
+          );
+          await this.loadUserConfig();
+          await loadCurrentStats();
+        } finally {
+          patchState(store, { savingDayChartMode: false });
+        }
+      },
+
+      async addQuickEntry(reps: number) {
+        const now = new Date();
+        const y = now.getFullYear();
+        const m = String(now.getMonth() + 1).padStart(2, '0');
+        const d = String(now.getDate()).padStart(2, '0');
+        const hh = String(now.getHours()).padStart(2, '0');
+        const mm = String(now.getMinutes()).padStart(2, '0');
+
+        await this.onCreateEntry({
+          timestamp: `${y}-${m}-${d}T${hh}:${mm}`,
+          reps,
+          source: 'web',
+          type: 'Standard',
+        });
+      },
+    };
+  })
+);

--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -158,9 +158,9 @@
       <app-filter-bar
         [from]="from()"
         [to]="to()"
-        (fromChange)="from.set($event)"
-        (toChange)="to.set($event)"
-        (modeChange)="rangeMode.set($event)"
+        (fromChange)="onFromChange($event)"
+        (toChange)="onToChange($event)"
+        (modeChange)="onModeChange($event)"
       />
     </section>
 

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -2,61 +2,21 @@ import { DatePipe, DOCUMENT, isPlatformBrowser } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
-  computed,
   effect,
   inject,
-  linkedSignal,
   PLATFORM_ID,
   REQUEST,
-  resource,
-  signal,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import {
-  PushupLiveService,
-  StatsApiService,
-  UserConfigApiService,
-} from '@pu-stats/data-access';
-import {
-  PushupRecord,
-  StatsGranularity,
-  StatsResponse,
-  StatsSeriesEntry,
-} from '@pu-stats/models';
-import { firstValueFrom } from 'rxjs';
-import { UserContextService } from '../../user-context.service';
-import { createWeekRange } from '../../util/date/create-week-range';
-import { inferRangeMode } from '../../util/date/infer-range-mode';
-import { RangeModes } from '../../util/date/range-modes.type';
-import { toLocalIsoDate } from '../../util/date/to-local-iso-date';
+import { PushupLiveService } from '@pu-stats/data-access';
 import { FilterBarComponent } from '../components/filter-bar/filter-bar.component';
 import { StatsChartComponent } from '../components/stats-chart/stats-chart.component';
 import { StatsTableComponent } from '../components/stats-table/stats-table.component';
-
-const EMPTY_STATS: StatsResponse = {
-  meta: {
-    from: null,
-    to: null,
-    entries: 0,
-    days: 0,
-    total: 0,
-    granularity: 'daily',
-  },
-  series: [],
-};
-
-const PERIOD_TITLE_MAP: Record<RangeModes | 'today', string> = {
-  today: $localize`:@@period.today:Heute`,
-  day: $localize`:@@period.day:Tag`,
-  week: $localize`:@@period.week:Woche`,
-  month: $localize`:@@period.month:Monat`,
-  year: $localize`:@@period.year:Jahr`,
-  custom: $localize`:@@period.range:Zeitraum`,
-};
+import { DashboardStore } from './dashboard.store';
 
 @Component({
   selector: 'app-stats-dashboard',
@@ -76,7 +36,6 @@ const PERIOD_TITLE_MAP: Record<RangeModes | 'today', string> = {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StatsDashboardComponent {
-  private readonly api = inject(StatsApiService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly document = inject(DOCUMENT);
   private readonly request = inject(REQUEST, { optional: true }) as {
@@ -84,143 +43,46 @@ export class StatsDashboardComponent {
   } | null;
   private readonly live = inject(PushupLiveService);
 
-  private readonly defaultRange = createWeekRange();
-  private readonly initialRange = this.resolveInitialRange();
+  readonly store = inject(DashboardStore);
 
-  readonly from = signal(this.initialRange.from);
-  readonly to = signal(this.initialRange.to);
-  readonly rangeMode = linkedSignal<RangeModes>(() =>
-    inferRangeMode(this.initialRange.from, this.initialRange.to)
-  );
-  readonly busyAction = signal<'create' | 'update' | 'delete' | null>(null);
-  readonly busyId = signal<string | null>(null);
+  readonly from = this.store.from;
+  readonly to = this.store.to;
+  readonly rangeMode = this.store.rangeMode;
+  readonly busyAction = this.store.busyAction;
+  readonly busyId = this.store.busyId;
 
-  private readonly filter = computed(() => ({
-    from: this.from() || undefined,
-    to: this.to() || undefined,
-  }));
+  readonly total = this.store.total;
+  readonly days = this.store.days;
+  readonly entries = this.store.entries;
+  readonly avg = this.store.avg;
 
-  readonly statsResource = resource({
-    params: () => this.filter(),
-    loader: async ({ params }) => firstValueFrom(this.api.load(params)),
-  });
+  readonly allTimeTotal = this.store.allTimeTotal;
+  readonly allTimeDays = this.store.allTimeDays;
+  readonly allTimeEntries = this.store.allTimeEntries;
+  readonly allTimeAvg = this.store.allTimeAvg;
 
-  readonly entriesResource = resource({
-    params: () => this.filter(),
-    loader: async ({ params }) => firstValueFrom(this.api.listPushups(params)),
-  });
+  readonly granularity = this.store.granularity;
+  readonly rows = this.store.rows;
+  readonly entryRows = this.store.entryRows;
 
-  readonly allTimeResource = resource({
-    loader: async () => firstValueFrom(this.api.load({})),
-  });
+  readonly dailyGoal = this.store.dailyGoal;
+  readonly dayChartMode = this.store.dayChartMode;
+  readonly savingDayChartMode = this.store.savingDayChartMode;
 
-  readonly stats = computed(() => this.statsResource.value() ?? EMPTY_STATS);
-  readonly allTimeStats = computed(
-    () => this.allTimeResource.value() ?? EMPTY_STATS
-  );
-
-  readonly total = computed(() => this.stats().meta.total);
-  readonly days = computed(() => this.stats().meta.days);
-  readonly entries = computed(() => this.stats().meta.entries);
-  readonly avg = computed(() =>
-    this.days() ? (this.total() / this.days()).toFixed(1) : '0'
-  );
-
-  readonly allTimeTotal = computed(() => this.allTimeStats().meta.total);
-  readonly allTimeDays = computed(() => this.allTimeStats().meta.days);
-  readonly allTimeEntries = computed(() => this.allTimeStats().meta.entries);
-  readonly allTimeAvg = computed(() =>
-    this.allTimeDays()
-      ? (this.allTimeTotal() / this.allTimeDays()).toFixed(1)
-      : '0'
-  );
-  readonly granularity = computed<StatsGranularity>(
-    () => this.stats().meta.granularity
-  );
-  readonly rows = computed<StatsSeriesEntry[]>(() => this.stats().series);
-  readonly entryRows = computed<PushupRecord[]>(
-    () => this.entriesResource.value() ?? []
-  );
-  private readonly user = inject(UserContextService);
-  private readonly userConfigApi = inject(UserConfigApiService);
-
-  readonly dailyGoal = signal(100);
-  readonly dayChartMode = signal<'24h' | '14h'>('14h');
-  readonly savingDayChartMode = signal(false);
-
-  readonly userConfigResource = resource({
-    params: () => ({ userId: this.user.userIdSafe() }),
-    loader: async ({ params }) =>
-      firstValueFrom(this.userConfigApi.getConfig(params.userId)),
-  });
-
-  readonly selectedDayTotal = computed(() => {
-    const day = this.from() || toLocalIsoDate(new Date());
-    return this.entryRows()
-      .filter((entry) => entry.timestamp.slice(0, 10) === day)
-      .reduce((sum, entry) => sum + entry.reps, 0);
-  });
-
-  readonly periodTotal = computed(() => {
-    // Use entry data for day view (more robust when user browses non-today days)
-    if (this.rangeMode() === 'day') return this.selectedDayTotal();
-    return this.total();
-  });
-
-  readonly periodGoal = computed(() => {
-    const multiplier =
-      this.rangeMode() === 'day' ? 1 : Math.max(1, this.days());
-    return this.dailyGoal() * multiplier;
-  });
-
-  readonly goalProgressPercent = computed(() =>
-    this.periodGoal()
-      ? Math.min(
-          100,
-          Math.round((this.periodTotal() / this.periodGoal()) * 100)
-        )
-      : 0
-  );
-
-  readonly periodTitle = computed(() => {
-    if (
-      this.rangeMode() === 'day' &&
-      toLocalIsoDate(new Date()) === this.from()
-    ) {
-      return PERIOD_TITLE_MAP['today'];
-    }
-    return PERIOD_TITLE_MAP[this.rangeMode()];
-  });
-
-  readonly lastEntry = computed<PushupRecord | null>(() => {
-    const rows = this.entryRows();
-    if (!rows.length) return null;
-    return (
-      [...rows].sort(
-        (a, b) =>
-          new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-      )[0] ?? null
-    );
-  });
-  readonly latestEntries = computed<PushupRecord[]>(() => {
-    return [...this.entryRows()]
-      .sort(
-        (a, b) =>
-          new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-      )
-      .slice(0, 10);
-  });
-  readonly loading = computed(() => {
-    const status = this.statsResource.status();
-    return status === 'loading' || status === 'reloading';
-  });
-  readonly errorMessage = computed(() => {
-    if (!this.statsResource.error()) return '';
-    return 'Daten konnten nicht geladen werden. Bitte Zeitraum prüfen oder die Seite neu laden.';
-  });
-  readonly liveConnected = computed(() => this.live.connected());
+  readonly selectedDayTotal = this.store.selectedDayTotal;
+  readonly periodTotal = this.store.periodTotal;
+  readonly periodGoal = this.store.periodGoal;
+  readonly goalProgressPercent = this.store.goalProgressPercent;
+  readonly periodTitle = this.store.periodTitle;
+  readonly lastEntry = this.store.lastEntry;
+  readonly latestEntries = this.store.latestEntries;
+  readonly loading = this.store.loading;
+  readonly errorMessage = this.store.errorMessage;
+  readonly liveConnected = this.store.liveConnected;
 
   constructor() {
+    void this.store.initFromUrl(this.resolveSearchString());
+
     effect(() => {
       if (!isPlatformBrowser(this.platformId)) return;
       const params = new URLSearchParams();
@@ -235,121 +97,54 @@ export class StatsDashboardComponent {
     });
 
     effect(() => {
-      const cfg = this.userConfigResource.value();
-      if (!cfg) return;
-      this.dailyGoal.set(cfg.dailyGoal ?? 100);
-      this.dayChartMode.set(cfg.ui?.dayChartMode === '24h' ? '24h' : '14h');
-    });
-
-    effect(() => {
       if (!isPlatformBrowser(this.platformId)) return;
       const tick = this.live.updateTick();
       if (!tick) return;
-      this.refreshAll();
+      void this.store.refreshAll();
     });
   }
 
-  async onCreateEntry(payload: {
+  onFromChange(from: string) {
+    this.store.setFrom(from);
+  }
+
+  onToChange(to: string) {
+    this.store.setTo(to);
+  }
+
+  onModeChange(mode: 'day' | 'week' | 'month' | 'year' | 'custom') {
+    this.store.setRangeMode(mode);
+  }
+
+  onCreateEntry(payload: {
     timestamp: string;
     reps: number;
     source?: string;
     type?: string;
   }) {
-    this.busyAction.set('create');
-    this.busyId.set(null);
-    try {
-      await firstValueFrom(this.api.createPushup(payload));
-      this.refreshAll();
-    } finally {
-      this.busyAction.set(null);
-      this.busyId.set(null);
-    }
+    return this.store.onCreateEntry(payload);
   }
 
-  async onUpdateEntry(payload: {
+  onUpdateEntry(payload: {
     id: string;
     timestamp: string;
     reps: number;
     source?: string;
     type?: string;
   }) {
-    this.busyAction.set('update');
-    this.busyId.set(payload.id);
-    try {
-      await firstValueFrom(
-        this.api.updatePushup(payload.id, {
-          timestamp: payload.timestamp,
-          reps: payload.reps,
-          source: payload.source,
-          type: payload.type,
-        })
-      );
-      this.refreshAll();
-    } finally {
-      this.busyAction.set(null);
-      this.busyId.set(null);
-    }
+    return this.store.onUpdateEntry(payload);
   }
 
-  async onDeleteEntry(id: string) {
-    this.busyAction.set('delete');
-    this.busyId.set(id);
-    try {
-      await firstValueFrom(this.api.deletePushup(id));
-      this.refreshAll();
-    } finally {
-      this.busyAction.set(null);
-      this.busyId.set(null);
-    }
+  onDeleteEntry(id: string) {
+    return this.store.onDeleteEntry(id);
   }
 
-  async onDayChartModeChange(mode: '24h' | '14h') {
-    if (!mode || mode === this.dayChartMode()) return;
-    this.dayChartMode.set(mode);
-    this.savingDayChartMode.set(true);
-    try {
-      await firstValueFrom(
-        this.userConfigApi.updateConfig(this.user.userIdSafe(), {
-          ui: {
-            dayChartMode: mode,
-          },
-        })
-      );
-      this.userConfigResource.reload();
-      this.statsResource.reload();
-    } finally {
-      this.savingDayChartMode.set(false);
-    }
+  onDayChartModeChange(mode: '24h' | '14h') {
+    return this.store.onDayChartModeChange(mode);
   }
 
-  async addQuickEntry(reps: number) {
-    const now = new Date();
-    const y = now.getFullYear();
-    const m = String(now.getMonth() + 1).padStart(2, '0');
-    const d = String(now.getDate()).padStart(2, '0');
-    const hh = String(now.getHours()).padStart(2, '0');
-    const mm = String(now.getMinutes()).padStart(2, '0');
-
-    await this.onCreateEntry({
-      timestamp: `${y}-${m}-${d}T${hh}:${mm}`,
-      reps,
-      source: 'web',
-      type: 'Standard',
-    });
-  }
-
-  private refreshAll() {
-    this.statsResource.reload();
-    this.allTimeResource.reload();
-    this.entriesResource.reload();
-  }
-
-  private resolveInitialRange(): { from: string; to: string } {
-    const search = this.resolveSearchString();
-    const params = new URLSearchParams(search);
-    const from = params.get('from') ?? this.defaultRange.from;
-    const to = params.get('to') ?? this.defaultRange.to;
-    return { from, to };
+  addQuickEntry(reps: number) {
+    return this.store.addQuickEntry(reps);
   }
 
   private resolveSearchString(): string {


### PR DESCRIPTION
## Summary
- migrate dashboard page state management from component-local signals/resources to a dedicated DashboardStore based on @ngrx/signals
- keep UI behavior and bindings stable while moving domain logic (range stats, goals, quick actions, CRUD busy state, user config) into store methods/computed signals
- keep URL sync + live tick wiring in component; delegate data refresh and mutations to store

## Scope (Issue #96)
- ✅ Dashboard state moved to Signal Store
- ✅ Existing dashboard tests still green after migration
- ✅ No user-facing behavior changes intended

## Validation
- `npm exec nx test web` ✅
- `npm exec nx lint web` ✅
- `npm exec nx build web` ✅ (known pre-existing warnings: i18n + bundle budget/commonjs)

Closes #96