### PR TITLE
refactor(state): global pushup entity signal store in data-access (#97)

### DIFF
--- a/libs/data-access/src/index.ts
+++ b/libs/data-access/src/index.ts
@@ -6,3 +6,4 @@ export * from './lib/live/pushup-live-data.service';
 export * from './lib/api/user-config-firestore.service';
 export * from './lib/api/pushup-firestore.service';
 export * from './lib/provide-firestore';
+export * from './lib/state/pushup-entities.store';

--- a/libs/data-access/src/lib/state/pushup-entities.store.ts
+++ b/libs/data-access/src/lib/state/pushup-entities.store.ts
@@ -1,0 +1,164 @@
+import { computed, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+import {
+  PushupCreate,
+  PushupRecord,
+  PushupUpdate,
+  StatsFilter,
+} from '@pu-stats/models';
+import { StatsApiService } from '../api/stats-api.service';
+
+type PushupEntitiesState = {
+  entityMap: Record<string, PushupRecord>;
+  ids: string[];
+  filter: StatsFilter;
+  loading: boolean;
+  error: string | null;
+  busyAction: 'create' | 'update' | 'delete' | null;
+  busyId: string | null;
+};
+
+const initialState: PushupEntitiesState = {
+  entityMap: {},
+  ids: [],
+  filter: {},
+  loading: false,
+  error: null,
+  busyAction: null,
+  busyId: null,
+};
+
+function normalizeRows(rows: PushupRecord[]): {
+  entityMap: Record<string, PushupRecord>;
+  ids: string[];
+} {
+  const sorted = [...rows].sort((a, b) =>
+    a.timestamp.localeCompare(b.timestamp)
+  );
+  const entityMap: Record<string, PushupRecord> = {};
+  const ids: string[] = [];
+
+  for (const row of sorted) {
+    if (!row._id) continue;
+    entityMap[row._id] = row;
+    ids.push(row._id);
+  }
+
+  return { entityMap, ids };
+}
+
+export const PushupEntitiesStore = signalStore(
+  { providedIn: 'root' },
+  withState(initialState),
+  withComputed((store) => ({
+    entries: computed(() =>
+      store
+        .ids()
+        .map((id) => store.entityMap()[id])
+        .filter(Boolean)
+    ),
+    entriesDesc: computed(() =>
+      [...store.ids()]
+        .reverse()
+        .map((id) => store.entityMap()[id])
+        .filter(Boolean)
+    ),
+    sourceOptions: computed(
+      () =>
+        [
+          ...new Set(
+            store
+              .ids()
+              .map((id) => store.entityMap()[id]?.source)
+              .filter(Boolean)
+          ),
+        ].sort((a, b) => String(a).localeCompare(String(b))) as string[]
+    ),
+    typeOptions: computed(
+      () =>
+        [
+          ...new Set(
+            store
+              .ids()
+              .map((id) => store.entityMap()[id]?.type || 'Standard')
+              .filter(Boolean)
+          ),
+        ].sort((a, b) => String(a).localeCompare(String(b))) as string[]
+    ),
+  })),
+  withMethods((store) => {
+    const api = inject(StatsApiService);
+
+    const loadWithFilter = async (filter: StatsFilter) => {
+      patchState(store, { loading: true, error: null, filter });
+      try {
+        const rows = await firstValueFrom(api.listPushups(filter));
+        const normalized = normalizeRows(rows ?? []);
+        patchState(store, {
+          ...normalized,
+          loading: false,
+        });
+      } catch {
+        patchState(store, {
+          loading: false,
+          error: 'Einträge konnten nicht geladen werden.',
+        });
+      }
+    };
+
+    return {
+      async load(filter: StatsFilter = {}) {
+        await loadWithFilter(filter);
+      },
+
+      async reload() {
+        await loadWithFilter(store.filter());
+      },
+
+      setFilter(filter: StatsFilter) {
+        patchState(store, { filter });
+      },
+
+      async setFilterAndLoad(filter: StatsFilter) {
+        await loadWithFilter(filter);
+      },
+
+      async create(payload: PushupCreate) {
+        patchState(store, { busyAction: 'create', busyId: null });
+        try {
+          await firstValueFrom(api.createPushup(payload));
+          await loadWithFilter(store.filter());
+        } finally {
+          patchState(store, { busyAction: null, busyId: null });
+        }
+      },
+
+      async update(id: string, payload: PushupUpdate) {
+        patchState(store, { busyAction: 'update', busyId: id });
+        try {
+          await firstValueFrom(api.updatePushup(id, payload));
+          await loadWithFilter(store.filter());
+        } finally {
+          patchState(store, { busyAction: null, busyId: null });
+        }
+      },
+
+      async remove(id: string) {
+        patchState(store, { busyAction: 'delete', busyId: id });
+        try {
+          await firstValueFrom(api.deletePushup(id));
+          await loadWithFilter(store.filter());
+        } finally {
+          patchState(store, { busyAction: null, busyId: null });
+        }
+      },
+    };
+  })
+);

--- a/web/src/app/stats/shell/entries-page.component.spec.ts
+++ b/web/src/app/stats/shell/entries-page.component.spec.ts
@@ -1,9 +1,8 @@
-import { Auth } from '@angular/fire/auth';
-import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { signal } from '@angular/core';
+import { Auth } from '@angular/fire/auth';
 import { EntriesPageComponent } from './entries-page.component';
-import { PushupLiveDataService, StatsApiService } from '@pu-stats/data-access';
+import { PushupEntitiesStore } from '@pu-stats/data-access';
 
 describe('EntriesPageComponent', () => {
   let fixture: ComponentFixture<EntriesPageComponent>;
@@ -32,16 +31,18 @@ describe('EntriesPageComponent', () => {
     },
   ];
 
-  const apiMock = {
-    listPushups: vitest.fn().mockReturnValue(of(rows)),
-    deletePushup: vitest.fn().mockReturnValue(of({ ok: true })),
-    createPushup: vitest.fn().mockReturnValue(of({ _id: 'x' })),
-    updatePushup: vitest.fn().mockReturnValue(of({ _id: '1' })),
-  };
-
-  const liveMock = {
-    connected: signal(true),
-    entries: signal(rows),
+  const storeMock = {
+    entriesDesc: signal(rows),
+    sourceOptions: signal(['wa', 'web']),
+    typeOptions: signal(['Diamond', 'Standard', 'Wide']),
+    busyAction: signal<'create' | 'update' | 'delete' | null>(null),
+    busyId: signal<string | null>(null),
+    load: vitest.fn().mockResolvedValue(undefined),
+    setFilterAndLoad: vitest.fn().mockResolvedValue(undefined),
+    create: vitest.fn().mockResolvedValue(undefined),
+    update: vitest.fn().mockResolvedValue(undefined),
+    remove: vitest.fn().mockResolvedValue(undefined),
+    reload: vitest.fn().mockResolvedValue(undefined),
   };
 
   beforeEach(async () => {
@@ -50,8 +51,7 @@ describe('EntriesPageComponent', () => {
     await TestBed.configureTestingModule({
       imports: [EntriesPageComponent],
       providers: [
-        { provide: StatsApiService, useValue: apiMock },
-        { provide: PushupLiveDataService, useValue: liveMock },
+        { provide: PushupEntitiesStore, useValue: storeMock },
         { provide: Auth, useValue: {} },
       ],
     }).compileComponents();
@@ -60,7 +60,7 @@ describe('EntriesPageComponent', () => {
     await fixture.whenStable();
   });
 
-  it('prefills date range with oldest and today (browser uses live entries)', () => {
+  it('prefills date range with oldest and today', () => {
     const component = fixture.componentInstance;
     expect(component.from()).toBe('2026-02-10');
     expect(component.to()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
@@ -76,7 +76,7 @@ describe('EntriesPageComponent', () => {
     expect(component.filteredRows().map((x) => x._id)).toEqual(['3']);
   });
 
-  it('creates an entry via api', async () => {
+  it('creates an entry via global store', async () => {
     const component = fixture.componentInstance;
 
     await component.onCreateEntry({
@@ -85,14 +85,14 @@ describe('EntriesPageComponent', () => {
       source: 'web',
     });
 
-    expect(apiMock.createPushup).toHaveBeenCalledWith({
+    expect(storeMock.create).toHaveBeenCalledWith({
       timestamp: '2026-02-11T20:00',
       reps: 12,
       source: 'web',
     });
   });
 
-  it('updates an entry via api', async () => {
+  it('updates an entry via global store', async () => {
     const component = fixture.componentInstance;
 
     await component.onUpdateEntry({
@@ -103,7 +103,7 @@ describe('EntriesPageComponent', () => {
       type: 'Diamond',
     });
 
-    expect(apiMock.updatePushup).toHaveBeenCalledWith('1', {
+    expect(storeMock.update).toHaveBeenCalledWith('1', {
       timestamp: '2026-02-11T20:00',
       reps: 14,
       source: 'web',
@@ -111,11 +111,11 @@ describe('EntriesPageComponent', () => {
     });
   });
 
-  it('deletes a single row via api', async () => {
+  it('deletes a single row via global store', async () => {
     const component = fixture.componentInstance;
 
     await component.onDeleteEntry('2');
 
-    expect(apiMock.deletePushup).toHaveBeenCalledWith('2');
+    expect(storeMock.remove).toHaveBeenCalledWith('2');
   });
 });

--- a/web/src/app/stats/shell/entries-page.component.ts
+++ b/web/src/app/stats/shell/entries-page.component.ts
@@ -1,19 +1,9 @@
-import {
-  Component,
-  computed,
-  effect,
-  inject,
-  resource,
-  signal,
-} from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
-import { PLATFORM_ID } from '@angular/core';
+import { Component, computed, effect, inject, signal } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
-import { firstValueFrom } from 'rxjs';
-import { PushupLiveDataService, StatsApiService } from '@pu-stats/data-access';
+import { PushupEntitiesStore } from '@pu-stats/data-access';
 import { StatsTableComponent } from '../components/stats-table/stats-table.component';
 
 @Component({
@@ -108,8 +98,8 @@ import { StatsTableComponent } from '../components/stats-table/stats-table.compo
 
       <app-stats-table
         [entries]="filteredRows()"
-        [busyAction]="busyAction()"
-        [busyId]="busyId()"
+        [busyAction]="store.busyAction()"
+        [busyId]="store.busyId()"
         (create)="onCreateEntry($event)"
         (update)="onUpdateEntry($event)"
         (remove)="onDeleteEntry($event)"
@@ -132,9 +122,7 @@ import { StatsTableComponent } from '../components/stats-table/stats-table.compo
   `,
 })
 export class EntriesPageComponent {
-  private readonly api = inject(StatsApiService);
-  private readonly live = inject(PushupLiveDataService);
-  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  readonly store = inject(PushupEntitiesStore);
 
   readonly from = signal('');
   readonly to = signal('');
@@ -142,43 +130,10 @@ export class EntriesPageComponent {
   readonly type = signal('');
   readonly repsMin = signal<number | null>(null);
   readonly repsMax = signal<number | null>(null);
-  readonly busyAction = signal<'create' | 'update' | 'delete' | null>(null);
-  readonly busyId = signal<string | null>(null);
 
-  // SSR should keep using REST.
-  readonly entriesResource = resource({
-    params: () => ({
-      from: this.from() || undefined,
-      to: this.to() || undefined,
-    }),
-    loader: async ({ params }) => firstValueFrom(this.api.listPushups(params)),
-  });
-
-  readonly rows = computed(() => {
-    return this.isBrowser
-      ? this.live.entries()
-      : (this.entriesResource.value() ?? []);
-  });
-
-  readonly sourceOptions = computed(() => {
-    return [
-      ...new Set(
-        this.rows()
-          .map((x) => x.source)
-          .filter(Boolean)
-      ),
-    ].sort((a, b) => a.localeCompare(b));
-  });
-
-  readonly typeOptions = computed(() => {
-    return [
-      ...new Set(
-        this.rows()
-          .map((x) => x.type || 'Standard')
-          .filter(Boolean)
-      ),
-    ].sort((a, b) => a.localeCompare(b));
-  });
+  readonly rows = this.store.entriesDesc;
+  readonly sourceOptions = this.store.sourceOptions;
+  readonly typeOptions = this.store.typeOptions;
 
   readonly filteredRows = computed(() => {
     const source = this.source();
@@ -201,6 +156,17 @@ export class EntriesPageComponent {
   });
 
   constructor() {
+    void this.store.load({});
+
+    effect(() => {
+      const from = this.from();
+      const to = this.to();
+      void this.store.setFilterAndLoad({
+        from: from || undefined,
+        to: to || undefined,
+      });
+    });
+
     effect(() => {
       const rows = this.rows();
       if (!rows.length || this.from() || this.to()) return;
@@ -230,58 +196,32 @@ export class EntriesPageComponent {
     return Number.isNaN(num) ? null : num;
   }
 
-  async onCreateEntry(payload: {
+  onCreateEntry(payload: {
     timestamp: string;
     reps: number;
     source?: string;
     type?: string;
   }) {
-    this.busyAction.set('create');
-    this.busyId.set(null);
-    try {
-      await firstValueFrom(this.api.createPushup(payload));
-      if (!this.isBrowser) this.entriesResource.reload();
-    } finally {
-      this.busyAction.set(null);
-      this.busyId.set(null);
-    }
+    return this.store.create(payload);
   }
 
-  async onUpdateEntry(payload: {
+  onUpdateEntry(payload: {
     id: string;
     timestamp: string;
     reps: number;
     source?: string;
     type?: string;
   }) {
-    this.busyAction.set('update');
-    this.busyId.set(payload.id);
-    try {
-      await firstValueFrom(
-        this.api.updatePushup(payload.id, {
-          timestamp: payload.timestamp,
-          reps: payload.reps,
-          source: payload.source,
-          type: payload.type,
-        })
-      );
-      if (!this.isBrowser) this.entriesResource.reload();
-    } finally {
-      this.busyAction.set(null);
-      this.busyId.set(null);
-    }
+    return this.store.update(payload.id, {
+      timestamp: payload.timestamp,
+      reps: payload.reps,
+      source: payload.source,
+      type: payload.type,
+    });
   }
 
-  async onDeleteEntry(id: string) {
-    this.busyAction.set('delete');
-    this.busyId.set(id);
-    try {
-      await firstValueFrom(this.api.deletePushup(id));
-      if (!this.isBrowser) this.entriesResource.reload();
-    } finally {
-      this.busyAction.set(null);
-      this.busyId.set(null);
-    }
+  onDeleteEntry(id: string) {
+    return this.store.remove(id);
   }
 
   private todayIso(): string {

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -17,6 +17,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import {
+  PushupEntitiesStore,
   PushupLiveService,
   StatsApiService,
   UserConfigApiService,
@@ -83,6 +84,7 @@ export class StatsDashboardComponent {
     url?: string;
   } | null;
   private readonly live = inject(PushupLiveService);
+  private readonly pushups = inject(PushupEntitiesStore);
 
   private readonly defaultRange = createWeekRange();
   private readonly initialRange = this.resolveInitialRange();
@@ -92,8 +94,8 @@ export class StatsDashboardComponent {
   readonly rangeMode = linkedSignal<RangeModes>(() =>
     inferRangeMode(this.initialRange.from, this.initialRange.to)
   );
-  readonly busyAction = signal<'create' | 'update' | 'delete' | null>(null);
-  readonly busyId = signal<string | null>(null);
+  readonly busyAction = this.pushups.busyAction;
+  readonly busyId = this.pushups.busyId;
 
   private readonly filter = computed(() => ({
     from: this.from() || undefined,
@@ -103,11 +105,6 @@ export class StatsDashboardComponent {
   readonly statsResource = resource({
     params: () => this.filter(),
     loader: async ({ params }) => firstValueFrom(this.api.load(params)),
-  });
-
-  readonly entriesResource = resource({
-    params: () => this.filter(),
-    loader: async ({ params }) => firstValueFrom(this.api.listPushups(params)),
   });
 
   readonly allTimeResource = resource({
@@ -138,9 +135,7 @@ export class StatsDashboardComponent {
     () => this.stats().meta.granularity
   );
   readonly rows = computed<StatsSeriesEntry[]>(() => this.stats().series);
-  readonly entryRows = computed<PushupRecord[]>(
-    () => this.entriesResource.value() ?? []
-  );
+  readonly entryRows = computed<PushupRecord[]>(() => this.pushups.entries());
   private readonly user = inject(UserContextService);
   private readonly userConfigApi = inject(UserConfigApiService);
 
@@ -242,6 +237,10 @@ export class StatsDashboardComponent {
     });
 
     effect(() => {
+      void this.pushups.setFilterAndLoad(this.filter());
+    });
+
+    effect(() => {
       if (!isPlatformBrowser(this.platformId)) return;
       const tick = this.live.updateTick();
       if (!tick) return;
@@ -255,15 +254,8 @@ export class StatsDashboardComponent {
     source?: string;
     type?: string;
   }) {
-    this.busyAction.set('create');
-    this.busyId.set(null);
-    try {
-      await firstValueFrom(this.api.createPushup(payload));
-      this.refreshAll();
-    } finally {
-      this.busyAction.set(null);
-      this.busyId.set(null);
-    }
+    await this.pushups.create(payload);
+    this.refreshStatsOnly();
   }
 
   async onUpdateEntry(payload: {
@@ -273,34 +265,18 @@ export class StatsDashboardComponent {
     source?: string;
     type?: string;
   }) {
-    this.busyAction.set('update');
-    this.busyId.set(payload.id);
-    try {
-      await firstValueFrom(
-        this.api.updatePushup(payload.id, {
-          timestamp: payload.timestamp,
-          reps: payload.reps,
-          source: payload.source,
-          type: payload.type,
-        })
-      );
-      this.refreshAll();
-    } finally {
-      this.busyAction.set(null);
-      this.busyId.set(null);
-    }
+    await this.pushups.update(payload.id, {
+      timestamp: payload.timestamp,
+      reps: payload.reps,
+      source: payload.source,
+      type: payload.type,
+    });
+    this.refreshStatsOnly();
   }
 
   async onDeleteEntry(id: string) {
-    this.busyAction.set('delete');
-    this.busyId.set(id);
-    try {
-      await firstValueFrom(this.api.deletePushup(id));
-      this.refreshAll();
-    } finally {
-      this.busyAction.set(null);
-      this.busyId.set(null);
-    }
+    await this.pushups.remove(id);
+    this.refreshStatsOnly();
   }
 
   async onDayChartModeChange(mode: '24h' | '14h') {
@@ -339,9 +315,13 @@ export class StatsDashboardComponent {
   }
 
   private refreshAll() {
+    this.refreshStatsOnly();
+    void this.pushups.reload();
+  }
+
+  private refreshStatsOnly() {
     this.statsResource.reload();
     this.allTimeResource.reload();
-    this.entriesResource.reload();
   }
 
   private resolveInitialRange(): { from: string; to: string } {


### PR DESCRIPTION
## Summary
- add a global `PushupEntitiesStore` in `libs/data-access` as central state for pushup entries (entity map + ids + filter + loading/busy state)
- migrate `EntriesPageComponent` to consume the global store (load/filter/create/update/delete)
- wire `StatsDashboardComponent` entry CRUD + row data to the same global store while keeping dashboard stats resources intact
- export the new store from `@pu-stats/data-access`

## Why
This establishes one central source of truth for pushup entity data and removes duplicate page-local CRUD/data-loading logic.

## Validation
- `npm exec nx test web` ✅
- `npm exec nx lint web` ✅
- `npm exec nx build web` ✅ (pre-existing warnings: i18n/commonjs/bundle budget)

Closes #97
