### PR TITLE
feat(i18n): complete English translations, remove stale units

### DIFF
--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1,2504 +1,311 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<?xml version="1.0" encoding="UTF-8"?>
 <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="de" trgLang="en">
   <file id="ngi18n" original="ng.template">
-    <unit id="1713004850888488155">
-      <notes>
-        <note category="location">web/src/app/app.ts:81</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Neue Version verfügbar</source>
-        <target>New version available</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="1933013871016789910">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:34</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Gesamt</source>
-        <target>Total</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="2361265238320887165">
-      <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.html:26,27</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Abmelden</source>
-        <target>Logout</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="2721806142807617942">
-      <segment state="translated">
-        <source/>
-        <target> Register </target>
-      </segment>
-    </unit>
-    <unit id="5889607835368180076">
-      <notes>
-        <note category="location">web/src/app/app.ts:82</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Neu laden</source>
-        <target>Reload</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="6031063121455734122">
-      <segment state="translated">
-        <source/>
-        <target> Back </target>
-      </segment>
-    </unit>
     <unit id="7638356697128454089">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:25,26</note>
 
-        
             </notes>
       <segment state="translated">
         <source>Anmeldung erfolgreich!</source>
         <target>Login successful!</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="activeUser">
+    <unit id="2361265238320887165">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:64,65</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.html:26,27</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ activeUserId() }}"/>
-Aktiv:         </source>
-        <target>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ activeUserId() }}"/>
-Active:         </target>
+        <source>Abmelden</source>
+        <target>Logout</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="ads.dashboard.aria">
-      <segment state="translated">
-        <source>Werbung</source>
-        <target>Advertisement</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="ads.landing.aria">
-      <segment state="translated">
-        <source>Werbung</source>
-        <target>Advertisement</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="allTimeAvg">
+    <unit id="validate.email.required">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:92,93</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:66</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>All-Time Ø/Tag</source>
-        <target>All-time avg/day</target>
+        <source>Bitte E-Mail eingeben!</source>
+        <target>Please enter email!</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="allTimeDays">
+    <unit id="validate.email.email">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:84,85</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:69</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>All-Time Tage</source>
-        <target>All-time days</target>
+        <source>Bitte gültige E-Mail eingeben!</source>
+        <target>Please enter a valid email!</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="allTimeEntries">
+    <unit id="validate.password.required">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:88,89</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:72</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>All-Time Einträge</source>
-        <target>All-time entries</target>
+        <source>Bitte Passwort eingeben!</source>
+        <target>Please enter password!</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="allTimeSummaryAria">
+    <unit id="validate.password.minLength">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:76,77</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:75</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>All-Time Kurzübersicht</source>
-        <target>All-time summary</target>
+        <source>Passwort muss mindestens 6 Zeichen lang sein!</source>
+        <target>Password must be at least 6 characters long!</target>
 
-        
-        
             </segment>
 
-      
-      
-        </unit>
-    <unit id="allTimeTotal">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:80,81</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>All-Time Gesamt</source>
-        <target>All-time total</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.bestDay">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:87,89</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Bester Tag:</source>
-        <target>Best day:</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.bestSingleEntry">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:82,84</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Bestwert Einzel-Eintrag:</source>
-        <target>Best single entry:</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.bestStreaksTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,78</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Bestwerte &amp; Streaks</source>
-        <target>Best values &amp; streaks</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.currentStreak">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:93,95</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Aktuelle Streak:</source>
-        <target>Current streak:</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.heatmapTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:126,128</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Heatmap (Wochentag/Uhrzeit)</source>
-        <target>Heatmap (weekday/time)</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.longestStreak">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:101,103</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Längste Streak:</source>
-        <target>Longest streak:</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.monthCol">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:57,58</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Monat</source>
-        <target>Month</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.monthTrendTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:50,52</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Monatstrend</source>
-        <target>Monthly trend</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.repsCol">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:37,38</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:63,64</note>
-
-        
-        
-            </notes>
-      <segment state="translated">
-        <source>Reps</source>
-        <target>Reps</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.streakDays">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:96,97</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:104,105</note>
-
-        
-        
-            </notes>
-      <segment state="translated">
-        <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ currentStreak() }}"/>
- Tage        </source>
-        <target>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ currentStreak() }}"/>
- days        </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.typesTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:114,116</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Typen (Anteile)</source>
-        <target>Types (shares)</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.weekCol">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:31,32</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Woche</source>
-        <target>Week</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="analysis.weekTrendTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:24,26</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Wochentrend</source>
-        <target>Weekly trend</target>
-
-        
-        
-            </segment>
-
-      
-      
         </unit>
     <unit id="app.title">
       <notes>
         <note category="location">web/src/app/app.html:11,12</note>
         <note category="location">web/src/app/app.html:114,115</note>
 
-        
-        
             </notes>
       <segment state="translated">
         <source>Pushups</source>
         <target>Pushups</target>
 
-        
-        
             </segment>
 
-      
-      
-        </unit>
-    <unit id="auth.email">
-      <segment state="translated">
-        <source/>
-        <target>Email</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.emailInUse">
-      <segment state="translated">
-        <source/>
-        <target>An account already exists for this email.</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.generic">
-      <segment state="translated">
-        <source/>
-        <target>Login failed. Please try again.</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.internalError">
-      <segment state="translated">
-        <source/>
-        <target>A technical error occurred. Please try again shortly.</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.invalidCredential">
-      <segment state="translated">
-        <source/>
-        <target>Email or password is incorrect.</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.invalidEmail">
-      <segment state="translated">
-        <source/>
-        <target>Please enter a valid email address.</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.network">
-      <segment state="translated">
-        <source/>
-        <target>Network error. Please check your internet connection and try again.</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.popupBlocked">
-      <segment state="translated">
-        <source/>
-        <target>Popup was blocked. Please allow popups and try again.</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.popupClosed">
-      <segment state="translated">
-        <source/>
-        <target>Google sign-in was canceled. The sign-in window was closed.</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.tooManyRequests">
-      <segment state="translated">
-        <source/>
-        <target>Too many attempts. Please wait a moment and try again.</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.userDisabled">
-      <segment state="translated">
-        <source/>
-        <target>This account is disabled.</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.userNotFound">
-      <segment state="translated">
-        <source/>
-        <target>No account found for this email.</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.weakPassword">
-      <segment state="translated">
-        <source/>
-        <target>Password is too weak (at least 6 characters).</target>
-      </segment>
-    </unit>
-    <unit id="auth.error.wrongPassword">
-      <segment state="translated">
-        <source/>
-        <target>Email or password is incorrect.</target>
-      </segment>
-    </unit>
-    <unit id="auth.google.signin">
-      <segment state="translated">
-        <source/>
-        <target> Sign in with Google </target>
-      </segment>
-    </unit>
-    <unit id="auth.google.signup">
-      <segment state="translated">
-        <source/>
-        <target> Sign up with Google </target>
-      </segment>
-    </unit>
-    <unit id="auth.login.loading">
-      <segment state="translated">
-        <source/>
-        <target>Signing in...</target>
-      </segment>
-    </unit>
-    <unit id="auth.login.submit">
-      <segment state="translated">
-        <source/>
-        <target>Sign in</target>
-      </segment>
-    </unit>
-    <unit id="auth.login.subtitle">
-      <segment state="translated">
-        <source/>
-        <target>Please sign in</target>
-      </segment>
-    </unit>
-    <unit id="auth.login.title">
-      <segment state="translated">
-        <source/>
-        <target>Welcome to PushUp Stats</target>
-      </segment>
-    </unit>
-    <unit id="auth.next">
-      <segment state="translated">
-        <source/>
-        <target> Next </target>
-      </segment>
-    </unit>
-    <unit id="auth.onboarding.google.consent.checkbox">
-      <segment state="translated">
-        <source/>
-        <target> Grant consent </target>
-      </segment>
-    </unit>
-    <unit id="auth.onboarding.google.consent.text">
-      <segment state="translated">
-        <source/>
-        <target> I consent to data processing for technically required data collection, statistical analysis, and personalized advertising. </target>
-      </segment>
-    </unit>
-    <unit id="auth.onboarding.google.error.consentRequired">
-      <segment state="translated">
-        <source/>
-        <target>Please consent to data processing.</target>
-      </segment>
-    </unit>
-    <unit id="auth.onboarding.google.error.noUser">
-      <segment state="translated">
-        <source/>
-        <target>No logged-in user found.</target>
-      </segment>
-    </unit>
-    <unit id="auth.onboarding.google.error.saveFailed">
-      <segment state="translated">
-        <source/>
-        <target>Onboarding could not be saved. Please try again.</target>
-      </segment>
-    </unit>
-    <unit id="auth.onboarding.google.finish">
-      <segment state="translated">
-        <source/>
-        <target> Finish </target>
-      </segment>
-    </unit>
-    <unit id="auth.onboarding.google.goal">
-      <segment state="translated">
-        <source/>
-        <target>Daily goal</target>
-      </segment>
-    </unit>
-    <unit id="auth.onboarding.google.title">
-      <segment state="translated">
-        <source/>
-        <target> Complete setup </target>
-      </segment>
-    </unit>
-    <unit id="auth.onboarding.google.username">
-      <segment state="translated">
-        <source/>
-        <target>Username</target>
-      </segment>
-    </unit>
-    <unit id="auth.onboarding.google.username.hint">
-      <segment state="translated">
-        <source/>
-        <target>At least 2 characters.</target>
-      </segment>
-    </unit>
-    <unit id="auth.or">
-      <segment state="translated">
-        <source/>
-        <target>or</target>
-      </segment>
-    </unit>
-    <unit id="auth.password">
-      <segment state="translated">
-        <source/>
-        <target>Password</target>
-      </segment>
-    </unit>
-    <unit id="auth.register.back">
-      <segment state="translated">
-        <source/>
-        <target> Back </target>
-      </segment>
-    </unit>
-    <unit id="auth.register.finalizing">
-      <segment state="translated">
-        <source/>
-        <target>Creating account and saving profile...</target>
-      </segment>
-    </unit>
-    <unit id="auth.register.google.skipPassword">
-      <segment state="translated">
-        <source/>
-        <target> Password step skipped (Google registration). </target>
-      </segment>
-    </unit>
-    <unit id="auth.register.noAccount">
-      <segment state="translated">
-        <source/>
-        <target>No account yet?</target>
-      </segment>
-    </unit>
-    <unit id="auth.register.password.hint">
-      <segment state="translated">
-        <source/>
-        <target>Min. 8 characters, 1 number, and 1 special character.</target>
-      </segment>
-    </unit>
-    <unit id="auth.register.password.invalid">
-      <segment state="translated">
-        <source/>
-        <target>Password does not meet requirements.</target>
-      </segment>
-    </unit>
-    <unit id="auth.register.password.repeat">
-      <segment state="translated">
-        <source/>
-        <target>Repeat password</target>
-      </segment>
-    </unit>
-    <unit id="auth.register.password.repeat.invalid">
-      <segment state="translated">
-        <source/>
-        <target>Passwords do not match.</target>
-      </segment>
-    </unit>
-    <unit id="auth.register.processing">
-      <segment state="translated">
-        <source/>
-        <target>Preparing registration...</target>
-      </segment>
-    </unit>
-    <unit id="auth.register.submit">
-      <segment state="translated">
-        <source/>
-        <target> Register </target>
-      </segment>
-    </unit>
-    <unit id="auth.register.subtitle">
-      <segment state="translated">
-        <source/>
-        <target>Create your account</target>
-      </segment>
-    </unit>
-    <unit id="auth.register.success.dashboard">
-      <segment state="translated">
-        <source/>
-        <target> Go to dashboard </target>
-      </segment>
-    </unit>
-    <unit id="auth.register.success.text">
-      <segment state="translated">
-        <source/>
-        <target> Your account is ready. Time for the first push-ups 💪 </target>
-      </segment>
-    </unit>
-    <unit id="auth.register.success.title">
-      <segment state="translated">
-        <source/>
-        <target>Done! 🎉</target>
-      </segment>
-    </unit>
-    <unit id="auth.register.title">
-      <segment state="translated">
-        <source/>
-        <target>Registration</target>
-      </segment>
-    </unit>
-    <unit id="brandLogoAlt">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:6,7</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Pushup Tracker Logo</source>
-        <target>Pushup Tracker Logo</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="cancel">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:215,217</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:297,299</note>
-
-        
-        
-            </notes>
-      <segment state="translated">
-        <source> Abbrechen </source>
-        <target> Cancel </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="chart.dayIntegral">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:54,55</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Tages-Integral</source>
-        <target>Daily integral</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="chart.interval">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:48,49</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Intervallwert</source>
-        <target>Interval value</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="chart.legendAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Legende</source>
-        <target>Legend</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="chart.movingAvg">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:60,61</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Gleitender Durchschnitt</source>
-        <target>Moving average</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="chart.subtitle">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:30,31</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Intervallwerte als Balken, Tages-Integral + gleitender Durchschnitt als Trendlinien</source>
-        <target>Interval values as bars, daily integral + moving average as trend lines</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="chart.titleDaily">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:82</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Verlauf (Tageswerte)</source>
-        <target>Progress (daily values)</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="chart.titleHourly">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:81</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Verlauf (Stundenwerte)</source>
-        <target>Progress (hourly values)</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="colActions">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:102,103</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Aktion</source>
-        <target>Action</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="colReps">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:75,76</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Reps</source>
-        <target>Reps</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="colSource">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:93,94</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Quelle</source>
-        <target>Source</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="colTime">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:66,67</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Zeit</source>
-        <target>Time</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="colType">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:84,85</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Typ</source>
-        <target>Type</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="createDialogTitle">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:147,149</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Neuen Eintrag anlegen</source>
-        <target>Create new entry</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="createNewEntry">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:27,30</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc>
- Neu         </source>
-        <target>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc>
- New         </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="dailyGoalLabel">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:80,81</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Tagesziel (Reps)</source>
-        <target>Daily goal (reps)</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="dailyGoalPlaceholder">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:88</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>100</source>
-        <target>100</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="dashboard.leaderboard.subtitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Daily · Weekly · Monthly</source>
-        <target>Daily · Weekly · Monthly</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="dashboard.leaderboard.title">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Bestenliste</source>
-        <target>Leaderboard</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="dashboardSubtitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:13,16</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source> Behalte Trainingsvolumen und Verlauf im Blick – klar, schnell und mobil optimiert. </source>
-        <target> Keep an eye on training volume and progress – clear, fast, and mobile optimized. </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="dashboardTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:11,12</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Liegestütze Statistik</source>
-        <target>Pushup Statistics</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="dayChartMode14h">
-      <segment state="translated">
-        <source/>
-        <target>14h Day Mode</target>
-      </segment>
-    </unit>
-    <unit id="dayChartMode24h">
-      <segment state="translated">
-        <source/>
-        <target>24h</target>
-      </segment>
-    </unit>
-    <unit id="dayChartModeLabel">
-      <segment state="translated">
-        <source/>
-        <target>Day view</target>
-      </segment>
-    </unit>
-    <unit id="deleteAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:121</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Löschen</source>
-        <target>Delete</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="deleteTitle">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:123</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Löschen</source>
-        <target>Delete</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="displayNameLabel">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:69,70</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Anzeigename</source>
-        <target>Display name</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="displayNamePlaceholder">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:75</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Wolf</source>
-        <target>Wolf</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="editAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:108,109</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Bearbeiten</source>
-        <target>Edit</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="editDialogTitle">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:234,236</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Eintrag bearbeiten</source>
-        <target>Edit entry</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="editTitle">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:110,111</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Bearbeiten</source>
-        <target>Edit</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entries.allOption">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:64,66</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:76,78</note>
-
-        
-        
-            </notes>
-      <segment state="translated">
-        <source>Alle</source>
-        <target>All</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entries.dateFrom">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:41,42</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Datum von</source>
-        <target>Date from</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entries.dateTo">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:51,52</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Datum bis</source>
-        <target>Date to</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entries.repsMax">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:96,97</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Reps max</source>
-        <target>Reps max</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entries.repsMin">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:85,86</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Reps min</source>
-        <target>Reps min</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entries.sourceFilter">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:61,62</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Quelle</source>
-        <target>Source</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entries.subtitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:34,35</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Filter und Verwaltung</source>
-        <target>Filter and management</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entries.title">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:32,33</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Daten</source>
-        <target>Data</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entries.typeFilter">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:73,74</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Typ</source>
-        <target>Type</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entriesCount">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:5</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/>
- Einträge        </source>
-        <target>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/>
- entries        </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entriesInSelectedRange">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:175,177</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Einträge im gewählten Zeitraum</source>
-        <target>Entries in selected period</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="entriesTitle">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:3,4</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Einträge</source>
-        <target>Entries</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="eyebrowTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:10,11</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Pushup Stats</source>
-        <target>Pushup Stats</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="goalProgressTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:45,47</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Zielfortschritt</source>
-        <target>Goal progress</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="heatmap.loading">
-      <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:36,39</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source> Heatmap wird im Browser geladen… </source>
-        <target> Loading heatmap in browser… </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.cta.dashboard">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-      </notes>
-      <segment state="translated">
-        <source>Zum Dashboard</source>
-        <target>Go to Dashboard</target>
-      </segment>
-    </unit>
-    <unit id="landing.cta.guest">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Als Gast ausprobieren</source>
-        <target>Try as guest</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.cta.login">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Einloggen</source>
-        <target>Log in</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.cta.signup">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Jetzt registrieren</source>
-        <target>Sign up now</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.eyebrow">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Pushup Tracker</source>
-        <target>Pushup Tracker</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.feature.analytics.body">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Woche, Monat und Custom-Ranges mit klaren KPIs und Charts.</source>
-        <target>Week, month, and custom ranges with clear KPIs and charts.</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.feature.analytics.title">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Smarter Überblick</source>
-        <target>Smarter overview</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.feature.live.body">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Firestore Live-Sync hält deine Daten auf allen Geräten aktuell.</source>
-        <target>Firestore live sync keeps your data current across devices.</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.feature.live.title">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Live &amp; überall</source>
-        <target>Live &amp; everywhere</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.feature.quick.body">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Neue Einträge in Sekunden per Schnellaktionen oder Tabelle.</source>
-        <target>Add new entries in seconds via quick actions or table.</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.feature.quick.title">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Quick Logging</source>
-        <target>Quick logging</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.leaderboard.daily">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Tag</source>
-        <target>Day</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.leaderboard.empty">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Noch keine Daten</source>
-        <target>No data yet</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.leaderboard.monthly">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Monat</source>
-        <target>Month</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.leaderboard.ownPosition">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>
-          <x id="INTERPOLATION" equiv-text="{{ me.rank }}"/>
-          <x id="INTERPOLATION_1" equiv-text="{{ me.reps }}"/>
-Deine Position: # ·  Reps        </source>
-        <target> Your position: #{$INTERPOLATION} · {$INTERPOLATION_1} reps </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.leaderboard.privacy">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Privacy first: Dein Nutzername wird nicht angezeigt, wenn du es nicht möchtest.</source>
-        <target>Privacy first: Your username is not shown if you do not want it.</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.leaderboard.reps">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Reps</source>
-        <target>Reps</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.leaderboard.title">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Tages-Bestenliste</source>
-        <target>Daily leaderboard</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.leaderboard.weekly">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Woche</source>
-        <target>Week</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.preview.alt">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Vorschau der Statistikansicht</source>
-        <target>Preview of the stats view</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.subtitle">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source> Tracke Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live- Updates. </source>
-        <target> Track reps, trends, and streaks in seconds — mobile, fast, and live-updated. </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="landing.title">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Dein Training. Klar visualisiert.</source>
-        <target>Your training. Clearly visualized.</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="lastEntryTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:59,60</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Letzter Eintrag</source>
-        <target>Last entry</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="latEntryReps">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:64,66</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/>
-          <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/>
-  Reps ·          </source>
-        <target>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/>
-          <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/>
-  reps ·          </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="leaderboard.page.subtitle">
-      <segment state="translated">
-        <source/>
-        <target>Daily · Weekly · Monthly</target>
-      </segment>
-    </unit>
-    <unit id="leaderboard.page.title">
-      <segment state="translated">
-        <source/>
-        <target>Leaderboard</target>
-      </segment>
-    </unit>
-    <unit id="liveStateLabel">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:21,23</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;verbunden&apos; : &apos;getrennt&apos; }}"/>
- Live:          </source>
-        <target>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;connected&apos; : &apos;disconnected&apos; }}"/>
- Live:          </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="loadingStats">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:162,166</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source> Lade Statistikdaten… </source>
-        <target> Loading statistics data… </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="nav.account">
-      <notes>
-        <note category="location">web/src/app/app.html:91,93</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source> Account </source>
-        <target> Account </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="nav.analysis">
-      <notes>
-        <note category="location">web/src/app/app.html:43,46</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Analyse</source>
-        <target>Analysis</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="nav.aria">
-      <notes>
-        <note category="location">web/src/app/app.html:101,102</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Pushup Navigation</source>
-        <target>Pushup Navigation</target>
-
-        
-        
-            </segment>
-
-      
-      
         </unit>
     <unit id="nav.dashboard">
       <notes>
         <note category="location">web/src/app/app.html:23,26</note>
 
-        
             </notes>
       <segment state="translated">
         <source>Dashboard</source>
         <target>Dashboard</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
     <unit id="nav.data">
       <notes>
         <note category="location">web/src/app/app.html:33,36</note>
 
-        
             </notes>
       <segment state="translated">
         <source>Daten</source>
         <target>Data</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="nav.lang.de">
+    <unit id="nav.analysis">
       <notes>
-        <note category="location">web/src/app/app.html:74,77</note>
+        <note category="location">web/src/app/app.html:43,46</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Deutsch</source>
-        <target>German</target>
+        <source>Analyse</source>
+        <target>Analysis</target>
 
-        
-        
             </segment>
 
-      
-      
-        </unit>
-    <unit id="nav.lang.en">
-      <notes>
-        <note category="location">web/src/app/app.html:83,85</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>English</source>
-        <target>English</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="nav.language">
-      <notes>
-        <note category="location">web/src/app/app.html:65,68</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source> Sprache </source>
-        <target> Language </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="nav.leaderboard">
-      <segment state="translated">
-        <source/>
-        <target>Leaderboard</target>
-      </segment>
-    </unit>
-    <unit id="nav.login">
-      <notes>
-        <note category="location">web/src/app/app.html:109,111</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Login</source>
-        <target>Login</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="nav.logout">
-      <notes>
-        <note category="location">web/src/app/app.html:104,106</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Logout</source>
-        <target>Logout</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="nav.openMenu">
-      <notes>
-        <note category="location">web/src/app/app.html:107,108</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Menü öffnen</source>
-        <target>Open menu</target>
-
-        
-        
-            </segment>
-
-      
-      
         </unit>
     <unit id="nav.settings">
       <notes>
         <note category="location">web/src/app/app.html:55,58</note>
 
-        
             </notes>
       <segment state="translated">
         <source>Einstellungen</source>
         <target>Settings</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="nav.toLanding">
+    <unit id="nav.language">
       <notes>
-        <note category="location">web/src/app/app.html</note>
+        <note category="location">web/src/app/app.html:65,68</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Zur Landingpage</source>
-        <target>Go to landing page</target>
+        <source> Sprache </source>
+        <target> Language </target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="noEntriesInSelectedRange">
+    <unit id="nav.lang.de">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:50,53</note>
+        <note category="location">web/src/app/app.html:74,77</note>
 
-        
             </notes>
       <segment state="translated">
-        <source> Keine Einträge im gewählten Zeitraum. </source>
-        <target> No entries in the selected period. </target>
+        <source>Deutsch</source>
+        <target>German</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="noEntryInPeriod">
+    <unit id="nav.lang.en">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:68,70</note>
+        <note category="location">web/src/app/app.html:83,85</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Noch kein Eintrag für diesen Zeitraum.</source>
-        <target>No entry for this period yet.</target>
+        <source>English</source>
+        <target>English</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="period.day">
+    <unit id="nav.account">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:52</note>
+        <note category="location">web/src/app/app.html:91,93</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Tag</source>
-        <target>Day</target>
+        <source> Account </source>
+        <target> Account </target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="period.month">
+    <unit id="nav.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:54</note>
+        <note category="location">web/src/app/app.html:101,102</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Monat</source>
-        <target>Month</target>
+        <source>Pushup Navigation</source>
+        <target>Pushup Navigation</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="period.range">
+    <unit id="nav.openMenu">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:56</note>
+        <note category="location">web/src/app/app.html:107,108</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Zeitraum</source>
-        <target>Period</target>
+        <source>Menü öffnen</source>
+        <target>Open menu</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="period.today">
+    <unit id="title.fallback">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:51</note>
+        <note category="location">web/src/app/app.ts:65</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Heute</source>
-        <target>Today</target>
+        <source>Dein Name 💪</source>
+        <target>Your name 💪</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="period.week">
+    <unit id="1713004850888488155">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:53</note>
+        <note category="location">web/src/app/app.ts:81</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Woche</source>
-        <target>Week</target>
+        <source>Neue Version verfügbar</source>
+        <target>New version available</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="period.year">
+    <unit id="5889607835368180076">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:55</note>
+        <note category="location">web/src/app/app.ts:82</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Jahr</source>
-        <target>Year</target>
+        <source>Neu laden</source>
+        <target>Reload</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="pie.noData">
+    <unit id="selectRangeTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:46,49</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:30,33</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Keine Daten</source>
-        <target>No data</target>
+        <source>Zeitraum auswählen</source>
+        <target>Select period</target>
 
-        
-        
             </segment>
 
-      
-      
-        </unit>
-    <unit id="quickActionsSubtitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:103,105</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Schnell eintragen ohne Dialog</source>
-        <target>Quick entry without dialog</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="quickActionsTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:100,102</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Schnellaktionen</source>
-        <target>Quick actions</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="quickAdd10">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:114,116</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">bolt</pc>
- +10 Reps         </source>
-        <target>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">bolt</pc>
- +10 reps         </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="quickAdd20">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:124,126</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flash_on</pc>
- +20 Reps         </source>
-        <target>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flash_on</pc>
- +20 reps         </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="quickAdd30">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:134,136</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">whatshot</pc>
- +30 Reps         </source>
-        <target>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">whatshot</pc>
- +30 reps         </target>
-
-        
-        
-            </segment>
-
-      
-      
         </unit>
     <unit id="quickRangeAria">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:35,36</note>
 
-        
             </notes>
       <segment state="translated">
         <source>Schnellwahl Zeitraum</source>
         <target>Quick select period</target>
 
-        
-        
             </segment>
 
-      
-      
+        </unit>
+    <unit id="rangeModeDay">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:43,44</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Tag</source>
+        <target>Day</target>
+
+            </segment>
+
+        </unit>
+    <unit id="rangeModeWeek">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:46,47</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Woche</source>
+        <target>Week</target>
+
+            </segment>
+
+        </unit>
+    <unit id="rangeModeMonth">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:49,50</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Monat</source>
+        <target>Month</target>
+
+            </segment>
+
         </unit>
     <unit id="rangeBack">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:60,62</note>
 
-        
             </notes>
       <segment state="translated">
         <source>
@@ -2508,18 +315,25 @@ Deine Position: # ·  Reps        </source>
           <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc>
  Back         </target>
 
-        
-        
             </segment>
 
-      
-      
+        </unit>
+    <unit id="rangeToday">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:69,70</note>
+
+            </notes>
+      <segment state="translated">
+        <source> Heute </source>
+        <target> Today </target>
+
+            </segment>
+
         </unit>
     <unit id="rangeForward">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77,80</note>
 
-        
             </notes>
       <segment state="translated">
         <source>
@@ -2529,610 +343,173 @@ Deine Position: # ·  Reps        </source>
           <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc>
  Forward         </target>
 
-        
-        
             </segment>
 
-      
-      
-        </unit>
-    <unit id="rangeFrom">
-      <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:90</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Von</source>
-        <target>From</target>
-
-        
-        
-            </segment>
-
-      
-      
         </unit>
     <unit id="rangeLabel">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:84,85</note>
 
-        
             </notes>
       <segment state="translated">
         <source>Zeitraum</source>
         <target>Period</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="rangeModeDay">
+    <unit id="rangeFrom">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:43,44</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:90</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Tag</source>
-        <target>Day</target>
+        <source>Von</source>
+        <target>From</target>
 
-        
-        
             </segment>
 
-      
-      
-        </unit>
-    <unit id="rangeModeMonth">
-      <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:49,50</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Monat</source>
-        <target>Month</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="rangeModeWeek">
-      <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:46,47</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Woche</source>
-        <target>Week</target>
-
-        
-        
-            </segment>
-
-      
-      
         </unit>
     <unit id="rangeTo">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:96</note>
 
-        
             </notes>
       <segment state="translated">
         <source>Bis</source>
         <target>To</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="rangeToday">
+    <unit id="heatmap.loading">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:69,70</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:36,39</note>
 
-        
             </notes>
       <segment state="translated">
-        <source> Heute </source>
-        <target> Today </target>
+        <source> Heatmap wird im Browser geladen… </source>
+        <target> Loading heatmap in browser… </target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="repsLabel">
+    <unit id="chart.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:162,163</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:249,250</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:30,31</note>
 
-        
-        
             </notes>
       <segment state="translated">
-        <source>Reps</source>
-        <target>Reps</target>
+        <source>Intervallwerte als Balken, Tages-Integral + gleitender Durchschnitt als Trendlinien</source>
+        <target>Interval values as bars, daily integral + moving average as trend lines</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="saveChanges">
+    <unit id="chart.legendAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:306,312</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>
-          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (editingId() &amp;&amp; isBusy(&apos;update&apos;, editBusyId())) {" dispEnd="}">
-            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"/>
-          </pc>
-          <pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Speichern </pc>
-        </source>
-        <target>
-          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (editingId() &amp;&amp; isBusy(&apos;update&apos;, editBusyId())) {" dispEnd="}">
-            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"/>
-          </pc>
-          <pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Save </pc>
-        </target>
+        <source>Legende</source>
+        <target>Legend</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="saved">
+    <unit id="chart.interval">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:112,113</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:48,49</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Gespeichert.</source>
-        <target>Saved.</target>
+        <source>Intervallwert</source>
+        <target>Interval value</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="saveEntry">
+    <unit id="chart.dayIntegral">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:224,230</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:54,55</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>
-          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (isCreateBusy()) {" dispEnd="}">
-            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"/>
-          </pc>
-          <pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Speichern </pc>
-        </source>
-        <target>
-          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (isCreateBusy()) {" dispEnd="}">
-            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"/>
-          </pc>
-          <pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Save </pc>
-        </target>
+        <source>Tages-Integral</source>
+        <target>Daily integral</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="saveSettings">
+    <unit id="chart.movingAvg">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:105,107</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:60,61</note>
 
-        
+            </notes>
+      <segment state="translated">
+        <source>Gleitender Durchschnitt</source>
+        <target>Moving average</target>
+
+            </segment>
+
+        </unit>
+    <unit id="chart.titleHourly">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:81</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Verlauf (Stundenwerte)</source>
+        <target>Progress (hourly values)</target>
+
+            </segment>
+
+        </unit>
+    <unit id="chart.titleDaily">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:82</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Verlauf (Tageswerte)</source>
+        <target>Progress (daily values)</target>
+
+            </segment>
+
+        </unit>
+    <unit id="entriesTitle">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:3,4</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Einträge</source>
+        <target>Entries</target>
+
+            </segment>
+
+        </unit>
+    <unit id="entriesCount">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:5</note>
+
             </notes>
       <segment state="translated">
         <source>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc>
- Speichern         </source>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/>
+ Einträge        </source>
         <target>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc>
- Save         </target>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/>
+ entries        </target>
 
-        
-        
             </segment>
 
-      
-      
-        </unit>
-    <unit id="saving">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:109,110</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Speichert…</source>
-        <target>Saving…</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="selectRangeTitle">
-      <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:30,33</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Zeitraum auswählen</source>
-        <target>Select period</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="seo.analysis.description">
-      <segment state="translated">
-        <source>Analysiere Trends, Verteilungen und Streaks deines Trainings.</source>
-        <target>Analyze trends, distributions, and streaks in your training.</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.analysis.title">
-      <segment state="translated">
-        <source>Analyse – Pushup Tracker</source>
-        <target>Analysis – Pushup Tracker</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.dashboard.description">
-      <segment state="translated">
-        <source>Behalte Trainingsvolumen und Verlauf im Blick – klar, schnell und mobil optimiert.</source>
-        <target>Keep training volume and progress in view – clear, fast, and mobile optimized.</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.dashboard.title">
-      <segment state="translated">
-        <source>Dashboard – Pushup Tracker</source>
-        <target>Dashboard – Pushup Tracker</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.data.description">
-      <segment state="translated">
-        <source>Verwalte Einträge, filtere nach Zeitraum und behalte deine Trainingsdaten im Griff.</source>
-        <target>Manage entries, filter by time range, and stay in control of your training data.</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.data.title">
-      <segment state="translated">
-        <source>Daten – Pushup Tracker</source>
-        <target>Data – Pushup Tracker</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.default.description">
-      <segment state="translated">
-        <source>Tracke Reps, Trends und Streaks mit Pushup Tracker.</source>
-        <target>Track reps, trends, and streaks with Pushup Tracker.</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.default.title">
-      <segment state="translated">
-        <source>Pushup Tracker</source>
-        <target>Pushup Tracker</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.landing.description">
-      <segment state="translated">
-        <source>Tracke Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live-Updates.</source>
-        <target>Track reps, trends, and streaks in seconds – mobile, fast, and with live updates.</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.landing.title">
-      <segment state="translated">
-        <source>Pushup Tracker – Dein Training. Klar visualisiert.</source>
-        <target>Pushup Tracker – Your training. Clearly visualized.</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.leaderboard.description">
-      <segment state="translated">
-        <source>Öffentliche Bestenliste für tägliche, wöchentliche und monatliche Pushup-Reps.</source>
-        <target>Public leaderboard for daily, weekly, and monthly pushup reps.</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.leaderboard.title">
-      <segment state="translated">
-        <source>Bestenliste – Pushup Tracker</source>
-        <target>Leaderboard – Pushup Tracker</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.login.description">
-      <segment state="translated">
-        <source>Melde dich an und tracke dein Pushup-Training über alle Geräte.</source>
-        <target>Sign in and track your pushup training across all devices.</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.login.title">
-      <segment state="translated">
-        <source>Login – Pushup Tracker</source>
-        <target>Login – Pushup Tracker</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.register.description">
-      <segment state="translated">
-        <source>Erstelle dein Konto und richte Profil, Tagesziel und Einwilligungen ein.</source>
-        <target>Create your account and set up profile, daily goal, and consent settings.</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.register.title">
-      <segment state="translated">
-        <source>Registrierung – Pushup Tracker</source>
-        <target>Sign up – Pushup Tracker</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.settings.description">
-      <segment state="translated">
-        <source>Verwalte Profil, Leaderboard-Sichtbarkeit und Tagesziel-Einstellungen.</source>
-        <target>Manage profile, leaderboard visibility, and daily goal settings.</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="seo.settings.title">
-      <segment state="translated">
-        <source>Einstellungen – Pushup Tracker</source>
-        <target>Settings – Pushup Tracker</target>
-
-        
-        
-            </segment>
-
-      
-        </unit>
-    <unit id="settings.adsConsentHint">
-      <segment state="translated">
-        <source/>
-        <target> Controls whether ad slots may be loaded on the dashboard. </target>
-      </segment>
-    </unit>
-    <unit id="settings.adsConsentOptIn">
-      <segment state="translated">
-        <source/>
-        <target> Enable personalized ads </target>
-      </segment>
-    </unit>
-    <unit id="settings.dangerZoneBody">
-      <segment state="translated">
-        <source/>
-        <target> Deleting your account removes your account. Training data remains anonymized for statistical analysis. </target>
-      </segment>
-    </unit>
-    <unit id="settings.dangerZoneTitle">
-      <segment state="translated">
-        <source/>
-        <target>Danger Zone</target>
-      </segment>
-    </unit>
-    <unit id="settings.deleteAccount">
-      <segment state="translated">
-        <source/>
-        <target>{$START_TAG_MAT_ICON}warning{$CLOSE_TAG_MAT_ICON} Delete account </target>
-      </segment>
-    </unit>
-    <unit id="settings.deleteConfirmFinal">
-      <segment state="translated">
-        <source/>
-        <target> Final delete </target>
-      </segment>
-    </unit>
-    <unit id="settings.deleteDialogInfo">
-      <segment state="translated">
-        <source/>
-        <target> Your account will be deleted. Training data remains anonymized for statistical analysis. </target>
-      </segment>
-    </unit>
-    <unit id="settings.deleteDialogPhraseHint">
-      <segment state="translated">
-        <source/>
-        <target>Please enter exactly &quot;löscchen&quot;.</target>
-      </segment>
-    </unit>
-    <unit id="settings.deleteDialogPhraseLabel">
-      <segment state="translated">
-        <source/>
-        <target>Enter confirmation word</target>
-      </segment>
-    </unit>
-    <unit id="settings.deleteDialogTitle">
-      <segment state="translated">
-        <source/>
-        <target> Really delete account? </target>
-      </segment>
-    </unit>
-    <unit id="settings.deleteDialogWarning">
-      <segment state="translated">
-        <source/>
-        <target> Warning: This action cannot be undone. </target>
-      </segment>
-    </unit>
-    <unit id="settings.deletingAccount">
-      <segment state="translated">
-        <source/>
-        <target>Deleting account…</target>
-      </segment>
-    </unit>
-    <unit id="settings.displayNameHint">
-      <segment state="translated">
-        <source/>
-        <target>May be shown on the leaderboard.</target>
-      </segment>
-    </unit>
-    <unit id="settings.goalHint">
-      <segment state="translated">
-        <source/>
-        <target>Shown prominently in the toolbar.</target>
-      </segment>
-    </unit>
-    <unit id="settings.leaderboardOptIn">
-      <segment state="translated">
-        <source/>
-        <target> Show in leaderboard </target>
-      </segment>
-    </unit>
-    <unit id="settings.leaderboardOptOutHint">
-      <segment state="translated">
-        <source/>
-        <target> If disabled, your profile will not be shown in the leaderboard. </target>
-      </segment>
-    </unit>
-    <unit id="settingsSubtitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:33,34</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>User-Profil &amp; Tagesziel</source>
-        <target>User profile &amp; daily goal</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
-    <unit id="settingsTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:31,32</note>
-
-        
-            </notes>
-      <segment state="translated">
-        <source>Einstellungen</source>
-        <target>Settings</target>
-
-        
-        
-            </segment>
-
-      
-      
         </unit>
     <unit id="sourceColumnToggle">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:15,20</note>
 
-        
             </notes>
       <segment state="translated">
         <source>
@@ -3150,73 +527,651 @@ Deine Position: # ·  Reps        </source>
           </pc>
  Source         </target>
 
-        
-        
             </segment>
 
-      
-      
+        </unit>
+    <unit id="createNewEntry">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:27,30</note>
+
+            </notes>
+      <segment state="translated">
+        <source>
+          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc>
+ Neu         </source>
+        <target>
+          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc>
+ New         </target>
+
+            </segment>
+
+        </unit>
+    <unit id="noEntriesInSelectedRange">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:50,53</note>
+
+            </notes>
+      <segment state="translated">
+        <source> Keine Einträge im gewählten Zeitraum. </source>
+        <target> No entries in the selected period. </target>
+
+            </segment>
+
+        </unit>
+    <unit id="colTime">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:66,67</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Zeit</source>
+        <target>Time</target>
+
+            </segment>
+
+        </unit>
+    <unit id="colReps">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:75,76</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Reps</source>
+        <target>Reps</target>
+
+            </segment>
+
+        </unit>
+    <unit id="colType">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:84,85</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Typ</source>
+        <target>Type</target>
+
+            </segment>
+
+        </unit>
+    <unit id="colSource">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:93,94</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Quelle</source>
+        <target>Source</target>
+
+            </segment>
+
+        </unit>
+    <unit id="colActions">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:102,103</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Aktion</source>
+        <target>Action</target>
+
+            </segment>
+
+        </unit>
+    <unit id="editAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:108,109</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Bearbeiten</source>
+        <target>Edit</target>
+
+            </segment>
+
+        </unit>
+    <unit id="editTitle">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:110,111</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Bearbeiten</source>
+        <target>Edit</target>
+
+            </segment>
+
+        </unit>
+    <unit id="deleteAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:121</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Löschen</source>
+        <target>Delete</target>
+
+            </segment>
+
+        </unit>
+    <unit id="deleteTitle">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:123</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Löschen</source>
+        <target>Delete</target>
+
+            </segment>
+
+        </unit>
+    <unit id="createDialogTitle">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:147,149</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Neuen Eintrag anlegen</source>
+        <target>Create new entry</target>
+
+            </segment>
+
+        </unit>
+    <unit id="timestampLabel">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:151,153</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:238,240</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Zeitpunkt</source>
+        <target>Timestamp</target>
+
+            </segment>
+
+        </unit>
+    <unit id="repsLabel">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:162,163</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:249,250</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Reps</source>
+        <target>Reps</target>
+
+            </segment>
+
+        </unit>
+    <unit id="typeLabel">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:174,175</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:261,262</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Typ</source>
+        <target>Type</target>
+
+            </segment>
+
+        </unit>
+    <unit id="typePlaceholder">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:180,181</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:267,268</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Pick one / Custom</source>
+        <target>Pick one / Custom</target>
+
+            </segment>
+
         </unit>
     <unit id="sourceLabel">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:191,193</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:278,280</note>
 
-        
-        
             </notes>
       <segment state="translated">
         <source>Quelle</source>
         <target>Source</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
     <unit id="sourcePlaceholder">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:197,198</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:284,285</note>
 
-        
-        
             </notes>
       <segment state="translated">
         <source>web / whatsapp / Custom</source>
         <target>web / whatsapp / Custom</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="sw.update.downloading">
+    <unit id="cancel">
       <notes>
-        <note category="location">web/src/app/app.ts</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:215,217</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:297,299</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Update wird im Hintergrund geladen …</source>
-        <target>Update is downloading in the background …</target>
+        <source> Abbrechen </source>
+        <target> Cancel </target>
 
-        
-        
             </segment>
 
-      
-      
+        </unit>
+    <unit id="saveEntry">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:224,230</note>
+
+            </notes>
+      <segment state="translated">
+        <source>
+          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (isCreateBusy()) {" dispEnd="}">
+            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"/>
+          </pc>
+          <pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Speichern </pc>
+        </source>
+        <target>
+          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (isCreateBusy()) {" dispEnd="}">
+            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"/>
+          </pc>
+          <pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Save </pc>
+        </target>
+
+            </segment>
+
+        </unit>
+    <unit id="editDialogTitle">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:234,236</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Eintrag bearbeiten</source>
+        <target>Edit entry</target>
+
+            </segment>
+
+        </unit>
+    <unit id="saveChanges">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:306,312</note>
+
+            </notes>
+      <segment state="translated">
+        <source>
+          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (editingId() &amp;&amp; isBusy(&apos;update&apos;, editBusyId())) {" dispEnd="}">
+            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"/>
+          </pc>
+          <pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Speichern </pc>
+        </source>
+        <target>
+          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (editingId() &amp;&amp; isBusy(&apos;update&apos;, editBusyId())) {" dispEnd="}">
+            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"/>
+          </pc>
+          <pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Save </pc>
+        </target>
+
+            </segment>
+
+        </unit>
+    <unit id="pie.noData">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:46,49</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Keine Daten</source>
+        <target>No data</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.weekTrendTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:24,26</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Wochentrend</source>
+        <target>Weekly trend</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.weekCol">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:31,32</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Woche</source>
+        <target>Week</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.repsCol">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:37,38</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:63,64</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Reps</source>
+        <target>Reps</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.monthTrendTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:50,52</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Monatstrend</source>
+        <target>Monthly trend</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.monthCol">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:57,58</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Monat</source>
+        <target>Month</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.bestStreaksTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,78</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Bestwerte &amp; Streaks</source>
+        <target>Best values &amp; streaks</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.bestSingleEntry">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:82,84</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Bestwert Einzel-Eintrag:</source>
+        <target>Best single entry:</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.bestDay">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:87,89</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Bester Tag:</source>
+        <target>Best day:</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.currentStreak">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:93,95</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Aktuelle Streak:</source>
+        <target>Current streak:</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.streakDays">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:96,97</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:104,105</note>
+
+            </notes>
+      <segment state="translated">
+        <source>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ currentStreak() }}"/>
+ Tage        </source>
+        <target>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ currentStreak() }}"/>
+ days        </target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.longestStreak">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:101,103</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Längste Streak:</source>
+        <target>Longest streak:</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.typesTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:114,116</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Typen (Anteile)</source>
+        <target>Types (shares)</target>
+
+            </segment>
+
+        </unit>
+    <unit id="analysis.heatmapTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:126,128</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Heatmap (Wochentag/Uhrzeit)</source>
+        <target>Heatmap (weekday/time)</target>
+
+            </segment>
+
+        </unit>
+    <unit id="entries.title">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:32,33</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Daten</source>
+        <target>Data</target>
+
+            </segment>
+
+        </unit>
+    <unit id="entries.subtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:34,35</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Filter und Verwaltung</source>
+        <target>Filter and management</target>
+
+            </segment>
+
+        </unit>
+    <unit id="entries.dateFrom">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:41,42</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Datum von</source>
+        <target>Date from</target>
+
+            </segment>
+
+        </unit>
+    <unit id="entries.dateTo">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:51,52</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Datum bis</source>
+        <target>Date to</target>
+
+            </segment>
+
+        </unit>
+    <unit id="entries.sourceFilter">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:61,62</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Quelle</source>
+        <target>Source</target>
+
+            </segment>
+
+        </unit>
+    <unit id="entries.allOption">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:64,66</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:76,78</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Alle</source>
+        <target>All</target>
+
+            </segment>
+
+        </unit>
+    <unit id="entries.typeFilter">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:73,74</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Typ</source>
+        <target>Type</target>
+
+            </segment>
+
+        </unit>
+    <unit id="entries.repsMin">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:85,86</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Reps min</source>
+        <target>Reps min</target>
+
+            </segment>
+
+        </unit>
+    <unit id="entries.repsMax">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:96,97</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Reps max</source>
+        <target>Reps max</target>
+
+            </segment>
+
+        </unit>
+    <unit id="settingsTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:31,32</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Einstellungen</source>
+        <target>Settings</target>
+
+            </segment>
+
+        </unit>
+    <unit id="settingsSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:33,34</note>
+
+            </notes>
+      <segment state="translated">
+        <source>User-Profil &amp; Tagesziel</source>
+        <target>User profile &amp; daily goal</target>
+
+            </segment>
+
+        </unit>
+    <unit id="userIdLabel">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:40,41</note>
+
+            </notes>
+      <segment state="translated">
+        <source>User ID</source>
+        <target>User ID</target>
+
+            </segment>
+
+        </unit>
+    <unit id="userIdPlaceholder">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:45,46</note>
+
+            </notes>
+      <segment state="translated">
+        <source>z.B. wolf</source>
+        <target>e.g. wolf</target>
+
+            </segment>
+
+        </unit>
+    <unit id="userIdHint">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:49,50</note>
+
+            </notes>
+      <segment state="translated">
+        <source> Wird für Multi-User-Zuordnung genutzt (Auth kommt später). </source>
+        <target> Used for multi-user assignment (auth coming later). </target>
+
+            </segment>
+
         </unit>
     <unit id="switchUser">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:60,62</note>
 
-        
             </notes>
       <segment state="translated">
         <source>
@@ -3226,417 +1181,484 @@ Deine Position: # ·  Reps        </source>
           <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">switch_account</pc>
  Switch user         </target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="timestampLabel">
+    <unit id="activeUser">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:151,153</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:238,240</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:64,65</note>
 
-        
-        
             </notes>
       <segment state="translated">
-        <source>Zeitpunkt</source>
-        <target>Timestamp</target>
+        <source>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ activeUserId() }}"/>
+Aktiv:         </source>
+        <target>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ activeUserId() }}"/>
+Active:         </target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="title.fallback">
+    <unit id="displayNameLabel">
       <notes>
-        <note category="location">web/src/app/app.ts:65</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:69,70</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Dein Name 💪</source>
-        <target>Your name 💪</target>
+        <source>Anzeigename</source>
+        <target>Display name</target>
 
-        
-        
             </segment>
 
-      
-      
+        </unit>
+    <unit id="displayNamePlaceholder">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:75</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Wolf</source>
+        <target>Wolf</target>
+
+            </segment>
+
+        </unit>
+    <unit id="dailyGoalLabel">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:80,81</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Tagesziel (Reps)</source>
+        <target>Daily goal (reps)</target>
+
+            </segment>
+
+        </unit>
+    <unit id="dailyGoalPlaceholder">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:88</note>
+
+            </notes>
+      <segment state="translated">
+        <source>100</source>
+        <target>100</target>
+
+            </segment>
+
+        </unit>
+    <unit id="saveSettings">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:105,107</note>
+
+            </notes>
+      <segment state="translated">
+        <source>
+          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc>
+ Speichern         </source>
+        <target>
+          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc>
+ Save         </target>
+
+            </segment>
+
+        </unit>
+    <unit id="saving">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:109,110</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Speichert…</source>
+        <target>Saving…</target>
+
+            </segment>
+
+        </unit>
+    <unit id="saved">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:112,113</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Gespeichert.</source>
+        <target>Saved.</target>
+
+            </segment>
+
+        </unit>
+    <unit id="brandLogoAlt">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:6,7</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Pushup Tracker Logo</source>
+        <target>Pushup Tracker Logo</target>
+
+            </segment>
+
+        </unit>
+    <unit id="eyebrowTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:10,11</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Pushup Stats</source>
+        <target>Pushup Stats</target>
+
+            </segment>
+
+        </unit>
+    <unit id="dashboardTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:11,12</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Liegestütze Statistik</source>
+        <target>Pushup Statistics</target>
+
+            </segment>
+
+        </unit>
+    <unit id="dashboardSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:13,16</note>
+
+            </notes>
+      <segment state="translated">
+        <source> Behalte Trainingsvolumen und Verlauf im Blick – klar, schnell und mobil optimiert. </source>
+        <target> Keep an eye on training volume and progress – clear, fast, and mobile optimized. </target>
+
+            </segment>
+
+        </unit>
+    <unit id="liveStateLabel">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:21,23</note>
+
+            </notes>
+      <segment state="translated">
+        <source>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;verbunden&apos; : &apos;getrennt&apos; }}"/>
+ Live:          </source>
+        <target>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;connected&apos; : &apos;disconnected&apos; }}"/>
+ Live:          </target>
+
+            </segment>
+
         </unit>
     <unit id="todayFocusAria">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:28,29</note>
 
-        
             </notes>
       <segment state="translated">
         <source>Tagesfokus</source>
         <target>Today&apos;s focus</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="toolbarDailyGoal">
-      <segment state="translated">
-        <source/>
-        <target>Daily goal</target>
-      </segment>
-    </unit>
-    <unit id="typeLabel">
+    <unit id="1933013871016789910">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:174,175</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:261,262</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:34</note>
 
-        
-        
             </notes>
       <segment state="translated">
-        <source>Typ</source>
-        <target>Type</target>
+        <source>Gesamt</source>
+        <target>Total</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="typePlaceholder">
+    <unit id="goalProgressTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:180,181</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:267,268</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:45,47</note>
 
-        
-        
             </notes>
       <segment state="translated">
-        <source>Pick one / Custom</source>
-        <target>Pick one / Custom</target>
+        <source>Zielfortschritt</source>
+        <target>Goal progress</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="userIdHint">
+    <unit id="lastEntryTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:49,50</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:59,60</note>
 
-        
             </notes>
       <segment state="translated">
-        <source> Wird für Multi-User-Zuordnung genutzt (Auth kommt später). </source>
-        <target> Used for multi-user assignment (auth coming later). </target>
+        <source>Letzter Eintrag</source>
+        <target>Last entry</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="userIdLabel">
+    <unit id="latEntryReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:40,41</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:64,66</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>User ID</source>
-        <target>User ID</target>
+        <source>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/>
+          <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/>
+  Reps ·          </source>
+        <target>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/>
+          <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/>
+  reps ·          </target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="userIdPlaceholder">
+    <unit id="noEntryInPeriod">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:45,46</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:68,70</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>z.B. wolf</source>
-        <target>e.g. wolf</target>
+        <source>Noch kein Eintrag für diesen Zeitraum.</source>
+        <target>No entry for this period yet.</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="validate.email.email">
+    <unit id="allTimeSummaryAria">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:69</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:76,77</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Bitte gültige E-Mail eingeben!</source>
-        <target>Please enter a valid email!</target>
+        <source>All-Time Kurzübersicht</source>
+        <target>All-time summary</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="validate.email.required">
+    <unit id="allTimeTotal">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:66</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:80,81</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Bitte E-Mail eingeben!</source>
-        <target>Please enter email!</target>
+        <source>All-Time Gesamt</source>
+        <target>All-time total</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="validate.password.minLength">
+    <unit id="allTimeDays">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:75</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:84,85</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Passwort muss mindestens 6 Zeichen lang sein!</source>
-        <target>Password must be at least 6 characters long!</target>
+        <source>All-Time Tage</source>
+        <target>All-time days</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="validate.password.required">
+    <unit id="allTimeEntries">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:72</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:88,89</note>
 
-        
             </notes>
       <segment state="translated">
-        <source>Bitte Passwort eingeben!</source>
-        <target>Please enter password!</target>
+        <source>All-Time Einträge</source>
+        <target>All-time entries</target>
 
-        
-        
             </segment>
 
-      
-      
         </unit>
-    <unit id="validate.password.policy">
+    <unit id="allTimeAvg">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:92,93</note>
+
             </notes>
       <segment state="translated">
-        <source>Passwort braucht Groß-/Kleinbuchstaben, Zahl und Sonderzeichen.</source>
-        <target>Password must contain upper and lowercase letters, a number and a special character.</target>
-            </segment>
-        </unit>
+        <source>All-Time Ø/Tag</source>
+        <target>All-time avg/day</target>
 
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-        <unit id="user.guestName">
+            </segment>
+
+        </unit>
+    <unit id="quickActionsTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:100,102</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Schnellaktionen</source>
+        <target>Quick actions</target>
+
+            </segment>
+
+        </unit>
+    <unit id="quickActionsSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:103,105</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Schnell eintragen ohne Dialog</source>
+        <target>Quick entry without dialog</target>
+
+            </segment>
+
+        </unit>
+    <unit id="quickAdd10">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:114,116</note>
+
+            </notes>
+      <segment state="translated">
+        <source>
+          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">bolt</pc>
+ +10 Reps         </source>
+        <target>
+          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">bolt</pc>
+ +10 reps         </target>
+
+            </segment>
+
+        </unit>
+    <unit id="quickAdd20">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:124,126</note>
+
+            </notes>
+      <segment state="translated">
+        <source>
+          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flash_on</pc>
+ +20 Reps         </source>
+        <target>
+          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flash_on</pc>
+ +20 reps         </target>
+
+            </segment>
+
+        </unit>
+    <unit id="quickAdd30">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:134,136</note>
+
+            </notes>
+      <segment state="translated">
+        <source>
+          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">whatshot</pc>
+ +30 Reps         </source>
+        <target>
+          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">whatshot</pc>
+ +30 reps         </target>
+
+            </segment>
+
+        </unit>
+    <unit id="loadingStats">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:162,166</note>
+
+            </notes>
+      <segment state="translated">
+        <source> Lade Statistikdaten… </source>
+        <target> Loading statistics data… </target>
+
+            </segment>
+
+        </unit>
+    <unit id="entriesInSelectedRange">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:175,177</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Einträge im gewählten Zeitraum</source>
+        <target>Entries in selected period</target>
+
+            </segment>
+
+        </unit>
+    <unit id="period.today">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:51</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Heute</source>
+        <target>Today</target>
+
+            </segment>
+
+        </unit>
+    <unit id="period.day">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:52</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Tag</source>
+        <target>Day</target>
+
+            </segment>
+
+        </unit>
+    <unit id="period.week">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:53</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Woche</source>
+        <target>Week</target>
+
+            </segment>
+
+        </unit>
+    <unit id="period.month">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:54</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Monat</source>
+        <target>Month</target>
+
+            </segment>
+
+        </unit>
+    <unit id="period.year">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:55</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Jahr</source>
+        <target>Year</target>
+
+            </segment>
+
+        </unit>
+    <unit id="period.range">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:56</note>
+
+            </notes>
+      <segment state="translated">
+        <source>Zeitraum</source>
+        <target>Period</target>
+
+            </segment>
+
+        </unit>
+    <unit id="user.guestName">
       <notes>
         <note category="location">web/src/app/user-context.service.ts:14</note>
       </notes>
@@ -3706,6 +1728,4 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
   </file>
-
-
 </xliff>


### PR DESCRIPTION
Closes part of #138

- Alle 145 aktuellen DE-Units haben jetzt EN-Übersetzungen
- 124 veraltete Units entfernt (nicht mehr im DE-Source vorhanden)
- Neue Units: Admin-Bereich, SEO-Tags, Preview-Banner, Settings-Erweiterungen