### PR TITLE
feat(seo): 302→301 Redirect + dynamische hreflang-Tags

### DIFF
--- a/data-store/firebase.json
+++ b/data-store/firebase.json
@@ -30,7 +30,7 @@
       {
         "source": "/",
         "destination": "/de",
-        "type": 302
+        "type": 301
       }
     ],
     "rewrites": [

--- a/web/src/app/core/seo.service.ts
+++ b/web/src/app/core/seo.service.ts
@@ -1,12 +1,16 @@
 import { DOCUMENT } from '@angular/common';
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, LOCALE_ID } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
+
+const BASE_URL = 'https://pushup-stats.de';
+const LOCALE_PREFIXES = ['de', 'en'];
 
 @Injectable({ providedIn: 'root' })
 export class SeoService {
   private readonly title = inject(Title);
   private readonly meta = inject(Meta);
   private readonly document = inject(DOCUMENT);
+  private readonly localeId = inject(LOCALE_ID);
 
   update(seoTitle: string, seoDescription: string, path: string): void {
     this.title.setTitle(seoTitle);
@@ -23,6 +27,31 @@ export class SeoService {
     const canonical = `${origin}${path}`;
     this.setTag('property', 'og:url', canonical);
     this.setCanonical(canonical);
+
+    const locale = this.detectLocale(path);
+    const ogLocale = locale === 'en' ? 'en_US' : 'de_DE';
+    this.setTag('property', 'og:locale', ogLocale);
+
+    const strippedPath = this.stripLocalePrefix(path);
+    this.setHreflang('alternate', 'de', `${BASE_URL}/de${strippedPath}`);
+    this.setHreflang('alternate', 'en', `${BASE_URL}/en${strippedPath}`);
+    this.setHreflang('alternate', 'x-default', `${BASE_URL}${strippedPath}`);
+  }
+
+  private detectLocale(path: string): string {
+    const lang = this.localeId?.split('-')[0]?.split('_')[0] ?? '';
+    if (LOCALE_PREFIXES.includes(lang)) return lang;
+    const segment = path.split('/')[1] ?? '';
+    return LOCALE_PREFIXES.includes(segment) ? segment : 'de';
+  }
+
+  private stripLocalePrefix(path: string): string {
+    const segment = path.split('/')[1] ?? '';
+    if (LOCALE_PREFIXES.includes(segment)) {
+      const rest = path.slice(segment.length + 1) || '/';
+      return rest.startsWith('/') ? rest : `/${rest}`;
+    }
+    return path || '/';
   }
 
   private setTag(
@@ -46,5 +75,21 @@ export class SeoService {
       head.appendChild(link);
     }
     link.href = url;
+  }
+
+  private setHreflang(rel: string, hreflang: string, href: string): void {
+    const head = this.document.head;
+    if (!head) return;
+
+    let link = head.querySelector(
+      `link[rel="${rel}"][hreflang="${hreflang}"]`
+    ) as HTMLLinkElement | null;
+    if (!link) {
+      link = this.document.createElement('link');
+      link.rel = rel;
+      link.setAttribute('hreflang', hreflang);
+      head.appendChild(link);
+    }
+    link.href = href;
   }
 }


### PR DESCRIPTION
Closes #138 (partially)

- firebase.json: 302 → 301 für / → /de
- SeoService: hreflang + x-default dynamisch pro Seite gesetzt
- og:locale dynamisch basierend auf aktivem Locale

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive multilingual SEO support with language variant meta tags and alternate language links for German, English, and default language options. This helps search engines properly index and serve language-appropriate content to users.

* **Improvements**
  * Optimized root path redirect and locale detection to ensure users are routed to language-specific content effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->