### PR TITLE
fix: logout redirects to landing page

### DIFF
--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -165,7 +165,7 @@ export class App {
   async logout(): Promise<void> {
     await this.auth.logout();
     this.navOpen.set(false);
-    await this.router.navigateByUrl('/login');
+    await this.router.navigateByUrl('/');
   }
 
   private currentLeafRoute(): ActivatedRoute {


### PR DESCRIPTION
## Problem
Nach dem Abmelden wurde der User zur `/login`-Seite weitergeleitet statt zur Startseite/Landingpage.

## Lösung
`navigateByUrl('/login')` → `navigateByUrl('/')` in `app.ts`

## Acceptance Criteria
- [ ] Nach dem Abmelden landet der User auf der Landingpage (`/`)
- [ ] Login-Seite ist weiterhin direkt über `/login` erreichbar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated logout behavior to redirect users to the application home page instead of the login page after signing out, providing a more streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->