### PR TITLE
feat(marketing): landing page reminder section + blog with 3 SEO articles

### DIFF
--- a/web/src/app/app.html
+++ b/web/src/app/app.html
@@ -53,6 +53,16 @@
         <span matListItemTitle i18n="@@nav.leaderboard">Bestenliste</span>
       </a>
 
+      <a
+        mat-list-item
+        routerLink="/blog"
+        routerLinkActive="active"
+        (click)="navOpen.set(false)"
+      >
+        <mat-icon matListItemIcon>article</mat-icon>
+        <span matListItemTitle i18n="@@nav.blog">Blog</span>
+      </a>
+
       <mat-divider></mat-divider>
 
       <div
@@ -151,6 +161,7 @@
         i18n="@@nav.leaderboard"
         >Bestenliste</a
       >
+      <a routerLink="/blog" routerLinkActive="active" i18n="@@nav.blog">Blog</a>
     </nav>
 
     <main class="app-content">

--- a/web/src/app/app.routes.server.ts
+++ b/web/src/app/app.routes.server.ts
@@ -34,6 +34,14 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Server,
   },
   {
+    path: 'blog',
+    renderMode: RenderMode.Server,
+  },
+  {
+    path: 'blog/:slug',
+    renderMode: RenderMode.Server,
+  },
+  {
     path: 'admin',
     renderMode: RenderMode.Client,
   },

--- a/web/src/app/app.routes.spec.ts
+++ b/web/src/app/app.routes.spec.ts
@@ -25,6 +25,7 @@ describe('appRoutes', () => {
       'analysis',
       'settings',
       'leaderboard',
+      'blog',
       'admin',
       '**',
     ]);

--- a/web/src/app/app.routes.ts
+++ b/web/src/app/app.routes.ts
@@ -103,6 +103,28 @@ export const appRoutes: Routes = [
       ),
   },
   {
+    path: 'blog',
+    children: [
+      {
+        path: '',
+        pathMatch: 'full',
+        data: {
+          seoTitle: $localize`:@@seo.blog.title:Blog – Liegestütze Tipps & Guides | Pushup Tracker`,
+          seoDescription: $localize`:@@seo.blog.description:Tipps, Trainingspläne und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten.`,
+        },
+        loadComponent: () =>
+          import('./blog/blog-list.component').then((m) => m.BlogListComponent),
+      },
+      {
+        path: ':slug',
+        loadComponent: () =>
+          import('./blog/blog-article.component').then(
+            (m) => m.BlogArticleComponent
+          ),
+      },
+    ],
+  },
+  {
     path: 'admin',
     canActivate: [adminGuard],
     loadComponent: () =>

--- a/web/src/app/blog/blog-article.component.ts
+++ b/web/src/app/blog/blog-article.component.ts
@@ -1,0 +1,203 @@
+import { DOCUMENT, DatePipe } from '@angular/common';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { SeoService } from '../core/seo.service';
+import { BLOG_POSTS, BlogPost } from './blog-posts.data';
+
+const BASE_URL = 'https://pushup-stats.de';
+
+@Component({
+  selector: 'app-blog-article',
+  imports: [RouterLink, MatButtonModule, MatIconModule, DatePipe],
+  template: `
+    @if (post) {
+      <article class="blog-article">
+        <header class="article-header">
+          <a
+            mat-button
+            routerLink="/blog"
+            class="back-link"
+            i18n="@@blog.article.back"
+          >
+            <mat-icon>arrow_back</mat-icon>
+            Blog
+          </a>
+          <h1>{{ post.title }}</h1>
+          <p class="article-meta">
+            <time [attr.datetime]="post.publishedAt">{{
+              post.publishedAt | date: 'd. MMMM yyyy' : '' : 'de'
+            }}</time>
+          </p>
+        </header>
+
+        <div class="article-body" [innerHTML]="post.content"></div>
+
+        <footer class="article-footer">
+          <a
+            mat-stroked-button
+            routerLink="/register"
+            i18n="@@blog.article.cta"
+          >
+            Kostenlos tracken – Jetzt registrieren
+          </a>
+        </footer>
+      </article>
+    } @else {
+      <div class="not-found">
+        <p i18n="@@blog.article.notFound">Artikel nicht gefunden.</p>
+        <a mat-stroked-button routerLink="/blog" i18n="@@blog.article.toList"
+          >Zur Übersicht</a
+        >
+      </div>
+    }
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      .blog-article {
+        max-width: 760px;
+        margin: 0 auto;
+        padding: clamp(20px, 4vw, 44px);
+      }
+
+      .article-header {
+        margin-bottom: 32px;
+      }
+
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        margin: 0 0 16px -8px;
+        color: #93adea;
+        font-size: 0.9rem;
+      }
+
+      h1 {
+        margin: 0 0 8px;
+        font-size: clamp(1.6rem, 4vw, 2.4rem);
+        line-height: 1.2;
+      }
+
+      .article-meta time {
+        font-size: 0.85rem;
+        color: #7a8fbb;
+      }
+
+      .article-body {
+        line-height: 1.75;
+        color: #d8e5ff;
+
+        ::ng-deep {
+          h2 {
+            margin: 32px 0 12px;
+            font-size: clamp(1.15rem, 2.5vw, 1.4rem);
+            color: #ebeff8;
+          }
+
+          p {
+            margin: 0 0 16px;
+          }
+
+          ul,
+          ol {
+            margin: 0 0 16px;
+            padding-left: 24px;
+          }
+
+          li {
+            margin-bottom: 6px;
+          }
+
+          strong {
+            color: #ebeff8;
+          }
+        }
+      }
+
+      .article-footer {
+        margin-top: 48px;
+        padding-top: 24px;
+        border-top: 1px solid rgba(123, 159, 255, 0.2);
+      }
+
+      .not-found {
+        max-width: 760px;
+        margin: 0 auto;
+        padding: clamp(20px, 4vw, 44px);
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        align-items: flex-start;
+        color: #b9c9ea;
+      }
+    `,
+  ],
+})
+export class BlogArticleComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly seo = inject(SeoService);
+  private readonly document = inject(DOCUMENT);
+  private readonly destroyRef = inject(DestroyRef);
+
+  post: BlogPost | null = null;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => this.removeJsonLd());
+  }
+
+  ngOnInit(): void {
+    const slug = this.route.snapshot.paramMap.get('slug');
+    const found = BLOG_POSTS.find((p) => p.slug === slug) ?? null;
+
+    if (!found) {
+      this.router.navigateByUrl('/blog');
+      return;
+    }
+
+    this.post = found;
+    this.seo.update(found.title, found.description, `/blog/${found.slug}`);
+    this.injectJsonLd(found);
+  }
+
+  private injectJsonLd(post: BlogPost): void {
+    const head = this.document.head;
+    if (!head) return;
+
+    this.removeJsonLd();
+
+    const script = this.document.createElement('script');
+    script.type = 'application/ld+json';
+    script.setAttribute('data-blog-ld', '1');
+    script.textContent = JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: post.title,
+      description: post.description,
+      datePublished: post.publishedAt,
+      author: {
+        '@type': 'Organization',
+        name: 'Pushup Tracker',
+        url: BASE_URL,
+      },
+      publisher: {
+        '@type': 'Organization',
+        name: 'Pushup Tracker',
+        url: BASE_URL,
+      },
+      url: `${BASE_URL}/blog/${post.slug}`,
+      keywords: post.keywords.join(', '),
+    });
+    head.appendChild(script);
+  }
+
+  private removeJsonLd(): void {
+    this.document.head?.querySelector('script[data-blog-ld]')?.remove();
+  }
+}

--- a/web/src/app/blog/blog-list.component.ts
+++ b/web/src/app/blog/blog-list.component.ts
@@ -1,0 +1,96 @@
+import { DatePipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { RouterLink } from '@angular/router';
+import { BLOG_POSTS } from './blog-posts.data';
+
+@Component({
+  selector: 'app-blog-list',
+  imports: [RouterLink, MatCardModule, MatButtonModule, DatePipe],
+  template: `
+    <main class="blog-list">
+      <h1 i18n="@@blog.list.title">Blog</h1>
+      <p class="blog-intro" i18n="@@blog.list.intro">
+        Tipps, Guides und Motivation rund um Liegestütze und Krafttraining.
+      </p>
+
+      <div class="articles">
+        @for (post of posts; track post.slug) {
+          <mat-card class="article-card">
+            <mat-card-header>
+              <mat-card-title>{{ post.title }}</mat-card-title>
+              <mat-card-subtitle>
+                <time [attr.datetime]="post.publishedAt">{{
+                  post.publishedAt | date: 'd. MMMM yyyy' : '' : 'de'
+                }}</time>
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <p>{{ post.description }}</p>
+            </mat-card-content>
+            <mat-card-actions>
+              <a
+                mat-stroked-button
+                [routerLink]="['/blog', post.slug]"
+                i18n="@@blog.list.readArticle"
+                >Artikel lesen</a
+              >
+            </mat-card-actions>
+          </mat-card>
+        }
+      </div>
+    </main>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      .blog-list {
+        max-width: 860px;
+        margin: 0 auto;
+        padding: clamp(20px, 4vw, 44px);
+      }
+
+      h1 {
+        margin: 0 0 8px;
+        font-size: clamp(1.8rem, 4vw, 2.6rem);
+      }
+
+      .blog-intro {
+        margin: 0 0 32px;
+        color: #b9c9ea;
+        font-size: 1rem;
+      }
+
+      .articles {
+        display: grid;
+        gap: 16px;
+      }
+
+      .article-card {
+        border: 1px solid rgba(123, 159, 255, 0.25);
+        border-radius: 16px;
+      }
+
+      mat-card-content p {
+        color: #b9c9ea;
+        margin: 0;
+      }
+
+      mat-card-actions {
+        padding: 0 16px 16px;
+      }
+
+      time {
+        font-size: 0.85rem;
+        color: #7a8fbb;
+      }
+    `,
+  ],
+})
+export class BlogListComponent {
+  readonly posts = BLOG_POSTS;
+}

--- a/web/src/app/blog/blog-posts.data.ts
+++ b/web/src/app/blog/blog-posts.data.ts
@@ -1,0 +1,230 @@
+export interface BlogPost {
+  slug: string;
+  title: string;
+  description: string;
+  publishedAt: string;
+  content: string;
+  keywords: string[];
+}
+
+export const BLOG_POSTS: BlogPost[] = [
+  {
+    slug: 'liegestuetze-steigern',
+    title: 'Von 0 auf 100: Liegestütze systematisch steigern',
+    description:
+      'Praktische Anleitung zum systematischen Steigern deiner Liegestütze – mit Trainingsplan, Technik-Tipps und der richtigen Regeneration.',
+    publishedAt: '2025-01-15',
+    keywords: [
+      'Liegestütze steigern',
+      'mehr Liegestütze',
+      'Trainingsplan Liegestütze',
+      'Liegestütze Fortschritt',
+      'Liegestütze lernen',
+    ],
+    content: `
+<h2>Warum systematisches Training den Unterschied macht</h2>
+<p>
+  Viele starten mit dem besten Willen: täglich so viele Liegestütze wie möglich, bis die Arme versagen.
+  Das Ergebnis? Nach wenigen Tagen Muskelkater, Stagnation und oft sogar Verletzungen. Der Schlüssel
+  zum Erfolg liegt nicht in blindem Durchhalten, sondern in progressiver Belastungssteigerung –
+  einem Prinzip, das Spitzensportler seit Jahrzehnten einsetzen.
+</p>
+
+<h2>Die Grundlage: Korrekte Technik zuerst</h2>
+<p>
+  Bevor du über Wiederholungszahlen nachdenkst, musst du die Bewegung beherrschen. Eine saubere
+  Liegestütze bedeutet:
+</p>
+<ul>
+  <li>Hände schulterbreit oder etwas breiter platzieren</li>
+  <li>Körper bildet eine gerade Linie von Kopf bis Ferse</li>
+  <li>Ellenbogen beim Absenken leicht zum Körper anwinkeln, nicht nach außen spreizen</li>
+  <li>Brust berührt den Boden oder kommt ihm sehr nahe</li>
+  <li>Bauch- und Gesäßmuskulatur während der gesamten Bewegung aktiv halten</li>
+</ul>
+<p>
+  Wenn du noch keine saubere Liegestütze schaffst, beginne mit Knie-Liegestützen oder Liegestützen
+  an einer erhöhten Fläche wie einer Fensterbank. Reduziere den Widerstand, bis die Form stimmt.
+</p>
+
+<h2>Der 6-Wochen-Aufbauplan</h2>
+<p>
+  Dieser Plan richtet sich an Einsteiger, die strukturiert von 0 auf 100 Liegestütze kommen möchten.
+  Die Basis: drei Trainingstage pro Woche mit mindestens einem Ruhetag dazwischen.
+</p>
+<ol>
+  <li><strong>Woche 1–2:</strong> 3 Sätze × so viele saubere Wiederholungen wie möglich (AMRAP), 90 Sekunden Pause zwischen Sätzen. Ziel: Grundlage aufbauen, Technik festigen.</li>
+  <li><strong>Woche 3–4:</strong> 4 Sätze × AMRAP mit 60 Sekunden Pause. Zusätzlich einmal pro Woche einen längeren Satz ohne Pause bis zur maximalen Wiederholungszahl.</li>
+  <li><strong>Woche 5–6:</strong> 5 Sätze mit Zielwiederholungen (z. B. 15-15-12-12-10), Pause nach Bedarf. Fokus auf gleichmäßiges Tempo und volle Bewegungsamplitude.</li>
+</ol>
+
+<h2>Regeneration ist kein Luxus</h2>
+<p>
+  Muskeln wachsen in der Ruhephase, nicht während des Trainings. Wer täglich ohne Pause trainiert,
+  riskiert Überlastungssyndrome und blockiert den Fortschritt. Plane mindestens einen Tag Ruhe
+  zwischen intensiven Einheiten ein. Schlaf, ausreichende Proteinzufuhr (1,5–2 g pro Kilogramm
+  Körpergewicht) und Dehnung der Brust- und Schultermuskulatur nach dem Training beschleunigen
+  die Erholung deutlich.
+</p>
+
+<h2>Plateaus überwinden</h2>
+<p>
+  Kommst du nicht mehr weiter, helfen Varianten wie Diamant-Liegestützen (Trizepsfokus), weite
+  Liegestützen (Brustfokus) oder langsame exzentrische Phasen (3–5 Sekunden beim Absenken).
+  Diese Variationen fordern die Muskulatur auf neue Weise und brechen Stagnation auf.
+</p>
+
+<h2>Fortschritt sichtbar machen</h2>
+<p>
+  Was gemessen wird, wird verbessert. Halte jede Einheit fest: Datum, Sätze, Wiederholungen.
+  So erkennst du Trends, weißt wann du die Last steigern kannst und bleibst langfristig motiviert.
+  Mit einem digitalen Tracker wie Pushup Tracker hast du alle Daten auf einen Blick – inklusive
+  Streak, Wochenvolumen und Bestleistungen.
+</p>
+    `.trim(),
+  },
+  {
+    slug: 'taeglich-liegestuetze',
+    title: 'Warum tägliche Liegestütze dein Leben verändern',
+    description:
+      'Tägliche Liegestütze verbessern Kraft, Haltung und Wohlbefinden. Erfahre die wissenschaftlich belegten Vorteile und wie du die Gewohnheit dauerhaft aufbaust.',
+    publishedAt: '2025-02-03',
+    keywords: [
+      'täglich Liegestütze',
+      'Liegestütze jeden Tag',
+      'Liegestütze Vorteile',
+      'Liegestütze Gewohnheit',
+      'Liegestütze Gesundheit',
+    ],
+    content: `
+<h2>Mehr als nur ein Fitness-Trend</h2>
+<p>
+  Liegestützen gelten oft als langweilige Grundübung – dabei sind sie eines der vielseitigsten
+  Ganzkörperübungen, die existieren. Wer sie täglich praktiziert, verändert nicht nur seine
+  Körperzusammensetzung, sondern auch seine Haltung, sein Energielevel und sogar sein mentales
+  Wohlbefinden. Das Beste: Kein Gerät, keine Mitgliedschaft, kein Aufwand nötig.
+</p>
+
+<h2>Was täglich passiert: Die Physiologie</h2>
+<p>
+  Schon nach wenigen Wochen regelmäßiger Liegestützen zeigen sich messbare Veränderungen:
+</p>
+<ul>
+  <li><strong>Muskelaufbau:</strong> Brust, Schultern, Trizeps und Rumpfmuskulatur werden stärker und definierter.</li>
+  <li><strong>Knochendichte:</strong> Belastungsübungen stimulieren den Knochen-Remodelling-Prozess und können Osteoporose vorbeugen.</li>
+  <li><strong>Stoffwechsel:</strong> Mehr Muskelmasse bedeutet einen höheren Grundumsatz – auch im Ruhezustand.</li>
+  <li><strong>Herzgesundheit:</strong> Studien zeigen, dass Männer, die mehr als 40 Liegestützen am Stück schaffen, ein signifikant geringeres kardiovaskuläres Risiko haben.</li>
+</ul>
+
+<h2>Haltung und Rückenschmerzen</h2>
+<p>
+  Büroarbeit und stundenlanges Sitzen schwächen die Rumpfmuskulatur und fördern eine vorgebeugte
+  Haltung. Liegestützen trainieren gezielt die stabilisierende Muskulatur entlang der Wirbelsäule,
+  stärken die Schulterblatt-Stabilisatoren und helfen, das muskuläre Ungleichgewicht zu korrigieren.
+  Viele berichten nach 4–6 Wochen täglichem Training von deutlich weniger Nacken- und Rückenschmerzen.
+</p>
+
+<h2>Die Kraft der Gewohnheit</h2>
+<p>
+  Der größte Feind des Fortschritts ist Unregelmäßigkeit. Gewohnheitsforscher empfehlen, neue
+  Routinen an bestehende zu koppeln: Liegestütze direkt nach dem Aufstehen, nach dem ersten Kaffee
+  oder nach der Mittagspause. Starte mit einer realistischen Zahl – auch 10 Liegestützen täglich
+  sind besser als 100 einmal pro Woche.
+</p>
+<p>
+  Besonders effektiv ist das Führen einer Streak: Wenn du siehst, dass du 14 Tage in Folge trainiert
+  hast, wächst die intrinsische Motivation, die Serie nicht zu unterbrechen. Genau dieses Prinzip
+  nutzt Pushup Tracker, um dich täglich auf Kurs zu halten.
+</p>
+
+<h2>Mentale Vorteile werden unterschätzt</h2>
+<p>
+  Körperliche Aktivität setzt Endorphine frei und reduziert Cortisol – das Stresshormon. Schon
+  eine kurze Trainingseinheit am Morgen kann die Stimmung für den gesamten Tag verbessern. Hinzu
+  kommt das Gefühl der Selbstwirksamkeit: Wer jeden Tag seine Einheit absolviert, entwickelt
+  Disziplin und Selbstvertrauen, die weit über das Training hinaus wirken.
+</p>
+
+<h2>Wie viele Liegestütze sind täglich sinnvoll?</h2>
+<p>
+  Für Einsteiger reichen 3 Sätze à 10–15 Wiederholungen täglich aus, um deutliche Fortschritte
+  zu erzielen. Fortgeschrittene können auf 50–100+ Wiederholungen aufteilen, z. B. 5 Sätze × 20.
+  Wichtiger als die Zahl ist die Kontinuität: Lieber moderat und täglich als intensiv und unregelmäßig.
+</p>
+
+<h2>Fazit</h2>
+<p>
+  Tägliche Liegestützen sind eine der effektivsten Investitionen, die du in deine Gesundheit machen
+  kannst. Kein Equipment, keine Ausreden. Starte heute mit einer realistischen Zahl, verfolge
+  deinen Fortschritt und erlebe, wie sich kleine tägliche Schritte zu einem echten Wandel summieren.
+</p>
+    `.trim(),
+  },
+  {
+    slug: 'liegestuetze-tracker',
+    title: 'Mit einem Tracker zur Liegestütz-Bestleistung',
+    description:
+      'Warum ein digitaler Liegestütze-Tracker den Unterschied macht – und wie Pushup Tracker dir hilft, Bestleistungen zu erzielen und dranzubleiben.',
+    publishedAt: '2025-03-10',
+    keywords: [
+      'Liegestütze tracker app',
+      'Liegestütze App',
+      'Liegestütze tracken',
+      'Pushup Tracker',
+      'Liegestütze Fortschritt verfolgen',
+    ],
+    content: `
+<h2>Das Problem mit dem Bauchgefühl</h2>
+<p>
+  Die meisten Menschen trainieren nach Gefühl. Sie wissen ungefähr, dass sie "letzte Woche mehr
+  gemacht haben" oder "es sich heute schwerer anfühlt". Doch ohne konkrete Zahlen ist Fortschritt
+  kaum zu erkennen – und oft wird er unterschätzt. Ein Trainingsjournal oder Tracker schafft Klarheit
+  dort, wo Erinnerungen trügen.
+</p>
+
+<h2>Warum Daten deinen Fortschritt beschleunigen</h2>
+<p>
+  Wenn du jede Einheit aufzeichnest, passieren mehrere Dinge gleichzeitig:
+</p>
+<ul>
+  <li><strong>Objektive Messung:</strong> Du siehst schwarz auf weiß, ob du wirklich Fortschritte machst oder seit Wochen stagnierst.</li>
+  <li><strong>Höhere Accountability:</strong> Das Wissen, eine Einheit eintragen zu müssen, erhöht die Trainingshäufigkeit nachweislich.</li>
+  <li><strong>Optimierung:</strong> Du erkennst, nach wie vielen Tagen Pause du besser performst, oder an welchen Wochentagen dein Energielevel am höchsten ist.</li>
+  <li><strong>Langzeitmotivation:</strong> Zahlen erzählen eine Geschichte. Wer sieht, wie er von 20 auf 80 Liegestützen gewachsen ist, bleibt motiviert.</li>
+</ul>
+
+<h2>Was Pushup Tracker bietet</h2>
+<p>
+  Pushup Tracker ist ein kostenloser, browserbasierter Tracker, der speziell für die Liegestütz-Community
+  entwickelt wurde. Statt aufgeblähter Feature-Listen konzentriert er sich auf das Wesentliche:
+</p>
+<ul>
+  <li><strong>Schnelle Erfassung:</strong> Einen Eintrag in unter 2 Sekunden anlegen – mit Schnellaktionen für häufige Wiederholungszahlen.</li>
+  <li><strong>Streak-Tracking:</strong> Sieh auf einen Blick, wie viele Tage du in Folge trainiert hast. Die Streak wird zum stärksten Motivator.</li>
+  <li><strong>Charts & KPIs:</strong> Tagesvolumen, Wochentrends und Bestleistungen als übersichtliche Grafiken – ohne Datenwust.</li>
+  <li><strong>Leaderboard:</strong> Misst du dich (optional und anonym) mit anderen Nutzern – täglich, wöchentlich oder monatlich.</li>
+  <li><strong>KI-Erinnerungen:</strong> Lass dich stündlich mit einem personalisierten KI-Motivationsspruch als Browser-Benachrichtigung erinnern.</li>
+  <li><strong>Gerätesync:</strong> Alle Daten in Echtzeit auf allen Geräten verfügbar – kein manuelles Synchronisieren nötig.</li>
+</ul>
+
+<h2>Für wen ist ein Liegestütze-Tracker sinnvoll?</h2>
+<p>
+  Kurz gesagt: für jeden, der ernsthaft Fortschritte machen will. Einsteiger profitieren von der
+  Struktur und der visuellen Bestätigung ihrer ersten Erfolge. Fortgeschrittene nutzen die Daten
+  zur Periodisierung und Plateauüberwindung. Selbst wer "nur" täglich 30 Liegestützen macht,
+  gewinnt durch die Aufzeichnung ein neues Bewusstsein für seinen Körper und seine Leistungsfähigkeit.
+</p>
+
+<h2>Kostenlos starten – ohne Risiko</h2>
+<p>
+  Pushup Tracker ist und bleibt kostenlos. Kein Abo, keine Kreditkarte, kein Haken. Du kannst
+  dich in Sekunden registrieren und sofort mit dem Tracken beginnen. Deine Daten gehören dir –
+  gespeichert in der Cloud, aber jederzeit exportierbar.
+</p>
+<p>
+  Starte noch heute und erlebe, wie viel einfacher es ist, dranzubleiben, wenn Fortschritt
+  sichtbar wird.
+</p>
+    `.trim(),
+  },
+];

--- a/web/src/app/marketing/components/reminder-feature-section/reminder-feature-section.component.ts
+++ b/web/src/app/marketing/components/reminder-feature-section/reminder-feature-section.component.ts
@@ -1,0 +1,129 @@
+import { Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-reminder-feature-section',
+  imports: [RouterLink, MatButtonModule, MatCardModule, MatIconModule],
+  template: `
+    <section class="reminder-section">
+      <div class="reminder-content">
+        <p class="eyebrow" i18n="@@reminder.feature.eyebrow">KI-Erinnerungen</p>
+        <h2 i18n="@@reminder.feature.headline">
+          Dein KI-Coach. Stündlich motiviert.
+        </h2>
+        <p class="reminder-desc" i18n="@@reminder.feature.desc">
+          Lass dich automatisch ans Training erinnern – mit individuellen
+          Motivationssprüchen direkt als Browser-Benachrichtigung, generiert von
+          einer KI.
+        </p>
+        <a
+          mat-flat-button
+          color="primary"
+          routerLink="/settings"
+          i18n="@@reminder.feature.cta"
+          >Jetzt einrichten</a
+        >
+      </div>
+
+      <div class="notification-mock-wrap" aria-hidden="true">
+        <mat-card class="notification-mock">
+          <mat-card-header>
+            <mat-icon mat-card-avatar>fitness_center</mat-icon>
+            <mat-card-title i18n="@@reminder.feature.mock.title"
+              >Pushups</mat-card-title
+            >
+            <mat-card-subtitle i18n="@@reminder.feature.mock.time"
+              >Jetzt</mat-card-subtitle
+            >
+          </mat-card-header>
+          <mat-card-content>
+            <mat-icon class="quote-icon">format_quote</mat-icon>
+            <p class="quote-text" i18n="@@reminder.feature.mock.quote">
+              Jede Wiederholung bringt dich näher ans Ziel. Dein nächstes Set
+              wartet auf dich!
+            </p>
+          </mat-card-content>
+        </mat-card>
+      </div>
+    </section>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      .reminder-section {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+        align-items: center;
+        border: 1px solid rgba(123, 159, 255, 0.25);
+        border-radius: 20px;
+        padding: clamp(18px, 3vw, 36px);
+        background: linear-gradient(
+          155deg,
+          rgba(30, 43, 74, 0.78),
+          rgba(14, 19, 33, 0.86)
+        );
+      }
+
+      @media (max-width: 640px) {
+        .reminder-section {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .eyebrow {
+        margin: 0 0 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: #93adea;
+        font-size: 0.74rem;
+      }
+
+      h2 {
+        margin: 0 0 12px;
+        font-size: clamp(1.4rem, 3vw, 2rem);
+        line-height: 1.2;
+      }
+
+      .reminder-desc {
+        margin: 0 0 20px;
+        color: #c4d2f2;
+        max-width: 52ch;
+      }
+
+      .notification-mock-wrap {
+        display: flex;
+        justify-content: center;
+      }
+
+      .notification-mock {
+        max-width: 340px;
+        width: 100%;
+        border: 1px solid rgba(123, 159, 255, 0.3);
+        border-radius: 12px;
+      }
+
+      .quote-icon {
+        color: #94b1ff;
+        font-size: 1.6rem;
+        height: 1.6rem;
+        width: 1.6rem;
+        margin-bottom: 4px;
+      }
+
+      .quote-text {
+        margin: 0;
+        font-style: italic;
+        color: #d8e5ff;
+        font-size: 0.95rem;
+      }
+    `,
+  ],
+})
+export class ReminderFeatureSectionComponent {}

--- a/web/src/app/marketing/shell/landing-page.component.html
+++ b/web/src/app/marketing/shell/landing-page.component.html
@@ -66,6 +66,8 @@
     </p>
   </section>
 
+  <app-reminder-feature-section></app-reminder-feature-section>
+
   <p class="trust-bar" i18n="@@landing.trust.bar">
     ✓ Kostenlos · ✓ Kein Abo · ✓ Keine Kreditkarte · ✓ Datenschutz first
   </p>

--- a/web/src/app/marketing/shell/landing-page.component.ts
+++ b/web/src/app/marketing/shell/landing-page.component.ts
@@ -13,6 +13,7 @@ import { Router, RouterLink } from '@angular/router';
 import { AdSlotComponent, AdsConfigService } from '@pu-stats/ads';
 import { AuthService, AuthStore } from '@pu-auth/auth';
 import { LeaderboardPeriod, LeaderboardService } from '@pu-stats/data-access';
+import { ReminderFeatureSectionComponent } from '../components/reminder-feature-section/reminder-feature-section.component';
 
 @Component({
   selector: 'app-landing-page',
@@ -22,6 +23,7 @@ import { LeaderboardPeriod, LeaderboardService } from '@pu-stats/data-access';
     MatCardModule,
     MatIconModule,
     AdSlotComponent,
+    ReminderFeatureSectionComponent,
   ],
   templateUrl: './landing-page.component.html',
   styleUrl: './landing-page.component.scss',


### PR DESCRIPTION
## Summary

### Landing Page — Reminder Feature Section
- New component `reminder-feature-section` nach dem Hero-Block
- Headline: "Dein KI-Coach. Stündlich motiviert."
- Browser-Notification-Mock mit KI-Motivationsspruch (mat-card)
- CTA: "Jetzt einrichten" → `/settings`
- Vollständig i18n-fähig (Quelle Deutsch)

### Blog-Infrastruktur
- Routen: `/blog` (Liste) + `/blog/:slug` (Artikel)
- Statische Artikel als TypeScript-Data-Files (kein CMS)
- SSR — Google indexiert vollständig
- Schema.org Article JSON-LD + SEO-Meta-Tags via SeoService
- Blog-Link in Navigation (Sidenav + Desktop)

### 3 Artikel (Deutsch, ~400-600 Wörter):
| Slug | Titel | SEO-Ziel |
|------|-------|----------|
| `liegestuetze-steigern` | Von 0 auf 100: Liegestütze systematisch steigern | "Liegestütze steigern" |
| `taeglich-liegestuetze` | Warum tägliche Liegestütze dein Leben verändern | "täglich Liegestütze" |
| `liegestuetze-tracker` | Mit einem Tracker zur Liegestütz-Bestleistung | "Liegestütze tracker app" |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Blog navigation to mobile and desktop menus
  * Blog listing page displaying all posts with titles, descriptions, and publication dates
  * Individual blog article pages with full content and SEO metadata support
  * New reminder feature section on the landing page

* **Tests**
  * Updated route tests to validate blog routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->