### PR TITLE
fix(push): resolve SW registration race that silenced Android background push

### DIFF
--- a/libs/reminders/src/lib/push/push-subscription.store.spec.ts
+++ b/libs/reminders/src/lib/push/push-subscription.store.spec.ts
@@ -1,0 +1,310 @@
+// Must be hoisted before any import of the store. Angular's `Functions`
+// token from @angular/fire/functions pulls in Firebase internals that break
+// the jest env; we stub them here.
+jest.mock('@angular/fire/functions', () => ({
+  Functions: class {},
+  httpsCallable: jest.fn(),
+}));
+
+import { TestBed } from '@angular/core/testing';
+import { Functions, httpsCallable } from '@angular/fire/functions';
+import { PushSubscriptionStore } from './push-subscription.store';
+import { VAPID_PUBLIC_KEY } from './vapid-key.token';
+
+type CallableResult = { data: { ok: boolean; subId: string; deviceCount: number } };
+
+const VAPID_KEY_B64 = 'BP1234567890abcdef';
+
+function mockHttpsCallable(deviceCount = 1): void {
+  const callable = jest
+    .fn()
+    .mockResolvedValue({
+      data: { ok: true, subId: 'sub-1', deviceCount },
+    } satisfies CallableResult);
+  (httpsCallable as jest.Mock).mockReturnValue(callable);
+}
+
+/**
+ * Build a mock PushSubscription that survives JSON round-trips.
+ */
+function makeMockSubscription(endpoint = 'https://fcm/endpoint'): PushSubscription {
+  return {
+    endpoint,
+    expirationTime: null,
+    options: {} as PushSubscriptionOptions,
+    getKey: () => null,
+    toJSON: () => ({
+      endpoint,
+      expirationTime: null,
+      keys: { p256dh: 'p', auth: 'a' },
+    }),
+    unsubscribe: jest.fn().mockResolvedValue(true),
+  } as unknown as PushSubscription;
+}
+
+describe('PushSubscriptionStore', () => {
+  const swDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    'serviceWorker'
+  );
+  const notifDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    'Notification'
+  );
+  const pushManagerDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    'PushManager'
+  );
+
+  // Silence expected console.error noise from the error paths
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockHttpsCallable();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    // Notification API – granted by default
+    Object.defineProperty(window, 'Notification', {
+      value: Object.assign(
+        jest.fn() as unknown as typeof Notification,
+        {
+          permission: 'granted' as NotificationPermission,
+          requestPermission: jest.fn().mockResolvedValue('granted'),
+        }
+      ),
+      configurable: true,
+      writable: true,
+    });
+
+    // PushManager must be a defined constructor so `'PushManager' in window`
+    // returns true in isSupported().
+    Object.defineProperty(window, 'PushManager', {
+      value: class {},
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    if (swDescriptor) {
+      Object.defineProperty(navigator, 'serviceWorker', swDescriptor);
+    } else {
+      delete (navigator as Record<string, unknown>)['serviceWorker'];
+    }
+    if (notifDescriptor) {
+      Object.defineProperty(window, 'Notification', notifDescriptor);
+    } else {
+      delete (window as Record<string, unknown>)['Notification'];
+    }
+    if (pushManagerDescriptor) {
+      Object.defineProperty(window, 'PushManager', pushManagerDescriptor);
+    } else {
+      delete (window as Record<string, unknown>)['PushManager'];
+    }
+  });
+
+  function setupStore(): InstanceType<typeof PushSubscriptionStore> {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: VAPID_PUBLIC_KEY, useValue: VAPID_KEY_B64 },
+        // Stub Functions so `inject(Functions, { optional: true })` returns
+        // a truthy value; the actual callable is faked via httpsCallable mock.
+        { provide: Functions, useValue: {} },
+      ],
+    });
+    return TestBed.inject(PushSubscriptionStore);
+  }
+
+  it('subscribe() succeeds when the Service Worker is already registered', async () => {
+    const subscribeMock = jest.fn().mockResolvedValue(makeMockSubscription());
+    const registration = {
+      pushManager: {
+        getSubscription: jest.fn().mockResolvedValue(null),
+        subscribe: subscribeMock,
+      },
+    } as unknown as ServiceWorkerRegistration;
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        getRegistration: jest.fn().mockResolvedValue(registration),
+        addEventListener: jest.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const store = setupStore();
+    const ok = await store.subscribe();
+
+    expect(ok).toBe(true);
+    expect(store.status()).toBe('subscribed');
+    expect(subscribeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userVisibleOnly: true })
+    );
+  });
+
+  it('subscribe() waits for a late SW registration and still succeeds', async () => {
+    // First call (initial check) returns undefined, then .ready resolves
+    // after ~3s — well inside the 15s timeout but past the old 5s limit
+    // that caused the bug on first load.
+    const subscribeMock = jest.fn().mockResolvedValue(makeMockSubscription());
+    const registration = {
+      pushManager: {
+        getSubscription: jest.fn().mockResolvedValue(null),
+        subscribe: subscribeMock,
+      },
+    } as unknown as ServiceWorkerRegistration;
+
+    const readyPromise = new Promise<ServiceWorkerRegistration>((resolve) => {
+      setTimeout(() => resolve(registration), 3_000);
+    });
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        getRegistration: jest.fn().mockResolvedValue(undefined),
+        // `.ready` is a getter that returns a Promise resolving when the SW
+        // becomes active. Emulate a 3s activation delay.
+        get ready() {
+          return readyPromise;
+        },
+        addEventListener: jest.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    jest.useFakeTimers();
+    const store = setupStore();
+    const subscribePromise = store.subscribe();
+
+    // Advance past the 3s SW activation delay (but well under 15s timeout)
+    await jest.advanceTimersByTimeAsync(3_000);
+    jest.useRealTimers();
+
+    const ok = await subscribePromise;
+
+    expect(ok).toBe(true);
+    expect(store.status()).toBe('subscribed');
+    expect(subscribeMock).toHaveBeenCalled();
+  });
+
+  it('subscribe() sets status=error (not not-subscribed) when SW never registers', async () => {
+    // Simulate the bug: SW registration never happens (e.g. dev mode, or
+    // registerWhenStable delay exceeds the subscribe timeout). The store
+    // must surface this as 'error', not silently fall back to
+    // 'not-subscribed' — otherwise the UI shows the toggle as enabled
+    // while no real subscription exists and background push never arrives.
+    const neverResolve = new Promise<never>(() => {
+      /* intentionally never resolves */
+    });
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        getRegistration: jest.fn().mockResolvedValue(undefined),
+        get ready() {
+          return neverResolve;
+        },
+        addEventListener: jest.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    jest.useFakeTimers();
+    const store = setupStore();
+    const subscribePromise = store.subscribe();
+
+    // Advance past the 15s timeout
+    await jest.advanceTimersByTimeAsync(15_000);
+    jest.useRealTimers();
+
+    const ok = await subscribePromise;
+
+    expect(ok).toBe(false);
+    expect(store.status()).toBe('error');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Service Worker not available')
+    );
+  });
+
+  it('init() sets status=not-subscribed when SW is registered but has no subscription', async () => {
+    const registration = {
+      pushManager: {
+        getSubscription: jest.fn().mockResolvedValue(null),
+      },
+    } as unknown as ServiceWorkerRegistration;
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        getRegistration: jest.fn().mockResolvedValue(registration),
+        addEventListener: jest.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const store = setupStore();
+    await store.init();
+
+    expect(store.status()).toBe('not-subscribed');
+    expect(store.deviceCount()).toBe(0);
+  });
+
+  it('init() rehydrates status=subscribed when an existing push subscription is found', async () => {
+    const existingSub = makeMockSubscription();
+    const registration = {
+      pushManager: {
+        getSubscription: jest.fn().mockResolvedValue(existingSub),
+      },
+    } as unknown as ServiceWorkerRegistration;
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        getRegistration: jest.fn().mockResolvedValue(registration),
+        addEventListener: jest.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    mockHttpsCallable(2);
+
+    const store = setupStore();
+    await store.init();
+
+    expect(store.status()).toBe('subscribed');
+    expect(store.deviceCount()).toBe(2);
+  });
+
+  it('subscribe() sets status=denied when Notification permission is denied', async () => {
+    Object.defineProperty(window, 'Notification', {
+      value: Object.assign(jest.fn() as unknown as typeof Notification, {
+        permission: 'default' as NotificationPermission,
+        requestPermission: jest.fn().mockResolvedValue('denied'),
+      }),
+      configurable: true,
+      writable: true,
+    });
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        getRegistration: jest.fn().mockResolvedValue({
+          pushManager: {
+            getSubscription: jest.fn(),
+            subscribe: jest.fn(),
+          },
+        }),
+        addEventListener: jest.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const store = setupStore();
+    const ok = await store.subscribe();
+
+    expect(ok).toBe(false);
+    expect(store.status()).toBe('denied');
+  });
+});

--- a/libs/reminders/src/lib/push/push-subscription.store.spec.ts
+++ b/libs/reminders/src/lib/push/push-subscription.store.spec.ts
@@ -145,87 +145,90 @@ describe('PushSubscriptionStore', () => {
   });
 
   it('subscribe() waits for a late SW registration and still succeeds', async () => {
-    // First call (initial check) returns undefined, then .ready resolves
-    // after ~3s — well inside the 15s timeout but past the old 5s limit
-    // that caused the bug on first load.
-    const subscribeMock = jest.fn().mockResolvedValue(makeMockSubscription());
-    const registration = {
-      pushManager: {
-        getSubscription: jest.fn().mockResolvedValue(null),
-        subscribe: subscribeMock,
-      },
-    } as unknown as ServiceWorkerRegistration;
-
-    const readyPromise = new Promise<ServiceWorkerRegistration>((resolve) => {
-      setTimeout(() => resolve(registration), 3_000);
-    });
-
-    Object.defineProperty(navigator, 'serviceWorker', {
-      value: {
-        getRegistration: jest.fn().mockResolvedValue(undefined),
-        // `.ready` is a getter that returns a Promise resolving when the SW
-        // becomes active. Emulate a 3s activation delay.
-        get ready() {
-          return readyPromise;
-        },
-        addEventListener: jest.fn(),
-      },
-      configurable: true,
-      writable: true,
-    });
-
+    // Enable fake timers BEFORE scheduling any timeouts so the polling
+    // loop inside getSwRegistration() and our activation-delay timer
+    // both run under Jest's control.
     jest.useFakeTimers();
-    const store = setupStore();
-    const subscribePromise = store.subscribe();
+    try {
+      // `getRegistration` returns undefined until the SW "activates"
+      // after ~3s — well inside the 15s timeout but past the old 5s
+      // limit that caused the bug on first load.
+      const subscribeMock = jest
+        .fn()
+        .mockResolvedValue(makeMockSubscription());
+      const registration = {
+        pushManager: {
+          getSubscription: jest.fn().mockResolvedValue(null),
+          subscribe: subscribeMock,
+        },
+      } as unknown as ServiceWorkerRegistration;
 
-    // Advance past the 3s SW activation delay (but well under 15s timeout)
-    await jest.advanceTimersByTimeAsync(3_000);
-    jest.useRealTimers();
+      let swActive: ServiceWorkerRegistration | undefined = undefined;
+      setTimeout(() => {
+        swActive = registration;
+      }, 3_000);
 
-    const ok = await subscribePromise;
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: {
+          getRegistration: jest.fn().mockImplementation(async () => swActive),
+          addEventListener: jest.fn(),
+        },
+        configurable: true,
+        writable: true,
+      });
 
-    expect(ok).toBe(true);
-    expect(store.status()).toBe('subscribed');
-    expect(subscribeMock).toHaveBeenCalled();
+      const store = setupStore();
+      const subscribePromise = store.subscribe();
+
+      // Advance past the 3s SW activation delay (but well under 15s timeout).
+      // Use a generous step to cover multiple 250ms poll intervals.
+      await jest.advanceTimersByTimeAsync(4_000);
+
+      const ok = await subscribePromise;
+
+      expect(ok).toBe(true);
+      expect(store.status()).toBe('subscribed');
+      expect(subscribeMock).toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('subscribe() sets status=error (not not-subscribed) when SW never registers', async () => {
-    // Simulate the bug: SW registration never happens (e.g. dev mode, or
-    // registerWhenStable delay exceeds the subscribe timeout). The store
-    // must surface this as 'error', not silently fall back to
-    // 'not-subscribed' — otherwise the UI shows the toggle as enabled
-    // while no real subscription exists and background push never arrives.
-    const neverResolve = new Promise<never>(() => {
-      /* intentionally never resolves */
-    });
-
-    Object.defineProperty(navigator, 'serviceWorker', {
-      value: {
-        getRegistration: jest.fn().mockResolvedValue(undefined),
-        get ready() {
-          return neverResolve;
-        },
-        addEventListener: jest.fn(),
-      },
-      configurable: true,
-      writable: true,
-    });
-
     jest.useFakeTimers();
-    const store = setupStore();
-    const subscribePromise = store.subscribe();
+    try {
+      // Simulate the bug: SW registration never happens (e.g. dev mode, or
+      // registerWhenStable delay exceeds the subscribe timeout). The store
+      // must surface this as 'error', not silently fall back to
+      // 'not-subscribed' — otherwise the UI shows the toggle as enabled
+      // while no real subscription exists and background push never arrives.
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: {
+          // Always undefined — polling loop must time out cleanly.
+          getRegistration: jest.fn().mockResolvedValue(undefined),
+          addEventListener: jest.fn(),
+        },
+        configurable: true,
+        writable: true,
+      });
 
-    // Advance past the 15s timeout
-    await jest.advanceTimersByTimeAsync(15_000);
-    jest.useRealTimers();
+      const store = setupStore();
+      const subscribePromise = store.subscribe();
 
-    const ok = await subscribePromise;
+      // Advance past the 15s polling deadline (add slack for the final
+      // poll iteration).
+      await jest.advanceTimersByTimeAsync(16_000);
 
-    expect(ok).toBe(false);
-    expect(store.status()).toBe('error');
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Service Worker not available')
-    );
+      const ok = await subscribePromise;
+
+      expect(ok).toBe(false);
+      expect(store.status()).toBe('error');
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Service Worker not available')
+      );
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('init() sets status=not-subscribed when SW is registered but has no subscription', async () => {

--- a/libs/reminders/src/lib/push/push-subscription.store.ts
+++ b/libs/reminders/src/lib/push/push-subscription.store.ts
@@ -105,27 +105,34 @@ export const PushSubscriptionStore = signalStore(
      * subscribe flow doesn't race the registration on first page load.
      */
     const SW_READY_TIMEOUT_MS = 15_000;
+    /** Poll interval while waiting for the SW to register. */
+    const SW_POLL_INTERVAL_MS = 250;
 
     /**
      * Get the SW registration, waiting for it if not yet available.
      *
      * The app uses `registerWhenStable:<delay>`, so on first load the SW may
-     * not be registered at the moment the user toggles push on. Falls back to
-     * `.ready` with a timeout so dev mode (no SW) doesn't hang forever.
+     * not be registered at the moment the user toggles push on. We poll
+     * `getRegistration()` instead of awaiting `navigator.serviceWorker.ready`
+     * because `.ready` hangs forever when no SW is ever registered
+     * (dev mode, SW disabled) — see CLAUDE.md "Push Notifications" rules.
      */
     async function getSwRegistration(): Promise<
       ServiceWorkerRegistration | undefined
     > {
-      const reg = await navigator.serviceWorker.getRegistration();
+      const deadline = Date.now() + SW_READY_TIMEOUT_MS;
+      // First attempt — likely hit on re-visits where the SW is already active.
+      let reg = await navigator.serviceWorker.getRegistration();
       if (reg) return reg;
-      // SW not yet registered — wait up to SW_READY_TIMEOUT_MS for it
-      const raced = await Promise.race([
-        navigator.serviceWorker.ready,
-        new Promise<undefined>((resolve) =>
-          setTimeout(() => resolve(undefined), SW_READY_TIMEOUT_MS)
-        ),
-      ]);
-      return raced ?? undefined;
+      // Poll until the SW shows up or we hit the timeout.
+      while (Date.now() < deadline) {
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, SW_POLL_INTERVAL_MS)
+        );
+        reg = await navigator.serviceWorker.getRegistration();
+        if (reg) return reg;
+      }
+      return undefined;
     }
 
     // Guard: prevent duplicate init() runs (e.g. from re-mounted components)

--- a/libs/reminders/src/lib/push/push-subscription.store.ts
+++ b/libs/reminders/src/lib/push/push-subscription.store.ts
@@ -99,21 +99,30 @@ export const PushSubscriptionStore = signalStore(
     }
 
     /**
-     * Get the SW registration, waiting briefly for it if not yet available.
-     * The app uses `registerWhenStable:30000`, so the SW may not be registered
-     * immediately. Falls back to `.ready` with a timeout so dev mode (no SW)
-     * doesn't hang forever.
+     * Max time to wait for the Angular service worker to become available
+     * before giving up. Must be comfortably larger than the
+     * `registerWhenStable:<delay>` in `provideServiceWorker(...)` so the
+     * subscribe flow doesn't race the registration on first page load.
+     */
+    const SW_READY_TIMEOUT_MS = 15_000;
+
+    /**
+     * Get the SW registration, waiting for it if not yet available.
+     *
+     * The app uses `registerWhenStable:<delay>`, so on first load the SW may
+     * not be registered at the moment the user toggles push on. Falls back to
+     * `.ready` with a timeout so dev mode (no SW) doesn't hang forever.
      */
     async function getSwRegistration(): Promise<
       ServiceWorkerRegistration | undefined
     > {
       const reg = await navigator.serviceWorker.getRegistration();
       if (reg) return reg;
-      // SW not yet registered — wait up to 5s for it
+      // SW not yet registered — wait up to SW_READY_TIMEOUT_MS for it
       const raced = await Promise.race([
         navigator.serviceWorker.ready,
         new Promise<undefined>((resolve) =>
-          setTimeout(() => resolve(undefined), 5_000)
+          setTimeout(() => resolve(undefined), SW_READY_TIMEOUT_MS)
         ),
       ]);
       return raced ?? undefined;
@@ -191,7 +200,18 @@ export const PushSubscriptionStore = signalStore(
 
           const reg = await getSwRegistration();
           if (!reg) {
-            patchState(store, { status: 'not-subscribed' });
+            // The SW never became available inside the timeout. Surface this
+            // as an error instead of 'not-subscribed' so the UI can show a
+            // "try again" state — silently flipping to 'not-subscribed' makes
+            // the toggle look enabled while no real subscription exists, and
+            // users only see notifications while the app is open (via the
+            // in-app interval), not in the background.
+            console.error(
+              '[PushSubscriptionStore] Service Worker not available within ' +
+                `${SW_READY_TIMEOUT_MS}ms — cannot subscribe to push. ` +
+                'Reload the app and try again.'
+            );
+            patchState(store, { status: 'error' });
             return false;
           }
           const existingSub = await reg.pushManager.getSubscription();
@@ -207,7 +227,8 @@ export const PushSubscriptionStore = signalStore(
           const { deviceCount } = await saveSubscription(subToSave);
           patchState(store, { status: 'subscribed', deviceCount });
           return true;
-        } catch {
+        } catch (err) {
+          console.error('[PushSubscriptionStore] subscribe() failed', err);
           patchState(store, { status: 'error' });
           return false;
         }

--- a/web/src/app/app.config.ts
+++ b/web/src/app/app.config.ts
@@ -98,7 +98,12 @@ export const appConfig: ApplicationConfig = {
     { provide: VAPID_PUBLIC_KEY, useValue: firebaseRuntime.vapidPublicKey },
     provideServiceWorker('sw-push.js', {
       enabled: !isDevMode(),
-      registrationStrategy: 'registerWhenStable:30000',
+      // Register the SW shortly after stabilization so push subscriptions
+      // can succeed on first visit. A long delay (previously 30s) caused a
+      // race where subscribe() timed out waiting for the SW, leaving users
+      // without a real push subscription — reminders then only fired while
+      // the app was open (via in-app interval), not in the background.
+      registrationStrategy: 'registerWhenStable:2000',
     }),
     ...(firebaseRuntime.useEmulators
       ? [

--- a/web/src/app/reminders/shell/reminders-page.component.ts
+++ b/web/src/app/reminders/shell/reminders-page.component.ts
@@ -476,7 +476,13 @@ export class RemindersPageComponent {
         // Auto-subscribe to server-side push only when reminders are being
         // newly enabled — not on every save. This preserves an explicit
         // push opt-out (user unsubscribed via the push toggle).
-        if (!wasEnabled && this.pushService.status() === 'not-subscribed') {
+        // Retry on 'error' too so a prior SW-registration timeout doesn't
+        // lock the user out of auto-subscription forever.
+        const priorPushStatus = this.pushService.status();
+        if (
+          !wasEnabled &&
+          (priorPushStatus === 'not-subscribed' || priorPushStatus === 'error')
+        ) {
           await this.pushService.subscribe();
           const pushStatus = this.pushService.status();
           if (pushStatus !== 'subscribed') {


### PR DESCRIPTION
The Angular service worker was registered 30s after app stabilization
(`registerWhenStable:30000`), but `PushSubscriptionStore.subscribe()`
only waited 5s for it via `navigator.serviceWorker.ready`. On first
visit, subscribe() timed out before the SW existed, silently set
status to 'not-subscribed', and the real `pushManager.subscribe()` call
never happened. Reminders then only fired while the PWA was open (via
the in-app `setInterval`) — users saw background push as broken on
Android because no subscription was ever saved server-side.

Changes:
- app.config.ts: drop SW registration delay from 30s to 2s so
  subscribe() can almost always find a live registration immediately.
- push-subscription.store.ts: bump SW wait timeout from 5s to 15s so
  even slow first-load registration still succeeds, and surface a hard
  'error' state (with a console.error) when the SW never becomes
  available instead of silently falling back to 'not-subscribed'.
- Added push-subscription.store.spec.ts covering: immediate SW hit,
  late-registering SW (3s delay) still succeeds, SW never available
  produces 'error' not 'not-subscribed', init() rehydration paths,
  and denied permission handling.

https://claude.ai/code/session_01LN1goA7WmQgxw93aMnjpZL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling when service worker registration isn’t available (retries, clearer error state and logging)
  * Auto-subscribe on reminder save now retries when prior push status was error as well as not-subscribed

* **Tests**
  * Added comprehensive tests covering push subscription flows, permission outcomes, and service worker timing scenarios

* **Chores**
  * Faster service worker push registration initialization timing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->