### PR TITLE
Fix SSR compatibility for Firebase and RemoteConfig services

### DIFF
--- a/libs/ads/src/lib/ads.store.spec.ts
+++ b/libs/ads/src/lib/ads.store.spec.ts
@@ -1,0 +1,30 @@
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { AdsStore } from './ads.store';
+
+describe('AdsStore (SSR)', () => {
+  it('should not crash on server platform and return safe defaults', () => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: PLATFORM_ID, useValue: 'server' }, AdsStore],
+    });
+
+    const store = TestBed.inject(AdsStore);
+
+    expect(store.enabled()).toBeUndefined();
+    expect(store.adClient()).toBeUndefined();
+    expect(store.dashboardInlineEnabled()).toBeUndefined();
+    expect(store.adsAllowed()).toBe(false);
+    expect(store.consentAnswered()).toBe(false);
+  });
+
+  it('should resolve init() as no-op on server', async () => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: PLATFORM_ID, useValue: 'server' }, AdsStore],
+    });
+
+    const store = TestBed.inject(AdsStore);
+    const result = await store.init();
+
+    expect(result).toBe(false);
+  });
+});

--- a/libs/ads/src/lib/ads.store.ts
+++ b/libs/ads/src/lib/ads.store.ts
@@ -51,7 +51,9 @@ export const AdsStore = signalStore(
     const isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
     // On SSR, RemoteConfig observables crash because the server app's
     // _initializePromise is null. Return inert signals on the server.
-    const remoteConfig = isBrowser ? inject(RemoteConfig) : null;
+    const remoteConfig = isBrowser
+      ? inject(RemoteConfig, { optional: true })
+      : null;
     return {
       _remoteConfig: remoteConfig,
       enabled: remoteConfig

--- a/libs/ads/src/lib/ads.store.ts
+++ b/libs/ads/src/lib/ads.store.ts
@@ -1,4 +1,4 @@
-import { computed, inject, PLATFORM_ID } from '@angular/core';
+import { computed, inject, PLATFORM_ID, signal } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { toSignal } from '@angular/core/rxjs-interop';
 import {
@@ -48,20 +48,29 @@ export const AdsStore = signalStore(
   { providedIn: 'root' },
   withState(initialState),
   withProps(() => {
-    const remoteConfig = inject(RemoteConfig);
+    const isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+    // On SSR, RemoteConfig observables crash because the server app's
+    // _initializePromise is null. Return inert signals on the server.
+    const remoteConfig = isBrowser ? inject(RemoteConfig) : null;
     return {
       _remoteConfig: remoteConfig,
-      enabled: toSignal(getBooleanChanges(remoteConfig, 'ads_enabled')),
-      dashboardInlineEnabled: toSignal(
-        getBooleanChanges(remoteConfig, 'ads_dashboard_inline_enabled')
-      ),
-      adClient: toSignal(getStringChanges(remoteConfig, 'ads_client')),
-      dashboardInlineSlot: toSignal(
-        getStringChanges(remoteConfig, 'ads_dashboard_inline_slot')
-      ),
-      landingInlineSlot: toSignal(
-        getStringChanges(remoteConfig, 'ads_landing_inline_slot')
-      ),
+      enabled: remoteConfig
+        ? toSignal(getBooleanChanges(remoteConfig, 'ads_enabled'))
+        : signal(undefined),
+      dashboardInlineEnabled: remoteConfig
+        ? toSignal(
+            getBooleanChanges(remoteConfig, 'ads_dashboard_inline_enabled')
+          )
+        : signal(undefined),
+      adClient: remoteConfig
+        ? toSignal(getStringChanges(remoteConfig, 'ads_client'))
+        : signal(undefined),
+      dashboardInlineSlot: remoteConfig
+        ? toSignal(getStringChanges(remoteConfig, 'ads_dashboard_inline_slot'))
+        : signal(undefined),
+      landingInlineSlot: remoteConfig
+        ? toSignal(getStringChanges(remoteConfig, 'ads_landing_inline_slot'))
+        : signal(undefined),
     };
   }),
   withComputed((store) => ({
@@ -69,7 +78,10 @@ export const AdsStore = signalStore(
     adsAllowed: computed(() => !!store.enabled() && store.consentAnswered()),
   })),
   withMethods((store) => ({
-    init: () => fetchAndActivate(store._remoteConfig),
+    init: () =>
+      store._remoteConfig
+        ? fetchAndActivate(store._remoteConfig)
+        : Promise.resolve(false),
     setTargetedAdsConsent: (value: boolean | undefined) => {
       if (typeof value !== 'boolean') return;
       patchState(store, { targetedAdsConsent: value, consentAnswered: true });

--- a/libs/auth/src/lib/adapters/auth.adapter.spec.ts
+++ b/libs/auth/src/lib/adapters/auth.adapter.spec.ts
@@ -76,11 +76,12 @@ describe('AuthAdapter', () => {
       ],
     });
     const adapter = fixture.debugElement.injector.get(AuthAdapter);
-    // On the server, signals return undefined instead of subscribing
-    expect(adapter.authUser()).toBeUndefined();
-    expect(adapter.authState()).toBeUndefined();
-    expect(adapter.idToken()).toBeUndefined();
+    // On the server, signals return null (= resolved, unauthenticated)
+    // so SSR renders the unauthenticated state, not a "loading" state
+    expect(adapter.authUser()).toBeNull();
+    expect(adapter.authState()).toBeNull();
+    expect(adapter.idToken()).toBeNull();
     expect(adapter.isAuthenticated()).toBe(false);
-    expect(adapter.authResolved()).toBe(false);
+    expect(adapter.authResolved()).toBe(true);
   });
 });

--- a/libs/auth/src/lib/adapters/auth.adapter.spec.ts
+++ b/libs/auth/src/lib/adapters/auth.adapter.spec.ts
@@ -1,3 +1,4 @@
+import { PLATFORM_ID } from '@angular/core';
 import { Auth, deleteUser as deleteUserFn } from '@angular/fire/auth';
 import { render } from '@testing-library/angular';
 import { AuthAdapter } from './auth.adapter';
@@ -64,5 +65,22 @@ describe('AuthAdapter', () => {
     const adapter = fixture.debugElement.injector.get(AuthAdapter);
     await adapter.deleteUser();
     expect(deleteUserMock).not.toHaveBeenCalled();
+  });
+
+  it('should not crash on server platform (SSR)', async () => {
+    const { fixture } = await render('', {
+      providers: [
+        { provide: Auth, useValue: mockAuth },
+        { provide: PLATFORM_ID, useValue: 'server' },
+        AuthAdapter,
+      ],
+    });
+    const adapter = fixture.debugElement.injector.get(AuthAdapter);
+    // On the server, signals return undefined instead of subscribing
+    expect(adapter.authUser()).toBeUndefined();
+    expect(adapter.authState()).toBeUndefined();
+    expect(adapter.idToken()).toBeUndefined();
+    expect(adapter.isAuthenticated()).toBe(false);
+    expect(adapter.authResolved()).toBe(false);
   });
 });

--- a/libs/auth/src/lib/adapters/auth.adapter.ts
+++ b/libs/auth/src/lib/adapters/auth.adapter.ts
@@ -58,13 +58,12 @@ export class AuthAdapter {
   }
 
   // On SSR, Firebase Auth observables crash because the server app's
-  // _initializePromise is null. Return inert signals on the server.
-  readonly authUser = this.isBrowser
-    ? toSignal(user(this.auth))
-    : signal(undefined);
+  // _initializePromise is null. Return null (= resolved, unauthenticated)
+  // so that authResolved() is true and SSR renders the unauthenticated state.
+  readonly authUser = this.isBrowser ? toSignal(user(this.auth)) : signal(null);
   readonly authState = this.isBrowser
     ? toSignal(authState(this.auth))
-    : signal(undefined);
+    : signal(null);
   readonly loading = signal(false);
   readonly error = signal<null | Error>(null);
   readonly isAuthenticated = computed(() => this.authState() != null);
@@ -72,7 +71,7 @@ export class AuthAdapter {
   readonly authResolved = computed(() => this.authState() !== undefined);
   readonly idToken = this.isBrowser
     ? toSignal(idToken(this.auth))
-    : signal(undefined);
+    : signal(null);
 
   async signInWithGoogle(): Promise<UserCredential> {
     const provider = new GoogleAuthProvider();

--- a/libs/auth/src/lib/adapters/auth.adapter.ts
+++ b/libs/auth/src/lib/adapters/auth.adapter.ts
@@ -1,4 +1,11 @@
-import { computed, inject, Injectable, signal } from '@angular/core';
+import {
+  computed,
+  inject,
+  Injectable,
+  PLATFORM_ID,
+  signal,
+} from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { toSignal } from '@angular/core/rxjs-interop';
 import {
   Auth,
@@ -29,6 +36,7 @@ export interface AuthCredentials {
 })
 export class AuthAdapter {
   private auth = inject(Auth);
+  private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   /**
    * Synchronous Firebase current user — available immediately after Firebase
@@ -49,15 +57,22 @@ export class AuthAdapter {
     return this.auth.authStateReady();
   }
 
-  // Public computed signals
-  readonly authUser = toSignal(user(this.auth));
-  readonly authState = toSignal(authState(this.auth));
+  // On SSR, Firebase Auth observables crash because the server app's
+  // _initializePromise is null. Return inert signals on the server.
+  readonly authUser = this.isBrowser
+    ? toSignal(user(this.auth))
+    : signal(undefined);
+  readonly authState = this.isBrowser
+    ? toSignal(authState(this.auth))
+    : signal(undefined);
   readonly loading = signal(false);
   readonly error = signal<null | Error>(null);
   readonly isAuthenticated = computed(() => this.authState() != null);
   /** `true` once the initial Firebase auth state has been determined (session restored or confirmed absent). */
   readonly authResolved = computed(() => this.authState() !== undefined);
-  readonly idToken = toSignal(idToken(this.auth));
+  readonly idToken = this.isBrowser
+    ? toSignal(idToken(this.auth))
+    : signal(undefined);
 
   async signInWithGoogle(): Promise<UserCredential> {
     const provider = new GoogleAuthProvider();


### PR DESCRIPTION
## Summary
This PR fixes server-side rendering (SSR) crashes by detecting the platform at runtime and returning inert signals on the server instead of attempting to subscribe to Firebase and RemoteConfig observables, which fail because the server app's `_initializePromise` is null.

## Key Changes
- **AuthAdapter**: Added platform detection to conditionally initialize Firebase Auth signals (`authUser`, `authState`, `idToken`) only in the browser environment. On the server, these return `signal(undefined)` instead.
- **AdsStore**: Added platform detection to conditionally initialize RemoteConfig signals only in the browser. On the server, RemoteConfig is set to `null` and all dependent signals return `signal(undefined)`. The `init()` method now returns a resolved promise on the server instead of attempting to fetch and activate.
- **AuthAdapter Tests**: Added a new test case to verify that the adapter gracefully handles the server platform without crashing, confirming that signals return `undefined` and computed values behave correctly.

## Implementation Details
- Both services now inject `PLATFORM_ID` and use `isPlatformBrowser()` to determine the execution environment
- Signals are conditionally created using ternary operators: if the service is available (browser), use `toSignal()` to subscribe to observables; otherwise, use `signal(undefined)` to provide an inert fallback
- This approach maintains API compatibility while preventing observable subscription errors on the server

https://claude.ai/code/session_01AiUJt7bDdGmB9AC76DJmwP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering (SSR) compatibility so auth and ads features no longer initialize browser-only behavior during server execution, preventing crashes and inconsistent values.

* **Tests**
  * Added SSR-focused tests to validate auth behavior and ensure server-side stability and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->