### PR TITLE
feat(blog): hero images, SEO metadata, reading time, and 2 research posts (Wim Hof + JAMA heart study)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"ad9261f5-15d4-41b2-a43e-3d4ade683c6a","pid":11314,"acquiredAt":1776956356582}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"ad9261f5-15d4-41b2-a43e-3d4ade683c6a","pid":11314,"acquiredAt":1776956356582}

--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,4 @@ package-lock.json
 
 .nx/polygraph
 .claude/worktrees
-.claude/settings.local.json
+.claude/settings.local.json.claude/scheduled_tasks.lock

--- a/docs/superpowers/specs/2026-04-23-blog-seo-images-research-design.md
+++ b/docs/superpowers/specs/2026-04-23-blog-seo-images-research-design.md
@@ -1,0 +1,68 @@
+# Blog SEO + Images + Research-Posts — Design
+
+Date: 2026-04-23
+Branch: `blog/seo-images-research-posts`
+
+## Goal
+
+Lift the blog from a pure text surface to a modern, SEO-optimized publication by
+adding hero images, per-post reading time, richer structured data, and two new
+research-backed article pairs (DE+EN) — including Wim Hof method content with
+inline citations to real primary sources.
+
+## Scope
+
+In scope:
+
+1. **Data model:** `BlogPost` gains `heroImage`, `heroImageAlt`,
+   `heroImageCredit`, optional `updatedAt`.
+2. **Reading time helper:** Pure function that strips HTML, counts words, returns
+   minutes (≈ 200 wpm). Tested.
+3. **SEO service:** `SeoService.update()` accepts optional image URL and
+   produces `og:image`, `og:image:alt`, `twitter:image`, `article:published_time`,
+   `article:modified_time`.
+4. **Article component:** Renders a 21:9 hero image, reading time, "Aktualisiert
+   am" (when present). Emits richer Article JSON-LD with `image`, `author`,
+   `publisher.logo`, `dateModified`, `mainEntityOfPage`, `wordCount`.
+5. **List component:** Shows small thumbnails per card so the overview doesn't
+   look bare.
+6. **Images:** All 10 existing posts plus 4 new posts get an Unsplash photo URL
+   via `images.unsplash.com/photo-…`. Photographer credit rendered in the
+   article footer.
+7. **New posts (4 total — 2 DE + 2 EN):**
+   - **Wim Hof & Push-Ups** — breath, cold exposure, recovery. Cites Kox et al.
+     2014 PNAS, Huberman Lab, Cleveland Clinic, official Wim Hof Method site.
+   - **40+ Push-Ups Heart Study** — JAMA Network Open 2019 (Yang et al.),
+     contextualized with AHA resistance-training guidance and Harvard's public
+     release.
+8. **Sitemap:** Parser is compatible with new fields (verified by regex test);
+   no changes required beyond verifying.
+
+Out of scope:
+
+- No CMS, no MDX, no image pipeline, no CDN, no AI-generated images, no
+  rewriting of existing article bodies (only metadata added).
+
+## Key technical decisions
+
+- **Unsplash hotlinking** is allowed per their license; we hand-pick stable
+  `images.unsplash.com/photo-{id}` URLs and include `?auto=format&fit=crop&w=1600&q=80`.
+- **Inline external links** use `rel="noopener nofollow ugc"` and `target="_blank"`.
+- **Reading time** computed at render time — lives with the component, not in the
+  data file. Keeps the data file readable.
+- **JSON-LD** follows schema.org Article; publisher logo points at
+  `/assets/pushup-logo.png` (existing asset).
+
+## Tests
+
+- `reading-time.spec.ts` — pure function edge cases (empty, HTML, multi-line).
+- `seo.service.spec.ts` — new `imageUrl` argument writes `og:image` /
+  `twitter:image` / `og:image:alt`; idempotency.
+- Existing sitemap tests unchanged (regex still matches).
+
+## PR flow
+
+1. Commit & push branch `blog/seo-images-research-posts`.
+2. Open PR.
+3. Up to 3 CodeRabbit review cycles: address actionable feedback, commit, push.
+4. `gh pr merge --auto --squash`.

--- a/docs/superpowers/specs/2026-04-23-blog-seo-images-research-design.md
+++ b/docs/superpowers/specs/2026-04-23-blog-seo-images-research-design.md
@@ -21,14 +21,15 @@ In scope:
 3. **SEO service:** `SeoService.update()` accepts optional image URL and
    produces `og:image`, `og:image:alt`, `twitter:image`, `article:published_time`,
    `article:modified_time`.
-4. **Article component:** Renders a 21:9 hero image, reading time, "Aktualisiert
+4. **Article component:** Renders a 16:9 hero image, reading time, "Aktualisiert
    am" (when present). Emits richer Article JSON-LD with `image`, `author`,
-   `publisher.logo`, `dateModified`, `mainEntityOfPage`, `wordCount`.
+   `publisher.logo`, `dateModified`, `mainEntityOfPage`, `wordCount` (exact).
 5. **List component:** Shows small thumbnails per card so the overview doesn't
    look bare.
-6. **Images:** All 10 existing posts plus 4 new posts get an Unsplash photo URL
-   via `images.unsplash.com/photo-…`. Photographer credit rendered in the
-   article footer.
+6. **Images:** All 12 existing posts (6 DE + 6 EN) plus 4 new posts get an
+   Unsplash photo URL via `images.unsplash.com/photo-…`. Credit rendered as a
+   small pill in the hero overlay. Graceful `onerror` fallback hides the
+   hero/thumbnail if the image fails to load.
 7. **New posts (4 total — 2 DE + 2 EN):**
    - **Wim Hof & Push-Ups** — breath, cold exposure, recovery. Cites Kox et al.
      2014 PNAS, Huberman Lab, Cleveland Clinic, official Wim Hof Method site.

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -85,6 +85,22 @@
     <xhtml:link rel="alternate" hreflang="en" href="https://pushup-stats.de/en/blog/pushups-over-40"/>
   </url>
   <url>
+    <loc>https://pushup-stats.de/de/blog/wim-hof-liegestuetze</loc>
+    <lastmod>2026-04-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="de" href="https://pushup-stats.de/de/blog/wim-hof-liegestuetze"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://pushup-stats.de/en/blog/wim-hof-pushups"/>
+  </url>
+  <url>
+    <loc>https://pushup-stats.de/de/blog/liegestuetze-herz-studie</loc>
+    <lastmod>2026-04-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="de" href="https://pushup-stats.de/de/blog/liegestuetze-herz-studie"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://pushup-stats.de/en/blog/pushups-heart-study"/>
+  </url>
+  <url>
     <loc>https://pushup-stats.de/en/blog/pushup-progression</loc>
     <lastmod>2025-01-15</lastmod>
     <changefreq>monthly</changefreq>
@@ -123,6 +139,22 @@
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="de" href="https://pushup-stats.de/de/blog/liegestuetze-ab-40"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://pushup-stats.de/en/blog/pushups-over-40"/>
+  </url>
+  <url>
+    <loc>https://pushup-stats.de/en/blog/wim-hof-pushups</loc>
+    <lastmod>2026-04-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="de" href="https://pushup-stats.de/de/blog/wim-hof-liegestuetze"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://pushup-stats.de/en/blog/wim-hof-pushups"/>
+  </url>
+  <url>
+    <loc>https://pushup-stats.de/en/blog/pushups-heart-study</loc>
+    <lastmod>2026-04-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="de" href="https://pushup-stats.de/de/blog/liegestuetze-herz-studie"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://pushup-stats.de/en/blog/pushups-heart-study"/>
   </url>
   <url>
     <loc>https://pushup-stats.de/en/blog/pushup-tracker-guide</loc>

--- a/web/src/app/blog/blog-article.component.ts
+++ b/web/src/app/blog/blog-article.component.ts
@@ -33,7 +33,7 @@ const LOGO_URL = `${BASE_URL}/assets/pushup-logo.png`;
             <mat-icon>arrow_back</mat-icon>
             Blog
           </a>
-          @if (post.heroImage) {
+          @if (post.heroImage && !heroImageFailed) {
             <figure class="article-hero">
               <img
                 [src]="post.heroImage"
@@ -42,6 +42,7 @@ const LOGO_URL = `${BASE_URL}/assets/pushup-logo.png`;
                 decoding="async"
                 width="1200"
                 height="675"
+                (error)="heroImageFailed = true"
               />
               @if (post.heroImageCredit) {
                 <figcaption [innerHTML]="post.heroImageCredit"></figcaption>
@@ -249,6 +250,7 @@ export class BlogArticleComponent implements OnInit {
 
   post: BlogPost | null = null;
   readingMinutes = 0;
+  heroImageFailed = false;
 
   constructor() {
     this.destroyRef.onDestroy(() => this.removeJsonLd());

--- a/web/src/app/blog/blog-article.component.ts
+++ b/web/src/app/blog/blog-article.component.ts
@@ -12,7 +12,7 @@ import { Meta } from '@angular/platform-browser';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SeoService } from '../core/seo.service';
 import { BlogPost, findBlogPost } from './blog-posts.data';
-import { readingMinutes } from './reading-time';
+import { countWords, readingMinutes } from './reading-time';
 
 const BASE_URL = 'https://pushup-stats.de';
 const LOGO_URL = `${BASE_URL}/assets/pushup-logo.png`;
@@ -54,10 +54,10 @@ const LOGO_URL = `${BASE_URL}/assets/pushup-logo.png`;
             <time [attr.datetime]="post.publishedAt">{{
               post.publishedAt | date: 'longDate'
             }}</time>
-            @if (readingMinutes) {
+            @if (readingTimeMinutes) {
               <span aria-hidden="true">·</span>
               <span i18n="@@blog.article.readingTime"
-                >{{ readingMinutes }} Min. Lesezeit</span
+                >{{ readingTimeMinutes }} Min. Lesezeit</span
               >
             }
             @if (post.updatedAt) {
@@ -249,7 +249,7 @@ export class BlogArticleComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
 
   post: BlogPost | null = null;
-  readingMinutes = 0;
+  readingTimeMinutes = 0;
   heroImageFailed = false;
 
   constructor() {
@@ -266,32 +266,23 @@ export class BlogArticleComponent implements OnInit {
     }
 
     this.post = found;
-    this.readingMinutes = readingMinutes(found.content);
+    const wordCount = countWords(found.content);
+    this.readingTimeMinutes = readingMinutes(found.content);
     this.seo.update(found.title, found.description, `/blog/${found.slug}`, {
       imageUrl: found.heroImage,
       imageAlt: found.heroImageAlt,
+      publishedTime: found.publishedAt,
+      modifiedTime: found.updatedAt,
     });
     this.meta.updateTag({ property: 'og:type', content: 'article' });
     this.meta.updateTag({
       name: 'keywords',
       content: found.keywords.join(', '),
     });
-    this.meta.updateTag({
-      property: 'article:published_time',
-      content: found.publishedAt,
-    });
-    if (found.updatedAt) {
-      this.meta.updateTag({
-        property: 'article:modified_time',
-        content: found.updatedAt,
-      });
-    } else {
-      this.meta.removeTag('property="article:modified_time"');
-    }
-    this.injectJsonLd(found);
+    this.injectJsonLd(found, wordCount);
   }
 
-  private injectJsonLd(post: BlogPost): void {
+  private injectJsonLd(post: BlogPost, wordCount: number): void {
     const head = this.document.head;
     if (!head) return;
 
@@ -305,7 +296,7 @@ export class BlogArticleComponent implements OnInit {
       description: post.description,
       datePublished: post.publishedAt,
       dateModified: post.updatedAt ?? post.publishedAt,
-      wordCount: readingMinutes(post.content) * 200,
+      wordCount,
       inLanguage: post.lang,
       author: {
         '@type': 'Organization',

--- a/web/src/app/blog/blog-article.component.ts
+++ b/web/src/app/blog/blog-article.component.ts
@@ -12,8 +12,10 @@ import { Meta } from '@angular/platform-browser';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SeoService } from '../core/seo.service';
 import { BlogPost, findBlogPost } from './blog-posts.data';
+import { readingMinutes } from './reading-time';
 
 const BASE_URL = 'https://pushup-stats.de';
+const LOGO_URL = `${BASE_URL}/assets/pushup-logo.png`;
 
 @Component({
   selector: 'app-blog-article',
@@ -31,11 +33,41 @@ const BASE_URL = 'https://pushup-stats.de';
             <mat-icon>arrow_back</mat-icon>
             Blog
           </a>
+          @if (post.heroImage) {
+            <figure class="article-hero">
+              <img
+                [src]="post.heroImage"
+                [alt]="post.heroImageAlt ?? post.title"
+                loading="eager"
+                decoding="async"
+                width="1200"
+                height="675"
+              />
+              @if (post.heroImageCredit) {
+                <figcaption [innerHTML]="post.heroImageCredit"></figcaption>
+              }
+            </figure>
+          }
           <h1>{{ post.title }}</h1>
           <p class="article-meta">
             <time [attr.datetime]="post.publishedAt">{{
               post.publishedAt | date: 'longDate'
             }}</time>
+            @if (readingMinutes) {
+              <span aria-hidden="true">·</span>
+              <span i18n="@@blog.article.readingTime"
+                >{{ readingMinutes }} Min. Lesezeit</span
+              >
+            }
+            @if (post.updatedAt) {
+              <span aria-hidden="true">·</span>
+              <span class="updated">
+                <span i18n="@@blog.article.updated">Aktualisiert am</span>
+                <time [attr.datetime]="post.updatedAt">{{
+                  post.updatedAt | date: 'longDate'
+                }}</time>
+              </span>
+            }
           </p>
         </header>
 
@@ -76,6 +108,41 @@ const BASE_URL = 'https://pushup-stats.de';
         margin-bottom: 32px;
       }
 
+      .article-hero {
+        margin: 8px 0 24px;
+        border-radius: 16px;
+        overflow: hidden;
+        background: var(--surface-subtle, #eee);
+        aspect-ratio: 16 / 9;
+        position: relative;
+      }
+
+      .article-hero img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      .article-hero figcaption {
+        position: absolute;
+        left: 12px;
+        bottom: 10px;
+        padding: 4px 10px;
+        border-radius: 999px;
+        font-size: 0.72rem;
+        line-height: 1.3;
+        color: #fff;
+        background: rgba(0, 0, 0, 0.45);
+        backdrop-filter: blur(4px);
+        -webkit-backdrop-filter: blur(4px);
+      }
+
+      .article-hero figcaption ::ng-deep a {
+        color: #fff;
+        text-decoration: underline;
+      }
+
       .back-link {
         display: inline-flex;
         align-items: center;
@@ -91,9 +158,24 @@ const BASE_URL = 'https://pushup-stats.de';
         line-height: 1.2;
       }
 
-      .article-meta time {
+      .article-meta {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 6px;
         font-size: 0.85rem;
         color: var(--text-subtle);
+      }
+
+      .article-meta time {
+        font-size: inherit;
+        color: inherit;
+      }
+
+      .article-meta .updated {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
       }
 
       .article-body {
@@ -123,6 +205,16 @@ const BASE_URL = 'https://pushup-stats.de';
 
           strong {
             color: var(--text-heading-secondary);
+          }
+
+          a {
+            color: var(--mat-sys-primary, #7c4dff);
+            text-decoration: underline;
+            text-underline-offset: 2px;
+          }
+
+          a:hover {
+            text-decoration-thickness: 2px;
           }
         }
       }
@@ -156,6 +248,7 @@ export class BlogArticleComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
 
   post: BlogPost | null = null;
+  readingMinutes = 0;
 
   constructor() {
     this.destroyRef.onDestroy(() => this.removeJsonLd());
@@ -171,12 +264,28 @@ export class BlogArticleComponent implements OnInit {
     }
 
     this.post = found;
-    this.seo.update(found.title, found.description, `/blog/${found.slug}`);
+    this.readingMinutes = readingMinutes(found.content);
+    this.seo.update(found.title, found.description, `/blog/${found.slug}`, {
+      imageUrl: found.heroImage,
+      imageAlt: found.heroImageAlt,
+    });
     this.meta.updateTag({ property: 'og:type', content: 'article' });
     this.meta.updateTag({
       name: 'keywords',
       content: found.keywords.join(', '),
     });
+    this.meta.updateTag({
+      property: 'article:published_time',
+      content: found.publishedAt,
+    });
+    if (found.updatedAt) {
+      this.meta.updateTag({
+        property: 'article:modified_time',
+        content: found.updatedAt,
+      });
+    } else {
+      this.meta.removeTag('property="article:modified_time"');
+    }
     this.injectJsonLd(found);
   }
 
@@ -186,15 +295,16 @@ export class BlogArticleComponent implements OnInit {
 
     this.removeJsonLd();
 
-    const script = this.document.createElement('script');
-    script.type = 'application/ld+json';
-    script.setAttribute('data-blog-ld', '1');
-    script.textContent = JSON.stringify({
+    const canonical = `${BASE_URL}/${this.locale.startsWith('en') ? 'en' : 'de'}/blog/${post.slug}`;
+    const jsonLd: Record<string, unknown> = {
       '@context': 'https://schema.org',
       '@type': 'Article',
       headline: post.title,
       description: post.description,
       datePublished: post.publishedAt,
+      dateModified: post.updatedAt ?? post.publishedAt,
+      wordCount: readingMinutes(post.content) * 200,
+      inLanguage: post.lang,
       author: {
         '@type': 'Organization',
         name: 'Pushup Tracker',
@@ -204,10 +314,23 @@ export class BlogArticleComponent implements OnInit {
         '@type': 'Organization',
         name: 'Pushup Tracker',
         url: BASE_URL,
+        logo: {
+          '@type': 'ImageObject',
+          url: LOGO_URL,
+        },
       },
-      url: `${BASE_URL}/blog/${post.slug}`,
+      url: canonical,
+      mainEntityOfPage: canonical,
       keywords: post.keywords.join(', '),
-    });
+    };
+    if (post.heroImage) {
+      jsonLd['image'] = [post.heroImage];
+    }
+
+    const script = this.document.createElement('script');
+    script.type = 'application/ld+json';
+    script.setAttribute('data-blog-ld', '1');
+    script.textContent = JSON.stringify(jsonLd);
     head.appendChild(script);
   }
 

--- a/web/src/app/blog/blog-list.component.ts
+++ b/web/src/app/blog/blog-list.component.ts
@@ -18,6 +18,20 @@ import { getBlogPostsByLocale } from './blog-posts.data';
       <div class="articles">
         @for (post of posts; track post.slug) {
           <mat-card class="article-card">
+            @if (post.heroImage) {
+              <a
+                [routerLink]="['/blog', post.slug]"
+                class="card-media"
+                [attr.aria-label]="post.title"
+              >
+                <img
+                  [src]="post.heroImage"
+                  [alt]="post.heroImageAlt ?? post.title"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </a>
+            }
             <mat-card-header>
               <mat-card-title>{{ post.title }}</mat-card-title>
               <mat-card-subtitle>
@@ -73,6 +87,26 @@ import { getBlogPostsByLocale } from './blog-posts.data';
       .article-card {
         border: 1px solid var(--border-subtle);
         border-radius: 16px;
+        overflow: hidden;
+      }
+
+      .card-media {
+        display: block;
+        aspect-ratio: 16 / 9;
+        overflow: hidden;
+        background: var(--surface-subtle, #eee);
+      }
+
+      .card-media img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+        transition: transform 200ms ease;
+      }
+
+      .card-media:hover img {
+        transform: scale(1.02);
       }
 
       mat-card-content p {

--- a/web/src/app/blog/blog-list.component.ts
+++ b/web/src/app/blog/blog-list.component.ts
@@ -18,7 +18,7 @@ import { getBlogPostsByLocale } from './blog-posts.data';
       <div class="articles">
         @for (post of posts; track post.slug) {
           <mat-card class="article-card">
-            @if (post.heroImage) {
+            @if (post.heroImage && !failedImages.has(post.slug)) {
               <a
                 [routerLink]="['/blog', post.slug]"
                 class="card-media"
@@ -29,6 +29,7 @@ import { getBlogPostsByLocale } from './blog-posts.data';
                   [alt]="post.heroImageAlt ?? post.title"
                   loading="lazy"
                   decoding="async"
+                  (error)="onImageError(post.slug)"
                 />
               </a>
             }
@@ -129,4 +130,9 @@ import { getBlogPostsByLocale } from './blog-posts.data';
 export class BlogListComponent {
   private readonly locale = inject(LOCALE_ID) as string;
   readonly posts = getBlogPostsByLocale(this.locale);
+  readonly failedImages = new Set<string>();
+
+  onImageError(slug: string): void {
+    this.failedImages.add(slug);
+  }
 }

--- a/web/src/app/blog/blog-posts.data.ts
+++ b/web/src/app/blog/blog-posts.data.ts
@@ -669,7 +669,7 @@ export const BLOG_POSTS: BlogPost[] = [
   Trainierende berichten typischerweise: bessere Toleranz gegenüber dem "Brennen" in höheren
   Wiederholungsbereichen, schnellere mentale Erholung nach harten Einheiten und deutlich weniger
   Muskelkater 24 Stunden später. Die reinen Kraftzahlen steigen nicht plötzlich – die Kontinuität steigt.
-  Wenn du ohnehin <a href="/blog/liegestuetze-tracker">einen Liegestütz-Tracker nutzt</a>, trage die
+  Wenn du ohnehin <a href="/de/blog/liegestuetze-tracker">einen Liegestütz-Tracker nutzt</a>, trage die
   Atem- und Kältesitzungen neben den Wiederholungen ein. Ein Monat Daten sagt dir mehr als jede Anekdote.
 </p>
 
@@ -780,9 +780,9 @@ export const BLOG_POSTS: BlogPost[] = [
   </li>
   <li>
     <strong>Rückwärts in strukturiertes Training übersetzen.</strong> Bei einem Startwert unter 10 bringt
-    dich der <a href="/blog/liegestuetze-steigern">Progressionsguide</a> in sechs Wochen auf ein solides
+    dich der <a href="/de/blog/liegestuetze-steigern">Progressionsguide</a> in sechs Wochen auf ein solides
     Niveau. Von 20 auf 40+ ist die
-    <a href="/blog/30-tage-liegestuetze-challenge">30-Tage-Challenge</a> dafür gemacht, dieses Plateau
+    <a href="/de/blog/30-tage-liegestuetze-challenge">30-Tage-Challenge</a> dafür gemacht, dieses Plateau
     zu durchbrechen.
   </li>
 </ol>
@@ -1359,7 +1359,7 @@ export const BLOG_POSTS: BlogPost[] = [
   Practitioners typically report: better tolerance of the "burn" in higher-rep sets, faster mood recovery
   after a hard session, and noticeably less soreness 24 h later. Strength numbers don't jump; consistency
   does. If you already use
-  <a href="/blog/pushup-tracker-guide">a push-up tracker</a>,
+  <a href="/en/blog/pushup-tracker-guide">a push-up tracker</a>,
   log the breathing + cold rounds alongside your reps — a month of data will tell you more than any
   anecdote.
 </p>
@@ -1471,8 +1471,8 @@ export const BLOG_POSTS: BlogPost[] = [
   </li>
   <li>
     <strong>Work backwards into structured training.</strong> If your baseline is under 10, the
-    <a href="/blog/pushup-progression">progression guide</a> gets you from there to a respectable capacity
-    over 6 weeks. From 20 to 40+, the <a href="/blog/30-day-pushup-challenge">30-day challenge</a> is
+    <a href="/en/blog/pushup-progression">progression guide</a> gets you from there to a respectable capacity
+    over 6 weeks. From 20 to 40+, the <a href="/en/blog/30-day-pushup-challenge">30-day challenge</a> is
     designed to push past that plateau.
   </li>
 </ol>

--- a/web/src/app/blog/blog-posts.data.ts
+++ b/web/src/app/blog/blog-posts.data.ts
@@ -4,10 +4,18 @@ export interface BlogPost {
   title: string;
   description: string;
   publishedAt: string;
+  /** Optional ISO date; when present the article shows "Updated on …" and sets article:modified_time. */
+  updatedAt?: string;
   content: string;
   keywords: string[];
   /** Slug of the same article in the other locale — enables hreflang pairing in the sitemap. */
   translationSlug?: string;
+  /** Absolute URL of the hero image rendered above the article body and used for og:image. */
+  heroImage?: string;
+  /** Accessible alt text for the hero image. */
+  heroImageAlt?: string;
+  /** Small credit line rendered under the hero — typically "Photo: Photographer on Unsplash". HTML allowed. */
+  heroImageCredit?: string;
 }
 
 export function getBlogPostsByLocale(locale: string): BlogPost[] {
@@ -39,6 +47,11 @@ export const BLOG_POSTS: BlogPost[] = [
       'Liegestütze Fortschritt',
       'Liegestütze lernen',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt: 'Athlet in Plank-Position bei einer sauberen Liegestütze.',
+    heroImageCredit:
+      'Foto: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>Warum systematisches Training den Unterschied macht</h2>
 <p>
@@ -116,6 +129,11 @@ export const BLOG_POSTS: BlogPost[] = [
       'Liegestütze Gewohnheit',
       'Liegestütze Gesundheit',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1581009146145-b5ef050c2e1e?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt: 'Sportler beim Bodyweight-Training im Fitnessstudio.',
+    heroImageCredit:
+      'Foto: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>Mehr als nur ein Fitness-Trend</h2>
 <p>
@@ -195,6 +213,12 @@ export const BLOG_POSTS: BlogPost[] = [
       'Pushup Tracker',
       'Liegestütze Fortschritt verfolgen',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1551887196-72e32bfc7bf3?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt:
+      'Smartphone mit Fitness-Tracker-App und Statistik-Diagrammen.',
+    heroImageCredit:
+      'Foto: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>Das Problem mit dem Bauchgefühl</h2>
 <p>
@@ -265,6 +289,12 @@ export const BLOG_POSTS: BlogPost[] = [
       'Liegestütze Muskeln',
       'Liegestütze fortgeschritten',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1534438327276-14e5300c3a48?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt:
+      'Athletischer Sportler bei fortgeschrittener Push-Up-Variante.',
+    heroImageCredit:
+      'Foto: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>Warum Variationen entscheidend sind</h2>
 <p>
@@ -358,6 +388,12 @@ export const BLOG_POSTS: BlogPost[] = [
       'Push-Up Challenge',
       'Liegestütze täglich steigern',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1599058917212-d750089bc07e?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt:
+      'Sportler bei intensivem Workout mit Kalender im Hintergrund.',
+    heroImageCredit:
+      'Foto: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>Was die 30-Tage-Challenge bewirkt</h2>
 <p>
@@ -436,6 +472,12 @@ export const BLOG_POSTS: BlogPost[] = [
       'Fitness über 40',
       'Liegestütze Gelenke schonen',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1526506118085-60ce8714f8c5?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt:
+      'Erfahrener Sportler mittleren Alters bei konzentriertem Krafttraining.',
+    heroImageCredit:
+      'Foto: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>Was sich ab 40 verändert</h2>
 <p>
@@ -509,6 +551,261 @@ export const BLOG_POSTS: BlogPost[] = [
     `.trim(),
   },
 
+  {
+    slug: 'wim-hof-liegestuetze',
+    lang: 'de',
+    translationSlug: 'wim-hof-pushups',
+    title: 'Wim Hof Methode für Liegestützen: Atmung, Kälte & mehr Leistung',
+    description:
+      'Wie sinnvoll ist die Wim Hof Methode für deine Liegestütze? Ein forschungsbasierter Blick auf Atemprotokoll, Kälteanwendung und was die Studienlage wirklich hergibt.',
+    publishedAt: '2026-04-23',
+    keywords: [
+      'Wim Hof Methode',
+      'Liegestütze Leistung',
+      'Atmung Leistungssteigerung',
+      'Kälteanwendung Regeneration',
+      'Wim Hof Atmung Liegestütze',
+    ],
+    heroImage:
+      'https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt:
+      'Sportler in verschneiter Landschaft – Sinnbild für die Wim Hof Methode.',
+    heroImageCredit:
+      'Foto: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
+    content: `
+<h2>Warum Wim Hof plötzlich in Fitness-Studios auftaucht</h2>
+<p>
+  Der niederländische Extremsportler Wim Hof wurde mit scheinbar unmöglichen Leistungen bekannt: Everest
+  in Shorts, Halbmarathon barfuß am Polarkreis, Atemanhalten über sechs Minuten. Was wie ein Zirkus-Trick
+  klang, ist tatsächlich ein strukturiertes Protokoll aus hyperventilationsähnlicher Atmung, Kälteexposition
+  und Konzentration – und in den letzten zehn Jahren gibt es genug peer-reviewte Studien, dass die Frage
+  für Trainierende legitim ist: Werden meine Liegestütze dadurch besser?
+</p>
+<p>
+  Die kurze Antwort: Die Wim Hof Methode (WHM) erhöht deine maximalen Wiederholungen nicht direkt. Aber sie
+  verändert zwei Dinge, die für das Liegestütz-Training zählen – den Zustand des Nervensystems, in dem du
+  trainierst, und das Tempo deiner Regeneration zwischen den Einheiten.
+</p>
+
+<h2>Was die Studienlage hergibt</h2>
+<p>
+  Die Leitstudie stammt von
+  <a href="https://pubmed.ncbi.nlm.nih.gov/24799686/" target="_blank" rel="noopener noreferrer nofollow ugc">Kox et al., 2014 (PNAS)</a>.
+  Ein Team der Radboud-Universität trainierte Probanden zehn Tage nach WHM und injizierte ihnen danach
+  bakterielles Endotoxin. Die trainierten Teilnehmer zeigten deutlich niedrigere entzündliche Marker und
+  weniger grippeähnliche Symptome als die Kontrollgruppe – der erste Nachweis am Menschen, dass freiwillige
+  Atmung und Kälte die angeborene Immunantwort modulieren können.
+</p>
+<p>
+  Ein
+  <a href="https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0161749" target="_blank" rel="noopener noreferrer nofollow ugc">randomisierter PLOS ONE Trial (Buijze et al., 2016)</a>
+  zeigte, dass 30 Tage heiß-kalte Duschen die selbstberichteten Krankheitstage um 29 % reduzierten. Eine
+  <a href="https://pubmed.ncbi.nlm.nih.gov/27500826/" target="_blank" rel="noopener noreferrer nofollow ugc">Übersichtsarbeit zur Kälteexposition 2016</a>
+  dokumentiert die hormonellen und kardiovaskulären Reaktionen im Detail.
+</p>
+<p>
+  Was die Evidenz <em>nicht</em> zeigt: einen direkten, groß angelegten Effekt auf Maximalkraft oder
+  Hypertrophie. Betrachte WHM also als <strong>Regenerations- und Nervensystem-Tool</strong>, nicht als
+  Kraft-Booster.
+</p>
+
+<h2>Das Atemprotokoll kurz und sauber</h2>
+<p>
+  Die offizielle Anleitung steht auf
+  <a href="https://www.wimhofmethod.com/practice-the-method" target="_blank" rel="noopener noreferrer nofollow ugc">wimhofmethod.com</a>.
+  Eine Runde sieht so aus:
+</p>
+<ol>
+  <li><strong>30–40 tiefe Atemzüge</strong> durch Nase oder Mund ein, entspannt ausatmen. Die Ausatmung
+    wird nicht erzwungen. Effektiv eine kontrollierte Hyperventilation.</li>
+  <li><strong>Retention nach Ausatmung</strong> – nach der letzten Ausatmung halten, bis der Atemdrang
+    zurückkommt. Mit Übung oft 60–120 Sekunden.</li>
+  <li><strong>Recovery-Atem</strong> – ein voller Einatemzug, 15 Sekunden halten, loslassen.</li>
+  <li>3–4 Runden.</li>
+</ol>
+<p>
+  Andrew Huberman erklärt den Mechanismus ausführlich im
+  <a href="https://www.hubermanlab.com/episode/how-to-breathe-correctly-for-optimal-health-mood-learning-and-performance" target="_blank" rel="noopener noreferrer nofollow ugc">Huberman Lab Podcast zur Atmung</a>:
+  Das Protokoll senkt den Blut-CO₂-Spiegel, hebt kurzfristig Adrenalin und löst anschließend einen
+  parasympathischen Rebound aus. Genau dieser Rebound ist die für Regeneration relevante Phase.
+</p>
+
+<h2>Ein ernstes Sicherheits-Wort vorab</h2>
+<p>
+  Hyperventilation in Kombination mit Atemanhalten kann zu einer Ohnmacht führen (Flachwasser-Blackout).
+  Die <strong>absolute Regel der Wim Hof Organisation selbst</strong>: niemals während des Autofahrens,
+  im Pool, in der Badewanne oder an Orten praktizieren, an denen eine Ohnmacht gefährlich wäre. Schwangere,
+  Personen mit Herz-Kreislauf-Erkrankungen, Epilepsie oder Panikstörungen sollten das Protokoll auslassen
+  oder erst mit einem Arzt sprechen.
+</p>
+
+<h2>Wie du es mit Liegestütz-Training kombinierst</h2>
+<p>
+  Drei konkrete Varianten, von niedrigstem zu höchstem Risiko:
+</p>
+<ol>
+  <li>
+    <strong>Atmung als Primer vor dem Satz (sicherste Variante).</strong>
+    Am Boden 2 Runden WHM-Atmung, dann aufhören – keine Liegestütze während des Atemhaltens. Den ersten
+    Satz Liegestütze starten, sobald die Atmung normalisiert ist (~60 s). Viele berichten von einem
+    fokussierteren, ruhigeren Startsatz. Kein zusätzliches Risiko über die Atmung hinaus.
+  </li>
+  <li>
+    <strong>Kalte Dusche als Finisher.</strong>
+    Nach dem Training 60–120 s kalte Dusche auf Brust, Schultern und Oberarme. Der PLOS-ONE-Trial von 2016
+    legt nahe, dass das für die Immun- und Stimmungseffekte ausreicht. Keine Alternative zu Schlaf und
+    Protein – sondern zusätzlich.
+  </li>
+  <li>
+    <strong>"Breath-Hold Push-Ups" (fortgeschritten, optional).</strong>
+    Auf der letzten Ausatmung einer WHM-Runde Liegestütze in der Retentionsphase ausführen. Die klassische
+    "Wim Hof Liegestütze". Das sind <em>keine</em> zusätzlichen Reps – der Atemstopp maskiert lediglich den
+    Luftmangel. Nur auf einer Matte, nie an harten Kanten oder in Wassernähe, nie allein.
+  </li>
+</ol>
+
+<h2>Was du nach 30 Tagen erwarten kannst</h2>
+<p>
+  Trainierende berichten typischerweise: bessere Toleranz gegenüber dem "Brennen" in höheren
+  Wiederholungsbereichen, schnellere mentale Erholung nach harten Einheiten und deutlich weniger
+  Muskelkater 24 Stunden später. Die reinen Kraftzahlen steigen nicht plötzlich – die Kontinuität steigt.
+  Wenn du ohnehin <a href="/blog/liegestuetze-tracker">einen Liegestütz-Tracker nutzt</a>, trage die
+  Atem- und Kältesitzungen neben den Wiederholungen ein. Ein Monat Daten sagt dir mehr als jede Anekdote.
+</p>
+
+<h2>Fazit</h2>
+<p>
+  Die Wim Hof Methode hat messbare Effekte auf Entzündungswerte und vegetative Balance. Sie ersetzt keine
+  progressive Belastungssteigerung, keinen Schlaf und kein Protein – aber als Regenerationsschicht um das
+  Liegestütz-Training herum ist die Evidenz gut genug für einen Versuch, solange du die Atemhalt-Regeln
+  respektierst.
+</p>
+    `.trim(),
+  },
+  {
+    slug: 'liegestuetze-herz-studie',
+    lang: 'de',
+    translationSlug: 'pushups-heart-study',
+    title:
+      'Die Harvard-Studie, die Liegestützen berühmt machte: 40+ Reps & Herzgesundheit',
+    description:
+      'Eine Harvard-Studie in JAMA 2019 rückte die Liegestütz-Kapazität auf die Herzrisiko-Landkarte. Was die Daten wirklich zeigen, was nicht – und wie du das für dein Training nutzt.',
+    publishedAt: '2026-04-23',
+    keywords: [
+      'Liegestütze Herzgesundheit',
+      'Liegestütze Herzrisiko Studie',
+      'Harvard Liegestütze Studie',
+      'JAMA Liegestütze',
+      'Fitness Herzerkrankung',
+    ],
+    heroImage:
+      'https://images.unsplash.com/photo-1540497077202-7c8a3999166f?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt:
+      'Läufer bei Sonnenaufgang – Sinnbild für kardiovaskuläre Gesundheit.',
+    heroImageCredit:
+      'Foto: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
+    content: `
+<h2>Warum eine einzige Liegestütz-Studie viral ging</h2>
+<p>
+  Im Februar 2019 veröffentlichte ein Team der Harvard T.H. Chan School of Public Health zehn Jahre Daten
+  über 1.104 aktive Männer – Feuerwehrleute aus Indiana – und stellte eine sehr einfache Frage: Lässt sich
+  aus der Liegestütz-Kapazität das spätere Herzinfarkt-Risiko vorhersagen?
+</p>
+<p>
+  Das Ergebnis, publiziert in
+  <a href="https://pubmed.ncbi.nlm.nih.gov/30821806/" target="_blank" rel="noopener noreferrer nofollow ugc">JAMA Network Open (Yang et al., 2019)</a>,
+  schaffte es aus gutem Grund auf die Titelseiten. Männer, die mehr als <strong>40 Liegestütze</strong>
+  am Stück schafften, hatten ein <strong>um 96 % geringeres</strong> kardiovaskuläres Ereignisrisiko in
+  den folgenden zehn Jahren – im Vergleich zu Männern, die weniger als 10 Reps schafften. Die offizielle
+  <a href="https://www.hsph.harvard.edu/news/press-releases/push-ups-correlated-with-reduced-cardiovascular-disease-risk-study/" target="_blank" rel="noopener noreferrer nofollow ugc">Harvard-Pressemitteilung</a>
+  fasst es in einem Satz zusammen: "Liegestützen korrelieren mit reduziertem Risiko für Herz-Kreislauf-Erkrankungen."
+</p>
+
+<h2>Was die Studie tatsächlich gemessen hat</h2>
+<p>
+  Es lohnt sich, hinter die Schlagzeile zu schauen:
+</p>
+<ul>
+  <li><strong>Stichprobe:</strong> 1.104 erwachsene Männer, Medianalter 39,6 Jahre, alle beruflich aktiv
+    (Feuerwehrleute). Reiner Männer- und Berufsfeuer-Datensatz.</li>
+  <li><strong>Test:</strong> Metronom-getaktete Liegestütz-Kapazität am Baseline (2000), mit Follow-up
+    kardiovaskulärer Ereignisse bis 2010.</li>
+  <li><strong>Ergebnisse:</strong> 37 CVD-Ereignisse über zehn Jahre – Herzinfarkte, koronare
+    Todesfälle, Koronareingriffe.</li>
+  <li><strong>Vergleich:</strong> Auch die treadmill-gemessene aerobe Kapazität war mit weniger CVD
+    assoziiert – aber das Liegestütz-Signal war in dieser Kohorte stärker als das Ausdauer-Signal.</li>
+</ul>
+<p>
+  Die Autoren waren in der Diskussion vorsichtig: Die Liegestütz-Kapazität ist ein Proxy für allgemeine
+  funktionelle Fitness, keine eigenständige Ursache besserer Herzgesundheit. Sie ist aber ein
+  <em>einfacher, kostenloser, geräteloser Feldtest</em>, der eng mit dem korreliert, was zählt: Muskelmasse,
+  aerobe Reserve und Bewegungsqualität.
+</p>
+
+<h2>Grenzen, die die Medien übersprungen haben</h2>
+<p>
+  Was die Studie <strong>nicht</strong> beweist:
+</p>
+<ul>
+  <li>Sie zeigt nicht, dass <em>das Machen</em> von mehr Liegestützen das Herzrisiko <em>kausal</em> senkt.
+    Für Kausalität bräuchte es eine randomisierte Interventionsstudie, das war diese nicht.</li>
+  <li>Sie gilt nicht direkt für Frauen, nicht für sitzende Populationen, nicht für ältere Erwachsene –
+    diese Gruppen waren schlicht nicht Teil der Stichprobe.</li>
+  <li>Sie bedeutet nicht, dass Liegestütze Ausdauertraining ersetzen. Die
+    <a href="https://www.who.int/news-room/fact-sheets/detail/physical-activity" target="_blank" rel="noopener noreferrer nofollow ugc">
+      WHO-Empfehlungen zu körperlicher Aktivität</a>
+    fordern weiterhin 150–300 Minuten moderates Ausdauertraining pro Woche <strong>plus</strong>
+    Kräftigung an zwei Tagen.</li>
+</ul>
+
+<h2>Wie AHA und ACSM den Befund einordnen</h2>
+<p>
+  Die
+  <a href="https://www.heart.org/en/healthy-living/fitness/fitness-basics/aha-recs-for-physical-activity-in-adults" target="_blank" rel="noopener noreferrer nofollow ugc">American Heart Association</a>
+  stellt Kräftigungstraining schon länger ins Zentrum der kardiovaskulären Prävention – neben Ausdauer.
+  Eigengewichtsübungen wie Liegestützen zählen dazu und sind der reibungsärmste Weg, die geforderten
+  zwei Krafteinheiten pro Woche abzuhaken.
+</p>
+
+<h2>Wie du das nutzt, ohne es zu überinterpretieren</h2>
+<p>
+  Die nützliche Botschaft lautet nicht "40 Liegestützen = gesundes Herz". Sie lautet: Ein einfacher
+  Feldtest korreliert mit dem Merkmalscocktail, den du ohnehin willst. Zwei praktische Anwendungen:
+</p>
+<ol>
+  <li>
+    <strong>Nutze ihn als Benchmark, nicht als Ziel.</strong> Einmal pro Monat einen Maximalsatz bis zur
+    Erschöpfung. Die Zahl loggen. Du trackst einen Proxy für den Gesamttrend deiner Fitness, keinen
+    Performance-Endwert.
+  </li>
+  <li>
+    <strong>Rückwärts in strukturiertes Training übersetzen.</strong> Bei einem Startwert unter 10 bringt
+    dich der <a href="/blog/liegestuetze-steigern">Progressionsguide</a> in sechs Wochen auf ein solides
+    Niveau. Von 20 auf 40+ ist die
+    <a href="/blog/30-tage-liegestuetze-challenge">30-Tage-Challenge</a> dafür gemacht, dieses Plateau
+    zu durchbrechen.
+  </li>
+</ol>
+
+<h2>Ein Wort zur Technik</h2>
+<p>
+  Eine "Liegestütze" in der Yang-et-al.-Studie bedeutete einen metronom-getakteten Rep mit vollem
+  Bewegungsumfang. Ego-Reps zählen in der Forschung nicht, und sie sollten auch für dich nicht zählen.
+  Brust auf Bodenhöhe oder wenige Zentimeter darüber. Körper gerade. Ellenbogen hinter die Schulter, nicht
+  breit nach außen. Wenn 40 saubere Wiederholungen noch weit weg sind, ist das der ehrliche Startpunkt –
+  und die Daten legen nahe, dass der Weg selbst die Intervention ist.
+</p>
+
+<h2>Das größere Bild</h2>
+<p>
+  Liegestützen sind keine Wundermittel. Sie sind ein ungewöhnlich effizienter Test: eine Minute Aufwand,
+  kein Equipment, skalierbar von Knie-Variante bis einarmig. Die Harvard-Daten von 2019 haben lediglich
+  Zahlen auf das gelegt, was Kraftcoaches seit Jahrzehnten sagen – wer den eigenen Körper wiederholt vom
+  Boden drücken kann, ist in vielen anderen Dimensionen meist ebenfalls gesund.
+</p>
+    `.trim(),
+  },
+
   // ── English blog posts ────────────────────────────────────────────────────
   {
     slug: 'pushup-progression',
@@ -525,6 +822,11 @@ export const BLOG_POSTS: BlogPost[] = [
       'push-up progress',
       'learn push-ups',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt: 'Athlete holding a clean plank during a push-up.',
+    heroImageCredit:
+      'Photo: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>Why Systematic Training Makes the Difference</h2>
 <p>
@@ -600,6 +902,11 @@ export const BLOG_POSTS: BlogPost[] = [
       'push-up habit',
       'push-up health',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1581009146145-b5ef050c2e1e?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt: 'Athlete doing bodyweight training in a gym.',
+    heroImageCredit:
+      'Photo: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>More Than Just a Fitness Trend</h2>
 <p>
@@ -678,6 +985,11 @@ export const BLOG_POSTS: BlogPost[] = [
       'push-up muscles',
       'advanced push-ups',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1534438327276-14e5300c3a48?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt: 'Muscular athlete performing an advanced push-up variation.',
+    heroImageCredit:
+      'Photo: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>Why Variations Are Essential</h2>
 <p>
@@ -770,6 +1082,11 @@ export const BLOG_POSTS: BlogPost[] = [
       'push-up challenge',
       'increase push-ups daily',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1599058917212-d750089bc07e?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt: 'Athlete committed to an intense 30-day training plan.',
+    heroImageCredit:
+      'Photo: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>What the 30-Day Challenge Achieves</h2>
 <p>
@@ -848,6 +1165,12 @@ export const BLOG_POSTS: BlogPost[] = [
       'fitness over 40',
       'push-ups for older adults',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1526506118085-60ce8714f8c5?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt:
+      'Experienced middle-aged athlete in focused strength training.',
+    heroImageCredit:
+      'Photo: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>What Changes After 40</h2>
 <p>
@@ -919,6 +1242,259 @@ export const BLOG_POSTS: BlogPost[] = [
     `.trim(),
   },
   {
+    slug: 'wim-hof-pushups',
+    lang: 'en',
+    translationSlug: 'wim-hof-liegestuetze',
+    title:
+      'The Wim Hof Method for Push-Ups: Breathing, Cold Exposure & Performance',
+    description:
+      'Can the Wim Hof Method really boost push-up performance and recovery? A research-based look at the breathing protocol, cold exposure, and what the evidence actually shows.',
+    publishedAt: '2026-04-23',
+    keywords: [
+      'Wim Hof Method',
+      'push-ups performance',
+      'breathing for performance',
+      'cold exposure recovery',
+      'Wim Hof breathing push-ups',
+    ],
+    heroImage:
+      'https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt:
+      'Athlete standing in a frozen landscape — Wim Hof Method imagery of breath and cold.',
+    heroImageCredit:
+      'Photo: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
+    content: `
+<h2>Why Wim Hof turned up in gyms</h2>
+<p>
+  Dutch extreme athlete Wim Hof became famous for feats that looked impossible: climbing Everest in shorts,
+  running a half-marathon barefoot above the Arctic Circle, holding his breath for more than six minutes.
+  What looked like a circus act is actually a structured protocol of hyperventilation-style breathing, cold
+  exposure, and concentration — and in the last decade it has drawn enough peer-reviewed attention that
+  fitness readers can reasonably ask: does it make my push-ups better?
+</p>
+<p>
+  The short answer: the Wim Hof Method (WHM) does not lift your max reps on its own. But used thoughtfully,
+  it changes two things that matter for push-up training — the nervous-system state you train in, and the
+  speed at which you recover between sessions.
+</p>
+
+<h2>What the research actually shows</h2>
+<p>
+  The headline study is
+  <a href="https://pubmed.ncbi.nlm.nih.gov/24799686/" target="_blank" rel="noopener noreferrer nofollow ugc">Kox et al., 2014 (PNAS)</a>.
+  Researchers at Radboud University trained healthy volunteers in the WHM for ten days, then injected them
+  with bacterial endotoxin. Trained subjects showed significantly lower pro-inflammatory markers and fewer
+  flu-like symptoms than untrained controls — the first demonstration in humans that voluntary breathing
+  and cold training can modulate the innate immune response.
+</p>
+<p>
+  A 2016 PLOS ONE
+  <a href="https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0161749" target="_blank" rel="noopener noreferrer nofollow ugc">randomized trial (Buijze et al.)</a>
+  found that 30-day hot-to-cold showers reduced self-reported sick-days by 29%. A
+  <a href="https://pubmed.ncbi.nlm.nih.gov/27500826/" target="_blank" rel="noopener noreferrer nofollow ugc">2016 cold-exposure review</a>
+  catalogs the hormonal and cardiovascular responses in more detail.
+</p>
+<p>
+  What the evidence does <em>not</em> yet show: a direct, large-trial effect on maximal strength or
+  hypertrophy. Treat WHM as a <strong>recovery and nervous-system tool</strong>, not a strength supplement.
+</p>
+
+<h2>The breathing protocol, stripped down</h2>
+<p>
+  The official description lives on
+  <a href="https://www.wimhofmethod.com/practice-the-method" target="_blank" rel="noopener noreferrer nofollow ugc">wimhofmethod.com</a>.
+  A single round looks like this:
+</p>
+<ol>
+  <li><strong>30–40 deep breaths</strong> in through the nose or mouth, out with a relaxed exhale. Do not
+    force the exhale. This is essentially controlled hyperventilation.</li>
+  <li><strong>Retention on exhale</strong> — after the final exhale, hold until the urge to breathe returns.
+    Typically 60–120 s once you're used to it.</li>
+  <li><strong>Recovery breath</strong> — a full inhale, hold 15 s, release.</li>
+  <li>Repeat 3–4 rounds.</li>
+</ol>
+<p>
+  Andrew Huberman's
+  <a href="https://www.hubermanlab.com/episode/how-to-breathe-correctly-for-optimal-health-mood-learning-and-performance" target="_blank" rel="noopener noreferrer nofollow ugc">Huberman Lab episode on breathing</a>
+  covers the mechanism well: the protocol drops blood CO₂, temporarily raises adrenaline, and then drives a
+  sharp parasympathetic rebound. That rebound is the part that matters for recovery.
+</p>
+
+<h2>A safety note before you try this</h2>
+<p>
+  Hyperventilation plus breath-hold can cause shallow-water blackout. The
+  <strong>absolute rule from the Wim Hof organization itself</strong>: never practice the breathing while
+  driving, in a pool, in a bathtub, or anywhere a fainting spell would be dangerous. Pregnant people,
+  people with cardiovascular disease, and people with a history of seizures or panic disorder should skip
+  the protocol or consult a physician first.
+</p>
+
+<h2>How to combine it with push-up training</h2>
+<p>
+  Three concrete protocols, from lowest to highest risk:
+</p>
+<ol>
+  <li>
+    <strong>Breath-work as a pre-set primer (safest).</strong>
+    On the floor, do 2 rounds of WHM breathing, then stop — no breath-hold push-ups.
+    Start your first set of push-ups once breathing has normalized (~60 s). Most people report a calmer,
+    more focused start set. No extra danger beyond the breathing itself.
+  </li>
+  <li>
+    <strong>Cold finisher for recovery.</strong>
+    After training, a 60–120 s cold shower targeting chest, shoulders, and upper arms. The 2016 PLOS ONE
+    trial suggests this is enough to trigger the immune and mood effects. Not instead of sleep and protein —
+    in addition to them.
+  </li>
+  <li>
+    <strong>"Breath-hold push-up" set (advanced, optional).</strong>
+    On the final exhale of a WHM round, perform push-ups during the retention phase. This is the classic
+    "Wim Hof push-up" challenge. It is <em>not</em> a way to train more reps — the breath-hold just masks
+    air hunger. Only do it on a mat, never near hard edges or water, and never when alone.
+  </li>
+</ol>
+
+<h2>What to expect after 30 days</h2>
+<p>
+  Practitioners typically report: better tolerance of the "burn" in higher-rep sets, faster mood recovery
+  after a hard session, and noticeably less soreness 24 h later. Strength numbers don't jump; consistency
+  does. If you already use
+  <a href="/blog/pushup-tracker-guide">a push-up tracker</a>,
+  log the breathing + cold rounds alongside your reps — a month of data will tell you more than any
+  anecdote.
+</p>
+
+<h2>Bottom line</h2>
+<p>
+  The Wim Hof Method has real, measurable effects on inflammation and autonomic tone.
+  It is not a replacement for progressive overload, sleep, or protein — but as a recovery layer around
+  push-up training, the evidence is good enough to try, provided you respect the breath-hold rules.
+</p>
+    `.trim(),
+  },
+  {
+    slug: 'pushups-heart-study',
+    lang: 'en',
+    translationSlug: 'liegestuetze-herz-studie',
+    title:
+      'The Harvard Study That Made Push-Ups Famous: 40+ Reps and Heart Health',
+    description:
+      'A 2019 JAMA study put push-up capacity on the cardiovascular-risk map. Here is what the data actually said, what it did not, and how to use it for your own training.',
+    publishedAt: '2026-04-23',
+    keywords: [
+      'push-ups heart health',
+      'push-up capacity cardiovascular',
+      'Harvard push-up study',
+      'JAMA push-ups',
+      'fitness heart disease',
+    ],
+    heroImage:
+      'https://images.unsplash.com/photo-1540497077202-7c8a3999166f?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt:
+      'Runner at sunrise — cardiovascular health and fitness capacity.',
+    heroImageCredit:
+      'Photo: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
+    content: `
+<h2>Why one push-up study went viral</h2>
+<p>
+  In February 2019, a research team at the Harvard T.H. Chan School of Public Health published a decade of
+  data on 1,104 active adult men — all firefighters in Indiana — and asked a very simple question: does
+  push-up capacity predict future heart disease?
+</p>
+<p>
+  The result, published in
+  <a href="https://pubmed.ncbi.nlm.nih.gov/30821806/" target="_blank" rel="noopener noreferrer nofollow ugc">JAMA Network Open (Yang et al., 2019)</a>,
+  landed on the front page of fitness blogs for a reason. Men who could complete <strong>more than 40
+  push-ups</strong> in a single set had a <strong>96% lower risk</strong> of cardiovascular events over
+  the following ten years compared with men who could not complete 10. The Harvard press release
+  summarizes it in plain English:
+  <a href="https://www.hsph.harvard.edu/news/press-releases/push-ups-correlated-with-reduced-cardiovascular-disease-risk-study/" target="_blank" rel="noopener noreferrer nofollow ugc">
+    "Push-ups correlated with reduced cardiovascular disease risk"
+  </a>.
+</p>
+
+<h2>What the study actually measured</h2>
+<p>
+  It's worth reading past the headline. Key design points:
+</p>
+<ul>
+  <li><strong>Sample:</strong> 1,104 adult men, median age 39.6, all occupationally active (firefighters).
+    All-male, single-profession sample.</li>
+  <li><strong>Test:</strong> A metronome-paced push-up capacity test at baseline (2000), with cardiovascular
+    events tracked through 2010.</li>
+  <li><strong>Outcomes:</strong> 37 CVD events in ten years — heart attacks, CAD-related deaths,
+    coronary procedures.</li>
+  <li><strong>Comparison:</strong> Treadmill-measured aerobic capacity was <em>also</em> associated with
+    lower CVD risk — but the push-up signal was stronger than the aerobic signal in this cohort.</li>
+</ul>
+<p>
+  The authors were careful in the discussion: push-up capacity is a proxy for overall functional fitness,
+  not an independent cause of better heart health. It is <em>a simple, free, no-equipment field test</em>
+  that correlates tightly with the things that matter: muscle mass, aerobic reserve, and movement quality.
+</p>
+
+<h2>Limits the news cycle skipped</h2>
+<p>
+  A few things the study <strong>does not</strong> prove:
+</p>
+<ul>
+  <li>It does not show that <em>doing</em> more push-ups <em>causes</em> a lower heart-disease risk.
+    Causation would need a randomized intervention trial, which this was not.</li>
+  <li>It does not apply directly to women, to sedentary populations, or to older adults — those groups
+    were simply not in the sample.</li>
+  <li>It does not mean push-ups replace aerobic exercise. The
+    <a href="https://www.who.int/news-room/fact-sheets/detail/physical-activity" target="_blank" rel="noopener noreferrer nofollow ugc">
+      WHO Physical Activity Guidelines</a>
+    still recommend 150–300 min of moderate aerobic activity per week
+    <strong>in addition to</strong> muscle-strengthening twice a week.</li>
+</ul>
+
+<h2>How the AHA and ACSM frame it</h2>
+<p>
+  The
+  <a href="https://www.heart.org/en/healthy-living/fitness/fitness-basics/aha-recs-for-physical-activity-in-adults" target="_blank" rel="noopener noreferrer nofollow ugc">American Heart Association activity recommendations</a>
+  already put muscle-strengthening at the center of cardiovascular prevention — alongside aerobic work.
+  Bodyweight exercises like push-ups count, and they are the lowest-friction way to hit the "two strength
+  sessions per week" target the AHA publishes.
+</p>
+
+<h2>How to use this without over-reading it</h2>
+<p>
+  The useful takeaway isn't "40 push-ups = good heart." It's that a simple field test correlates with the
+  combination of traits you actually want. Two practical uses:
+</p>
+<ol>
+  <li>
+    <strong>Use it as a benchmark, not a goal.</strong> Once a month, do a single max-effort set to full
+    fatigue. Log the number. You are tracking a proxy for your whole-body fitness trend, not a
+    performance target.
+  </li>
+  <li>
+    <strong>Work backwards into structured training.</strong> If your baseline is under 10, the
+    <a href="/blog/pushup-progression">progression guide</a> gets you from there to a respectable capacity
+    over 6 weeks. From 20 to 40+, the <a href="/blog/30-day-pushup-challenge">30-day challenge</a> is
+    designed to push past that plateau.
+  </li>
+</ol>
+
+<h2>A word on technique</h2>
+<p>
+  A "push-up" in the Yang et al. study meant a metronome-paced, full-range rep. Ego reps don't count in
+  research and shouldn't count for you either. Chest to the floor or within an inch. Body straight.
+  Elbows tracking behind the shoulders, not flared. If 40 perfect reps feel out of reach, that's the
+  honest place to start — and the data suggest the journey itself is the intervention.
+</p>
+
+<h2>The bigger picture</h2>
+<p>
+  Push-ups are not magic. What they are is an unusually efficient test: one minute of effort,
+  no equipment, scalable from a knee variant to a one-arm variant. The 2019 Harvard data simply
+  put numbers on what strength coaches have said for decades — the people who can push their own body
+  off the floor, repeatedly, tend to be healthy in a lot of other ways too.
+</p>
+    `.trim(),
+  },
+  {
     slug: 'pushup-tracker-guide',
     lang: 'en',
     translationSlug: 'liegestuetze-tracker',
@@ -933,6 +1509,12 @@ export const BLOG_POSTS: BlogPost[] = [
       'Pushup Tracker',
       'push-up progress tracking',
     ],
+    heroImage:
+      'https://images.unsplash.com/photo-1551887196-72e32bfc7bf3?auto=format&fit=crop&w=1600&q=80',
+    heroImageAlt:
+      'Smartphone showing a fitness tracker app with statistics charts.',
+    heroImageCredit:
+      'Photo: <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>',
     content: `
 <h2>The Problem with Gut Feeling</h2>
 <p>

--- a/web/src/app/blog/reading-time.spec.ts
+++ b/web/src/app/blog/reading-time.spec.ts
@@ -1,0 +1,28 @@
+import { readingMinutes } from './reading-time';
+
+describe('readingMinutes', () => {
+  it('returns at least 1 minute for any non-empty content', () => {
+    expect(readingMinutes('one word')).toBe(1);
+    expect(readingMinutes('')).toBe(1);
+  });
+
+  it('strips HTML tags before counting words', () => {
+    const html = '<p><strong>hello</strong> <em>world</em></p>';
+    expect(readingMinutes(html)).toBe(1);
+  });
+
+  it('rounds ~200 words per minute', () => {
+    const sentence = 'word '.repeat(600).trim();
+    expect(readingMinutes(sentence)).toBe(3);
+  });
+
+  it('decodes entities as whitespace (does not count as word chars)', () => {
+    const html = '<p>hello&nbsp;world&amp;more</p>';
+    expect(readingMinutes(html)).toBe(1);
+  });
+
+  it('ignores repeated whitespace and newlines', () => {
+    const html = '<p>hello\n\n\n   world</p>';
+    expect(readingMinutes(html)).toBe(1);
+  });
+});

--- a/web/src/app/blog/reading-time.spec.ts
+++ b/web/src/app/blog/reading-time.spec.ts
@@ -1,4 +1,15 @@
-import { readingMinutes } from './reading-time';
+import { countWords, readingMinutes } from './reading-time';
+
+describe('countWords', () => {
+  it('strips HTML and returns the word count', () => {
+    expect(countWords('<p>hello <strong>world</strong></p>')).toBe(2);
+  });
+
+  it('returns 0 for empty or tag-only input', () => {
+    expect(countWords('')).toBe(0);
+    expect(countWords('<p></p>')).toBe(0);
+  });
+});
 
 describe('readingMinutes', () => {
   it('returns at least 1 minute for any content (including empty)', () => {

--- a/web/src/app/blog/reading-time.spec.ts
+++ b/web/src/app/blog/reading-time.spec.ts
@@ -1,7 +1,7 @@
 import { readingMinutes } from './reading-time';
 
 describe('readingMinutes', () => {
-  it('returns at least 1 minute for any non-empty content', () => {
+  it('returns at least 1 minute for any content (including empty)', () => {
     expect(readingMinutes('one word')).toBe(1);
     expect(readingMinutes('')).toBe(1);
   });

--- a/web/src/app/blog/reading-time.ts
+++ b/web/src/app/blog/reading-time.ts
@@ -1,0 +1,11 @@
+const WORDS_PER_MINUTE = 200;
+
+export function readingMinutes(html: string): number {
+  const words = html
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z#0-9]+;/gi, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length;
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+}

--- a/web/src/app/blog/reading-time.ts
+++ b/web/src/app/blog/reading-time.ts
@@ -1,11 +1,14 @@
 const WORDS_PER_MINUTE = 200;
 
-export function readingMinutes(html: string): number {
-  const words = html
+export function countWords(html: string): number {
+  return html
     .replace(/<[^>]+>/g, ' ')
     .replace(/&[a-z#0-9]+;/gi, ' ')
     .trim()
     .split(/\s+/)
     .filter(Boolean).length;
-  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+}
+
+export function readingMinutes(html: string): number {
+  return Math.max(1, Math.round(countWords(html) / WORDS_PER_MINUTE));
 }

--- a/web/src/app/core/seo.service.spec.ts
+++ b/web/src/app/core/seo.service.spec.ts
@@ -189,6 +189,58 @@ describe('SeoService', () => {
     });
   });
 
+  describe('article timestamps', () => {
+    function getMetaContent(selector: string): string | null {
+      return (
+        document.head
+          .querySelector<HTMLMetaElement>(selector)
+          ?.getAttribute('content') ?? null
+      );
+    }
+
+    it('emits article:published_time / modified_time as full ISO-8601 strings', () => {
+      const seo = setup('de');
+      seo.update('T', 'D', '/blog/x', {
+        publishedTime: '2026-04-01',
+        modifiedTime: '2026-04-20',
+      });
+
+      expect(getMetaContent('meta[property="article:published_time"]')).toBe(
+        '2026-04-01T00:00:00Z'
+      );
+      expect(getMetaContent('meta[property="article:modified_time"]')).toBe(
+        '2026-04-20T00:00:00Z'
+      );
+    });
+
+    it('passes through values that already contain a time component', () => {
+      const seo = setup('de');
+      seo.update('T', 'D', '/blog/x', {
+        publishedTime: '2026-04-01T12:34:56+02:00',
+      });
+
+      expect(getMetaContent('meta[property="article:published_time"]')).toBe(
+        '2026-04-01T12:34:56+02:00'
+      );
+    });
+
+    it('removes article meta tags when a subsequent update omits them', () => {
+      const seo = setup('de');
+      seo.update('T', 'D', '/blog/x', {
+        publishedTime: '2026-04-01',
+        modifiedTime: '2026-04-20',
+      });
+      seo.update('T2', 'D2', '/');
+
+      expect(
+        document.head.querySelector('meta[property="article:published_time"]')
+      ).toBeNull();
+      expect(
+        document.head.querySelector('meta[property="article:modified_time"]')
+      ).toBeNull();
+    });
+  });
+
   describe('idempotency', () => {
     it('updates existing canonical/hreflang links instead of appending duplicates', () => {
       const seo = setup('de');

--- a/web/src/app/core/seo.service.spec.ts
+++ b/web/src/app/core/seo.service.spec.ts
@@ -14,6 +14,12 @@ describe('SeoService', () => {
     document.head
       .querySelectorAll('link[rel="canonical"], link[rel="alternate"]')
       .forEach((node) => node.remove());
+    // Remove image meta tags so each test starts from a clean slate.
+    document.head
+      .querySelectorAll(
+        'meta[property="og:image"], meta[property="og:image:alt"], meta[name="twitter:image"], meta[name="twitter:image:alt"]'
+      )
+      .forEach((node) => node.remove());
     return TestBed.inject(SeoService);
   }
 

--- a/web/src/app/core/seo.service.spec.ts
+++ b/web/src/app/core/seo.service.spec.ts
@@ -130,6 +130,59 @@ describe('SeoService', () => {
     });
   });
 
+  describe('image metadata', () => {
+    const IMAGE_URL = 'https://images.unsplash.com/photo-x?w=1200';
+    const IMAGE_ALT = 'A photo';
+
+    function getMetaContent(selector: string): string | null {
+      return (
+        document.head
+          .querySelector<HTMLMetaElement>(selector)
+          ?.getAttribute('content') ?? null
+      );
+    }
+
+    it('writes og:image and twitter:image when imageUrl is provided', () => {
+      const seo = setup('de');
+      seo.update('Title', 'Description', '/blog/hello', {
+        imageUrl: IMAGE_URL,
+        imageAlt: IMAGE_ALT,
+      });
+
+      expect(getMetaContent('meta[property="og:image"]')).toBe(IMAGE_URL);
+      expect(getMetaContent('meta[property="og:image:alt"]')).toBe(IMAGE_ALT);
+      expect(getMetaContent('meta[name="twitter:image"]')).toBe(IMAGE_URL);
+      expect(getMetaContent('meta[name="twitter:image:alt"]')).toBe(IMAGE_ALT);
+    });
+
+    it('falls back to the title as image alt when imageAlt is omitted', () => {
+      const seo = setup('de');
+      seo.update('Great Title', 'Description', '/blog/hello', {
+        imageUrl: IMAGE_URL,
+      });
+
+      expect(getMetaContent('meta[property="og:image:alt"]')).toBe(
+        'Great Title'
+      );
+    });
+
+    it('removes stale image tags when a subsequent update has no image', () => {
+      const seo = setup('de');
+      seo.update('Title', 'Description', '/blog/hello', {
+        imageUrl: IMAGE_URL,
+        imageAlt: IMAGE_ALT,
+      });
+      seo.update('Title 2', 'Description', '/');
+
+      expect(
+        document.head.querySelector('meta[property="og:image"]')
+      ).toBeNull();
+      expect(
+        document.head.querySelector('meta[name="twitter:image"]')
+      ).toBeNull();
+    });
+  });
+
   describe('idempotency', () => {
     it('updates existing canonical/hreflang links instead of appending duplicates', () => {
       const seo = setup('de');

--- a/web/src/app/core/seo.service.ts
+++ b/web/src/app/core/seo.service.ts
@@ -18,7 +18,12 @@ export class SeoService {
   private readonly document = inject(DOCUMENT);
   private readonly localeId = inject(LOCALE_ID);
 
-  update(seoTitle: string, seoDescription: string, path: string): void {
+  update(
+    seoTitle: string,
+    seoDescription: string,
+    path: string,
+    options: { imageUrl?: string; imageAlt?: string } = {}
+  ): void {
     this.title.setTitle(seoTitle);
 
     this.setTag('name', 'description', seoDescription);
@@ -44,6 +49,22 @@ export class SeoService {
     this.setHreflang('alternate', 'de', deUrl);
     this.setHreflang('alternate', 'en', enUrl);
     this.setHreflang('alternate', 'x-default', deUrl);
+
+    this.applyImage(options.imageUrl, options.imageAlt ?? seoTitle);
+  }
+
+  private applyImage(imageUrl: string | undefined, alt: string): void {
+    if (imageUrl) {
+      this.setTag('property', 'og:image', imageUrl);
+      this.setTag('property', 'og:image:alt', alt);
+      this.setTag('name', 'twitter:image', imageUrl);
+      this.setTag('name', 'twitter:image:alt', alt);
+    } else {
+      this.removeTag('property', 'og:image');
+      this.removeTag('property', 'og:image:alt');
+      this.removeTag('name', 'twitter:image');
+      this.removeTag('name', 'twitter:image:alt');
+    }
   }
 
   private detectLocale(path: string): LocalePrefix {
@@ -69,6 +90,10 @@ export class SeoService {
     content: string
   ): void {
     this.meta.updateTag({ [kind]: key, content });
+  }
+
+  private removeTag(kind: 'name' | 'property', key: string): void {
+    this.meta.removeTag(`${kind}='${key}'`);
   }
 
   private setCanonical(url: string): void {

--- a/web/src/app/core/seo.service.ts
+++ b/web/src/app/core/seo.service.ts
@@ -11,6 +11,11 @@ function isKnownLocale(value: string): value is LocalePrefix {
   return (LOCALE_PREFIXES as readonly string[]).includes(value);
 }
 
+function toIsoDateTime(value: string | undefined): string | null {
+  if (!value) return null;
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00Z` : value;
+}
+
 @Injectable({ providedIn: 'root' })
 export class SeoService {
   private readonly title = inject(Title);
@@ -22,7 +27,12 @@ export class SeoService {
     seoTitle: string,
     seoDescription: string,
     path: string,
-    options: { imageUrl?: string; imageAlt?: string } = {}
+    options: {
+      imageUrl?: string;
+      imageAlt?: string;
+      publishedTime?: string;
+      modifiedTime?: string;
+    } = {}
   ): void {
     this.title.setTitle(seoTitle);
 
@@ -51,6 +61,7 @@ export class SeoService {
     this.setHreflang('alternate', 'x-default', deUrl);
 
     this.applyImage(options.imageUrl, options.imageAlt ?? seoTitle);
+    this.applyArticleTimes(options.publishedTime, options.modifiedTime);
   }
 
   private applyImage(imageUrl: string | undefined, alt: string): void {
@@ -64,6 +75,24 @@ export class SeoService {
       this.removeTag('property', 'og:image:alt');
       this.removeTag('name', 'twitter:image');
       this.removeTag('name', 'twitter:image:alt');
+    }
+  }
+
+  private applyArticleTimes(
+    publishedTime: string | undefined,
+    modifiedTime: string | undefined
+  ): void {
+    const published = toIsoDateTime(publishedTime);
+    const modified = toIsoDateTime(modifiedTime);
+    if (published) {
+      this.setTag('property', 'article:published_time', published);
+    } else {
+      this.removeTag('property', 'article:published_time');
+    }
+    if (modified) {
+      this.setTag('property', 'article:modified_time', modified);
+    } else {
+      this.removeTag('property', 'article:modified_time');
     }
   }
 

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -4215,6 +4215,18 @@ Deine Position: # ·  Reps        </source>
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">arrow_back</pc> Blog </target>
       </segment>
     </unit>
+    <unit id="blog.article.readingTime">
+      <segment state="translated">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingMinutes }}"/> Min. Lesezeit</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ readingMinutes }}"/> min read</target>
+      </segment>
+    </unit>
+    <unit id="blog.article.updated">
+      <segment state="translated">
+        <source>Aktualisiert am</source>
+        <target>Updated on</target>
+      </segment>
+    </unit>
     <unit id="blog.article.cta">
       <segment state="translated">
         <source> Kostenlos tracken – Jetzt registrieren </source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -4217,8 +4217,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="blog.article.readingTime">
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingMinutes }}"/> Min. Lesezeit</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ readingMinutes }}"/> min read</target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}"/> Min. Lesezeit</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}"/> min read</target>
       </segment>
     </unit>
     <unit id="blog.article.updated">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -1403,15 +1403,31 @@
     </unit>
     <unit id="blog.article.back">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:31,33</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:33,35</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">arrow_back</pc> Blog </source>
       </segment>
     </unit>
+    <unit id="blog.article.readingTime">
+      <notes>
+        <note category="location">web/src/app/blog/blog-article.component.ts:59,60</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingMinutes }}"/> Min. Lesezeit</source>
+      </segment>
+    </unit>
+    <unit id="blog.article.updated">
+      <notes>
+        <note category="location">web/src/app/blog/blog-article.component.ts:65,66</note>
+      </notes>
+      <segment>
+        <source>Aktualisiert am</source>
+      </segment>
+    </unit>
     <unit id="blog.article.cta">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:50,52</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:82,84</note>
       </notes>
       <segment>
         <source> Kostenlos tracken – Jetzt registrieren </source>
@@ -1419,7 +1435,7 @@
     </unit>
     <unit id="blog.article.notFound">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:56,57</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:88,89</note>
       </notes>
       <segment>
         <source>Artikel nicht gefunden.</source>
@@ -1427,7 +1443,7 @@
     </unit>
     <unit id="blog.article.toList">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:58,62</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:90,94</note>
       </notes>
       <segment>
         <source>Zur Übersicht</source>
@@ -1451,7 +1467,7 @@
     </unit>
     <unit id="blog.list.readArticle">
       <notes>
-        <note category="location">web/src/app/blog/blog-list.component.ts:37,39</note>
+        <note category="location">web/src/app/blog/blog-list.component.ts:51,53</note>
       </notes>
       <segment>
         <source>Artikel lesen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -1411,15 +1411,15 @@
     </unit>
     <unit id="blog.article.readingTime">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:59,60</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:60,61</note>
       </notes>
       <segment>
-        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingMinutes }}"/> Min. Lesezeit</source>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}"/> Min. Lesezeit</source>
       </segment>
     </unit>
     <unit id="blog.article.updated">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:65,66</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:66,67</note>
       </notes>
       <segment>
         <source>Aktualisiert am</source>
@@ -1427,7 +1427,7 @@
     </unit>
     <unit id="blog.article.cta">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:82,84</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:83,85</note>
       </notes>
       <segment>
         <source> Kostenlos tracken – Jetzt registrieren </source>
@@ -1435,7 +1435,7 @@
     </unit>
     <unit id="blog.article.notFound">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:88,89</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:89,90</note>
       </notes>
       <segment>
         <source>Artikel nicht gefunden.</source>
@@ -1443,7 +1443,7 @@
     </unit>
     <unit id="blog.article.toList">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:90,94</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:91,95</note>
       </notes>
       <segment>
         <source>Zur Übersicht</source>
@@ -1467,7 +1467,7 @@
     </unit>
     <unit id="blog.list.readArticle">
       <notes>
-        <note category="location">web/src/app/blog/blog-list.component.ts:51,53</note>
+        <note category="location">web/src/app/blog/blog-list.component.ts:52,54</note>
       </notes>
       <segment>
         <source>Artikel lesen</source>


### PR DESCRIPTION
## Summary

- Blog gets **hero images**, **reading-time**, **"Aktualisiert am"**, richer **Article JSON-LD**, and real `og:image` / `twitter:image` / `article:published_time` tags.
- All 12 existing posts (6 DE + 6 EN) receive matching Unsplash hero images with localized alt text and attribution.
- Two new **research-backed post pairs** (DE + EN), with inline links to real primary sources:
  - **Wim Hof Methode für Liegestütze / The Wim Hof Method for Push-Ups** — breathing + cold exposure for push-up performance. Links: PNAS (Kox et al. 2014), PLOS ONE cold-shower RCT (Buijze et al. 2016), Huberman Lab, official Wim Hof Method.
  - **Die Harvard-Studie … / The Harvard Study That Made Push-Ups Famous** — JAMA 2019 "40+ push-ups ↔ cardiovascular events", framed with AHA & WHO recommendations.
- List view: added 16:9 thumbnails per card.
- Sitemap now emits **21 URLs** (5 static + 16 posts), properly paired via hreflang.

## What's new technically

- `BlogPost` gains `heroImage`, `heroImageAlt`, `heroImageCredit`, `updatedAt?`.
- `SeoService.update()` has a new `{ imageUrl, imageAlt }` option — emits the image meta tags and cleans them up on subsequent calls without an image (avoids stale OG).
- New `readingMinutes()` helper + unit tests (~200 wpm, strips HTML / entities).
- `BlogArticleComponent` renders a hero figure with absolute-positioned credit pill, reading-time, and updated date; injects richer Article JSON-LD including `image`, `publisher.logo`, `dateModified`, `wordCount`, `mainEntityOfPage`, `inLanguage`.
- Two new i18n ids (`blog.article.readingTime`, `blog.article.updated`) + EN translations.

## Test plan

- [x] `pnpm nx test web` — all unit tests green (incl. new `SeoService` image tests).
- [x] `pnpm nx run tools:test` — sitemap tests green.
- [x] `pnpm nx lint web` — no new errors (pre-existing warnings unchanged).
- [x] `pnpm nx run web:build -c production` — builds, prerenders all 16 blog pages in DE + EN, emits `og:image` / `article:published_time` / JSON-LD in the HTML.
- [x] `pnpm nx run tools:generate-sitemap` — writes 21 URLs with correct hreflang pairs for the new posts.
- [ ] Manual smoke: open `/de/blog`, click a post, confirm hero renders and credit link opens Unsplash.
- [ ] View-source on one new post: confirm `<script type="application/ld+json" data-blog-ld>` contains `image`, `dateModified`, `wordCount`.

## Notes for review

- Unsplash image URLs use the stable `images.unsplash.com/photo-{id}` permalink form with `?auto=format&fit=crop&w=1600&q=80`; all 8 unique IDs were HTTP-checked to return `200 image/jpeg` before commit.
- Attribution text uses Unsplash's free-use license requirement: a visible "Photo: Unsplash" link in the hero credit.
- External research links are all `rel="noopener nofollow ugc"` and `target="_blank"`.
- Sitemap generator needed no changes — the extraction regex is anchored on `slug/lang/translationSlug/publishedAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Blog articles now display estimated reading time and optional update dates.
  * Added hero images to articles and list cards with image credit attribution.
  * Enhanced SEO metadata with image tags and publication timestamps in social sharing.

* **Documentation**
  * Added design specification for blog SEO and images feature.

* **Tests**
  * Added test coverage for reading time calculation and image metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->