### PR TITLE
ci: dynamic Nx agent allocation (4→10 based on changeset size)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,14 @@ jobs:
 
       - uses: nrwl/nx-set-shas@v5
       - name: Nx Cloud distributed run starten
-        run: pnpm nx-cloud start-ci-run --distribute-on="4 linux-medium-js" --stop-agents-after="lint,test,build,e2e-ci"
+        # Dynamic agent allocation: small PRs use 4 agents, large changesets
+        # scale up to 10 so the 5-shard e2e-ci target finishes in one round
+        # instead of two. Config: .nx/workflows/distribution-config.yaml
+        run: pnpm nx-cloud start-ci-run --distribute-on=".nx/workflows/distribution-config.yaml" --stop-agents-after="e2e-ci"
       - name: Nx affected (lint + test + build)
-        run: pnpm nx affected -t=lint,test,build -c=production --parallel=3
+        run: pnpm nx affected -t=lint,test,build -c=production --parallel=4
       - name: Nx affected e2e-ci (parallel)
-        run: pnpm nx affected -t=e2e-ci --parallel=4
+        run: pnpm nx affected -t=e2e-ci --parallel=5
       - name: Nx fix-ci (always)
         if: always()
         run: pnpm nx fix-ci

--- a/.nx/workflows/distribution-config.yaml
+++ b/.nx/workflows/distribution-config.yaml
@@ -1,0 +1,13 @@
+# Nx Cloud dynamic agent allocation.
+# Nx Cloud picks one of these buckets based on the percentage of workspace
+# projects affected by the change. Small PRs stay cheap; main-branch pushes
+# and large refactors get enough agents to parallelise the 5-shard e2e-ci
+# target and 11+ unit-test targets without a single agent doubling up.
+#
+# Referenced from .github/workflows/ci.yml via
+#   pnpm nx-cloud start-ci-run --distribute-on=.nx/workflows/distribution-config.yaml
+distribute-on:
+  small-changeset: 4 linux-medium-js
+  medium-changeset: 6 linux-medium-js
+  large-changeset: 8 linux-medium-js
+  extra-large-changeset: 10 linux-medium-js


### PR DESCRIPTION
## Summary
- Switches `nx-cloud start-ci-run` from a fixed `4 linux-medium-js` pool to a dynamic distribution config at `.nx/workflows/distribution-config.yaml`.
- Small PRs stay at 4 agents; medium/large/xl changesets scale up to 6/8/10 agents.
- Bumps coordinator `--parallel` (lint/test/build 3→4, e2e 4→5) to match the larger agent pool.
- Drops the redundant targets from `--stop-agents-after` (only the last target matters).

## Why
Yesterday's push of `2d695a7` (#143) spent 28+ min in CI. The `e2e-ci` target on `web` has 5 sharded spec tasks, and with only 4 agents one agent always had to run two shards back-to-back. Large refactors and main-branch pushes that touch many projects hit the same ceiling on unit tests (11+ test targets).

Dynamic allocation lets Nx Cloud pick the right agent count per run — cheap for tiny PRs, fast for main pushes.

## Test plan
- [ ] CI run completes on this PR (validates distribution-config.yaml parsing + agent spin-up)
- [ ] e2e-ci wall-clock ≤ previous runs (not a regression)
- [ ] Observe which tier is picked for this PR (should be small or medium — only `.github/workflows/ci.yml` and a new `.nx/` file)

## Cost note
Small PRs unchanged. Large/main runs can use up to 2.5× more agent-minutes in exchange for wall-clock speed. Tier thresholds in `.nx/workflows/distribution-config.yaml` are trivial to dial back if the bill gets uncomfortable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration workflow with dynamic build agent allocation that automatically scales based on the scope of affected changes.
  * Increased parallelization for linting, testing, build, and end-to-end processes to accelerate CI execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->