### PR TITLE
Add goal-reached celebration dialog with vaporize animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
     "@sentry/node": "^10.45.0",
     "axios": "1.15.1",
     "chart.js": "4.5.1",
+    "html2canvas": "^1.4.1",
+    "@wolsok/thanos": "^16.0.1",
     "chartjs-adapter-date-fns": "^3.0.0",
     "chartjs-chart-matrix": "3.0.0",
     "cors": "2.8.6",
@@ -139,5 +141,20 @@
     "socket.io": "4.8.3",
     "socket.io-client": "4.8.3"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "pnpm": {
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "@wolsok/thanos>@angular/core": "21",
+        "@wolsok/thanos>@angular/common": "21",
+        "@wolsok/thanos>@angular/platform-browser": "21",
+        "@wolsok/thanos>@angular/platform-browser-dynamic": "21",
+        "@wolsok/thanos>rxjs": "7.8.0",
+        "@wolsok/thanos>zone.js": "*"
+      },
+      "ignoreMissing": [
+        "zone.js"
+      ]
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@sentry/node':
         specifier: ^10.45.0
         version: 10.49.0
+      '@wolsok/thanos':
+        specifier: ^16.0.1
+        version: 16.0.1(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(@angular/platform-browser-dynamic@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0)))(html2canvas@1.4.1)(rxjs@7.8.0)
       axios:
         specifier: 1.15.1
         version: 1.15.1
@@ -104,6 +107,9 @@ importers:
       firebase-admin:
         specifier: ^13.7.0
         version: 13.8.0(encoding@0.1.13)
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
       http-proxy:
         specifier: 1.18.1
         version: 1.18.1(debug@4.4.3)
@@ -4940,6 +4946,17 @@ packages:
       webpack-dev-server:
         optional: true
 
+  '@wolsok/thanos@16.0.1':
+    resolution: {integrity: sha512-8IzS4eRqNT0y0+LU9cfZ39NYp0JIvu/BqswNY/6ikmuzxm2LvLUPxt+s92sDVvQ0b3aSGHVRsv+UxDlULR1fFA==}
+    peerDependencies:
+      '@angular/common': ^16.0.0
+      '@angular/core': ^16.0.0
+      '@angular/platform-browser': 16.0.0
+      '@angular/platform-browser-dynamic': 16.0.0
+      html2canvas: ^1.4.1
+      rxjs: 7.8.1
+      zone.js: 0.13.0
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -5346,6 +5363,10 @@ packages:
 
   bare-url@2.4.1:
     resolution: {integrity: sha512-fZapLWNB25gS+etK27NV9KgBNXgo2yeYHuj+OyPblQd6GYAE3JVy6aKxszMV5jhGGFwraXQKA5fldvf3lMyEqw==}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -5870,6 +5891,9 @@ packages:
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-loader@6.11.0:
     resolution: {integrity: sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==}
@@ -6995,6 +7019,10 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
@@ -10075,6 +10103,9 @@ packages:
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -10427,6 +10458,9 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -16950,6 +16984,16 @@ snapshots:
     optionalDependencies:
       webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.105.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.27.3)(webpack-cli@6.0.1))
 
+  '@wolsok/thanos@16.0.1(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(@angular/platform-browser-dynamic@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0)))(html2canvas@1.4.1)(rxjs@7.8.0)':
+    dependencies:
+      '@angular/common': 21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0)
+      '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0)
+      '@angular/platform-browser': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))
+      '@angular/platform-browser-dynamic': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0))(rxjs@7.8.0))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.0)))
+      html2canvas: 1.4.1
+      rxjs: 7.8.0
+      tslib: 2.8.1
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -17412,6 +17456,8 @@ snapshots:
   bare-url@2.4.1:
     dependencies:
       bare-path: 3.0.0
+
+  base64-arraybuffer@1.0.2: {}
 
   base64-js@1.5.1: {}
 
@@ -17980,6 +18026,10 @@ snapshots:
   css-declaration-sorter@7.4.0(postcss@8.5.10):
     dependencies:
       postcss: 8.5.10
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   css-loader@6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.19))(webpack@5.106.2):
     dependencies:
@@ -19429,6 +19479,11 @@ snapshots:
     optional: true
 
   html-escaper@2.0.2: {}
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   htmlparser2@10.1.0:
     dependencies:
@@ -23073,6 +23128,10 @@ snapshots:
 
   text-hex@1.0.0: {}
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -23427,6 +23486,10 @@ snapshots:
       which-typed-array: 1.1.20
 
   utils-merge@1.0.1: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@11.1.0: {}
 

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.html
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.html
@@ -1,0 +1,27 @@
+<div #card class="goal-card" data-testid="goal-reached-card">
+  <div class="hero">
+    <mat-icon class="hero-icon">{{ copy().icon }}</mat-icon>
+  </div>
+  <h2 class="title" mat-dialog-title>{{ copy().title }}</h2>
+  <p class="progress" data-testid="goal-reached-progress">
+    {{ progressLabel() }}
+    <span class="progress-suffix" i18n="@@goalReached.repsSuffix"
+      >Liegestütze</span
+    >
+  </p>
+  <p class="note">{{ copy().note }}</p>
+  <div class="actions">
+    <button
+      type="button"
+      mat-flat-button
+      class="snap-btn"
+      data-testid="goal-reached-snap"
+      [disabled]="snapping()"
+      [attr.aria-label]="snapAriaLabel"
+      (click)="onSnap()"
+    >
+      <mat-icon>auto_awesome</mat-icon>
+      <span>{{ snapLabel }}</span>
+    </button>
+  </div>
+</div>

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
@@ -1,0 +1,82 @@
+:host {
+  display: block;
+}
+
+.goal-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem 1.5rem 1.5rem;
+  text-align: center;
+  border-radius: 16px;
+  background:
+    radial-gradient(circle at top, rgba(255, 211, 95, 0.35), transparent 60%),
+    linear-gradient(135deg, rgba(255, 184, 28, 0.95), rgba(214, 118, 12, 0.95));
+  color: #fff8ea;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+}
+
+.hero {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 255, 255, 0.35),
+    0 0 24px rgba(255, 220, 120, 0.4);
+}
+
+.hero-icon {
+  font-size: 56px;
+  width: 56px;
+  height: 56px;
+  color: #fff;
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.25));
+}
+
+.title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.progress {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  opacity: 0.95;
+}
+
+.progress-suffix {
+  margin-left: 0.35rem;
+  font-weight: 400;
+  opacity: 0.85;
+}
+
+.note {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.9;
+  max-width: 32ch;
+}
+
+.actions {
+  margin-top: 0.5rem;
+}
+
+.snap-btn {
+  background: rgba(255, 255, 255, 0.95);
+  color: #b35c00;
+  font-weight: 700;
+
+  &[disabled] {
+    opacity: 0.7;
+  }
+}

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.spec.ts
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.spec.ts
@@ -1,0 +1,136 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Subject } from 'rxjs';
+
+// Replace the real package (which has unresolved missing-extension imports
+// under Node ESM) with a stub class. Tests provide a useValue mock for the
+// WsThanosService DI token, so this stub never has to actually run.
+vi.mock('@wolsok/thanos', () => {
+  class WsThanosService {
+    vaporize(_el: HTMLElement): unknown {
+      return null;
+    }
+  }
+  return { WsThanosService };
+});
+
+import { WsThanosService } from '@wolsok/thanos';
+import {
+  GoalReachedDialogComponent,
+  GoalReachedDialogData,
+} from './goal-reached-dialog.component';
+
+describe('GoalReachedDialogComponent', () => {
+  let fixture: ComponentFixture<GoalReachedDialogComponent>;
+  const closeSpy = vitest.fn();
+  let vaporizeSubject: Subject<unknown>;
+  const vaporizeSpy = vitest.fn(() => vaporizeSubject.asObservable());
+
+  async function setup(data: GoalReachedDialogData): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [GoalReachedDialogComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: { close: closeSpy } },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: WsThanosService, useValue: { vaporize: vaporizeSpy } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GoalReachedDialogComponent);
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    vaporizeSubject = new Subject<unknown>();
+    vitest.clearAllMocks();
+  });
+
+  describe('Given the dialog renders for a daily goal', () => {
+    it('Then it shows the daily title, progress total/goal, and snap button', async () => {
+      // Given
+      await setup({ kind: 'daily', total: 100, goal: 100 });
+
+      // When
+      const text = fixture.nativeElement.textContent ?? '';
+
+      // Then
+      expect(text).toContain('Tagesziel erreicht!');
+      expect(text).toContain('100 / 100');
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="goal-reached-snap"]')
+      ).toBeTruthy();
+    });
+  });
+
+  describe('Given the dialog renders for a weekly goal', () => {
+    it('Then it shows the weekly title and progress', async () => {
+      // Given
+      await setup({ kind: 'weekly', total: 540, goal: 500 });
+
+      // When
+      const text = fixture.nativeElement.textContent ?? '';
+
+      // Then
+      expect(text).toContain('Wochenziel erreicht!');
+      expect(text).toContain('540 / 500');
+    });
+  });
+
+  describe('Given the dialog renders for a monthly goal', () => {
+    it('Then it shows the monthly title and progress', async () => {
+      // Given
+      await setup({ kind: 'monthly', total: 2200, goal: 2000 });
+
+      // When
+      const text = fixture.nativeElement.textContent ?? '';
+
+      // Then
+      expect(text).toContain('Monatsziel erreicht!');
+      expect(text).toContain('2200 / 2000');
+    });
+  });
+
+  describe('Given the user clicks Snap', () => {
+    it('Then it lazy-vaporizes the card element and closes the dialog on completion', async () => {
+      // Given
+      await setup({ kind: 'daily', total: 50, goal: 50 });
+      const card = fixture.nativeElement.querySelector(
+        '[data-testid="goal-reached-card"]'
+      ) as HTMLElement;
+      const snapBtn = fixture.nativeElement.querySelector(
+        '[data-testid="goal-reached-snap"]'
+      ) as HTMLButtonElement;
+
+      // When
+      snapBtn.click();
+      await fixture.whenStable();
+
+      // Then — vaporize called with the card element
+      expect(vaporizeSpy).toHaveBeenCalledTimes(1);
+      expect(vaporizeSpy).toHaveBeenCalledWith(card);
+      expect(closeSpy).not.toHaveBeenCalled();
+
+      // When the animation completes
+      vaporizeSubject.complete();
+
+      // Then the dialog closes
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Then it ignores rapid double-clicks (only one vaporize)', async () => {
+      // Given
+      await setup({ kind: 'daily', total: 50, goal: 50 });
+      const snapBtn = fixture.nativeElement.querySelector(
+        '[data-testid="goal-reached-snap"]'
+      ) as HTMLButtonElement;
+
+      // When
+      snapBtn.click();
+      snapBtn.click();
+      await fixture.whenStable();
+
+      // Then
+      expect(vaporizeSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts
@@ -1,0 +1,99 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ElementRef,
+  EnvironmentInjector,
+  inject,
+  PLATFORM_ID,
+  runInInjectionContext,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+
+export type GoalKind = 'daily' | 'weekly' | 'monthly';
+
+export interface GoalReachedDialogData {
+  readonly kind: GoalKind;
+  readonly total: number;
+  readonly goal: number;
+}
+
+interface GoalCopy {
+  readonly icon: string;
+  readonly title: string;
+  readonly note: string;
+}
+
+@Component({
+  selector: 'app-goal-reached-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatDialogModule, MatButtonModule, MatIconModule],
+  templateUrl: './goal-reached-dialog.component.html',
+  styleUrl: './goal-reached-dialog.component.scss',
+})
+export class GoalReachedDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<GoalReachedDialogComponent>);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly envInjector = inject(EnvironmentInjector);
+  protected readonly data = inject<GoalReachedDialogData>(MAT_DIALOG_DATA);
+
+  protected readonly cardRef =
+    viewChild.required<ElementRef<HTMLElement>>('card');
+  protected readonly snapping = signal(false);
+
+  protected readonly copy = computed<GoalCopy>(() => {
+    switch (this.data.kind) {
+      case 'weekly':
+        return {
+          icon: 'military_tech',
+          title: $localize`:@@goalReached.weekly.title:Wochenziel erreicht!`,
+          note: $localize`:@@goalReached.weekly.note:Sieben Tage, ein Sieg. Du bist on fire.`,
+        };
+      case 'monthly':
+        return {
+          icon: 'workspace_premium',
+          title: $localize`:@@goalReached.monthly.title:Monatsziel erreicht!`,
+          note: $localize`:@@goalReached.monthly.note:Ein ganzer Monat Disziplin. Legendär.`,
+        };
+      default:
+        return {
+          icon: 'emoji_events',
+          title: $localize`:@@goalReached.daily.title:Tagesziel erreicht!`,
+          note: $localize`:@@goalReached.daily.note:Heute hast du dein Versprechen gehalten.`,
+        };
+    }
+  });
+
+  protected readonly snapAriaLabel = $localize`:@@goalReached.snapAria:Erfolg vaporisieren`;
+  protected readonly snapLabel = $localize`:@@goalReached.snap:Snap!`;
+  protected readonly progressLabel = computed(
+    () => `${this.data.total} / ${this.data.goal}`
+  );
+
+  protected async onSnap(): Promise<void> {
+    if (this.snapping()) return;
+    if (!isPlatformBrowser(this.platformId)) {
+      this.dialogRef.close();
+      return;
+    }
+    this.snapping.set(true);
+    const el = this.cardRef().nativeElement;
+    const { WsThanosService } = await import('@wolsok/thanos');
+    runInInjectionContext(this.envInjector, () => {
+      inject(WsThanosService)
+        .vaporize(el)
+        .subscribe({
+          complete: () => this.dialogRef.close(),
+        });
+    });
+  }
+}

--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -161,6 +161,10 @@ export const DashboardStore = signalStore(
     );
 
     const configuredDailyGoal = computed(() => store._userConfig.dailyGoal());
+    const configuredWeeklyGoal = computed(() => store._userConfig.weeklyGoal());
+    const configuredMonthlyGoal = computed(() =>
+      store._userConfig.monthlyGoal()
+    );
     const dailyGoalConfigured = computed(() => configuredDailyGoal() > 0);
     const remainingToGoal = computed(() =>
       Math.max(0, configuredDailyGoal() - todayTotal())
@@ -266,6 +270,15 @@ export const DashboardStore = signalStore(
         : 0
     );
 
+    const weeklyGoalReached = computed(
+      () => configuredWeeklyGoal() > 0 && weekReps() >= configuredWeeklyGoal()
+    );
+
+    const monthlyGoalReached = computed(
+      () =>
+        configuredMonthlyGoal() > 0 && monthReps() >= configuredMonthlyGoal()
+    );
+
     const loading = computed(() => {
       const status = store.entriesResource.status();
       return status === 'loading' || status === 'reloading';
@@ -299,6 +312,8 @@ export const DashboardStore = signalStore(
       quickAddButtons,
       weeklyGoalProgressPercent,
       monthlyGoalProgressPercent,
+      weeklyGoalReached,
+      monthlyGoalReached,
       todayTotal,
       goalProgressPercent,
       dailyGoalConfigured,

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { of } from 'rxjs';
 import { StatsDashboardComponent } from './stats-dashboard.component';
 import {
@@ -89,6 +89,12 @@ describe('StatsDashboardComponent', () => {
     targetedAdsConsent: () => true,
   };
 
+  const dialogOpenSpy = vitest.fn().mockReturnValue({
+    afterClosed: () => of(null),
+    close: vi.fn(),
+  } as unknown as MatDialogRef<unknown>);
+  const dialogMock = { open: dialogOpenSpy } as unknown as MatDialog;
+
   beforeEach(async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(frozenDate);
@@ -97,7 +103,9 @@ describe('StatsDashboardComponent', () => {
     liveConnected.set(false);
     window.history.replaceState({}, '', '/');
 
-    await TestBed.configureTestingModule({
+    dialogOpenSpy.mockClear();
+
+    TestBed.configureTestingModule({
       imports: [StatsDashboardComponent],
       providers: [
         { provide: StatsApiService, useValue: serviceMock },
@@ -143,7 +151,13 @@ describe('StatsDashboardComponent', () => {
           },
         },
       ],
-    }).compileComponents();
+    });
+
+    // Override MatDialog at the deep-injector level so that even
+    // standalone-component scoped injectors resolve to our mock.
+    TestBed.overrideProvider(MatDialog, { useValue: dialogMock });
+
+    await TestBed.compileComponents();
 
     fixture = TestBed.createComponent(StatsDashboardComponent);
     await fixture.whenStable();
@@ -316,17 +330,14 @@ describe('StatsDashboardComponent', () => {
 
     describe('When openCreateDialog is called', () => {
       it('Then MatDialog.open is invoked with CreateEntryDialogComponent', () => {
-        // Given — access the same MatDialog instance used by the component
-        const dialog = fixture.debugElement.injector.get(MatDialog);
-        const openSpy = vitest.spyOn(dialog, 'open').mockReturnValue({
-          afterClosed: () => of(undefined),
-        } as unknown as ReturnType<typeof dialog.open>);
+        // Given
+        dialogOpenSpy.mockClear();
 
         // When
         fixture.componentInstance.openCreateDialog();
 
         // Then
-        expect(openSpy).toHaveBeenCalledWith(
+        expect(dialogOpenSpy).toHaveBeenCalledWith(
           expect.any(Function), // CreateEntryDialogComponent
           expect.objectContaining({ width: 'min(92vw, 420px)' })
         );
@@ -582,6 +593,98 @@ describe('StatsDashboardComponent', () => {
       const button = findQuickActionsGoalButton(fixture.nativeElement);
       button!.click();
       expect(svc.fillToGoal).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Goal-reached celebration dialog', () => {
+    async function flushDynamicImport(): Promise<void> {
+      // Wait for the lazy `import('./goal-reached-dialog.component')` chain
+      // to resolve, then drain the microtasks for the awaited continuation
+      // that calls MatDialog.open.
+      await vi.dynamicImportSettled();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
+    function configWithGoals(goals: {
+      dailyGoal: number;
+      weeklyGoal: number;
+      monthlyGoal: number;
+    }): void {
+      const configApi = TestBed.inject(UserConfigApiService);
+      (configApi.getConfig as ReturnType<typeof vitest.fn>).mockReturnValue(
+        of({ userId: 'u1', ...goals })
+      );
+      TestBed.inject(UserConfigStore).reload();
+    }
+
+    it('Given the daily goal becomes reached, Then the celebration dialog opens with kind=daily', async () => {
+      // Given — daily goal set so todayTotal (12) >= dailyGoal (10)
+      fixture.destroy();
+      configWithGoals({ dailyGoal: 10, weeklyGoal: 1000, monthlyGoal: 5000 });
+      dialogOpenSpy.mockClear();
+
+      // When
+      const freshFixture = TestBed.createComponent(StatsDashboardComponent);
+      await freshFixture.whenStable();
+      await flushDynamicImport();
+
+      // Then
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      const [, config] = dialogOpenSpy.mock.calls[0];
+      expect(config?.data).toEqual({ kind: 'daily', total: 12, goal: 10 });
+    });
+
+    it('Given the weekly goal becomes reached, Then the celebration dialog opens with kind=weekly', async () => {
+      // Given — weekReps (8 + 12 = 20) >= weeklyGoal (15)
+      fixture.destroy();
+      configWithGoals({ dailyGoal: 1000, weeklyGoal: 15, monthlyGoal: 5000 });
+      dialogOpenSpy.mockClear();
+
+      // When
+      const freshFixture = TestBed.createComponent(StatsDashboardComponent);
+      await freshFixture.whenStable();
+      await flushDynamicImport();
+
+      // Then
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      const [, config] = dialogOpenSpy.mock.calls[0];
+      expect(config?.data).toEqual({ kind: 'weekly', total: 20, goal: 15 });
+    });
+
+    it('Given the monthly goal becomes reached, Then the celebration dialog opens with kind=monthly', async () => {
+      // Given — monthReps (20) >= monthlyGoal (15)
+      fixture.destroy();
+      configWithGoals({ dailyGoal: 1000, weeklyGoal: 1000, monthlyGoal: 15 });
+      dialogOpenSpy.mockClear();
+
+      // When
+      const freshFixture = TestBed.createComponent(StatsDashboardComponent);
+      await freshFixture.whenStable();
+      await flushDynamicImport();
+
+      // Then
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      const [, config] = dialogOpenSpy.mock.calls[0];
+      expect(config?.data).toEqual({ kind: 'monthly', total: 20, goal: 15 });
+    });
+
+    it('Given no goals reached, Then the celebration dialog does not open', async () => {
+      // Given — defaults (dailyGoal=100) keep all goals unreached
+      fixture.destroy();
+      dialogOpenSpy.mockClear();
+
+      // When
+      const freshFixture = TestBed.createComponent(StatsDashboardComponent);
+      await freshFixture.whenStable();
+      await flushDynamicImport();
+
+      // Then — no goal-reached dialog
+      const goalDialogCalls = dialogOpenSpy.mock.calls.filter((call) => {
+        const config = call[1] as { data?: { kind?: string } } | undefined;
+        return config?.data?.kind !== undefined;
+      });
+      expect(goalDialogCalls).toHaveLength(0);
     });
   });
 

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -58,6 +58,11 @@ export class StatsDashboardComponent {
   private readonly live = inject(LiveDataStore);
   private readonly quickAdd = inject(QuickAddOrchestrationService);
 
+  private readonly goalReachedDialogShown: Record<
+    'daily' | 'weekly' | 'monthly',
+    boolean
+  > = { daily: false, weekly: false, monthly: false };
+
   readonly store = inject(DashboardStore);
 
   // Delegate store signals for template access
@@ -83,6 +88,8 @@ export class StatsDashboardComponent {
   readonly dailyGoalConfigured = this.store.dailyGoalConfigured;
   readonly remainingToGoal = this.store.remainingToGoal;
   readonly goalReached = this.store.goalReached;
+  readonly weeklyGoalReached = this.store.weeklyGoalReached;
+  readonly monthlyGoalReached = this.store.monthlyGoalReached;
   readonly fillToGoalInFlight = this.quickAdd.fillToGoalInFlight;
   readonly quickAddButtons = this.store.quickAddButtons;
   readonly adSlotDashboardInline = this.store.adSlotDashboardInline;
@@ -123,7 +130,67 @@ export class StatsDashboardComponent {
       this.refreshCounter.update((c) => c + 1);
     });
 
+    this.registerGoalReachedTrigger(
+      'daily',
+      this.goalReached,
+      this.todayTotal,
+      this.store.dailyGoal
+    );
+    this.registerGoalReachedTrigger(
+      'weekly',
+      this.weeklyGoalReached,
+      this.weekReps,
+      this.weeklyGoal
+    );
+    this.registerGoalReachedTrigger(
+      'monthly',
+      this.monthlyGoalReached,
+      this.monthReps,
+      this.monthlyGoal
+    );
+
     this.store.loadQuote();
+  }
+
+  private registerGoalReachedTrigger(
+    kind: 'daily' | 'weekly' | 'monthly',
+    reached: () => boolean,
+    total: () => number,
+    goal: () => number
+  ): void {
+    effect(() => {
+      if (!isPlatformBrowser(this.platformId)) return;
+      const isReached = reached();
+      if (!isReached) {
+        this.goalReachedDialogShown[kind] = false;
+        return;
+      }
+      if (this.goalReachedDialogShown[kind]) return;
+      this.goalReachedDialogShown[kind] = true;
+      untracked(() => {
+        void this.openGoalReachedDialog(kind, {
+          total: total(),
+          goal: goal(),
+        });
+      });
+    });
+  }
+
+  private async openGoalReachedDialog(
+    kind: 'daily' | 'weekly' | 'monthly',
+    snapshot: { total: number; goal: number }
+  ): Promise<void> {
+    const { GoalReachedDialogComponent } =
+      await import('../components/goal-reached-dialog/goal-reached-dialog.component');
+    this.dialog.open(GoalReachedDialogComponent, {
+      panelClass: 'goal-reached-dialog-panel',
+      backdropClass: 'goal-reached-dialog-backdrop',
+      autoFocus: 'dialog',
+      restoreFocus: true,
+      width: 'min(92vw, 460px)',
+      maxWidth: '92vw',
+      data: { kind, total: snapshot.total, goal: snapshot.goal },
+    });
   }
 
   fillToGoal(): void {

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -5322,5 +5322,59 @@ Deine Position: # ·  Reps        </source>
         <target>Goal reached ✓</target>
       </segment>
     </unit>
+    <unit id="goalReached.daily.title">
+      <segment state="translated">
+        <source>Tagesziel erreicht!</source>
+        <target>Daily goal reached!</target>
+      </segment>
+    </unit>
+    <unit id="goalReached.daily.note">
+      <segment state="translated">
+        <source>Heute hast du dein Versprechen gehalten.</source>
+        <target>Today you kept your promise.</target>
+      </segment>
+    </unit>
+    <unit id="goalReached.weekly.title">
+      <segment state="translated">
+        <source>Wochenziel erreicht!</source>
+        <target>Weekly goal reached!</target>
+      </segment>
+    </unit>
+    <unit id="goalReached.weekly.note">
+      <segment state="translated">
+        <source>Sieben Tage, ein Sieg. Du bist on fire.</source>
+        <target>Seven days, one victory. You are on fire.</target>
+      </segment>
+    </unit>
+    <unit id="goalReached.monthly.title">
+      <segment state="translated">
+        <source>Monatsziel erreicht!</source>
+        <target>Monthly goal reached!</target>
+      </segment>
+    </unit>
+    <unit id="goalReached.monthly.note">
+      <segment state="translated">
+        <source>Ein ganzer Monat Disziplin. Legendär.</source>
+        <target>A whole month of discipline. Legendary.</target>
+      </segment>
+    </unit>
+    <unit id="goalReached.snap">
+      <segment state="translated">
+        <source>Snap!</source>
+        <target>Snap!</target>
+      </segment>
+    </unit>
+    <unit id="goalReached.snapAria">
+      <segment state="translated">
+        <source>Erfolg vaporisieren</source>
+        <target>Vaporize the success</target>
+      </segment>
+    </unit>
+    <unit id="goalReached.repsSuffix">
+      <segment state="translated">
+        <source>Liegestütze</source>
+        <target>push-ups</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2909,6 +2909,78 @@
         <source>Bis</source>
       </segment>
     </unit>
+    <unit id="goalReached.repsSuffix">
+      <notes>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.html:9,12</note>
+      </notes>
+      <segment>
+        <source>Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="goalReached.weekly.title">
+      <notes>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:60</note>
+      </notes>
+      <segment>
+        <source>Wochenziel erreicht!</source>
+      </segment>
+    </unit>
+    <unit id="goalReached.weekly.note">
+      <notes>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:61</note>
+      </notes>
+      <segment>
+        <source>Sieben Tage, ein Sieg. Du bist on fire.</source>
+      </segment>
+    </unit>
+    <unit id="goalReached.monthly.title">
+      <notes>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:66</note>
+      </notes>
+      <segment>
+        <source>Monatsziel erreicht!</source>
+      </segment>
+    </unit>
+    <unit id="goalReached.monthly.note">
+      <notes>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:67</note>
+      </notes>
+      <segment>
+        <source>Ein ganzer Monat Disziplin. Legendär.</source>
+      </segment>
+    </unit>
+    <unit id="goalReached.daily.title">
+      <notes>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:72</note>
+      </notes>
+      <segment>
+        <source>Tagesziel erreicht!</source>
+      </segment>
+    </unit>
+    <unit id="goalReached.daily.note">
+      <notes>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:73</note>
+      </notes>
+      <segment>
+        <source>Heute hast du dein Versprechen gehalten.</source>
+      </segment>
+    </unit>
+    <unit id="goalReached.snapAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:78</note>
+      </notes>
+      <segment>
+        <source>Erfolg vaporisieren</source>
+      </segment>
+    </unit>
+    <unit id="goalReached.snap">
+      <notes>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:79</note>
+      </notes>
+      <segment>
+        <source>Snap!</source>
+      </segment>
+    </unit>
     <unit id="heatmap.loading">
       <notes>
         <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:36,39</note>

--- a/web/src/types/wolsok-thanos.d.ts
+++ b/web/src/types/wolsok-thanos.d.ts
@@ -1,0 +1,18 @@
+// The npm package's `exports` map only declares `esm2022` / `default`
+// conditions (no `types` condition). Under `moduleResolution: bundler` TS
+// will not fall back to the package-root `typings` field, so the imports
+// resolve to a `.mjs` with no adjacent `.d.ts`. Expose a thin module shim
+// for the public API surface we rely on.
+declare module '@wolsok/thanos' {
+  import type { Observable } from 'rxjs';
+
+  export interface AnimationState {
+    readonly progress?: number;
+    readonly running?: boolean;
+    readonly [key: string]: unknown;
+  }
+
+  export class WsThanosService {
+    vaporize(elem: HTMLElement): Observable<AnimationState>;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a celebratory dialog that displays when users reach their daily, weekly, or monthly fitness goals. The dialog features a visually appealing card with goal-specific messaging and an interactive "Snap!" button that triggers a vaporization animation before closing.

## Key Changes

- **New GoalReachedDialogComponent**: Standalone component that displays goal achievement celebrations with:
  - Goal-specific titles, icons, and motivational messages (daily/weekly/monthly)
  - Progress display showing total reps vs. goal
  - "Snap!" button that triggers the `@wolsok/thanos` vaporization animation
  - Protection against rapid double-clicks via a `snapping` signal
  - Lazy-loaded component to minimize initial bundle size

- **Dashboard Integration**: 
  - Added `weeklyGoalReached` and `monthlyGoalReached` computed signals to `DashboardStore`
  - Implemented `registerGoalReachedTrigger()` effect-based mechanism to detect goal achievement and open dialogs
  - Tracks shown dialogs per goal type to prevent duplicate celebrations
  - Uses dynamic imports for lazy-loading the dialog component

- **Styling & UX**:
  - Golden gradient background with radial highlight for celebratory feel
  - Circular hero icon container with glow effect
  - Responsive layout with Material Design components
  - Accessible button with proper ARIA labels

- **Localization**:
  - Added German and English translations for all dialog copy
  - Supports `$localize` for i18n integration

- **Testing**:
  - Comprehensive test suite for GoalReachedDialogComponent covering all goal types
  - Tests for vaporization animation flow and double-click protection
  - Integration tests in StatsDashboardComponent verifying dialog opens at correct thresholds
  - Mock setup for `@wolsok/thanos` to handle ESM import issues in test environment

- **Dependencies**:
  - Added `@wolsok/thanos` (^16.0.1) for vaporization animation
  - Added `html2canvas` (^1.4.1) as transitive dependency
  - Configured pnpm peer dependency rules to allow version mismatches with `@wolsok/thanos`

## Notable Implementation Details

- The component uses `runInInjectionContext()` to inject `WsThanosService` within the lazy-loaded module's context
- Goal detection uses Angular's `effect()` with `untracked()` to prevent circular dependencies
- Dialog state is tracked in a component-level object to ensure celebrations only show once per goal type per session
- TypeScript module declaration file added for `@wolsok/thanos` to work around missing type exports

https://claude.ai/code/session_01AgWbUdcZWNGaKLvVXnya5Z