### PR TITLE
feat(admin): show user details in a dialog on row click

### DIFF
--- a/web/src/app/admin/admin-page.component.spec.ts
+++ b/web/src/app/admin/admin-page.component.spec.ts
@@ -6,8 +6,9 @@ import {
   MatDialogRef,
 } from '@angular/material/dialog';
 import { of } from 'rxjs';
-import { AdminPageComponent } from './admin-page.component';
+import { AdminPageComponent, AdminUser } from './admin-page.component';
 import { DeleteFeedbackDialogComponent } from './delete-feedback-dialog.component';
+import { UserDetailsDialogComponent } from './user-details-dialog.component';
 
 vi.mock('@angular/fire/functions', () => ({
   Functions: class {},
@@ -201,6 +202,69 @@ describe('AdminPageComponent', () => {
         read: true,
       });
       expect(component.feedbackList()[0].read).toBe(true);
+    });
+  });
+
+  describe('openDetailsDialog', () => {
+    const sampleUser: AdminUser = {
+      uid: 'user-1',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      anonymous: false,
+      pushupCount: 12,
+      lastEntry: '2026-04-09T10:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      role: null,
+    };
+
+    it('opens UserDetailsDialogComponent with the clicked user as data', async () => {
+      await createComponent();
+      dialogOpenSpy.mockReturnValue(stubDialogRef(undefined));
+
+      component.openDetailsDialog(sampleUser);
+
+      expect(dialogOpenSpy).toHaveBeenCalledWith(
+        UserDetailsDialogComponent,
+        expect.objectContaining({ data: sampleUser })
+      );
+    });
+
+    it('does NOT open the details dialog when a row action button is clicked', async () => {
+      // Render a single user so a row exists in the table.
+      setupCallables([
+        { name: 'adminListUsers', impl: async () => ({ data: [sampleUser] }) },
+        { name: 'adminListFeedback', impl: async () => ({ data: [] }) },
+      ]);
+      await TestBed.configureTestingModule({
+        imports: [AdminPageComponent, MatDialogModule],
+        providers: [{ provide: Functions, useValue: {} }],
+      }).compileComponents();
+      fixture = TestBed.createComponent(AdminPageComponent);
+      component = fixture.componentInstance;
+      dialogOpenSpy = vi.spyOn(
+        fixture.debugElement.injector.get(MatDialog),
+        'open'
+      );
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const actionsCell = fixture.nativeElement.querySelector(
+        'mat-cell.mat-column-actions'
+      ) as HTMLElement | null;
+      expect(actionsCell).toBeTruthy();
+
+      const event = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      });
+      actionsCell!.dispatchEvent(event);
+
+      // The actions cell stops propagation, so the row handler must not fire.
+      expect(dialogOpenSpy).not.toHaveBeenCalledWith(
+        UserDetailsDialogComponent,
+        expect.anything()
+      );
     });
   });
 });

--- a/web/src/app/admin/admin-page.component.spec.ts
+++ b/web/src/app/admin/admin-page.component.spec.ts
@@ -8,6 +8,7 @@ import {
 import { of } from 'rxjs';
 import { AdminPageComponent, AdminUser } from './admin-page.component';
 import { DeleteFeedbackDialogComponent } from './delete-feedback-dialog.component';
+import { DeleteUserDialogComponent } from './delete-user-dialog.component';
 import { UserDetailsDialogComponent } from './user-details-dialog.component';
 
 vi.mock('@angular/fire/functions', () => ({
@@ -229,8 +230,8 @@ describe('AdminPageComponent', () => {
       );
     });
 
-    it('does NOT open the details dialog when a row action button is clicked', async () => {
-      // Render a single user so a row exists in the table.
+    it('opens the details dialog when a non-actions cell of a rendered row is clicked', async () => {
+      // Render a row so the template (click) wiring is exercised.
       setupCallables([
         { name: 'adminListUsers', impl: async () => ({ data: [sampleUser] }) },
         { name: 'adminListFeedback', impl: async () => ({ data: [] }) },
@@ -245,22 +246,66 @@ describe('AdminPageComponent', () => {
         fixture.debugElement.injector.get(MatDialog),
         'open'
       );
+      dialogOpenSpy.mockReturnValue(stubDialogRef(undefined));
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
 
-      const actionsCell = fixture.nativeElement.querySelector(
-        'mat-cell.mat-column-actions'
+      // Pick a non-actions cell so we don't hit the stopPropagation handler.
+      const nameCell = fixture.nativeElement.querySelector(
+        'mat-row.clickable-row mat-cell.mat-column-displayName'
       ) as HTMLElement | null;
-      expect(actionsCell).toBeTruthy();
+      expect(nameCell).toBeTruthy();
 
-      const event = new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      });
-      actionsCell!.dispatchEvent(event);
+      nameCell!.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      );
 
-      // The actions cell stops propagation, so the row handler must not fire.
+      expect(dialogOpenSpy).toHaveBeenCalledWith(
+        UserDetailsDialogComponent,
+        expect.objectContaining({ data: sampleUser })
+      );
+    });
+
+    it('opens only the delete dialog (not the details dialog) when the row delete button is clicked', async () => {
+      // Render a single user so a row + delete button exist in the table.
+      setupCallables([
+        { name: 'adminListUsers', impl: async () => ({ data: [sampleUser] }) },
+        { name: 'adminListFeedback', impl: async () => ({ data: [] }) },
+      ]);
+      await TestBed.configureTestingModule({
+        imports: [AdminPageComponent, MatDialogModule],
+        providers: [{ provide: Functions, useValue: {} }],
+      }).compileComponents();
+      fixture = TestBed.createComponent(AdminPageComponent);
+      component = fixture.componentInstance;
+      dialogOpenSpy = vi.spyOn(
+        fixture.debugElement.injector.get(MatDialog),
+        'open'
+      );
+      // Stub the delete-confirmation dialog so the (await) delete flow does
+      // not actually call the (mocked-missing) adminDeleteUser callable.
+      dialogOpenSpy.mockReturnValue(stubDialogRef(undefined));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const deleteButton = fixture.nativeElement.querySelector(
+        'mat-cell.mat-column-actions button'
+      ) as HTMLButtonElement | null;
+      expect(deleteButton).toBeTruthy();
+
+      deleteButton!.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      );
+      await fixture.whenStable();
+
+      // The delete dialog should open ...
+      expect(dialogOpenSpy).toHaveBeenCalledWith(
+        DeleteUserDialogComponent,
+        expect.objectContaining({ data: sampleUser })
+      );
+      // ... but the row click handler must NOT fire (stopPropagation works).
       expect(dialogOpenSpy).not.toHaveBeenCalledWith(
         UserDetailsDialogComponent,
         expect.anything()

--- a/web/src/app/admin/admin-page.component.ts
+++ b/web/src/app/admin/admin-page.component.ts
@@ -22,6 +22,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { DeleteUserDialogComponent } from './delete-user-dialog.component';
 import { DeleteFeedbackDialogComponent } from './delete-feedback-dialog.component';
+import { UserDetailsDialogComponent } from './user-details-dialog.component';
 
 export interface AdminUser {
   uid: string;
@@ -229,7 +230,7 @@ interface AdminFeedback {
             <!-- actions column -->
             <ng-container matColumnDef="actions">
               <mat-header-cell *matHeaderCellDef></mat-header-cell>
-              <mat-cell *matCellDef="let u">
+              <mat-cell *matCellDef="let u" (click)="$event.stopPropagation()">
                 <button
                   mat-icon-button
                   color="warn"
@@ -242,7 +243,11 @@ interface AdminFeedback {
             </ng-container>
 
             <mat-header-row *matHeaderRowDef="displayedColumns" />
-            <mat-row *matRowDef="let row; columns: displayedColumns" />
+            <mat-row
+              *matRowDef="let row; columns: displayedColumns"
+              class="clickable-row"
+              (click)="openDetailsDialog(row)"
+            />
           </mat-table>
         </mat-card>
       }
@@ -440,6 +445,12 @@ interface AdminFeedback {
     }
     mat-table {
       width: 100%;
+    }
+    .clickable-row {
+      cursor: pointer;
+    }
+    .clickable-row:hover {
+      background: var(--mat-sys-surface-variant);
     }
     h2 {
       margin-top: 48px;
@@ -645,6 +656,14 @@ export class AdminPageComponent {
     } finally {
       this.setFeedbackLoading(feedback.id, false);
     }
+  }
+
+  openDetailsDialog(user: AdminUser): void {
+    this.dialog.open(UserDetailsDialogComponent, {
+      data: user,
+      width: 'min(92vw, 480px)',
+      maxWidth: '92vw',
+    });
   }
 
   async openDeleteDialog(user: AdminUser): Promise<void> {

--- a/web/src/app/admin/admin-page.component.ts
+++ b/web/src/app/admin/admin-page.component.ts
@@ -192,7 +192,7 @@ interface AdminFeedback {
               >
               <mat-cell *matCellDef="let u">
                 @if (u.anonymous) {
-                  <mat-icon [matTooltip]="'Anonym'" color="warn"
+                  <mat-icon [matTooltip]="'Anonym'" class="anon-icon-warn"
                     >person_outline</mat-icon
                   >
                 }
@@ -246,7 +246,12 @@ interface AdminFeedback {
             <mat-row
               *matRowDef="let row; columns: displayedColumns"
               class="clickable-row"
+              tabindex="0"
+              role="button"
+              [attr.aria-label]="detailsAriaLabel(row)"
               (click)="openDetailsDialog(row)"
+              (keydown.enter)="openDetailsDialog(row)"
+              (keydown.space)="openDetailsDialog(row); $event.preventDefault()"
             />
           </mat-table>
         </mat-card>
@@ -443,6 +448,9 @@ interface AdminFeedback {
       padding: 2px 6px;
       border-radius: 4px;
     }
+    .anon-icon-warn {
+      color: var(--mat-sys-error);
+    }
     mat-table {
       width: 100%;
     }
@@ -450,6 +458,11 @@ interface AdminFeedback {
       cursor: pointer;
     }
     .clickable-row:hover {
+      background: var(--mat-sys-surface-variant);
+    }
+    .clickable-row:focus-visible {
+      outline: 2px solid var(--mat-sys-primary);
+      outline-offset: -2px;
       background: var(--mat-sys-surface-variant);
     }
     h2 {
@@ -664,6 +677,11 @@ export class AdminPageComponent {
       width: 'min(92vw, 480px)',
       maxWidth: '92vw',
     });
+  }
+
+  detailsAriaLabel(user: AdminUser): string {
+    const identifier = user.displayName ?? user.email ?? user.uid;
+    return $localize`:@@admin.row.detailsAria:Details öffnen für ${identifier}:identifier:`;
   }
 
   async openDeleteDialog(user: AdminUser): Promise<void> {

--- a/web/src/app/admin/user-details-dialog.component.spec.ts
+++ b/web/src/app/admin/user-details-dialog.component.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { AdminUser } from './admin-page.component';
+import { UserDetailsDialogComponent } from './user-details-dialog.component';
+
+describe('UserDetailsDialogComponent', () => {
+  function setup(user: AdminUser) {
+    TestBed.configureTestingModule({
+      imports: [UserDetailsDialogComponent, MatDialogModule],
+      providers: [{ provide: MAT_DIALOG_DATA, useValue: user }],
+    });
+    const fixture = TestBed.createComponent(UserDetailsDialogComponent);
+    fixture.detectChanges();
+    return { fixture, component: fixture.componentInstance };
+  }
+
+  const baseUser: AdminUser = {
+    uid: 'user-uid-1234567890',
+    displayName: 'Alice',
+    email: 'alice@example.com',
+    anonymous: false,
+    pushupCount: 42,
+    lastEntry: '2026-04-20T10:00:00.000Z',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    role: 'admin',
+  };
+
+  it('renders the full UID (not truncated like in the table)', () => {
+    const { fixture } = setup(baseUser);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('user-uid-1234567890');
+  });
+
+  it('shows the display name and email', () => {
+    const { fixture } = setup(baseUser);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Alice');
+    expect(text).toContain('alice@example.com');
+  });
+
+  it('falls back to the empty label when name and email are missing', () => {
+    const { fixture, component } = setup({
+      ...baseUser,
+      displayName: null,
+      email: null,
+    });
+    const dds = Array.from(
+      fixture.nativeElement.querySelectorAll('dd') as NodeListOf<HTMLElement>
+    ).map((el) => el.textContent?.trim());
+    // Name + email cells should render the placeholder
+    expect(dds).toContain(component.emptyLabel);
+  });
+
+  it('renders the role and pushup count', () => {
+    const { fixture } = setup(baseUser);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('admin');
+    expect(text).toContain('42');
+  });
+
+  it('shows an icon and "Ja" for anonymous users', () => {
+    const { fixture } = setup({ ...baseUser, anonymous: true });
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Ja');
+    const icon = fixture.nativeElement.querySelector('mat-icon');
+    expect(icon).toBeTruthy();
+  });
+
+  it('shows "Nein" for non-anonymous users', () => {
+    const { fixture } = setup({ ...baseUser, anonymous: false });
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Nein');
+  });
+
+  it('includes a close button in the dialog actions', () => {
+    const { fixture } = setup(baseUser);
+    const closeButton = fixture.nativeElement.querySelector(
+      'mat-dialog-actions button[mat-dialog-close]'
+    );
+    expect(closeButton).toBeTruthy();
+  });
+});

--- a/web/src/app/admin/user-details-dialog.component.ts
+++ b/web/src/app/admin/user-details-dialog.component.ts
@@ -1,9 +1,8 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
-import { MatDialogModule } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { AdminUser } from './admin-page.component';
 
 @Component({
@@ -26,7 +25,7 @@ import { AdminUser } from './admin-page.component';
         <dt i18n="@@admin.details.anonymous">Anonym</dt>
         <dd>
           @if (user.anonymous) {
-            <mat-icon class="anon-icon" color="warn">person_outline</mat-icon>
+            <mat-icon class="anon-icon">person_outline</mat-icon>
             <span i18n="@@admin.details.anonymous.yes">Ja</span>
           } @else {
             <span i18n="@@admin.details.anonymous.no">Nein</span>
@@ -82,6 +81,7 @@ import { AdminUser } from './admin-page.component';
     .anon-icon {
       vertical-align: middle;
       margin-right: 4px;
+      color: var(--mat-sys-error);
     }
   `,
 })

--- a/web/src/app/admin/user-details-dialog.component.ts
+++ b/web/src/app/admin/user-details-dialog.component.ts
@@ -1,0 +1,91 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { AdminUser } from './admin-page.component';
+
+@Component({
+  selector: 'app-user-details-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe, MatButtonModule, MatDialogModule, MatIconModule],
+  template: `
+    <h2 mat-dialog-title i18n="@@admin.details.title">Benutzerdetails</h2>
+    <mat-dialog-content class="details-content">
+      <dl class="details-list">
+        <dt i18n="@@admin.details.uid">UID</dt>
+        <dd class="mono">{{ user.uid }}</dd>
+
+        <dt i18n="@@admin.details.displayName">Name</dt>
+        <dd>{{ user.displayName ?? emptyLabel }}</dd>
+
+        <dt i18n="@@admin.details.email">E-Mail</dt>
+        <dd>{{ user.email ?? emptyLabel }}</dd>
+
+        <dt i18n="@@admin.details.anonymous">Anonym</dt>
+        <dd>
+          @if (user.anonymous) {
+            <mat-icon class="anon-icon" color="warn">person_outline</mat-icon>
+            <span i18n="@@admin.details.anonymous.yes">Ja</span>
+          } @else {
+            <span i18n="@@admin.details.anonymous.no">Nein</span>
+          }
+        </dd>
+
+        <dt i18n="@@admin.details.role">Rolle</dt>
+        <dd>{{ user.role ?? emptyLabel }}</dd>
+
+        <dt i18n="@@admin.details.pushupCount">Pushups</dt>
+        <dd>{{ user.pushupCount }}</dd>
+
+        <dt i18n="@@admin.details.lastEntry">Letzter Eintrag</dt>
+        <dd>
+          {{ (user.lastEntry | date: 'medium') ?? emptyLabel }}
+        </dd>
+
+        <dt i18n="@@admin.details.createdAt">Erstellt</dt>
+        <dd>
+          {{ (user.createdAt | date: 'medium') ?? emptyLabel }}
+        </dd>
+      </dl>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close i18n="@@admin.details.close">
+        Schließen
+      </button>
+    </mat-dialog-actions>
+  `,
+  styles: `
+    .details-content {
+      min-width: min(92vw, 420px);
+    }
+    .details-list {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      gap: 8px 16px;
+      margin: 0;
+    }
+    .details-list dt {
+      color: var(--mat-sys-on-surface-variant);
+      font-size: 0.85em;
+      align-self: center;
+    }
+    .details-list dd {
+      margin: 0;
+      word-break: break-word;
+    }
+    .mono {
+      font-family: monospace;
+      font-size: 0.9em;
+    }
+    .anon-icon {
+      vertical-align: middle;
+      margin-right: 4px;
+    }
+  `,
+})
+export class UserDetailsDialogComponent {
+  readonly user = inject<AdminUser>(MAT_DIALOG_DATA);
+  readonly emptyLabel = '–';
+}

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -4101,6 +4101,12 @@ Deine Position: # ·  Reps        </source>
         <target>User details</target>
       </segment>
     </unit>
+    <unit id="admin.row.detailsAria">
+      <segment state="translated">
+        <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier"/></source>
+        <target>Open details for <ph id="0" equiv="identifier" disp="identifier"/></target>
+      </segment>
+    </unit>
     <unit id="admin.details.uid">
       <segment state="translated">
         <source>UID</source>
@@ -4164,7 +4170,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="admin.details.close">
       <segment state="translated">
         <source> Schließen </source>
-        <target>Close</target>
+        <target> Close </target>
       </segment>
     </unit>
     <unit id="admin.delete.anonymize">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -4095,6 +4095,78 @@ Deine Position: # ·  Reps        </source>
         <target>Delete user</target>
       </segment>
     </unit>
+    <unit id="admin.details.title">
+      <segment state="translated">
+        <source>Benutzerdetails</source>
+        <target>User details</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.uid">
+      <segment state="translated">
+        <source>UID</source>
+        <target>UID</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.displayName">
+      <segment state="translated">
+        <source>Name</source>
+        <target>Name</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.email">
+      <segment state="translated">
+        <source>E-Mail</source>
+        <target>Email</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.anonymous">
+      <segment state="translated">
+        <source>Anonym</source>
+        <target>Anonymous</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.anonymous.yes">
+      <segment state="translated">
+        <source>Ja</source>
+        <target>Yes</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.anonymous.no">
+      <segment state="translated">
+        <source>Nein</source>
+        <target>No</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.role">
+      <segment state="translated">
+        <source>Rolle</source>
+        <target>Role</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.pushupCount">
+      <segment state="translated">
+        <source>Pushups</source>
+        <target>Pushups</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.lastEntry">
+      <segment state="translated">
+        <source>Letzter Eintrag</source>
+        <target>Last entry</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.createdAt">
+      <segment state="translated">
+        <source>Erstellt</source>
+        <target>Created</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.close">
+      <segment state="translated">
+        <source> Schließen </source>
+        <target>Close</target>
+      </segment>
+    </unit>
     <unit id="admin.delete.anonymize">
       <segment state="translated">
         <source>Daten anonymisieren (Pushups behalten)</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -691,7 +691,7 @@
     </unit>
     <unit id="admin.title">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:69,71</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:70,72</note>
       </notes>
       <segment>
         <source>Admin-Bereich</source>
@@ -699,7 +699,7 @@
     </unit>
     <unit id="admin.bulk.title">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:75,77</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:76,78</note>
       </notes>
       <segment>
         <source>Anonyme Benutzer aufräumen</source>
@@ -707,7 +707,7 @@
     </unit>
     <unit id="admin.bulk.daysLabel">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:81,83</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:82,84</note>
       </notes>
       <segment>
         <source>Inaktiv seit (Tage)</source>
@@ -715,7 +715,7 @@
     </unit>
     <unit id="admin.bulk.hint">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:92,95</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:93,96</note>
       </notes>
       <segment>
         <source> Löscht anonyme Benutzer ohne Pushups in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}"/> Tagen. </source>
@@ -723,7 +723,7 @@
     </unit>
     <unit id="admin.bulk.button">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:108,109</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:109,110</note>
       </notes>
       <segment>
         <source>Inaktive löschen</source>
@@ -731,7 +731,7 @@
     </unit>
     <unit id="admin.bulk.deleted">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:116,117</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:117,118</note>
       </notes>
       <segment>
         <source>Gelöscht:</source>
@@ -739,7 +739,7 @@
     </unit>
     <unit id="admin.bulk.skipped">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:118,119</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:119,120</note>
       </notes>
       <segment>
         <source>Übersprungen:</source>
@@ -747,7 +747,7 @@
     </unit>
     <unit id="admin.filter.anonymous">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:137,138</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:138,139</note>
       </notes>
       <segment>
         <source> Nur anonyme Benutzer </source>
@@ -755,7 +755,7 @@
     </unit>
     <unit id="admin.col.uid">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:160,161</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:161,162</note>
       </notes>
       <segment>
         <source>UID</source>
@@ -763,7 +763,7 @@
     </unit>
     <unit id="admin.col.name">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:172,173</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:173,174</note>
       </notes>
       <segment>
         <source>Name</source>
@@ -771,7 +771,7 @@
     </unit>
     <unit id="admin.col.email">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:182,183</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:183,184</note>
       </notes>
       <segment>
         <source>E-Mail</source>
@@ -779,7 +779,7 @@
     </unit>
     <unit id="admin.col.anon">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:190,191</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:191,192</note>
       </notes>
       <segment>
         <source>Anon</source>
@@ -787,7 +787,7 @@
     </unit>
     <unit id="admin.col.pushups">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:204,205</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:205,206</note>
       </notes>
       <segment>
         <source>Pushups</source>
@@ -795,7 +795,7 @@
     </unit>
     <unit id="admin.col.lastEntry">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:212,214</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:213,215</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -803,7 +803,7 @@
     </unit>
     <unit id="admin.col.createdAt">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:222,224</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:223,225</note>
       </notes>
       <segment>
         <source>Erstellt</source>
@@ -811,7 +811,7 @@
     </unit>
     <unit id="admin.feedback.title">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:251,253</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:256,258</note>
       </notes>
       <segment>
         <source>Feedback</source>
@@ -819,7 +819,7 @@
     </unit>
     <unit id="admin.feedback.empty">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:270,272</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:275,277</note>
       </notes>
       <segment>
         <source>Noch kein Feedback vorhanden.</source>
@@ -827,7 +827,7 @@
     </unit>
     <unit id="admin.feedback.col.date">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:281,283</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:286,288</note>
       </notes>
       <segment>
         <source>Datum</source>
@@ -835,7 +835,7 @@
     </unit>
     <unit id="admin.feedback.col.name">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:292,294</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:297,299</note>
       </notes>
       <segment>
         <source>Name</source>
@@ -843,7 +843,7 @@
     </unit>
     <unit id="admin.feedback.col.email">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:301,303</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:306,308</note>
       </notes>
       <segment>
         <source>E-Mail</source>
@@ -851,7 +851,7 @@
     </unit>
     <unit id="admin.feedback.col.message">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:310,312</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:315,317</note>
       </notes>
       <segment>
         <source>Nachricht</source>
@@ -859,7 +859,7 @@
     </unit>
     <unit id="admin.feedback.col.userId">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:321,323</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:326,328</note>
       </notes>
       <segment>
         <source>User</source>
@@ -867,7 +867,7 @@
     </unit>
     <unit id="admin.refresh">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:481</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:492</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -875,7 +875,7 @@
     </unit>
     <unit id="admin.feedback.anon">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:482</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:493</note>
       </notes>
       <segment>
         <source>Anonym</source>
@@ -883,7 +883,7 @@
     </unit>
     <unit id="admin.feedback.markRead">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:483</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:494</note>
       </notes>
       <segment>
         <source>Als gelesen markieren</source>
@@ -891,7 +891,7 @@
     </unit>
     <unit id="admin.feedback.markUnread">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:484</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:495</note>
       </notes>
       <segment>
         <source>Als ungelesen markieren</source>
@@ -899,7 +899,7 @@
     </unit>
     <unit id="admin.feedback.createIssue">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:485</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:496</note>
       </notes>
       <segment>
         <source>GitHub-Issue erstellen</source>
@@ -907,7 +907,7 @@
     </unit>
     <unit id="admin.feedback.openIssue">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:486</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:497</note>
       </notes>
       <segment>
         <source>GitHub-Issue öffnen</source>
@@ -915,7 +915,7 @@
     </unit>
     <unit id="admin.feedback.delete">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:487</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:498</note>
       </notes>
       <segment>
         <source>Feedback löschen</source>
@@ -991,6 +991,102 @@
       </notes>
       <segment>
         <source> Löschen </source>
+      </segment>
+    </unit>
+    <unit id="admin.details.title">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:14,15</note>
+      </notes>
+      <segment>
+        <source>Benutzerdetails</source>
+      </segment>
+    </unit>
+    <unit id="admin.details.uid">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:18</note>
+      </notes>
+      <segment>
+        <source>UID</source>
+      </segment>
+    </unit>
+    <unit id="admin.details.displayName">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:20,21</note>
+      </notes>
+      <segment>
+        <source>Name</source>
+      </segment>
+    </unit>
+    <unit id="admin.details.email">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:23,24</note>
+      </notes>
+      <segment>
+        <source>E-Mail</source>
+      </segment>
+    </unit>
+    <unit id="admin.details.anonymous">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:26,28</note>
+      </notes>
+      <segment>
+        <source>Anonym</source>
+      </segment>
+    </unit>
+    <unit id="admin.details.anonymous.yes">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:30,32</note>
+      </notes>
+      <segment>
+        <source>Ja</source>
+      </segment>
+    </unit>
+    <unit id="admin.details.anonymous.no">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:32,36</note>
+      </notes>
+      <segment>
+        <source>Nein</source>
+      </segment>
+    </unit>
+    <unit id="admin.details.role">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:36,37</note>
+      </notes>
+      <segment>
+        <source>Rolle</source>
+      </segment>
+    </unit>
+    <unit id="admin.details.pushupCount">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:39,40</note>
+      </notes>
+      <segment>
+        <source>Pushups</source>
+      </segment>
+    </unit>
+    <unit id="admin.details.lastEntry">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:42,44</note>
+      </notes>
+      <segment>
+        <source>Letzter Eintrag</source>
+      </segment>
+    </unit>
+    <unit id="admin.details.createdAt">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:47,49</note>
+      </notes>
+      <segment>
+        <source>Erstellt</source>
+      </segment>
+    </unit>
+    <unit id="admin.details.close">
+      <notes>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:55,57</note>
+      </notes>
+      <segment>
+        <source> Schließen </source>
       </segment>
     </unit>
     <unit id="app.title">
@@ -2911,7 +3007,7 @@
     </unit>
     <unit id="goalReached.repsSuffix">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.html:9,12</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.html:11,14</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -2919,7 +3015,7 @@
     </unit>
     <unit id="goalReached.weekly.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:60</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:64</note>
       </notes>
       <segment>
         <source>Wochenziel erreicht!</source>
@@ -2927,7 +3023,7 @@
     </unit>
     <unit id="goalReached.weekly.note">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:61</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:65</note>
       </notes>
       <segment>
         <source>Sieben Tage, ein Sieg. Du bist on fire.</source>
@@ -2935,7 +3031,7 @@
     </unit>
     <unit id="goalReached.monthly.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:66</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:70</note>
       </notes>
       <segment>
         <source>Monatsziel erreicht!</source>
@@ -2943,7 +3039,7 @@
     </unit>
     <unit id="goalReached.monthly.note">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:67</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:71</note>
       </notes>
       <segment>
         <source>Ein ganzer Monat Disziplin. Legendär.</source>
@@ -2951,7 +3047,7 @@
     </unit>
     <unit id="goalReached.daily.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:72</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:76</note>
       </notes>
       <segment>
         <source>Tagesziel erreicht!</source>
@@ -2959,7 +3055,7 @@
     </unit>
     <unit id="goalReached.daily.note">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:73</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:77</note>
       </notes>
       <segment>
         <source>Heute hast du dein Versprechen gehalten.</source>
@@ -2967,7 +3063,7 @@
     </unit>
     <unit id="goalReached.snapAria">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:78</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:82</note>
       </notes>
       <segment>
         <source>Erfolg vaporisieren</source>
@@ -2975,7 +3071,7 @@
     </unit>
     <unit id="goalReached.snap">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:79</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:83</note>
       </notes>
       <segment>
         <source>Snap!</source>
@@ -3087,7 +3183,7 @@
     </unit>
     <unit id="chart.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43,44</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43,45</note>
       </notes>
       <segment>
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
@@ -3095,7 +3191,7 @@
     </unit>
     <unit id="chart.modeToggleAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:51,52</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:52,53</note>
       </notes>
       <segment>
         <source>Zeitraum der Stundenansicht</source>
@@ -3103,7 +3199,7 @@
     </unit>
     <unit id="chart.mode14h">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:55,56</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:56,57</note>
       </notes>
       <segment>
         <source>14h</source>
@@ -3111,7 +3207,7 @@
     </unit>
     <unit id="chart.mode24h">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:58,59</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:59,60</note>
       </notes>
       <segment>
         <source>24h</source>
@@ -3119,7 +3215,7 @@
     </unit>
     <unit id="chart.legendAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:72</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:73</note>
       </notes>
       <segment>
         <source>Legende</source>
@@ -3127,8 +3223,8 @@
     </unit>
     <unit id="chart.interval">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:77,78</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:125</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:78,79</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:126</note>
       </notes>
       <segment>
         <source>Intervallwert</source>
@@ -3136,8 +3232,8 @@
     </unit>
     <unit id="chart.dayIntegral">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:83,84</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:126</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:84,85</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:127</note>
       </notes>
       <segment>
         <source>Tages-Integral</source>
@@ -3145,8 +3241,8 @@
     </unit>
     <unit id="chart.movingAvg">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:89,90</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:127</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:90,91</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:128</note>
       </notes>
       <segment>
         <source>Gleitender Durchschnitt</source>
@@ -3154,8 +3250,8 @@
     </unit>
     <unit id="chart.withSets">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:96,97</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:153</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:97,98</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:154</note>
       </notes>
       <segment>
         <source>Mit Sets</source>
@@ -3163,7 +3259,7 @@
     </unit>
     <unit id="chart.titleHourly">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:123</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:124</note>
       </notes>
       <segment>
         <source>Verlauf (Stundenwerte)</source>
@@ -3171,7 +3267,7 @@
     </unit>
     <unit id="chart.titleDaily">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:124</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:125</note>
       </notes>
       <segment>
         <source>Verlauf (Tageswerte)</source>
@@ -3179,7 +3275,7 @@
     </unit>
     <unit id="chart.setsTooltip">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:152</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:153</note>
       </notes>
       <segment>
         <source>Sets</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -811,7 +811,7 @@
     </unit>
     <unit id="admin.feedback.title">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:256,258</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:261,263</note>
       </notes>
       <segment>
         <source>Feedback</source>
@@ -819,7 +819,7 @@
     </unit>
     <unit id="admin.feedback.empty">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:275,277</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:280,282</note>
       </notes>
       <segment>
         <source>Noch kein Feedback vorhanden.</source>
@@ -827,7 +827,7 @@
     </unit>
     <unit id="admin.feedback.col.date">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:286,288</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:291,293</note>
       </notes>
       <segment>
         <source>Datum</source>
@@ -835,7 +835,7 @@
     </unit>
     <unit id="admin.feedback.col.name">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:297,299</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:302,304</note>
       </notes>
       <segment>
         <source>Name</source>
@@ -843,7 +843,7 @@
     </unit>
     <unit id="admin.feedback.col.email">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:306,308</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:311,313</note>
       </notes>
       <segment>
         <source>E-Mail</source>
@@ -851,7 +851,7 @@
     </unit>
     <unit id="admin.feedback.col.message">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:315,317</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:320,322</note>
       </notes>
       <segment>
         <source>Nachricht</source>
@@ -859,7 +859,7 @@
     </unit>
     <unit id="admin.feedback.col.userId">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:326,328</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:331,333</note>
       </notes>
       <segment>
         <source>User</source>
@@ -867,7 +867,7 @@
     </unit>
     <unit id="admin.refresh">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:492</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:505</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -875,7 +875,7 @@
     </unit>
     <unit id="admin.feedback.anon">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:493</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:506</note>
       </notes>
       <segment>
         <source>Anonym</source>
@@ -883,7 +883,7 @@
     </unit>
     <unit id="admin.feedback.markRead">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:494</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:507</note>
       </notes>
       <segment>
         <source>Als gelesen markieren</source>
@@ -891,7 +891,7 @@
     </unit>
     <unit id="admin.feedback.markUnread">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:495</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:508</note>
       </notes>
       <segment>
         <source>Als ungelesen markieren</source>
@@ -899,7 +899,7 @@
     </unit>
     <unit id="admin.feedback.createIssue">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:496</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:509</note>
       </notes>
       <segment>
         <source>GitHub-Issue erstellen</source>
@@ -907,7 +907,7 @@
     </unit>
     <unit id="admin.feedback.openIssue">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:497</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:510</note>
       </notes>
       <segment>
         <source>GitHub-Issue öffnen</source>
@@ -915,10 +915,18 @@
     </unit>
     <unit id="admin.feedback.delete">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:498</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:511</note>
       </notes>
       <segment>
         <source>Feedback löschen</source>
+      </segment>
+    </unit>
+    <unit id="admin.row.detailsAria">
+      <notes>
+        <note category="location">web/src/app/admin/admin-page.component.ts:684</note>
+      </notes>
+      <segment>
+        <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier"/></source>
       </segment>
     </unit>
     <unit id="admin.feedback.delete.title">
@@ -995,7 +1003,7 @@
     </unit>
     <unit id="admin.details.title">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:14,15</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:13,14</note>
       </notes>
       <segment>
         <source>Benutzerdetails</source>
@@ -1003,7 +1011,7 @@
     </unit>
     <unit id="admin.details.uid">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:18</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:17</note>
       </notes>
       <segment>
         <source>UID</source>
@@ -1011,7 +1019,7 @@
     </unit>
     <unit id="admin.details.displayName">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:20,21</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:19,20</note>
       </notes>
       <segment>
         <source>Name</source>
@@ -1019,7 +1027,7 @@
     </unit>
     <unit id="admin.details.email">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:23,24</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:22,23</note>
       </notes>
       <segment>
         <source>E-Mail</source>
@@ -1027,7 +1035,7 @@
     </unit>
     <unit id="admin.details.anonymous">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:26,28</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:25,27</note>
       </notes>
       <segment>
         <source>Anonym</source>
@@ -1035,7 +1043,7 @@
     </unit>
     <unit id="admin.details.anonymous.yes">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:30,32</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:29,31</note>
       </notes>
       <segment>
         <source>Ja</source>
@@ -1043,7 +1051,7 @@
     </unit>
     <unit id="admin.details.anonymous.no">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:32,36</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:31,35</note>
       </notes>
       <segment>
         <source>Nein</source>
@@ -1051,7 +1059,7 @@
     </unit>
     <unit id="admin.details.role">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:36,37</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:35,36</note>
       </notes>
       <segment>
         <source>Rolle</source>
@@ -1059,7 +1067,7 @@
     </unit>
     <unit id="admin.details.pushupCount">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:39,40</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:38,39</note>
       </notes>
       <segment>
         <source>Pushups</source>
@@ -1067,7 +1075,7 @@
     </unit>
     <unit id="admin.details.lastEntry">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:42,44</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:41,43</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -1075,7 +1083,7 @@
     </unit>
     <unit id="admin.details.createdAt">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:47,49</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:46,48</note>
       </notes>
       <segment>
         <source>Erstellt</source>
@@ -1083,7 +1091,7 @@
     </unit>
     <unit id="admin.details.close">
       <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:55,57</note>
+        <note category="location">web/src/app/admin/user-details-dialog.component.ts:54,56</note>
       </notes>
       <segment>
         <source> Schließen </source>


### PR DESCRIPTION
Clicking a row in the admin users table now opens a read-only
UserDetailsDialogComponent showing the full UID, name, email,
role, anonymous status, pushup count, last entry, and creation
date. The actions cell stops click propagation so the delete
button still works as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin users can now click table rows to view detailed user information in a dedicated dialog.
  * Dialog displays comprehensive user details including UID, name, email, role, pushup count, and activity dates.
  * Added visual indicators for row interactivity with cursor and hover styling.
  * Action buttons no longer trigger the details dialog.

* **Tests**
  * Added comprehensive test coverage for user details dialog and row click functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->