### PR TITLE
fix(entries): refresh toolbar count after delete/update

### DIFF
--- a/plans/architecture-improvement-plan.md
+++ b/plans/architecture-improvement-plan.md
@@ -60,7 +60,7 @@ Wird nur verwendet um `user().displayName` für Motivation-Quotes zu bekommen (Z
 - Timestamp-Formatierung
 - API-Call via `statsApi.createPushup()`
 - SnackBar-Feedback
-- Resource-Reload via `appData.reloadAfterQuickAdd()`
+- Resource-Reload via `appData.reloadAfterMutation()`
 
 Das ist Business-Logik die nicht in die Root-Komponente gehört.
 

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -266,7 +266,7 @@ export class App {
   }
 
   handleFabOpened(): void {
-    this.appData.reloadAfterQuickAdd();
+    this.appData.reloadAfterMutation();
   }
 
   openFeedbackDialog(prefill = true): void {

--- a/web/src/app/core/app-data.facade.ts
+++ b/web/src/app/core/app-data.facade.ts
@@ -67,7 +67,7 @@ export class AppDataFacade {
     return goal > 0 && this.todayProgress() >= goal;
   });
 
-  reloadAfterQuickAdd(): void {
+  reloadAfterMutation(): void {
     this.recentEntriesResource.reload();
     this.dailyProgressResource.reload();
   }

--- a/web/src/app/core/quick-add-orchestration.service.spec.ts
+++ b/web/src/app/core/quick-add-orchestration.service.spec.ts
@@ -10,7 +10,7 @@ import { AppDataFacade } from './app-data.facade';
 
 describe('QuickAddOrchestrationService.fillToGoal', () => {
   const remainingToGoal = signal(42);
-  const reloadAfterQuickAdd = vitest.fn();
+  const reloadAfterMutation = vitest.fn();
 
   const statsApiMock = {
     createPushup: vitest.fn(),
@@ -21,7 +21,7 @@ describe('QuickAddOrchestrationService.fillToGoal', () => {
 
   const appDataMock: Partial<AppDataFacade> = {
     remainingToGoal: remainingToGoal.asReadonly(),
-    reloadAfterQuickAdd,
+    reloadAfterMutation,
   };
 
   function setup(): QuickAddOrchestrationService {
@@ -74,7 +74,7 @@ describe('QuickAddOrchestrationService.fillToGoal', () => {
     expect(snackBarMock.open).toHaveBeenCalledTimes(1);
     const message = snackBarMock.open.mock.calls[0][0] as string;
     expect(message).toContain('Tagesziel erreicht');
-    expect(reloadAfterQuickAdd).toHaveBeenCalledTimes(1);
+    expect(reloadAfterMutation).toHaveBeenCalledTimes(1);
   });
 
   it('Given createPushup errors, When fillToGoal() is called, Then error snackbar opens and reload is not called', () => {
@@ -86,7 +86,7 @@ describe('QuickAddOrchestrationService.fillToGoal', () => {
     expect(snackBarMock.open).toHaveBeenCalledTimes(1);
     const message = snackBarMock.open.mock.calls[0][0] as string;
     expect(message).toContain('konnte nicht');
-    expect(reloadAfterQuickAdd).not.toHaveBeenCalled();
+    expect(reloadAfterMutation).not.toHaveBeenCalled();
   });
 
   it('Given a previous fillToGoal() is still in flight, When called again, Then createPushup is called only once', () => {

--- a/web/src/app/core/quick-add-orchestration.service.ts
+++ b/web/src/app/core/quick-add-orchestration.service.ts
@@ -35,7 +35,7 @@ export class QuickAddOrchestrationService {
               verticalPosition: 'bottom',
             }
           );
-          this.appData.reloadAfterQuickAdd();
+          this.appData.reloadAfterMutation();
         },
         error: () =>
           this.snackBar.open(
@@ -73,7 +73,7 @@ export class QuickAddOrchestrationService {
               verticalPosition: 'bottom',
             }
           );
-          this.appData.reloadAfterQuickAdd();
+          this.appData.reloadAfterMutation();
           this._fillToGoalInFlight.set(false);
         },
         error: () => {

--- a/web/src/app/stats/entries.store.spec.ts
+++ b/web/src/app/stats/entries.store.spec.ts
@@ -29,7 +29,7 @@ describe('EntriesStore', () => {
   };
 
   const appDataMock = {
-    reloadAfterQuickAdd: vitest.fn(),
+    reloadAfterMutation: vitest.fn(),
   };
 
   function setup(): InstanceType<typeof EntriesStore> {
@@ -53,7 +53,7 @@ describe('EntriesStore', () => {
       await store.deleteEntry('1');
 
       expect(apiMock.deletePushup).toHaveBeenCalledWith('1');
-      expect(appDataMock.reloadAfterQuickAdd).toHaveBeenCalledTimes(1);
+      expect(appDataMock.reloadAfterMutation).toHaveBeenCalledTimes(1);
     });
 
     it('Given a failing delete, When the api throws, Then app-level resources are not reloaded', async () => {
@@ -64,7 +64,7 @@ describe('EntriesStore', () => {
 
       await store.deleteEntry('1');
 
-      expect(appDataMock.reloadAfterQuickAdd).not.toHaveBeenCalled();
+      expect(appDataMock.reloadAfterMutation).not.toHaveBeenCalled();
       expect(store.error()).toBe('boom');
     });
   });
@@ -79,7 +79,7 @@ describe('EntriesStore', () => {
       });
 
       expect(apiMock.createPushup).toHaveBeenCalled();
-      expect(appDataMock.reloadAfterQuickAdd).toHaveBeenCalledTimes(1);
+      expect(appDataMock.reloadAfterMutation).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -94,7 +94,23 @@ describe('EntriesStore', () => {
       });
 
       expect(apiMock.updatePushup).toHaveBeenCalled();
-      expect(appDataMock.reloadAfterQuickAdd).toHaveBeenCalledTimes(1);
+      expect(appDataMock.reloadAfterMutation).toHaveBeenCalledTimes(1);
+    });
+
+    it('Given a failing update, When the api throws, Then app-level resources are not reloaded', async () => {
+      const store = setup();
+      apiMock.updatePushup.mockReturnValueOnce(
+        throwError(() => new Error('boom'))
+      );
+
+      await store.updateEntry({
+        id: '1',
+        timestamp: '2026-04-27T08:00:00',
+        reps: 25,
+      });
+
+      expect(appDataMock.reloadAfterMutation).not.toHaveBeenCalled();
+      expect(store.error()).toBe('boom');
     });
   });
 });

--- a/web/src/app/stats/entries.store.spec.ts
+++ b/web/src/app/stats/entries.store.spec.ts
@@ -69,6 +69,20 @@ describe('EntriesStore', () => {
     });
   });
 
+  describe('createEntry', () => {
+    it('Given a successful create, When createEntry resolves, Then app-level resources are reloaded so the toolbar count refreshes', async () => {
+      const store = setup();
+
+      await store.createEntry({
+        timestamp: '2026-04-27T08:00:00',
+        reps: 12,
+      });
+
+      expect(apiMock.createPushup).toHaveBeenCalled();
+      expect(appDataMock.reloadAfterQuickAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('updateEntry', () => {
     it('Given a successful update, When updateEntry resolves, Then app-level resources are reloaded so the toolbar count refreshes', async () => {
       const store = setup();

--- a/web/src/app/stats/entries.store.spec.ts
+++ b/web/src/app/stats/entries.store.spec.ts
@@ -1,0 +1,86 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
+import { AppDataFacade } from '../core/app-data.facade';
+import { EntriesStore } from './entries.store';
+
+describe('EntriesStore', () => {
+  const rows = [
+    {
+      _id: '1',
+      timestamp: '2026-04-27T08:00:00',
+      reps: 10,
+      source: 'web',
+      type: 'Standard',
+    },
+  ];
+
+  const apiMock = {
+    listPushups: vitest.fn().mockReturnValue(of(rows)),
+    deletePushup: vitest.fn().mockReturnValue(of({ ok: true })),
+    createPushup: vitest.fn().mockReturnValue(of({ _id: 'x' })),
+    updatePushup: vitest.fn().mockReturnValue(of({ _id: '1' })),
+  };
+
+  const liveMock = {
+    connected: signal(true),
+    entries: signal(rows),
+  };
+
+  const appDataMock = {
+    reloadAfterQuickAdd: vitest.fn(),
+  };
+
+  function setup(): InstanceType<typeof EntriesStore> {
+    vitest.clearAllMocks();
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        EntriesStore,
+        { provide: StatsApiService, useValue: apiMock },
+        { provide: LiveDataStore, useValue: liveMock },
+        { provide: AppDataFacade, useValue: appDataMock },
+      ],
+    });
+    return TestBed.inject(EntriesStore);
+  }
+
+  describe('deleteEntry', () => {
+    it('Given a successful delete, When deleteEntry resolves, Then app-level resources are reloaded so the toolbar count refreshes', async () => {
+      const store = setup();
+
+      await store.deleteEntry('1');
+
+      expect(apiMock.deletePushup).toHaveBeenCalledWith('1');
+      expect(appDataMock.reloadAfterQuickAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('Given a failing delete, When the api throws, Then app-level resources are not reloaded', async () => {
+      const store = setup();
+      apiMock.deletePushup.mockReturnValueOnce(
+        throwError(() => new Error('boom'))
+      );
+
+      await store.deleteEntry('1');
+
+      expect(appDataMock.reloadAfterQuickAdd).not.toHaveBeenCalled();
+      expect(store.error()).toBe('boom');
+    });
+  });
+
+  describe('updateEntry', () => {
+    it('Given a successful update, When updateEntry resolves, Then app-level resources are reloaded so the toolbar count refreshes', async () => {
+      const store = setup();
+
+      await store.updateEntry({
+        id: '1',
+        timestamp: '2026-04-27T08:00:00',
+        reps: 25,
+      });
+
+      expect(apiMock.updatePushup).toHaveBeenCalled();
+      expect(appDataMock.reloadAfterQuickAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/web/src/app/stats/entries.store.ts
+++ b/web/src/app/stats/entries.store.ts
@@ -10,6 +10,7 @@ import {
 } from '@ngrx/signals';
 import { firstValueFrom } from 'rxjs';
 import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
+import { AppDataFacade } from '../core/app-data.facade';
 
 type EntriesState = {
   from: string;
@@ -40,6 +41,7 @@ export const EntriesStore = signalStore(
   withProps(() => ({
     _api: inject(StatsApiService),
     _live: inject(LiveDataStore),
+    _appData: inject(AppDataFacade),
     _isBrowser: isPlatformBrowser(inject(PLATFORM_ID)),
   })),
   withProps((store) => ({
@@ -100,7 +102,7 @@ export const EntriesStore = signalStore(
       });
     }),
   })),
-  withMethods(({ _api, _isBrowser, _entriesResource, ...store }) => ({
+  withMethods(({ _api, _appData, _isBrowser, _entriesResource, ...store }) => ({
     setFrom(value: string): void {
       patchState(store, { from: value });
     },
@@ -130,6 +132,7 @@ export const EntriesStore = signalStore(
       try {
         await firstValueFrom(_api.createPushup(payload));
         if (!_isBrowser) _entriesResource.reload();
+        _appData.reloadAfterQuickAdd();
       } catch (err) {
         patchState(store, {
           error: err instanceof Error ? err.message : String(err),
@@ -162,6 +165,7 @@ export const EntriesStore = signalStore(
           })
         );
         if (!_isBrowser) _entriesResource.reload();
+        _appData.reloadAfterQuickAdd();
       } catch (err) {
         patchState(store, {
           error: err instanceof Error ? err.message : String(err),
@@ -175,6 +179,7 @@ export const EntriesStore = signalStore(
       try {
         await firstValueFrom(_api.deletePushup(id));
         if (!_isBrowser) _entriesResource.reload();
+        _appData.reloadAfterQuickAdd();
       } catch (err) {
         patchState(store, {
           error: err instanceof Error ? err.message : String(err),

--- a/web/src/app/stats/entries.store.ts
+++ b/web/src/app/stats/entries.store.ts
@@ -132,7 +132,7 @@ export const EntriesStore = signalStore(
       try {
         await firstValueFrom(_api.createPushup(payload));
         if (!_isBrowser) _entriesResource.reload();
-        _appData.reloadAfterQuickAdd();
+        _appData.reloadAfterMutation();
       } catch (err) {
         patchState(store, {
           error: err instanceof Error ? err.message : String(err),
@@ -165,7 +165,7 @@ export const EntriesStore = signalStore(
           })
         );
         if (!_isBrowser) _entriesResource.reload();
-        _appData.reloadAfterQuickAdd();
+        _appData.reloadAfterMutation();
       } catch (err) {
         patchState(store, {
           error: err instanceof Error ? err.message : String(err),
@@ -179,7 +179,7 @@ export const EntriesStore = signalStore(
       try {
         await firstValueFrom(_api.deletePushup(id));
         if (!_isBrowser) _entriesResource.reload();
-        _appData.reloadAfterQuickAdd();
+        _appData.reloadAfterMutation();
       } catch (err) {
         patchState(store, {
           error: err instanceof Error ? err.message : String(err),

--- a/web/src/app/stats/shell/entries-page.component.spec.ts
+++ b/web/src/app/stats/shell/entries-page.component.spec.ts
@@ -49,7 +49,7 @@ describe('EntriesPageComponent', () => {
   };
 
   const appDataMock = {
-    reloadAfterQuickAdd: vitest.fn(),
+    reloadAfterMutation: vitest.fn(),
   };
 
   beforeEach(async () => {

--- a/web/src/app/stats/shell/entries-page.component.spec.ts
+++ b/web/src/app/stats/shell/entries-page.component.spec.ts
@@ -5,6 +5,7 @@ import { EntriesPageComponent } from './entries-page.component';
 import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
 import { AuthStore } from '@pu-auth/auth';
 import { makeAuthStoreMock } from '@pu-stats/testing';
+import { AppDataFacade } from '../../core/app-data.facade';
 import { EntriesStore } from '../entries.store';
 
 describe('EntriesPageComponent', () => {
@@ -47,6 +48,10 @@ describe('EntriesPageComponent', () => {
     entries: signal(rows),
   };
 
+  const appDataMock = {
+    reloadAfterQuickAdd: vitest.fn(),
+  };
+
   beforeEach(async () => {
     vitest.clearAllMocks();
 
@@ -56,6 +61,7 @@ describe('EntriesPageComponent', () => {
         { provide: StatsApiService, useValue: apiMock },
         { provide: LiveDataStore, useValue: liveMock },
         { provide: AuthStore, useValue: makeAuthStoreMock() },
+        { provide: AppDataFacade, useValue: appDataMock },
       ],
     }).compileComponents();
 

--- a/web/src/app/stats/shell/entries-page.component.ssr.spec.ts
+++ b/web/src/app/stats/shell/entries-page.component.ssr.spec.ts
@@ -6,6 +6,7 @@ import { EntriesPageComponent } from './entries-page.component';
 import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
 import { AuthStore } from '@pu-auth/auth';
 import { makeAuthStoreMock } from '@pu-stats/testing';
+import { AppDataFacade } from '../../core/app-data.facade';
 import { EntriesStore } from '../entries.store';
 
 describe('EntriesPageComponent (SSR/REST)', () => {
@@ -44,6 +45,10 @@ describe('EntriesPageComponent (SSR/REST)', () => {
         { provide: LiveDataStore, useValue: liveMock },
         { provide: Auth, useValue: {} },
         { provide: AuthStore, useValue: makeAuthStoreMock() },
+        {
+          provide: AppDataFacade,
+          useValue: { reloadAfterQuickAdd: vitest.fn() },
+        },
       ],
     }).compileComponents();
 

--- a/web/src/app/stats/shell/entries-page.component.ssr.spec.ts
+++ b/web/src/app/stats/shell/entries-page.component.ssr.spec.ts
@@ -47,7 +47,7 @@ describe('EntriesPageComponent (SSR/REST)', () => {
         { provide: AuthStore, useValue: makeAuthStoreMock() },
         {
           provide: AppDataFacade,
-          useValue: { reloadAfterQuickAdd: vitest.fn() },
+          useValue: { reloadAfterMutation: vitest.fn() },
         },
       ],
     }).compileComponents();

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -90,8 +90,8 @@ describe('StatsDashboardComponent', () => {
     targetedAdsConsent: () => true,
   };
 
-  const reloadAfterQuickAddSpy = vitest.fn();
-  const appDataMock = { reloadAfterQuickAdd: reloadAfterQuickAddSpy };
+  const reloadAfterMutationSpy = vitest.fn();
+  const appDataMock = { reloadAfterMutation: reloadAfterMutationSpy };
 
   const dialogOpenSpy = vitest.fn().mockReturnValue({
     afterClosed: () => of(null),
@@ -346,7 +346,7 @@ describe('StatsDashboardComponent', () => {
         });
 
         // Then
-        expect(reloadAfterQuickAddSpy).toHaveBeenCalledTimes(1);
+        expect(reloadAfterMutationSpy).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -360,7 +360,7 @@ describe('StatsDashboardComponent', () => {
         await component.addQuickEntry(10);
 
         // Then
-        expect(reloadAfterQuickAddSpy).toHaveBeenCalledTimes(1);
+        expect(reloadAfterMutationSpy).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -14,6 +14,7 @@ import { signal } from '@angular/core';
 import { makeAuthStoreMock } from '@pu-stats/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { QuickAddOrchestrationService } from '../../core/quick-add-orchestration.service';
+import { AppDataFacade } from '../../core/app-data.facade';
 import { UserConfigStore } from '../../core/user-config.store';
 
 describe('StatsDashboardComponent', () => {
@@ -89,6 +90,9 @@ describe('StatsDashboardComponent', () => {
     targetedAdsConsent: () => true,
   };
 
+  const reloadAfterQuickAddSpy = vitest.fn();
+  const appDataMock = { reloadAfterQuickAdd: reloadAfterQuickAddSpy };
+
   const dialogOpenSpy = vitest.fn().mockReturnValue({
     afterClosed: () => of(null),
     close: vi.fn(),
@@ -150,6 +154,7 @@ describe('StatsDashboardComponent', () => {
             fillToGoalInFlight: signal(false).asReadonly(),
           },
         },
+        { provide: AppDataFacade, useValue: appDataMock },
       ],
     });
 
@@ -325,6 +330,37 @@ describe('StatsDashboardComponent', () => {
 
         // Then
         expect(serviceMock.listPushups).toHaveBeenCalled();
+      });
+
+      it('Then it should reload AppDataFacade so the toolbar count refreshes', async () => {
+        // Given
+        const component = fixture.componentInstance;
+        vi.clearAllMocks();
+
+        // When
+        await component.createEntry({
+          timestamp: todayTs,
+          reps: 15,
+          source: 'web',
+          type: 'Diamond',
+        });
+
+        // Then
+        expect(reloadAfterQuickAddSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('When addQuickEntry is called', () => {
+      it('Then it should reload AppDataFacade so the toolbar count refreshes', async () => {
+        // Given
+        const component = fixture.componentInstance;
+        vi.clearAllMocks();
+
+        // When
+        await component.addQuickEntry(10);
+
+        // Then
+        expect(reloadAfterQuickAddSpy).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -177,7 +177,7 @@ export class StatsDashboardComponent {
   }) {
     await firstValueFrom(this.api.createPushup(entry));
     this.store.refreshAll();
-    this.appData.reloadAfterQuickAdd();
+    this.appData.reloadAfterMutation();
     this.refreshCounter.update((c) => c + 1);
   }
 
@@ -199,7 +199,7 @@ export class StatsDashboardComponent {
       })
     );
     this.store.refreshAll();
-    this.appData.reloadAfterQuickAdd();
+    this.appData.reloadAfterMutation();
     this.refreshCounter.update((c) => c + 1);
   }
 }

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -20,6 +20,7 @@ import { appendLocalOffset } from '@pu-stats/models';
 import { firstValueFrom } from 'rxjs';
 import { QuickAddBridgeService } from '@pu-stats/quick-add';
 import { QuickAddOrchestrationService } from '../../core/quick-add-orchestration.service';
+import { AppDataFacade } from '../../core/app-data.facade';
 import { AdSlotComponent } from '@pu-stats/ads';
 import { AnalysisTeaserCardComponent } from '../components/analysis-teaser-card/analysis-teaser-card.component';
 import { PreviewBannerComponent } from '../components/preview-banner/preview-banner.component';
@@ -57,6 +58,7 @@ export class StatsDashboardComponent {
   private readonly router = inject(Router);
   private readonly live = inject(LiveDataStore);
   private readonly quickAdd = inject(QuickAddOrchestrationService);
+  private readonly appData = inject(AppDataFacade);
 
   readonly store = inject(DashboardStore);
 
@@ -175,6 +177,7 @@ export class StatsDashboardComponent {
   }) {
     await firstValueFrom(this.api.createPushup(entry));
     this.store.refreshAll();
+    this.appData.reloadAfterQuickAdd();
     this.refreshCounter.update((c) => c + 1);
   }
 
@@ -196,6 +199,7 @@ export class StatsDashboardComponent {
       })
     );
     this.store.refreshAll();
+    this.appData.reloadAfterQuickAdd();
     this.refreshCounter.update((c) => c + 1);
   }
 }


### PR DESCRIPTION
EntriesStore.deleteEntry and updateEntry now reload AppDataFacade's
dailyProgressResource, matching what the quick-add flow already does
on create. Without this, deleting (or editing) a history entry left
the toolbar's "Tagesziel" pill stale until the next page reload, since
the resource only reloaded on quick-add success.

Also reload after createEntry from EntriesStore so dialog-driven
creates on the entries page stay consistent.

Adds entries.store.spec.ts as a regression test.

https://claude.ai/code/session_01NkUuNjkq9ziTo6rgVDS9pu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures app-level data reloads after creating, updating, or deleting entries for consistent UI state.

* **Tests**
  * Added and updated tests to verify reload behavior and error handling during entry mutations.

* **Documentation**
  * Updated architecture guidance to use the unified post-mutation reload pathway.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->