### PR TITLE
fix(reactivity): derive dashboard + facade signals from LiveDataStore

### DIFF
--- a/web/src/app/core/app-data.facade.spec.ts
+++ b/web/src/app/core/app-data.facade.spec.ts
@@ -2,9 +2,14 @@ import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { signal } from '@angular/core';
 import { AppDataFacade } from './app-data.facade';
-import { StatsApiService, UserConfigApiService } from '@pu-stats/data-access';
+import {
+  LiveDataStore,
+  StatsApiService,
+  UserConfigApiService,
+} from '@pu-stats/data-access';
 import { UserContextService } from '@pu-auth/auth';
 import { AdaptiveQuickAddService } from '@pu-stats/quick-add';
+import type { PushupRecord } from '@pu-stats/models';
 
 describe('AppDataFacade', () => {
   const userId = signal<string>('u1');
@@ -32,10 +37,16 @@ describe('AppDataFacade', () => {
       .mockReturnValue(of({ userId: 'u1', dailyGoal: 100 })),
   };
 
+  // Default LiveDataStore mock: disconnected (browser uses SSR fallback path).
+  // Tests that exercise the live-reactive path opt in by providing connected.
+  let liveConnected = signal(false);
+  let liveEntries = signal<PushupRecord[]>([]);
+
   function setup(
     options: {
       dailyGoal?: number;
       todayTotal?: number;
+      live?: { connected: boolean; entries: PushupRecord[] };
     } = {}
   ): AppDataFacade {
     vitest.clearAllMocks();
@@ -60,6 +71,9 @@ describe('AppDataFacade', () => {
       );
     }
 
+    liveConnected = signal(options.live?.connected ?? false);
+    liveEntries = signal<PushupRecord[]>(options.live?.entries ?? []);
+
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       providers: [
@@ -72,6 +86,14 @@ describe('AppDataFacade', () => {
         {
           provide: AdaptiveQuickAddService,
           useValue: { compute: vitest.fn().mockReturnValue([1, 5, 10]) },
+        },
+        {
+          provide: LiveDataStore,
+          useValue: {
+            connected: liveConnected.asReadonly(),
+            entries: liveEntries.asReadonly(),
+            updateTick: signal(0).asReadonly(),
+          },
         },
       ],
     });
@@ -171,6 +193,127 @@ describe('AppDataFacade', () => {
       await flushResources();
 
       expect(facade.quickAddSuggestions()).toEqual([]);
+    });
+  });
+
+  describe('Firestore live reactivity (regression: SpeedDial → fill-to-goal button stale)', () => {
+    function todayBerlinIsoDate(): string {
+      // Match the AppDataFacade implementation (toBerlinIsoDate(new Date())).
+      const date = new Date();
+      const parts = new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'Europe/Berlin',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      }).formatToParts(date);
+      const y = parts.find((p) => p.type === 'year')?.value ?? '1970';
+      const m = parts.find((p) => p.type === 'month')?.value ?? '01';
+      const d = parts.find((p) => p.type === 'day')?.value ?? '01';
+      return `${y}-${m}-${d}`;
+    }
+
+    it('Given live is connected, When a new pushup arrives via Firestore, Then todayProgress, remainingToGoal and goalReached update reactively without an explicit reload', async () => {
+      // Given a connected LiveDataStore with no entries today and a 100-rep goal
+      const facade = setup({
+        dailyGoal: 100,
+        live: { connected: true, entries: [] },
+      });
+      await flushResources();
+
+      expect(facade.todayProgress()).toBe(0);
+      expect(facade.remainingToGoal()).toBe(100);
+      expect(facade.goalReached()).toBe(false);
+
+      // When Firestore pushes a new entry (simulates the SpeedDial flow:
+      // user taps quick-add → CF writes to Firestore → onSnapshot fires →
+      // LiveDataStore.entries updates → derived signals must follow)
+      liveEntries.set([
+        {
+          _id: 'live-1',
+          userId: 'u1',
+          timestamp: `${todayBerlinIsoDate()}T08:30:00`,
+          reps: 30,
+          source: 'quick-add',
+        } as PushupRecord,
+      ]);
+
+      // Then the goal-related signals reflect the new entry without anyone
+      // calling reloadAfterMutation()
+      expect(facade.todayProgress()).toBe(30);
+      expect(facade.remainingToGoal()).toBe(70);
+      expect(facade.goalReached()).toBe(false);
+
+      // And after another live update that fills the goal:
+      liveEntries.update((rows) => [
+        ...rows,
+        {
+          _id: 'live-2',
+          userId: 'u1',
+          timestamp: `${todayBerlinIsoDate()}T09:00:00`,
+          reps: 70,
+          source: 'quick-add',
+        } as PushupRecord,
+      ]);
+
+      expect(facade.todayProgress()).toBe(100);
+      expect(facade.remainingToGoal()).toBe(0);
+      expect(facade.goalReached()).toBe(true);
+    });
+
+    it('Given live is connected, When entries change, Then quickAddSuggestions recompute from the updated live entries', async () => {
+      // Given the adaptive service echoes the entry count for assertion
+      const adaptive = {
+        compute: vitest.fn((rows: PushupRecord[]) => {
+          const len = rows.length;
+          return [len, len * 2, len * 3] as [number, number, number];
+        }),
+      };
+
+      vitest.clearAllMocks();
+      userConfigApiMock.getConfig.mockReturnValue(
+        of({ userId: 'u1', dailyGoal: 100 })
+      );
+      liveConnected = signal(true);
+      liveEntries = signal<PushupRecord[]>([]);
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: StatsApiService, useValue: statsApiMock },
+          { provide: UserConfigApiService, useValue: userConfigApiMock },
+          {
+            provide: UserContextService,
+            useValue: { userIdSafe: () => userId() },
+          },
+          { provide: AdaptiveQuickAddService, useValue: adaptive },
+          {
+            provide: LiveDataStore,
+            useValue: {
+              connected: liveConnected.asReadonly(),
+              entries: liveEntries.asReadonly(),
+              updateTick: signal(0).asReadonly(),
+            },
+          },
+        ],
+      });
+      const facade = TestBed.inject(AppDataFacade);
+      await flushResources();
+
+      expect(facade.quickAddSuggestions()).toEqual([0, 0, 0]);
+
+      // When live data arrives
+      liveEntries.set([
+        {
+          _id: '1',
+          userId: 'u1',
+          timestamp: `${todayBerlinIsoDate()}T08:00:00`,
+          reps: 10,
+          source: 'web',
+        } as PushupRecord,
+      ]);
+
+      // Then suggestions recompute
+      expect(facade.quickAddSuggestions()).toEqual([1, 2, 3]);
     });
   });
 

--- a/web/src/app/core/app-data.facade.ts
+++ b/web/src/app/core/app-data.facade.ts
@@ -1,13 +1,26 @@
-import { computed, inject, Injectable, resource } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import {
+  computed,
+  inject,
+  Injectable,
+  PLATFORM_ID,
+  resource,
+} from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { UserContextService } from '@pu-auth/auth';
-import { StatsApiService } from '@pu-stats/data-access';
+import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
+import { toBerlinIsoDate } from '@pu-stats/models';
 import { AdaptiveQuickAddService } from '@pu-stats/quick-add';
 import { UserConfigStore } from './user-config.store';
 
 /**
  * Facade that consolidates app-level data resources.
- * Avoids cluttering the root component with multiple resource() calls.
+ *
+ * In the browser the facade derives all entry-based signals from
+ * `LiveDataStore.entries()` so Firestore real-time updates propagate to
+ * consumers without an explicit reload. The REST `resource()`s are kept as
+ * SSR / cold-start fallbacks and reloaded on mutation only to keep the SSR
+ * cache warm.
  */
 @Injectable({ providedIn: 'root' })
 export class AppDataFacade {
@@ -15,6 +28,8 @@ export class AppDataFacade {
   private readonly statsApi = inject(StatsApiService);
   private readonly adaptiveQuickAdd = inject(AdaptiveQuickAddService);
   private readonly userConfig = inject(UserConfigStore);
+  private readonly live = inject(LiveDataStore);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   readonly recentEntriesResource = resource({
     params: () => ({ userId: this.user.userIdSafe() }),
@@ -27,6 +42,19 @@ export class AppDataFacade {
     },
   });
 
+  /** Last 7 days of entries — derived live from Firestore in the browser. */
+  private readonly recentEntries = computed(() => {
+    if (this.isBrowser && this.live.connected()) {
+      const sevenDaysAgo = new Date();
+      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+      const cutoff = sevenDaysAgo.toISOString().slice(0, 10);
+      return this.live
+        .entries()
+        .filter((e) => e.timestamp.slice(0, 10) >= cutoff);
+    }
+    return this.recentEntriesResource.value() ?? [];
+  });
+
   readonly quickAddSuggestions = computed(() => {
     const configured = this.userConfig.quickAdds();
     if (configured.length > 0) {
@@ -35,9 +63,7 @@ export class AppDataFacade {
         .map((q) => q.reps)
         .slice(0, 3);
     }
-    return this.adaptiveQuickAdd.compute(
-      this.recentEntriesResource.value() ?? []
-    );
+    return this.adaptiveQuickAdd.compute(this.recentEntries());
   });
 
   readonly dailyGoal = computed(() => this.userConfig.dailyGoal() || 100);
@@ -54,9 +80,16 @@ export class AppDataFacade {
     },
   });
 
-  readonly todayProgress = computed(
-    () => this.dailyProgressResource.value() ?? 0
-  );
+  readonly todayProgress = computed(() => {
+    if (this.isBrowser && this.live.connected()) {
+      const berlinToday = toBerlinIsoDate(new Date());
+      return this.live
+        .entries()
+        .filter((e) => e.timestamp.slice(0, 10) === berlinToday)
+        .reduce((sum, e) => sum + e.reps, 0);
+    }
+    return this.dailyProgressResource.value() ?? 0;
+  });
 
   readonly remainingToGoal = computed(() =>
     Math.max(0, this.userConfig.dailyGoal() - this.todayProgress())
@@ -67,6 +100,12 @@ export class AppDataFacade {
     return goal > 0 && this.todayProgress() >= goal;
   });
 
+  /**
+   * Refreshes the SSR / cold-start fallback resources. In the browser, live
+   * updates flow automatically through `LiveDataStore` so this is mostly a
+   * no-op — kept for callers that need the SSR cache invalidated and for
+   * defence-in-depth if the Firestore listener ever drops.
+   */
   reloadAfterMutation(): void {
     this.recentEntriesResource.reload();
     this.dailyProgressResource.reload();

--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -1,4 +1,5 @@
-import { computed, inject, resource } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { computed, inject, PLATFORM_ID, resource } from '@angular/core';
 import {
   signalStore,
   withComputed,
@@ -85,8 +86,13 @@ export const DashboardStore = signalStore(
     _live: inject(LiveDataStore),
     _ads: inject(AdsStore),
     _motivation: inject(MotivationStore),
+    _isBrowser: isPlatformBrowser(inject(PLATFORM_ID)),
   })),
   withProps((store) => ({
+    // SSR fallback only. In the browser we read entries from `_live.entries()`
+    // directly so Firestore real-time updates propagate without an extra REST
+    // round-trip. The resource is still reloaded by `refreshAll()` to keep the
+    // SSR cache warm.
     entriesResource: resource({
       loader: async () => firstValueFrom(store._api.listPushups({})),
     }),
@@ -106,9 +112,16 @@ export const DashboardStore = signalStore(
       () => store.allTimeResource.value() ?? EMPTY_STATS
     );
 
-    const entryRows = computed<PushupRecord[]>(
-      () => store.entriesResource.value() ?? []
-    );
+    // Source of truth for entries: Firestore-backed `LiveDataStore` once it
+    // has connected (reactive, real-time). Until then we fall back to the
+    // REST resource so SSR and the cold-start hydration window still render
+    // data instead of an empty state.
+    const entryRows = computed<PushupRecord[]>(() => {
+      if (store._isBrowser && store._live.connected()) {
+        return store._live.entries();
+      }
+      return store.entriesResource.value() ?? [];
+    });
 
     /** Precomputed server-side stats (null if not yet available). */
     const userStats = computed<UserStats | null>(
@@ -129,15 +142,18 @@ export const DashboardStore = signalStore(
     );
 
     const todayTotal = computed(() => {
-      const us = userStats();
       const berlinToday = toBerlinIsoDate(new Date());
-      if (us && us.dailyKey === berlinToday) {
-        return us.dailyReps;
-      }
-      // Fallback: compute from entries
-      return entryRows()
+      const liveTotal = entryRows()
         .filter((entry) => entry.timestamp.slice(0, 10) === berlinToday)
         .reduce((sum, entry) => sum + entry.reps, 0);
+      // In the browser, live entries are always fresher than server-precomputed
+      // userStats: the Cloud Function that aggregates UserStats runs after the
+      // pushup write, so a fresh fetch of UserStats can still return stale
+      // numbers right after a SpeedDial / Quick-Add insertion.
+      if (store._isBrowser && store._live.connected()) return liveTotal;
+      const us = userStats();
+      if (us && us.dailyKey === berlinToday) return us.dailyReps;
+      return liveTotal;
     });
 
     const dailyGoal = computed(() => store._userConfig.dailyGoal() || 10);
@@ -222,11 +238,9 @@ export const DashboardStore = signalStore(
       return streak;
     });
 
-    const weekReps = computed(() => {
-      const us = userStats();
-      if (us && us.weeklyKey === currentIsoWeekKey()) return us.weeklyReps;
-
-      // Fallback: client-side computation using Berlin date
+    // Live computation from entries — used as the primary source in the
+    // browser (always fresh) and as the fallback elsewhere.
+    const weekRepsFromEntries = computed(() => {
       const berlinToday = toBerlinIsoDate(new Date());
       const [by, bm, bd] = berlinToday.split('-').map(Number);
       const todayDate = new Date(by, bm - 1, bd);
@@ -246,16 +260,27 @@ export const DashboardStore = signalStore(
         .reduce((sum, entry) => sum + entry.reps, 0);
     });
 
-    const monthReps = computed(() => {
+    const weekReps = computed(() => {
+      if (store._isBrowser && store._live.connected())
+        return weekRepsFromEntries();
       const us = userStats();
-      if (us && us.monthlyKey === currentMonthKey()) return us.monthlyReps;
+      if (us && us.weeklyKey === currentIsoWeekKey()) return us.weeklyReps;
+      return weekRepsFromEntries();
+    });
 
-      // Fallback: client-side computation using Berlin date
+    const monthRepsFromEntries = computed(() => {
       const prefix = toBerlinIsoDate(new Date()).slice(0, 7);
-
       return entryRows()
         .filter((entry) => entry.timestamp.startsWith(prefix))
         .reduce((sum, entry) => sum + entry.reps, 0);
+    });
+
+    const monthReps = computed(() => {
+      if (store._isBrowser && store._live.connected())
+        return monthRepsFromEntries();
+      const us = userStats();
+      if (us && us.monthlyKey === currentMonthKey()) return us.monthlyReps;
+      return monthRepsFromEntries();
     });
 
     const weeklyGoalProgressPercent = computed(() =>
@@ -280,6 +305,12 @@ export const DashboardStore = signalStore(
     );
 
     const loading = computed(() => {
+      if (store._isBrowser) {
+        // Treat the dashboard as "loading" only until the Firestore listener
+        // has emitted at least once; subsequent updates happen reactively
+        // through `_live.entries()` without a loading flicker.
+        return !store._live.connected() && entryRows().length === 0;
+      }
       const status = store.entriesResource.status();
       return status === 'loading' || status === 'reloading';
     });

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -75,9 +75,19 @@ describe('StatsDashboardComponent', () => {
 
   const liveTick = signal(0);
   const liveConnected = signal(false);
+  const liveEntries = signal<
+    Array<{
+      _id: string;
+      timestamp: string;
+      reps: number;
+      source?: string;
+      type?: string;
+    }>
+  >([]);
   const liveMock = {
     updateTick: liveTick.asReadonly(),
     connected: liveConnected.asReadonly(),
+    entries: liveEntries.asReadonly(),
   };
 
   const adsConfigMock = {
@@ -105,6 +115,7 @@ describe('StatsDashboardComponent', () => {
     vi.clearAllMocks();
     liveTick.set(0);
     liveConnected.set(false);
+    liveEntries.set([]);
     window.history.replaceState({}, '', '/');
 
     dialogOpenSpy.mockClear();
@@ -629,6 +640,48 @@ describe('StatsDashboardComponent', () => {
       const button = findQuickActionsGoalButton(fixture.nativeElement);
       button!.click();
       expect(svc.fillToGoal).toHaveBeenCalledTimes(1);
+    });
+
+    it('Regression: Given live is connected, When Firestore pushes a new entry (SpeedDial flow), Then the "+X bis zum Ziel" label updates without an explicit reload', async () => {
+      // Given a connected live store with one entry today (12 reps), goal 100
+      liveConnected.set(true);
+      liveEntries.set([
+        {
+          _id: '2',
+          timestamp: todayTs,
+          reps: 12,
+          source: 'web',
+          type: 'Diamond',
+        },
+      ]);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      let button = findQuickActionsGoalButton(fixture.nativeElement);
+      expect(button).not.toBeNull();
+      expect(button!.textContent ?? '').toContain('88');
+
+      // When Firestore pushes a new 30-rep entry (the SpeedDial path) —
+      // simulated by a LiveDataStore.entries update. Crucially we do NOT call
+      // refreshAll(): the bug was that derived signals only updated when REST
+      // resources reloaded, ignoring the live signal.
+      liveEntries.update((rows) => [
+        ...rows,
+        {
+          _id: 'new',
+          timestamp: '2025-01-15T13:00:00',
+          reps: 30,
+          source: 'quick-add',
+          type: 'Standard',
+        },
+      ]);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      // Then the label reflects the new total reactively (12 + 30 = 42, gap = 58)
+      button = findQuickActionsGoalButton(fixture.nativeElement);
+      expect(button).not.toBeNull();
+      expect(button!.textContent ?? '').toContain('58');
     });
   });
 


### PR DESCRIPTION
The Schnellaktionen "+X bis zum Ziel" button (and other today/week/month
totals) did not update after a SpeedDial-triggered quick add. Root cause:
`DashboardStore.todayTotal` and `AppDataFacade.todayProgress` read from
server-precomputed UserStats / a REST resource that needs explicit
reload. The Cloud Function aggregating UserStats runs *after* the
pushup write, so the post-mutation reload often returned stale numbers
even though Firestore had already pushed the new entry to the live
listener.

LiveDataStore is the only truly reactive source — it pipes Firestore
`onSnapshot` updates into a signal. Make it the source of truth for
entry-derived signals: `entryRows`, `todayTotal`, `weekReps`, `monthReps`
in DashboardStore and `recentEntries`, `todayProgress`,
`remainingToGoal`, `goalReached`, `quickAddSuggestions` in AppDataFacade
all derive from `live.entries()` whenever the listener is connected.
REST resources are kept as SSR / cold-start fallbacks.

Adds regression tests that simulate the SpeedDial flow by pushing a
new record into the LiveDataStore mock and asserting derived signals
update without anyone calling `reloadAfterMutation()`.

https://claude.ai/code/session_01MZjAVvYU76tc3ZjeX2yKCC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Real-time live data synchronization: stats, progress metrics, and quick-add suggestions now update automatically when new entries are detected, eliminating the need for manual page refreshes.

* **Tests**
  * Added regression tests to verify live data changes propagate correctly through the app and recalculate displayed values without triggering reload mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->