### PR TITLE
feat(reminders): one-tap pushup logging from notification action

### DIFF
--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -35,6 +35,7 @@ import {
   isLeaseStale,
   pushSubscriptionId,
   PUSH_SEND_OPTIONS,
+  sanitizeQuickLogReps,
   shouldSendReminder,
   STALE_LEASE_MS,
   validateSubscriptionPayload,
@@ -982,13 +983,13 @@ export const dispatchPushReminders = onSchedule(
 
           const body = buildNotificationPayload(reminder?.language);
           const lang = reminder?.language === 'en' ? 'en' : 'de';
-          const actions = buildReminderActions(lang, reminder?.quickLogReps);
-          const quickLogAction = actions.find(
-            (a) => a.action === 'quick-log'
-          );
-          const quickLogReps = quickLogAction
-            ? Math.floor(reminder?.quickLogReps ?? 0)
-            : undefined;
+          // Single source of truth: sanitize once, then use the same value for
+          // both the action title and the data payload. Computing them
+          // independently caused the title to clamp to 500 while the payload
+          // shipped the raw (potentially absurd) Firestore value, so the SW
+          // logged a different count than the user saw on the button.
+          const quickLogReps = sanitizeQuickLogReps(reminder?.quickLogReps);
+          const actions = buildReminderActions(lang, quickLogReps);
           const payload = JSON.stringify({
             title: 'PushUp Stats',
             body,

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -30,6 +30,7 @@ import { UserProfile } from './profile';
 import type { ReminderConfig } from './push';
 import {
   buildNotificationPayload,
+  buildReminderActions,
   isExpiredSubscriptionError,
   isLeaseStale,
   pushSubscriptionId,
@@ -981,16 +982,13 @@ export const dispatchPushReminders = onSchedule(
 
           const body = buildNotificationPayload(reminder?.language);
           const lang = reminder?.language === 'en' ? 'en' : 'de';
-          const actions =
-            lang === 'en'
-              ? [
-                  { action: 'snooze', title: '⏰ Snooze 30 min' },
-                  { action: 'log', title: '✅ Log push-ups' },
-                ]
-              : [
-                  { action: 'snooze', title: '⏰ 30 Min snoozen' },
-                  { action: 'log', title: '✅ Eintragen' },
-                ];
+          const actions = buildReminderActions(lang, reminder?.quickLogReps);
+          const quickLogAction = actions.find(
+            (a) => a.action === 'quick-log'
+          );
+          const quickLogReps = quickLogAction
+            ? Math.floor(reminder?.quickLogReps ?? 0)
+            : undefined;
           const payload = JSON.stringify({
             title: 'PushUp Stats',
             body,
@@ -998,7 +996,11 @@ export const dispatchPushReminders = onSchedule(
             badge: '/icons/badge-72x72.png',
             tag: 'reminder',
             renotify: true,
-            data: { url: `/${lang}/app`, locale: lang },
+            data: {
+              url: `/${lang}/app`,
+              locale: lang,
+              ...(quickLogReps ? { quickLogReps } : {}),
+            },
             actions,
           });
 

--- a/data-store/functions/src/push/reminders.spec.ts
+++ b/data-store/functions/src/push/reminders.spec.ts
@@ -2,10 +2,13 @@ import { describe, it, expect } from '@jest/globals';
 import {
   shouldSendReminder,
   buildNotificationPayload,
+  buildReminderActions,
+  sanitizeQuickLogReps,
   isExpiredSubscriptionError,
   isLeaseStale,
   STALE_LEASE_MS,
   PUSH_SEND_OPTIONS,
+  QUICK_LOG_REPS_MAX,
   ReminderConfig,
   FirestoreTimestamp,
 } from './reminders';
@@ -448,6 +451,65 @@ describe('push/reminders', () => {
 
     it('uses a topic so FCM collapses queued reminders', () => {
       expect(PUSH_SEND_OPTIONS.topic).toBe('reminder');
+    });
+  });
+
+  describe('sanitizeQuickLogReps', () => {
+    it('returns undefined for missing / non-finite / non-positive input', () => {
+      expect(sanitizeQuickLogReps(undefined)).toBeUndefined();
+      expect(sanitizeQuickLogReps(NaN)).toBeUndefined();
+      expect(sanitizeQuickLogReps(Number.POSITIVE_INFINITY)).toBeUndefined();
+      expect(sanitizeQuickLogReps(0)).toBeUndefined();
+      expect(sanitizeQuickLogReps(-5)).toBeUndefined();
+    });
+
+    it('floors fractional values', () => {
+      expect(sanitizeQuickLogReps(12.7)).toBe(12);
+    });
+
+    it('clamps values larger than the maximum', () => {
+      expect(sanitizeQuickLogReps(QUICK_LOG_REPS_MAX + 1000)).toBe(
+        QUICK_LOG_REPS_MAX
+      );
+    });
+  });
+
+  describe('buildReminderActions', () => {
+    it('returns the generic German log action when no quickLogReps configured', () => {
+      const actions = buildReminderActions('de', undefined);
+      expect(actions).toEqual([
+        { action: 'snooze', title: '⏰ 30 Min snoozen' },
+        { action: 'log', title: '✅ Eintragen' },
+      ]);
+    });
+
+    it('returns the generic English log action when no quickLogReps configured', () => {
+      const actions = buildReminderActions('en', undefined);
+      expect(actions).toEqual([
+        { action: 'snooze', title: '⏰ Snooze 30 min' },
+        { action: 'log', title: '✅ Log push-ups' },
+      ]);
+    });
+
+    it('emits a quick-log action with the configured count (German)', () => {
+      const actions = buildReminderActions('de', 25);
+      expect(actions[1]).toEqual({
+        action: 'quick-log',
+        title: '✅ 25 eintragen',
+      });
+    });
+
+    it('emits a quick-log action with the configured count (English)', () => {
+      const actions = buildReminderActions('en', 25);
+      expect(actions[1]).toEqual({
+        action: 'quick-log',
+        title: '✅ Log 25',
+      });
+    });
+
+    it('falls back to generic log when quickLogReps is invalid', () => {
+      const actions = buildReminderActions('de', NaN);
+      expect(actions[1].action).toBe('log');
     });
   });
 });

--- a/data-store/functions/src/push/reminders.ts
+++ b/data-store/functions/src/push/reminders.ts
@@ -204,10 +204,16 @@ export interface NotificationAction {
 }
 
 /**
- * Builds the notification `actions` array. When `quickLogReps` is configured,
- * the second slot becomes a one-tap "Log N" button (action `quick-log`)
- * carrying the count via `data.quickLogReps`. Otherwise the existing generic
- * "log" action that opens the create-entry dialog is used.
+ * Builds the notification `actions` array. When `quickLogReps` is configured
+ * (and passes `sanitizeQuickLogReps`), the second slot becomes a one-tap
+ * "Log N" button (action `quick-log`). Otherwise the generic "log" action
+ * that opens the create-entry dialog is used.
+ *
+ * Note: this only returns the `actions` array — the enclosing notification
+ * payload must populate `data.quickLogReps` with the same sanitized count
+ * when the `quick-log` action is present, otherwise the SW handler
+ * (`libs/sw-push/src/handlers.ts`) cannot route the click. Pass the result
+ * of `sanitizeQuickLogReps` to both call sites.
  */
 export function buildReminderActions(
   language: string | undefined,

--- a/data-store/functions/src/push/reminders.ts
+++ b/data-store/functions/src/push/reminders.ts
@@ -11,6 +11,8 @@ export interface ReminderConfig {
   quietHours?: Array<{ from: string; to: string }>;
   intervalMinutes?: number;
   language?: string;
+  /** One-tap pushup count surfaced as a notification action. */
+  quickLogReps?: number;
 }
 
 export interface FirestoreTimestamp {
@@ -187,6 +189,61 @@ export function isExpiredSubscriptionError(
   // the next 5-min tick retries.
   if (hostIsInvalidTld) return true;
   return false;
+}
+
+/**
+ * Maximum sane quick-log count surfaced from a notification button.
+ * Mirrors `QUICK_LOG_REPS_MAX` in the shared model — guards against absurd
+ * values written client-side bypassing the form.
+ */
+export const QUICK_LOG_REPS_MAX = 500;
+
+export interface NotificationAction {
+  action: string;
+  title: string;
+}
+
+/**
+ * Builds the notification `actions` array. When `quickLogReps` is configured,
+ * the second slot becomes a one-tap "Log N" button (action `quick-log`)
+ * carrying the count via `data.quickLogReps`. Otherwise the existing generic
+ * "log" action that opens the create-entry dialog is used.
+ */
+export function buildReminderActions(
+  language: string | undefined,
+  quickLogReps: number | undefined
+): NotificationAction[] {
+  const lang = language === 'en' ? 'en' : 'de';
+  const snooze: NotificationAction =
+    lang === 'en'
+      ? { action: 'snooze', title: '⏰ Snooze 30 min' }
+      : { action: 'snooze', title: '⏰ 30 Min snoozen' };
+
+  const reps = sanitizeQuickLogReps(quickLogReps);
+  if (reps) {
+    const title =
+      lang === 'en' ? `✅ Log ${reps}` : `✅ ${reps} eintragen`;
+    return [snooze, { action: 'quick-log', title }];
+  }
+
+  const log: NotificationAction =
+    lang === 'en'
+      ? { action: 'log', title: '✅ Log push-ups' }
+      : { action: 'log', title: '✅ Eintragen' };
+  return [snooze, log];
+}
+
+/**
+ * Returns a clean integer in [1, QUICK_LOG_REPS_MAX] or `undefined` when the
+ * input is missing/invalid. Used to gate inclusion of the quick-log action.
+ */
+export function sanitizeQuickLogReps(
+  raw: number | undefined
+): number | undefined {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return undefined;
+  const intVal = Math.floor(raw);
+  if (intVal < 1) return undefined;
+  return Math.min(intVal, QUICK_LOG_REPS_MAX);
 }
 
 /**

--- a/docs/gotchas/push-and-service-workers.md
+++ b/docs/gotchas/push-and-service-workers.md
@@ -22,3 +22,34 @@ In-app reminders use `ReminderService` with `setInterval`. Server-side reminders
 ## Cloud Function lease handling
 
 `dispatchPushReminders` uses a transactional lease (`inProgress` flag) to prevent duplicate sends. **Always release the lease in `finally`** — any early return path that skips the release leaves the lease stuck until the next write to the doc.
+
+## Notification action data must match the action title
+
+`ServiceWorkerRegistration.showNotification(title, { actions })` accepts a list of buttons; the click payload is delivered to `notificationclick` with the original `notification.data`. When the button label embeds a value (e.g. "✅ Log 25"), **derive the displayed value and the data payload from the same sanitized variable**. Computing them independently caused a real PR #249 regression: the title clamped to 500 via `sanitizeQuickLogReps` while `data.quickLogReps` shipped raw `Math.floor(reminder.quickLogReps ?? 0)`, so the SW silently logged 9999 push-ups when the user tapped a button labelled "Log 500".
+
+Pattern (CF `dispatchPushReminders`):
+
+```ts
+const quickLogReps = sanitizeQuickLogReps(reminder?.quickLogReps);
+const actions = buildReminderActions(lang, quickLogReps);
+const payload = JSON.stringify({
+  // ...
+  data: { url, locale, ...(quickLogReps ? { quickLogReps } : {}) },
+  actions,
+});
+```
+
+Defense-in-depth: clamp again in the SW handler (`libs/sw-push/src/handlers.ts`) and in the in-app listener (`QuickLogListenerService`). Stale payloads from older SW deployments stay in the push queue for `TTL: 1800` seconds and can outlive a server-side validator change.
+
+## Notification deep-links are untrusted input
+
+When the SW falls back to `clients.openWindow('/app?quickLog=N')` (no client open), the count round-trips through the URL. Treat it like any user-controllable input: clamp into the valid range before persisting. The same handler covers two callers (legitimate notification click + URL-tampered reload), so the validation lives at the dashboard, not at the SW.
+
+## Source attribution must be consistent across paths
+
+A single user action ("tap notification button") can route through two code paths depending on whether an app tab is already open:
+
+- **App open** → SW posts `QUICK_LOG_PUSHUPS` to the client; client writes `source: 'reminder'`.
+- **App closed** → SW opens `/app?quickLog=N`; dashboard writes `source: 'reminder'`.
+
+Both must set the same `source`, otherwise source-based filtering/analytics quietly drift apart. Add a regression test that asserts both paths produce the same `source`.

--- a/libs/reminders/src/index.ts
+++ b/libs/reminders/src/index.ts
@@ -3,6 +3,7 @@ export { ReminderService } from './lib/reminder.service';
 export type { ReminderUserContext } from './lib/reminder.service';
 export { ReminderPermissionService } from './lib/reminder-permission.service';
 export { PushSubscriptionService } from './lib/push/push-subscription.service';
+export { QuickLogListenerService } from './lib/push/quick-log-listener.service';
 export {
   PushSwRegistrationService,
   buildPushSwPaths,

--- a/libs/reminders/src/lib/push/quick-log-listener.service.spec.ts
+++ b/libs/reminders/src/lib/push/quick-log-listener.service.spec.ts
@@ -1,0 +1,132 @@
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { StatsApiService } from '@pu-stats/data-access';
+import { of, throwError } from 'rxjs';
+import { QuickLogListenerService } from './quick-log-listener.service';
+
+describe('QuickLogListenerService', () => {
+  const swDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    'serviceWorker'
+  );
+
+  let messageListeners: Array<(ev: MessageEvent) => void>;
+  let createPushup: jest.Mock;
+  let snackOpen: jest.Mock;
+
+  function emitMessage(data: unknown): void {
+    for (const listener of messageListeners) {
+      listener({ data } as MessageEvent);
+    }
+  }
+
+  beforeEach(() => {
+    messageListeners = [];
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        addEventListener: jest.fn(
+          (type: string, listener: (ev: MessageEvent) => void) => {
+            if (type === 'message') messageListeners.push(listener);
+          }
+        ),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    createPushup = jest.fn().mockReturnValue(of({ _id: 'new-entry' }));
+    snackOpen = jest.fn();
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: StatsApiService,
+          useValue: { createPushup },
+        },
+        {
+          provide: MatSnackBar,
+          useValue: { open: snackOpen },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    if (swDescriptor) {
+      Object.defineProperty(navigator, 'serviceWorker', swDescriptor);
+    } else {
+      delete (navigator as Record<string, unknown>)['serviceWorker'];
+    }
+  });
+
+  it('creates a pushup entry when a QUICK_LOG_PUSHUPS message arrives', async () => {
+    const service = TestBed.inject(QuickLogListenerService);
+    service.init();
+
+    emitMessage({ type: 'QUICK_LOG_PUSHUPS', reps: 15 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(createPushup).toHaveBeenCalledTimes(1);
+    const payload = createPushup.mock.calls[0][0];
+    expect(payload.reps).toBe(15);
+    expect(payload.sets).toEqual([15]);
+    expect(payload.source).toBe('reminder');
+    expect(payload.type).toBe('Standard');
+    expect(typeof payload.timestamp).toBe('string');
+  });
+
+  it('ignores messages with non-positive or non-finite reps', async () => {
+    const service = TestBed.inject(QuickLogListenerService);
+    service.init();
+
+    emitMessage({ type: 'QUICK_LOG_PUSHUPS', reps: 0 });
+    emitMessage({ type: 'QUICK_LOG_PUSHUPS', reps: -3 });
+    emitMessage({ type: 'QUICK_LOG_PUSHUPS', reps: Number.POSITIVE_INFINITY });
+    emitMessage({ type: 'QUICK_LOG_PUSHUPS' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(createPushup).not.toHaveBeenCalled();
+  });
+
+  it('ignores unrelated SW messages', async () => {
+    const service = TestBed.inject(QuickLogListenerService);
+    service.init();
+
+    emitMessage({ type: 'SNOOZE_REMINDER', snoozeMinutes: 30 });
+    emitMessage({ type: 'PUSH_SUBSCRIPTION_CHANGED', sub: {} });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(createPushup).not.toHaveBeenCalled();
+  });
+
+  it('only registers the message listener once across multiple init() calls', () => {
+    const service = TestBed.inject(QuickLogListenerService);
+    service.init();
+    service.init();
+    service.init();
+    expect(messageListeners.length).toBe(1);
+  });
+
+  it('floors fractional reps', async () => {
+    const service = TestBed.inject(QuickLogListenerService);
+    service.init();
+    emitMessage({ type: 'QUICK_LOG_PUSHUPS', reps: 12.9 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(createPushup.mock.calls[0][0].reps).toBe(12);
+  });
+
+  it('shows a success snackbar after a successful entry', async () => {
+    const service = TestBed.inject(QuickLogListenerService);
+    await service.logEntry(20);
+    expect(snackOpen).toHaveBeenCalled();
+    const message = snackOpen.mock.calls[0][0];
+    expect(message).toContain('20');
+  });
+
+  it('shows an error snackbar when createPushup fails', async () => {
+    createPushup.mockReturnValue(throwError(() => new Error('boom')));
+    const service = TestBed.inject(QuickLogListenerService);
+    await service.logEntry(10);
+    expect(snackOpen).toHaveBeenCalled();
+  });
+});

--- a/libs/reminders/src/lib/push/quick-log-listener.service.spec.ts
+++ b/libs/reminders/src/lib/push/quick-log-listener.service.spec.ts
@@ -115,6 +115,15 @@ describe('QuickLogListenerService', () => {
     expect(createPushup.mock.calls[0][0].reps).toBe(12);
   });
 
+  it('clamps oversized reps to QUICK_LOG_REPS_MAX (defense-in-depth)', async () => {
+    const service = TestBed.inject(QuickLogListenerService);
+    service.init();
+    emitMessage({ type: 'QUICK_LOG_PUSHUPS', reps: 9999 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(createPushup).toHaveBeenCalledTimes(1);
+    expect(createPushup.mock.calls[0][0].reps).toBe(500);
+  });
+
   it('shows a success snackbar after a successful entry', async () => {
     const service = TestBed.inject(QuickLogListenerService);
     await service.logEntry(20);

--- a/libs/reminders/src/lib/push/quick-log-listener.service.ts
+++ b/libs/reminders/src/lib/push/quick-log-listener.service.ts
@@ -2,7 +2,11 @@ import { isPlatformBrowser } from '@angular/common';
 import { inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { StatsApiService } from '@pu-stats/data-access';
-import { appendLocalOffset } from '@pu-stats/models';
+import {
+  appendLocalOffset,
+  QUICK_LOG_REPS_MAX,
+  QUICK_LOG_REPS_MIN,
+} from '@pu-stats/models';
 import { firstValueFrom } from 'rxjs';
 
 /**
@@ -40,12 +44,12 @@ export class QuickLogListenerService {
         reps?: number;
       } | null;
       if (data?.type !== 'QUICK_LOG_PUSHUPS') return;
-      const reps = Number(data.reps);
-      if (!Number.isFinite(reps) || reps <= 0) return;
+      const clamped = clampReps(data.reps);
+      if (clamped == null) return;
       // SW message events fire outside Angular's zone — re-enter so any
       // signals/snackbar triggered downstream propagate change detection.
       this.zone.run(() => {
-        void this.logEntry(Math.floor(reps));
+        void this.logEntry(clamped);
       });
     });
   }
@@ -75,6 +79,18 @@ export class QuickLogListenerService {
       );
     }
   }
+}
+
+/**
+ * Mirrors the dispatch CF sanitizer: returns an integer in
+ * `[QUICK_LOG_REPS_MIN, QUICK_LOG_REPS_MAX]`, or `null` for missing/invalid
+ * input. Defense-in-depth — the CF and SW already clamp, but stale payloads
+ * from older deployments can still reach this handler.
+ */
+function clampReps(raw: unknown): number | null {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < QUICK_LOG_REPS_MIN) return null;
+  return Math.min(Math.floor(n), QUICK_LOG_REPS_MAX);
 }
 
 function currentLocalTimestamp(): string {

--- a/libs/reminders/src/lib/push/quick-log-listener.service.ts
+++ b/libs/reminders/src/lib/push/quick-log-listener.service.ts
@@ -1,0 +1,88 @@
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { StatsApiService } from '@pu-stats/data-access';
+import { appendLocalOffset } from '@pu-stats/models';
+import { firstValueFrom } from 'rxjs';
+
+/**
+ * Listens for `QUICK_LOG_PUSHUPS` messages posted by the push service worker
+ * (`libs/sw-push/src/handlers.ts`) when the user taps the "✅ N eintragen"
+ * notification action. The message arrives only when a window client is open;
+ * if it isn't, the SW navigates to `?quickLog=N` and the dashboard handles
+ * it on render instead.
+ *
+ * Idempotency: registration is guarded by a flag — calling `init()` multiple
+ * times (per-page injection, route changes) installs only one listener.
+ */
+@Injectable({ providedIn: 'root' })
+export class QuickLogListenerService {
+  private readonly api = inject(StatsApiService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly zone = inject(NgZone);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
+  private registered = false;
+
+  init(): void {
+    if (
+      this.registered ||
+      !this.isBrowser ||
+      !('serviceWorker' in navigator)
+    ) {
+      return;
+    }
+    this.registered = true;
+
+    navigator.serviceWorker.addEventListener('message', (event) => {
+      const data = (event as MessageEvent).data as {
+        type?: string;
+        reps?: number;
+      } | null;
+      if (data?.type !== 'QUICK_LOG_PUSHUPS') return;
+      const reps = Number(data.reps);
+      if (!Number.isFinite(reps) || reps <= 0) return;
+      // SW message events fire outside Angular's zone — re-enter so any
+      // signals/snackbar triggered downstream propagate change detection.
+      this.zone.run(() => {
+        void this.logEntry(Math.floor(reps));
+      });
+    });
+  }
+
+  /** Visible for testing — invokes the same flow as the SW message handler. */
+  async logEntry(reps: number): Promise<void> {
+    try {
+      await firstValueFrom(
+        this.api.createPushup({
+          timestamp: appendLocalOffset(currentLocalTimestamp()),
+          reps,
+          sets: [reps],
+          source: 'reminder',
+          type: 'Standard',
+        })
+      );
+      this.snackBar.open(
+        $localize`:@@reminder.quickLog.success:${reps}:reps: Push-ups eingetragen ✓`,
+        $localize`:@@snackbar.close:Schließen`,
+        { duration: 3000 }
+      );
+    } catch {
+      this.snackBar.open(
+        $localize`:@@reminder.quickLog.error:Eintrag konnte nicht gespeichert werden.`,
+        $localize`:@@snackbar.close:Schließen`,
+        { duration: 5000 }
+      );
+    }
+  }
+}
+
+function currentLocalTimestamp(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  const hh = String(now.getHours()).padStart(2, '0');
+  const mm = String(now.getMinutes()).padStart(2, '0');
+  return `${y}-${m}-${d}T${hh}:${mm}`;
+}

--- a/libs/reminders/src/test-setup.ts
+++ b/libs/reminders/src/test-setup.ts
@@ -1,3 +1,4 @@
+import '@angular/localize/init';
 import 'whatwg-fetch';
 import { setupZonelessTestEnv } from 'jest-preset-angular/setup-env/zoneless';
 

--- a/libs/stats/src/lib/models/reminder-config.models.ts
+++ b/libs/stats/src/lib/models/reminder-config.models.ts
@@ -8,4 +8,13 @@ export interface ReminderConfig {
   timezone: string;
   language: 'de' | 'en';
   lastQuoteFetchAt?: string;
+  /**
+   * One-tap pushup count surfaced as a notification action button. When set
+   * (and > 0), reminders show "✅ N eintragen" instead of the generic log
+   * action — tapping it logs the entry without the user opening the app.
+   */
+  quickLogReps?: number;
 }
+
+export const QUICK_LOG_REPS_MIN = 1;
+export const QUICK_LOG_REPS_MAX = 500;

--- a/libs/sw-push/src/handlers.spec.ts
+++ b/libs/sw-push/src/handlers.spec.ts
@@ -381,6 +381,44 @@ describe('handleNotificationClick', () => {
     expect(openWindow).toHaveBeenCalledWith('/de/app?log=1');
   });
 
+  it('quick-log: clamps an out-of-range payload to the SW max (defense-in-depth)', async () => {
+    const client: ClientLike = {
+      url: 'https://pushup-stats.de/de/app',
+      focus: jest.fn().mockResolvedValue(undefined),
+      postMessage: jest.fn(),
+    };
+    const { ctx } = makeCtx({ matchAllResult: [client] });
+    let waited: Promise<unknown> | undefined;
+    const { event } = makeEvent('quick-log', {
+      locale: 'de',
+      quickLogReps: 99999,
+    });
+    event.waitUntil = (p) => {
+      waited = p;
+    };
+    handleNotificationClick(event, ctx);
+    await waited;
+    expect(client.postMessage).toHaveBeenCalledWith({
+      type: 'QUICK_LOG_PUSHUPS',
+      reps: 500,
+    });
+  });
+
+  it('quick-log: clamps the deep-link reps when no client is open', async () => {
+    const { ctx, openWindow } = makeCtx({ matchAllResult: [] });
+    let waited: Promise<unknown> | undefined;
+    const { event } = makeEvent('quick-log', {
+      locale: 'en',
+      quickLogReps: 99999,
+    });
+    event.waitUntil = (p) => {
+      waited = p;
+    };
+    handleNotificationClick(event, ctx);
+    await waited;
+    expect(openWindow).toHaveBeenCalledWith('/en/app?quickLog=500');
+  });
+
   it('quick-log: floors fractional reps to an integer', async () => {
     const client: ClientLike = {
       url: 'https://pushup-stats.de/de/app',

--- a/libs/sw-push/src/handlers.spec.ts
+++ b/libs/sw-push/src/handlers.spec.ts
@@ -262,7 +262,9 @@ describe('handlePushSubscriptionChange', () => {
 describe('handleNotificationClick', () => {
   function makeEvent(
     action: string,
-    data?: { locale?: string; url?: string } | null
+    data?:
+      | { locale?: string; url?: string; quickLogReps?: number }
+      | null
   ): { event: NotificationClickEventLike; close: jest.Mock } {
     const close = jest.fn();
     return {
@@ -325,6 +327,81 @@ describe('handleNotificationClick', () => {
     handleNotificationClick(event, ctx);
     await waited;
     expect(openWindow).toHaveBeenCalledWith('/de/app?log=1');
+  });
+
+  it('quick-log: posts QUICK_LOG_PUSHUPS to an open client and skips openWindow', async () => {
+    const client: ClientLike = {
+      url: 'https://pushup-stats.de/de/app',
+      focus: jest.fn().mockResolvedValue(undefined),
+      postMessage: jest.fn(),
+    };
+    const { ctx, openWindow } = makeCtx({ matchAllResult: [client] });
+    let waited: Promise<unknown> | undefined;
+    const { event } = makeEvent('quick-log', {
+      locale: 'de',
+      quickLogReps: 25,
+    });
+    event.waitUntil = (p) => {
+      waited = p;
+    };
+    handleNotificationClick(event, ctx);
+    await waited;
+    expect(client.postMessage).toHaveBeenCalledWith({
+      type: 'QUICK_LOG_PUSHUPS',
+      reps: 25,
+    });
+    expect(client.focus).toHaveBeenCalled();
+    expect(openWindow).not.toHaveBeenCalled();
+  });
+
+  it('quick-log: opens the app with ?quickLog=N when no client is open', async () => {
+    const { ctx, openWindow } = makeCtx({ matchAllResult: [] });
+    let waited: Promise<unknown> | undefined;
+    const { event } = makeEvent('quick-log', {
+      locale: 'en',
+      quickLogReps: 7,
+    });
+    event.waitUntil = (p) => {
+      waited = p;
+    };
+    handleNotificationClick(event, ctx);
+    await waited;
+    expect(openWindow).toHaveBeenCalledWith('/en/app?quickLog=7');
+  });
+
+  it('quick-log: falls back to ?log=1 when payload reps are missing/invalid', async () => {
+    const { ctx, openWindow } = makeCtx({ matchAllResult: [] });
+    let waited: Promise<unknown> | undefined;
+    const { event } = makeEvent('quick-log', { locale: 'de' });
+    event.waitUntil = (p) => {
+      waited = p;
+    };
+    handleNotificationClick(event, ctx);
+    await waited;
+    expect(openWindow).toHaveBeenCalledWith('/de/app?log=1');
+  });
+
+  it('quick-log: floors fractional reps to an integer', async () => {
+    const client: ClientLike = {
+      url: 'https://pushup-stats.de/de/app',
+      focus: jest.fn().mockResolvedValue(undefined),
+      postMessage: jest.fn(),
+    };
+    const { ctx } = makeCtx({ matchAllResult: [client] });
+    let waited: Promise<unknown> | undefined;
+    const { event } = makeEvent('quick-log', {
+      locale: 'de',
+      quickLogReps: 12.9,
+    });
+    event.waitUntil = (p) => {
+      waited = p;
+    };
+    handleNotificationClick(event, ctx);
+    await waited;
+    expect(client.postMessage).toHaveBeenCalledWith({
+      type: 'QUICK_LOG_PUSHUPS',
+      reps: 12,
+    });
   });
 
   it('focuses an existing window if it already points to the target URL', async () => {

--- a/libs/sw-push/src/handlers.ts
+++ b/libs/sw-push/src/handlers.ts
@@ -14,6 +14,15 @@ declare const __SW_PUSH_VERSION__: string;
 export const SW_PUSH_VERSION: string =
   typeof __SW_PUSH_VERSION__ === 'string' ? __SW_PUSH_VERSION__ : 'unversioned';
 
+/**
+ * Defense-in-depth cap mirrored from `@pu-stats/models#QUICK_LOG_REPS_MAX` and
+ * the dispatch CF (`data-store/functions/src/push/reminders.ts`). Inlined to
+ * keep the sw-push bundle self-contained — if either value changes, update
+ * here too. The CF already sanitizes before sending; this guard catches stale
+ * payloads from older deployments and any payload tampering.
+ */
+const SW_QUICK_LOG_MAX = 500;
+
 export interface PushSubscriptionChangeEventLike {
   oldSubscription: PushSubscription | null;
   newSubscription: PushSubscription | null;
@@ -207,9 +216,15 @@ export function handleNotificationClick(
 
   if (action === 'quick-log') {
     const repsRaw = event.notification.data?.quickLogReps;
-    const reps =
+    const repsFloored =
       typeof repsRaw === 'number' && Number.isFinite(repsRaw)
         ? Math.floor(repsRaw)
+        : NaN;
+    // Clamp into [1, SW_QUICK_LOG_MAX] so a stale or tampered payload can't
+    // smuggle a 9999-rep entry past the dispatch sanitizer.
+    const reps =
+      Number.isFinite(repsFloored) && repsFloored > 0
+        ? Math.min(repsFloored, SW_QUICK_LOG_MAX)
         : NaN;
     event.waitUntil(
       (async () => {

--- a/libs/sw-push/src/handlers.ts
+++ b/libs/sw-push/src/handlers.ts
@@ -31,7 +31,12 @@ export interface PushEventLike {
 export interface NotificationClickEventLike {
   action: string;
   notification: {
-    data?: { locale?: string; url?: string } | null;
+    data?: {
+      locale?: string;
+      url?: string;
+      /** Set when the dispatch CF includes a `quick-log` action button. */
+      quickLogReps?: number;
+    } | null;
     close(): void;
   };
   waitUntil(promise: Promise<unknown>): void;
@@ -197,6 +202,48 @@ export function handleNotificationClick(
 
   if (action === 'log') {
     event.waitUntil(ctx.clients.openWindow(`/${locale}/app?log=1`));
+    return;
+  }
+
+  if (action === 'quick-log') {
+    const repsRaw = event.notification.data?.quickLogReps;
+    const reps =
+      typeof repsRaw === 'number' && Number.isFinite(repsRaw)
+        ? Math.floor(repsRaw)
+        : NaN;
+    event.waitUntil(
+      (async () => {
+        // No valid count → fall back to the standard log flow so the user
+        // doesn't get an unresponsive button.
+        if (!Number.isFinite(reps) || reps <= 0) {
+          await ctx.clients.openWindow(`/${locale}/app?log=1`);
+          return;
+        }
+        const clientList = await ctx.clients.matchAll({
+          type: 'window',
+          includeUncontrolled: true,
+        });
+        if (clientList.length > 0) {
+          // App is open somewhere — log silently in the existing tab so the
+          // user gets feedback without a navigation flicker.
+          clientList[0].postMessage({
+            type: 'QUICK_LOG_PUSHUPS',
+            reps,
+          });
+          if ('focus' in clientList[0]) {
+            await (
+              clientList[0] as { focus: () => Promise<unknown> }
+            )
+              .focus()
+              .catch(() => undefined);
+          }
+          return;
+        }
+        // No open client — open a new tab with `?quickLog=N`; the dashboard
+        // creates the entry on first render.
+        await ctx.clients.openWindow(`/${locale}/app?quickLog=${reps}`);
+      })()
+    );
     return;
   }
 

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -36,6 +36,7 @@ import { UserContextService } from '@pu-auth/auth';
 import {
   PushSubscriptionService,
   PushSwRegistrationService,
+  QuickLogListenerService,
 } from '@pu-reminders/reminders';
 import { CookieConsentBannerComponent } from '@pu-stats/ads';
 import { QuickAddFabComponent } from '@pu-stats/quick-add';
@@ -89,6 +90,7 @@ export class App {
   );
   private readonly pushService = inject(PushSubscriptionService);
   private readonly pushSwRegistration = inject(PushSwRegistrationService);
+  private readonly quickLogListener = inject(QuickLogListenerService);
   // Eagerly register the push service worker on boot so:
   //   - fresh visitors have the SW installed before they ever open /reminders
   //     (no cold-start race on the first `subscribe()` click), and
@@ -98,6 +100,7 @@ export class App {
   // for PUSH_SUBSCRIPTION_CHANGED events fired by the push SW.
   private readonly _initPushBridge = afterNextRender(() => {
     this.pushService.registerSwListener();
+    this.quickLogListener.init();
     void this.pushSwRegistration.getRegistration();
   });
   // Snooze param from SW notification click — must wait for auth to resolve

--- a/web/src/app/reminders/shell/reminder-form.store.spec.ts
+++ b/web/src/app/reminders/shell/reminder-form.store.spec.ts
@@ -63,6 +63,53 @@ describe('ReminderFormStore', () => {
     expect(store.dirty()).toBe(false);
   });
 
+  describe('quickLog (one-tap notification action)', () => {
+    it('initializes with quickLog disabled and the default count', () => {
+      expect(store.quickLogEnabled()).toBe(false);
+      expect(store.quickLogReps()).toBe(10);
+    });
+
+    it('marks the form dirty when quickLog is toggled', () => {
+      store.setQuickLogEnabled(true);
+      expect(store.quickLogEnabled()).toBe(true);
+      expect(store.dirty()).toBe(true);
+    });
+
+    it('omits quickLogReps from the saved config when toggle is off', () => {
+      store.setQuickLogEnabled(false);
+      const config = store.toConfig('Europe/Berlin');
+      expect(config.quickLogReps).toBeUndefined();
+    });
+
+    it('writes the configured count when toggle is on', () => {
+      store.setQuickLogEnabled(true);
+      store.setQuickLogReps(25);
+      const config = store.toConfig('Europe/Berlin');
+      expect(config.quickLogReps).toBe(25);
+    });
+
+    it('clamps to the [1, 500] range on blur', () => {
+      store.setQuickLogReps(9999);
+      store.clampQuickLogReps();
+      expect(store.quickLogReps()).toBe(500);
+      store.setQuickLogReps(0);
+      store.clampQuickLogReps();
+      expect(store.quickLogReps()).toBe(1);
+    });
+
+    it('hydrates from a config with quickLogReps set', () => {
+      store.syncFromConfig({ ...defaultConfig, quickLogReps: 30 });
+      expect(store.quickLogEnabled()).toBe(true);
+      expect(store.quickLogReps()).toBe(30);
+    });
+
+    it('hydrates as disabled when quickLogReps is missing or invalid', () => {
+      store.syncFromConfig({ ...defaultConfig, quickLogReps: 0 });
+      expect(store.quickLogEnabled()).toBe(false);
+      expect(store.quickLogReps()).toBe(10);
+    });
+  });
+
   describe('syncIfClean (race condition guard)', () => {
     it('syncs when form is clean', () => {
       const config: ReminderConfig = { ...defaultConfig, enabled: true };

--- a/web/src/app/reminders/shell/reminder-form.store.spec.ts
+++ b/web/src/app/reminders/shell/reminder-form.store.spec.ts
@@ -108,6 +108,12 @@ describe('ReminderFormStore', () => {
       expect(store.quickLogEnabled()).toBe(false);
       expect(store.quickLogReps()).toBe(10);
     });
+
+    it('clamps a persisted out-of-range value on hydrate', () => {
+      store.syncFromConfig({ ...defaultConfig, quickLogReps: 9999 });
+      expect(store.quickLogEnabled()).toBe(true);
+      expect(store.quickLogReps()).toBe(500);
+    });
   });
 
   describe('syncIfClean (race condition guard)', () => {

--- a/web/src/app/reminders/shell/reminder-form.store.ts
+++ b/web/src/app/reminders/shell/reminder-form.store.ts
@@ -6,23 +6,38 @@ import {
   withState,
 } from '@ngrx/signals';
 import { computed } from '@angular/core';
-import type { ReminderConfig } from '@pu-stats/models';
+import {
+  type ReminderConfig,
+  QUICK_LOG_REPS_MAX,
+  QUICK_LOG_REPS_MIN,
+} from '@pu-stats/models';
 
 type ReminderFormState = {
   enabled: boolean;
   intervalMinutes: number;
   language: 'de' | 'en';
   quietHours: { from: string; to: string }[];
+  /**
+   * Whether the one-tap quick-log notification action is enabled. Tracked as
+   * a separate flag so the count can be edited while the toggle is off
+   * without losing the value.
+   */
+  quickLogEnabled: boolean;
+  quickLogReps: number;
   dirty: boolean;
   saving: boolean;
   saved: boolean;
 };
+
+const DEFAULT_QUICK_LOG_REPS = 10;
 
 const initialState: ReminderFormState = {
   enabled: false,
   intervalMinutes: 60,
   language: 'de',
   quietHours: [],
+  quickLogEnabled: false,
+  quickLogReps: DEFAULT_QUICK_LOG_REPS,
   dirty: false,
   saving: false,
   saved: false,
@@ -39,11 +54,20 @@ export const ReminderFormStore = signalStore(
   })),
   withMethods((store) => ({
     syncFromConfig(config: ReminderConfig | null): void {
+      const savedReps = config?.quickLogReps;
+      const repsValid =
+        typeof savedReps === 'number' &&
+        Number.isFinite(savedReps) &&
+        savedReps >= QUICK_LOG_REPS_MIN;
       patchState(store, {
         enabled: config?.enabled ?? false,
         intervalMinutes: config?.intervalMinutes ?? 60,
         language: config?.language ?? 'de',
         quietHours: config?.quietHours ? [...config.quietHours] : [],
+        quickLogEnabled: repsValid,
+        quickLogReps: repsValid
+          ? Math.floor(savedReps as number)
+          : DEFAULT_QUICK_LOG_REPS,
         dirty: false,
         saved: false,
       });
@@ -94,6 +118,22 @@ export const ReminderFormStore = signalStore(
       patchState(store, { intervalMinutes: clamped });
     },
 
+    setQuickLogEnabled(value: boolean): void {
+      patchState(store, { quickLogEnabled: value, dirty: true });
+    },
+
+    setQuickLogReps(value: number): void {
+      patchState(store, { quickLogReps: value, dirty: true });
+    },
+
+    clampQuickLogReps(): void {
+      const val = store.quickLogReps();
+      const clamped = Number.isFinite(val)
+        ? Math.min(QUICK_LOG_REPS_MAX, Math.max(QUICK_LOG_REPS_MIN, val))
+        : DEFAULT_QUICK_LOG_REPS;
+      patchState(store, { quickLogReps: Math.floor(clamped) });
+    },
+
     setSaving(value: boolean): void {
       patchState(store, { saving: value });
     },
@@ -107,13 +147,20 @@ export const ReminderFormStore = signalStore(
     },
 
     toConfig(timezone: string): ReminderConfig {
-      return {
+      const config: ReminderConfig = {
         enabled: store.enabled(),
         intervalMinutes: store.intervalMinutes(),
         quietHours: store.quietHours(),
         timezone,
         language: store.language(),
       };
+      if (store.quickLogEnabled()) {
+        const reps = Math.floor(store.quickLogReps());
+        if (Number.isFinite(reps) && reps >= QUICK_LOG_REPS_MIN) {
+          config.quickLogReps = Math.min(reps, QUICK_LOG_REPS_MAX);
+        }
+      }
+      return config;
     },
   }))
 );

--- a/web/src/app/reminders/shell/reminder-form.store.ts
+++ b/web/src/app/reminders/shell/reminder-form.store.ts
@@ -54,11 +54,16 @@ export const ReminderFormStore = signalStore(
   })),
   withMethods((store) => ({
     syncFromConfig(config: ReminderConfig | null): void {
+      // Clamp to both bounds on hydrate so a Firestore value written by an
+      // older client (or via an admin tool) can't leak an out-of-range count
+      // into the form (CodeRabbit/Copilot, PR #249).
       const savedReps = config?.quickLogReps;
+      const normalizedReps =
+        typeof savedReps === 'number' && Number.isFinite(savedReps)
+          ? Math.floor(savedReps)
+          : undefined;
       const repsValid =
-        typeof savedReps === 'number' &&
-        Number.isFinite(savedReps) &&
-        savedReps >= QUICK_LOG_REPS_MIN;
+        normalizedReps !== undefined && normalizedReps >= QUICK_LOG_REPS_MIN;
       patchState(store, {
         enabled: config?.enabled ?? false,
         intervalMinutes: config?.intervalMinutes ?? 60,
@@ -66,7 +71,7 @@ export const ReminderFormStore = signalStore(
         quietHours: config?.quietHours ? [...config.quietHours] : [],
         quickLogEnabled: repsValid,
         quickLogReps: repsValid
-          ? Math.floor(savedReps as number)
+          ? Math.min(normalizedReps as number, QUICK_LOG_REPS_MAX)
           : DEFAULT_QUICK_LOG_REPS,
         dirty: false,
         saved: false,

--- a/web/src/app/reminders/shell/reminders-page.component.ts
+++ b/web/src/app/reminders/shell/reminders-page.component.ts
@@ -162,8 +162,10 @@ import { ReminderFormStore } from './reminder-form.store';
                   </p>
                   <p class="muted" i18n="@@reminder.quickLog.desc">
                     Zeigt einen "Eintragen"-Button auf der
-                    Push-Benachrichtigung. Tippen speichert die konfigurierte
-                    Anzahl Liegestütze, ohne dass du die App öffnen musst.
+                    Push-Benachrichtigung. Wenn die App schon geöffnet ist,
+                    wird der Eintrag im Hintergrund gespeichert; ansonsten
+                    öffnet sich kurz ein Tab, der den Eintrag automatisch
+                    anlegt.
                   </p>
                   <div class="reminder-row">
                     <mat-slide-toggle

--- a/web/src/app/reminders/shell/reminders-page.component.ts
+++ b/web/src/app/reminders/shell/reminders-page.component.ts
@@ -156,6 +156,50 @@ import { ReminderFormStore } from './reminder-form.store';
                   </mat-button-toggle-group>
                 </div>
 
+                <div>
+                  <p class="field-label" i18n="@@reminder.quickLog.label">
+                    Direkt-Eintrag aus der Benachrichtigung
+                  </p>
+                  <p class="muted" i18n="@@reminder.quickLog.desc">
+                    Zeigt einen "Eintragen"-Button auf der
+                    Push-Benachrichtigung. Tippen speichert die konfigurierte
+                    Anzahl Liegestütze, ohne dass du die App öffnen musst.
+                  </p>
+                  <div class="reminder-row">
+                    <mat-slide-toggle
+                      [checked]="form.quickLogEnabled()"
+                      [disabled]="form.saving()"
+                      (change)="form.setQuickLogEnabled($event.checked)"
+                      i18n="@@reminder.quickLog.toggle"
+                    >
+                      Schnell-Eintrag aktivieren
+                    </mat-slide-toggle>
+                    @if (form.quickLogEnabled()) {
+                      <mat-form-field
+                        appearance="outline"
+                        class="quick-log-field"
+                      >
+                        <mat-label i18n="@@reminder.quickLog.reps.label"
+                          >Anzahl Liegestütze</mat-label
+                        >
+                        <input
+                          matInput
+                          type="number"
+                          min="1"
+                          max="500"
+                          [disabled]="form.saving()"
+                          [value]="form.quickLogReps()"
+                          (input)="form.setQuickLogReps(asNumber($event))"
+                          (blur)="form.clampQuickLogReps()"
+                        />
+                        <mat-hint i18n="@@reminder.quickLog.reps.hint"
+                          >1–500 Wiederholungen</mat-hint
+                        >
+                      </mat-form-field>
+                    }
+                  </div>
+                </div>
+
                 <div class="quiet-hours-section">
                   <p class="field-label" i18n="@@reminder.quietHours.label">
                     Ruhezeiten
@@ -389,6 +433,9 @@ import { ReminderFormStore } from './reminder-form.store';
       margin-top: 8px;
       max-width: 180px;
     }
+    .quick-log-field {
+      max-width: 180px;
+    }
     .quiet-hours-section {
       display: grid;
       gap: 8px;
@@ -529,6 +576,9 @@ export class RemindersPageComponent {
   async saveReminderSettings(): Promise<void> {
     const userId = this.activeUserId();
     this.form.clampInterval();
+    if (this.form.quickLogEnabled()) {
+      this.form.clampQuickLogReps();
+    }
     if (!userId) {
       this.snackBar.open(
         $localize`:@@reminder.save.error:Einstellungen konnten nicht gespeichert werden.`,

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -16,7 +16,11 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
-import { appendLocalOffset } from '@pu-stats/models';
+import {
+  appendLocalOffset,
+  QUICK_LOG_REPS_MAX,
+  QUICK_LOG_REPS_MIN,
+} from '@pu-stats/models';
 import { firstValueFrom } from 'rxjs';
 import { QuickAddBridgeService } from '@pu-stats/quick-add';
 import { QuickAddOrchestrationService } from '../../core/quick-add-orchestration.service';
@@ -158,19 +162,26 @@ export class StatsDashboardComponent {
    *   - `?log=1`     → open create-entry dialog (existing behavior)
    *   - `?quickLog=N` → silently log N pushups (notification button click
    *                     when no app tab was open — see sw-push handlers).
+   *
+   * `quickLog` arrives via URL and is therefore untrusted: clamp into the
+   * configured `[QUICK_LOG_REPS_MIN, QUICK_LOG_REPS_MAX]` range so a tampered
+   * link can't persist absurd entries (CodeRabbit/Copilot/Codex P1, PR #249).
    */
   private readonly _handleLogParam = afterNextRender(() => {
     const params = this.route.snapshot.queryParamMap;
     const quickLog = params.get('quickLog');
     const quickReps = quickLog != null ? Number(quickLog) : NaN;
-    if (Number.isFinite(quickReps) && quickReps > 0) {
+    if (Number.isFinite(quickReps) && quickReps >= QUICK_LOG_REPS_MIN) {
+      const clamped = Math.min(Math.floor(quickReps), QUICK_LOG_REPS_MAX);
       void this.router.navigate([], {
         relativeTo: this.route,
         queryParams: { quickLog: null },
         queryParamsHandling: 'merge',
         replaceUrl: true,
       });
-      void this.addQuickEntry(Math.floor(quickReps));
+      // Attribute deep-link entries to the reminder so source-based analytics
+      // match the in-tab `QUICK_LOG_PUSHUPS` path (CodeRabbit/Copilot P2).
+      void this.addQuickEntry(clamped, 'reminder');
       return;
     }
     const log = params.get('log');
@@ -199,7 +210,7 @@ export class StatsDashboardComponent {
     this.refreshCounter.update((c) => c + 1);
   }
 
-  async addQuickEntry(reps: number) {
+  async addQuickEntry(reps: number, source: 'web' | 'reminder' = 'web') {
     const now = new Date();
     const y = now.getFullYear();
     const m = String(now.getMonth() + 1).padStart(2, '0');
@@ -212,7 +223,7 @@ export class StatsDashboardComponent {
         timestamp: appendLocalOffset(`${y}-${m}-${d}T${hh}:${mm}`),
         reps,
         sets: [reps],
-        source: 'web',
+        source,
         type: 'Standard',
       })
     );

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -153,9 +153,27 @@ export class StatsDashboardComponent {
     });
   }
 
-  /** Called after render — opens create dialog if ?log=1 is in the URL */
+  /**
+   * Called after render — handles two notification deep-links:
+   *   - `?log=1`     → open create-entry dialog (existing behavior)
+   *   - `?quickLog=N` → silently log N pushups (notification button click
+   *                     when no app tab was open — see sw-push handlers).
+   */
   private readonly _handleLogParam = afterNextRender(() => {
-    const log = this.route.snapshot.queryParamMap.get('log');
+    const params = this.route.snapshot.queryParamMap;
+    const quickLog = params.get('quickLog');
+    const quickReps = quickLog != null ? Number(quickLog) : NaN;
+    if (Number.isFinite(quickReps) && quickReps > 0) {
+      void this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: { quickLog: null },
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
+      void this.addQuickEntry(Math.floor(quickReps));
+      return;
+    }
+    const log = params.get('log');
     if (log === '1') {
       // Clean up URL without re-navigating
       void this.router.navigate([], {

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -4599,6 +4599,48 @@ Deine Position: # ·  Reps        </source>
         <target>EN</target>
       </segment>
     </unit>
+    <unit id="reminder.quickLog.label">
+      <segment state="translated">
+        <source> Direkt-Eintrag aus der Benachrichtigung </source>
+        <target> Quick log from the notification </target>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.desc">
+      <segment state="translated">
+        <source> Zeigt einen "Eintragen"-Button auf der Push-Benachrichtigung. Tippen speichert die konfigurierte Anzahl Liegestütze, ohne dass du die App öffnen musst. </source>
+        <target> Adds a "Log" button to the push notification. Tapping it saves the configured number of push-ups without opening the app. </target>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.toggle">
+      <segment state="translated">
+        <source> Schnell-Eintrag aktivieren </source>
+        <target> Enable quick log </target>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.reps.label">
+      <segment state="translated">
+        <source>Anzahl Liegestütze</source>
+        <target>Push-up count</target>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.reps.hint">
+      <segment state="translated">
+        <source>1–500 Wiederholungen</source>
+        <target>1–500 reps</target>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.success">
+      <segment state="translated">
+        <source><ph id="0" equiv="reps" disp="reps"/> Push-ups eingetragen ✓</source>
+        <target><ph id="0" equiv="reps" disp="reps"/> push-ups logged ✓</target>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.error">
+      <segment state="translated">
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+        <target>Could not save the entry.</target>
+      </segment>
+    </unit>
     <unit id="reminder.quietHours.label">
       <segment state="translated">
         <source> Ruhezeiten </source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -4607,8 +4607,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="reminder.quickLog.desc">
       <segment state="translated">
-        <source> Zeigt einen "Eintragen"-Button auf der Push-Benachrichtigung. Tippen speichert die konfigurierte Anzahl Liegestütze, ohne dass du die App öffnen musst. </source>
-        <target> Adds a "Log" button to the push notification. Tapping it saves the configured number of push-ups without opening the app. </target>
+        <source> Zeigt einen "Eintragen"-Button auf der Push-Benachrichtigung. Wenn die App schon geöffnet ist, wird der Eintrag im Hintergrund gespeichert; ansonsten öffnet sich kurz ein Tab, der den Eintrag automatisch anlegt. </source>
+        <target> Adds a "Log" button to the push notification. If the app is already open, the entry is saved in the background; otherwise a tab opens briefly and creates the entry automatically. </target>
       </segment>
     </unit>
     <unit id="reminder.quickLog.toggle">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -237,7 +237,7 @@
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:199,200</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:252,253</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:289,290</note>
       </notes>
       <segment>
         <source> Abbrechen </source>
@@ -689,9 +689,41 @@
         <source><ph id="0" equiv="GAP" disp="gap"/> Liegestütze bis zum Tagesziel hinzufügen</source>
       </segment>
     </unit>
+    <unit id="reminder.quickLog.success">
+      <notes>
+        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:66</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="reps" disp="reps"/> Push-ups eingetragen ✓</source>
+      </segment>
+    </unit>
+    <unit id="snackbar.close">
+      <notes>
+        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:67</note>
+        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:73</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:507</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:535</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:551</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:566</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:585</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:604</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:626</note>
+      </notes>
+      <segment>
+        <source>Schließen</source>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.error">
+      <notes>
+        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:72</note>
+      </notes>
+      <segment>
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+      </segment>
+    </unit>
     <unit id="admin.title">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:70,72</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:74,76</note>
       </notes>
       <segment>
         <source>Admin-Bereich</source>
@@ -699,7 +731,7 @@
     </unit>
     <unit id="admin.bulk.title">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:76,78</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:80,82</note>
       </notes>
       <segment>
         <source>Anonyme Benutzer aufräumen</source>
@@ -707,7 +739,7 @@
     </unit>
     <unit id="admin.bulk.daysLabel">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:82,84</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:86,88</note>
       </notes>
       <segment>
         <source>Inaktiv seit (Tage)</source>
@@ -715,7 +747,7 @@
     </unit>
     <unit id="admin.bulk.hint">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:93,96</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:97,100</note>
       </notes>
       <segment>
         <source> Löscht anonyme Benutzer ohne Pushups in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}"/> Tagen. </source>
@@ -723,7 +755,7 @@
     </unit>
     <unit id="admin.bulk.button">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:109,110</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:113,114</note>
       </notes>
       <segment>
         <source>Inaktive löschen</source>
@@ -731,7 +763,7 @@
     </unit>
     <unit id="admin.bulk.deleted">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:117,118</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:121,122</note>
       </notes>
       <segment>
         <source>Gelöscht:</source>
@@ -739,7 +771,7 @@
     </unit>
     <unit id="admin.bulk.skipped">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:119,120</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:123,124</note>
       </notes>
       <segment>
         <source>Übersprungen:</source>
@@ -747,7 +779,7 @@
     </unit>
     <unit id="admin.filter.anonymous">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:138,139</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:142,143</note>
       </notes>
       <segment>
         <source> Nur anonyme Benutzer </source>
@@ -755,7 +787,7 @@
     </unit>
     <unit id="admin.col.uid">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:161,162</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:169,170</note>
       </notes>
       <segment>
         <source>UID</source>
@@ -763,7 +795,7 @@
     </unit>
     <unit id="admin.col.name">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:173,174</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:184,185</note>
       </notes>
       <segment>
         <source>Name</source>
@@ -771,7 +803,7 @@
     </unit>
     <unit id="admin.col.email">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:183,184</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:197,198</note>
       </notes>
       <segment>
         <source>E-Mail</source>
@@ -779,7 +811,7 @@
     </unit>
     <unit id="admin.col.anon">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:191,192</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:208,209</note>
       </notes>
       <segment>
         <source>Anon</source>
@@ -787,7 +819,7 @@
     </unit>
     <unit id="admin.col.pushups">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:205,206</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:225,226</note>
       </notes>
       <segment>
         <source>Pushups</source>
@@ -795,7 +827,7 @@
     </unit>
     <unit id="admin.col.lastEntry">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:213,215</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:236,238</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -803,7 +835,7 @@
     </unit>
     <unit id="admin.col.createdAt">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:223,225</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:249,251</note>
       </notes>
       <segment>
         <source>Erstellt</source>
@@ -811,7 +843,7 @@
     </unit>
     <unit id="admin.feedback.title">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:261,263</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:287,289</note>
       </notes>
       <segment>
         <source>Feedback</source>
@@ -819,7 +851,7 @@
     </unit>
     <unit id="admin.feedback.empty">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:280,282</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:306,308</note>
       </notes>
       <segment>
         <source>Noch kein Feedback vorhanden.</source>
@@ -827,7 +859,7 @@
     </unit>
     <unit id="admin.feedback.col.date">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:291,293</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:322,324</note>
       </notes>
       <segment>
         <source>Datum</source>
@@ -835,7 +867,7 @@
     </unit>
     <unit id="admin.feedback.col.name">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:302,304</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:334,336</note>
       </notes>
       <segment>
         <source>Name</source>
@@ -843,7 +875,7 @@
     </unit>
     <unit id="admin.feedback.col.email">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:311,313</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:344,346</note>
       </notes>
       <segment>
         <source>E-Mail</source>
@@ -851,7 +883,7 @@
     </unit>
     <unit id="admin.feedback.col.message">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:320,322</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:353,355</note>
       </notes>
       <segment>
         <source>Nachricht</source>
@@ -859,7 +891,7 @@
     </unit>
     <unit id="admin.feedback.col.userId">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:331,333</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:364,366</note>
       </notes>
       <segment>
         <source>User</source>
@@ -867,7 +899,7 @@
     </unit>
     <unit id="admin.refresh">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:505</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:538</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -875,7 +907,7 @@
     </unit>
     <unit id="admin.feedback.anon">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:506</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:539</note>
       </notes>
       <segment>
         <source>Anonym</source>
@@ -883,7 +915,7 @@
     </unit>
     <unit id="admin.feedback.markRead">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:507</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:540</note>
       </notes>
       <segment>
         <source>Als gelesen markieren</source>
@@ -891,7 +923,7 @@
     </unit>
     <unit id="admin.feedback.markUnread">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:508</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:541</note>
       </notes>
       <segment>
         <source>Als ungelesen markieren</source>
@@ -899,7 +931,7 @@
     </unit>
     <unit id="admin.feedback.createIssue">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:509</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:542</note>
       </notes>
       <segment>
         <source>GitHub-Issue erstellen</source>
@@ -907,7 +939,7 @@
     </unit>
     <unit id="admin.feedback.openIssue">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:510</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:543</note>
       </notes>
       <segment>
         <source>GitHub-Issue öffnen</source>
@@ -915,7 +947,7 @@
     </unit>
     <unit id="admin.feedback.delete">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:511</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:544</note>
       </notes>
       <segment>
         <source>Feedback löschen</source>
@@ -923,7 +955,7 @@
     </unit>
     <unit id="admin.row.detailsAria">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:684</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:770</note>
       </notes>
       <segment>
         <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier"/></source>
@@ -1468,7 +1500,7 @@
     </unit>
     <unit id="earlyAccess.text">
       <notes>
-        <note category="location">web/src/app/app.ts:117</note>
+        <note category="location">web/src/app/app.ts:121</note>
       </notes>
       <segment>
         <source>Early Access – pushup-stats.de befindet sich noch im Aufbau. Funktionen und Design können sich jederzeit ändern.</source>
@@ -1476,7 +1508,7 @@
     </unit>
     <unit id="earlyAccess.feedback">
       <notes>
-        <note category="location">web/src/app/app.ts:118</note>
+        <note category="location">web/src/app/app.ts:122</note>
       </notes>
       <segment>
         <source>Feedback</source>
@@ -1484,7 +1516,7 @@
     </unit>
     <unit id="seo.default.title">
       <notes>
-        <note category="location">web/src/app/app.ts:212</note>
+        <note category="location">web/src/app/app.ts:221</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -1492,7 +1524,7 @@
     </unit>
     <unit id="seo.default.description">
       <notes>
-        <note category="location">web/src/app/app.ts:215</note>
+        <note category="location">web/src/app/app.ts:224</note>
       </notes>
       <segment>
         <source>Tracke Reps, Trends und Streaks mit Pushup Tracker.</source>
@@ -1500,7 +1532,7 @@
     </unit>
     <unit id="sw.update.available">
       <notes>
-        <note category="location">web/src/app/app.ts:234</note>
+        <note category="location">web/src/app/app.ts:243</note>
       </notes>
       <segment>
         <source>Neue Version verfügbar</source>
@@ -1508,7 +1540,7 @@
     </unit>
     <unit id="sw.update.reload">
       <notes>
-        <note category="location">web/src/app/app.ts:235</note>
+        <note category="location">web/src/app/app.ts:244</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -1516,7 +1548,7 @@
     </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:293</note>
+        <note category="location">web/src/app/app.ts:302</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -1524,7 +1556,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:300</note>
+        <note category="location">web/src/app/app.ts:309</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>
@@ -1532,7 +1564,7 @@
     </unit>
     <unit id="sw.update.downloading">
       <notes>
-        <note category="location">web/src/app/app.ts:338</note>
+        <note category="location">web/src/app/app.ts:347</note>
       </notes>
       <segment>
         <source>Update wird im Hintergrund geladen …</source>
@@ -2509,9 +2541,49 @@
         <source>EN</source>
       </segment>
     </unit>
-    <unit id="reminder.quietHours.label">
+    <unit id="reminder.quickLog.label">
       <notes>
         <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:161,162</note>
+      </notes>
+      <segment>
+        <source> Direkt-Eintrag aus der Benachrichtigung </source>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.desc">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:164,166</note>
+      </notes>
+      <segment>
+        <source> Zeigt einen &quot;Eintragen&quot;-Button auf der Push-Benachrichtigung. Tippen speichert die konfigurierte Anzahl Liegestütze, ohne dass du die App öffnen musst. </source>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.toggle">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:175,176</note>
+      </notes>
+      <segment>
+        <source> Schnell-Eintrag aktivieren </source>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.reps.label">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:183,185</note>
+      </notes>
+      <segment>
+        <source>Anzahl Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.reps.hint">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:196,198</note>
+      </notes>
+      <segment>
+        <source>1–500 Wiederholungen</source>
+      </segment>
+    </unit>
+    <unit id="reminder.quietHours.label">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:205,206</note>
       </notes>
       <segment>
         <source> Ruhezeiten </source>
@@ -2519,7 +2591,7 @@
     </unit>
     <unit id="reminder.quietHours.from">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:167,169</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:211,213</note>
       </notes>
       <segment>
         <source>Von</source>
@@ -2527,7 +2599,7 @@
     </unit>
     <unit id="reminder.quietHours.to">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:185,186</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:229,230</note>
       </notes>
       <segment>
         <source>Bis</source>
@@ -2535,7 +2607,7 @@
     </unit>
     <unit id="reminder.quietHours.remove.aria">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:202,203</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:246,247</note>
       </notes>
       <segment>
         <source>Ruhezeit entfernen</source>
@@ -2543,7 +2615,7 @@
     </unit>
     <unit id="reminder.quietHours.add">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:216,218</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:260,262</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc> Ruhezeit hinzufügen </source>
@@ -2551,7 +2623,7 @@
     </unit>
     <unit id="reminder.save">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:231,233</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:275,277</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc> Erinnerungen speichern </source>
@@ -2559,7 +2631,7 @@
     </unit>
     <unit id="reminder.saved">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:235,237</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:279,281</note>
       </notes>
       <segment>
         <source>Gespeichert.</source>
@@ -2567,7 +2639,7 @@
     </unit>
     <unit id="push.section.title">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:242,243</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:286,287</note>
       </notes>
       <segment>
         <source>🔔 Erinnerungen</source>
@@ -2575,7 +2647,7 @@
     </unit>
     <unit id="push.section.desc">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:244,247</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:288,291</note>
       </notes>
       <segment>
         <source> Wir tippen dir auf die Schulter, wenn es Zeit für Liegestütze ist. </source>
@@ -2583,7 +2655,7 @@
     </unit>
     <unit id="push.status.unsupported">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:249,251</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:293,295</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">info</pc> Dein Browser unterstützt keine Push-Benachrichtigungen. </source>
@@ -2591,7 +2663,7 @@
     </unit>
     <unit id="push.status.denied">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:254,256</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:298,300</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Push-Benachrichtigungen sind blockiert. Bitte in den Browser-Einstellungen erlauben. </source>
@@ -2599,7 +2671,7 @@
     </unit>
     <unit id="push.status.browserInvalidated">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:263,268</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:307,312</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Dein Browser hat das Push-Abo für dieses Gerät als dauerhaft ungültig markiert. Bitte setze die Benachrichtigungs-Einstellungen für diese Seite in den Browser-Einstellungen zurück (Chrome → Einstellungen → Website-Einstellungen → Benachrichtigungen) und aktiviere Push danach erneut. </source>
@@ -2607,7 +2679,7 @@
     </unit>
     <unit id="push.status.subscribed">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:276,278</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:320,322</note>
       </notes>
       <segment>
         <source>Erinnerungen aktiv ✓</source>
@@ -2615,7 +2687,7 @@
     </unit>
     <unit id="push.unsubscribe">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:286,288</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:330,332</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications_off</pc> Deaktivieren </source>
@@ -2623,7 +2695,7 @@
     </unit>
     <unit id="push.device.count">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:294,295</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:338,339</note>
       </notes>
       <segment>
         <source> Aktiv auf <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}"/> Geräten </source>
@@ -2631,7 +2703,7 @@
     </unit>
     <unit id="push.cta.desc">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:300,301</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:344,345</note>
       </notes>
       <segment>
         <source> Nie wieder eine Einheit verpassen. </source>
@@ -2639,7 +2711,7 @@
     </unit>
     <unit id="push.subscribe">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:310,312</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:354,356</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications</pc> Push aktivieren </source>
@@ -2647,7 +2719,7 @@
     </unit>
     <unit id="unsubAll.section.title">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:318,319</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:362,363</note>
       </notes>
       <segment>
         <source>📵 Push auf allen Geräten</source>
@@ -2655,7 +2727,7 @@
     </unit>
     <unit id="unsubAll.section.desc">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:320,322</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:364,366</note>
       </notes>
       <segment>
         <source> Entfernt alle Push-Benachrichtigungs-Abos auf diesem und allen anderen Geräten. Du bleibst angemeldet und kannst Push jederzeit wieder aktivieren. </source>
@@ -2663,7 +2735,7 @@
     </unit>
     <unit id="unsubAll.button">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:333,335</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:377,379</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications_off</pc> Push auf allen Geräten deaktivieren </source>
@@ -2671,30 +2743,16 @@
     </unit>
     <unit id="push.subscribe.error">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:459</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:575</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:506</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:625</note>
       </notes>
       <segment>
         <source>Push konnte nicht aktiviert werden.</source>
       </segment>
     </unit>
-    <unit id="snackbar.close">
-      <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:460</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:488</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:504</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:519</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:535</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:554</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:576</note>
-      </notes>
-      <segment>
-        <source>Schließen</source>
-      </segment>
-    </unit>
     <unit id="unsubAll.error">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:487</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:534</note>
       </notes>
       <segment>
         <source>Entfernen der Push-Abos fehlgeschlagen.</source>
@@ -2702,7 +2760,7 @@
     </unit>
     <unit id="unsubAll.success">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:503</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:550</note>
       </notes>
       <segment>
         <source>Push-Abos aller Geräte entfernt.</source>
@@ -2710,7 +2768,7 @@
     </unit>
     <unit id="reminder.permission.snackbar">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:518</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:565</note>
       </notes>
       <segment>
         <source>Benachrichtigungen sind blockiert. Bitte in den Browser-Einstellungen erlauben.</source>
@@ -2718,8 +2776,8 @@
     </unit>
     <unit id="reminder.save.error">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:534</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:553</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:584</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:603</note>
       </notes>
       <segment>
         <source>Einstellungen konnten nicht gespeichert werden.</source>
@@ -3015,7 +3073,7 @@
     </unit>
     <unit id="goalReached.repsSuffix">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.html:11,14</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.html:25,28</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -3023,7 +3081,7 @@
     </unit>
     <unit id="goalReached.weekly.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:64</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:73</note>
       </notes>
       <segment>
         <source>Wochenziel erreicht!</source>
@@ -3031,7 +3089,7 @@
     </unit>
     <unit id="goalReached.weekly.note">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:65</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:74</note>
       </notes>
       <segment>
         <source>Sieben Tage, ein Sieg. Du bist on fire.</source>
@@ -3039,7 +3097,7 @@
     </unit>
     <unit id="goalReached.monthly.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:70</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:79</note>
       </notes>
       <segment>
         <source>Monatsziel erreicht!</source>
@@ -3047,7 +3105,7 @@
     </unit>
     <unit id="goalReached.monthly.note">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:71</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:80</note>
       </notes>
       <segment>
         <source>Ein ganzer Monat Disziplin. Legendär.</source>
@@ -3055,7 +3113,7 @@
     </unit>
     <unit id="goalReached.daily.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:76</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:85</note>
       </notes>
       <segment>
         <source>Tagesziel erreicht!</source>
@@ -3063,7 +3121,7 @@
     </unit>
     <unit id="goalReached.daily.note">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:77</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:86</note>
       </notes>
       <segment>
         <source>Heute hast du dein Versprechen gehalten.</source>
@@ -3071,7 +3129,7 @@
     </unit>
     <unit id="goalReached.snapAria">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:82</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:91</note>
       </notes>
       <segment>
         <source>Erfolg vaporisieren</source>
@@ -3079,7 +3137,7 @@
     </unit>
     <unit id="goalReached.snap">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:83</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:92</note>
       </notes>
       <segment>
         <source>Snap!</source>
@@ -3087,7 +3145,7 @@
     </unit>
     <unit id="goalReached.closeAria">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:84</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:93</note>
       </notes>
       <segment>
         <source>Schließen</source>
@@ -3681,7 +3739,7 @@
     </unit>
     <unit id="settingsTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:41,42</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:44,45</note>
       </notes>
       <segment>
         <source>Einstellungen</source>
@@ -3689,7 +3747,7 @@
     </unit>
     <unit id="settingsSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:43,44</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:46,47</note>
       </notes>
       <segment>
         <source>User-Profil &amp; Tagesziel</source>
@@ -3697,7 +3755,7 @@
     </unit>
     <unit id="guest.banner.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:52,54</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:55,57</note>
       </notes>
       <segment>
         <source>Du nutzt die App als Gast. Erstelle ein Konto um alle Funktionen zu nutzen.</source>
@@ -3705,7 +3763,7 @@
     </unit>
     <unit id="guest.banner.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:59,61</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:62,64</note>
       </notes>
       <segment>
         <source>Konto erstellen</source>
@@ -3713,7 +3771,7 @@
     </unit>
     <unit id="displayNameLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:65,66</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:68,69</note>
       </notes>
       <segment>
         <source>Anzeigename</source>
@@ -3721,7 +3779,7 @@
     </unit>
     <unit id="displayNamePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:71</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:74</note>
       </notes>
       <segment>
         <source>Wolf</source>
@@ -3729,7 +3787,7 @@
     </unit>
     <unit id="settings.displayNameHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:74,76</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:77,79</note>
       </notes>
       <segment>
         <source>Kann in der Bestenliste angezeigt werden.</source>
@@ -3737,7 +3795,7 @@
     </unit>
     <unit id="settings.leaderboardOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:83,84</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:86,87</note>
       </notes>
       <segment>
         <source> In Bestenliste anzeigen </source>
@@ -3745,7 +3803,7 @@
     </unit>
     <unit id="settings.leaderboardOptOutHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:87,90</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:90,93</note>
       </notes>
       <segment>
         <source> Wenn deaktiviert, wird dein Profil in der Bestenliste nicht angezeigt. </source>
@@ -3753,7 +3811,7 @@
     </unit>
     <unit id="settings.adsConsentOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:96,97</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:99,100</note>
       </notes>
       <segment>
         <source> Personalisierte Werbung aktivieren </source>
@@ -3761,7 +3819,7 @@
     </unit>
     <unit id="settings.adsConsentHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:100,103</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:103,106</note>
       </notes>
       <segment>
         <source> Steuert, ob Werbe-Slots im Dashboard geladen werden dürfen. </source>
@@ -3769,7 +3827,7 @@
     </unit>
     <unit id="dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:104,105</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:107,108</note>
       </notes>
       <segment>
         <source>Tagesziel (Reps)</source>
@@ -3777,7 +3835,7 @@
     </unit>
     <unit id="dailyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:114</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:117</note>
       </notes>
       <segment>
         <source>10</source>
@@ -3785,7 +3843,7 @@
     </unit>
     <unit id="settings.goalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:117,119</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:120,122</note>
       </notes>
       <segment>
         <source>Wird prominent in der Toolbar angezeigt.</source>
@@ -3793,7 +3851,7 @@
     </unit>
     <unit id="weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:122,123</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:125,126</note>
       </notes>
       <segment>
         <source>Wochenziel (Reps)</source>
@@ -3801,7 +3859,7 @@
     </unit>
     <unit id="weeklyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:132</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:135</note>
       </notes>
       <segment>
         <source>50</source>
@@ -3809,7 +3867,7 @@
     </unit>
     <unit id="settings.weeklyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:135,137</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:138,140</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Woche (Mo–So).</source>
@@ -3817,7 +3875,7 @@
     </unit>
     <unit id="monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:140,141</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:143,144</note>
       </notes>
       <segment>
         <source>Monatsziel (Reps)</source>
@@ -3825,7 +3883,7 @@
     </unit>
     <unit id="monthlyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:150</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:153</note>
       </notes>
       <segment>
         <source>200</source>
@@ -3833,7 +3891,7 @@
     </unit>
     <unit id="settings.monthlyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:153,155</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:156,158</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Monat.</source>
@@ -3841,7 +3899,7 @@
     </unit>
     <unit id="settings.snapQualityLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:165,167</note>
       </notes>
       <segment>
         <source>Snap-Animation Qualität</source>
@@ -3849,7 +3907,7 @@
     </unit>
     <unit id="settings.snapQuality.low">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:175,177</note>
       </notes>
       <segment>
         <source>Niedrig</source>
@@ -3857,7 +3915,7 @@
     </unit>
     <unit id="settings.snapQuality.middle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:180,182</note>
       </notes>
       <segment>
         <source>Mittel</source>
@@ -3865,7 +3923,7 @@
     </unit>
     <unit id="settings.snapQuality.high">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:185,187</note>
       </notes>
       <segment>
         <source>Hoch</source>
@@ -3873,15 +3931,15 @@
     </unit>
     <unit id="settings.snapQualityHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:189,191</note>
       </notes>
       <segment>
-        <source>Steuert die Partikelanzahl der „Ziel erreicht“-Animation (40k / 120k / 200k).</source>
+        <source> Steuert die Partikelanzahl der „Ziel erreicht“-Animation (40k / 120k / 200k). </source>
       </segment>
     </unit>
     <unit id="saveSettings">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:170,172</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:207,209</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc> Speichern </source>
@@ -3889,7 +3947,7 @@
     </unit>
     <unit id="saving">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:174,175</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:211,212</note>
       </notes>
       <segment>
         <source>Speichert…</source>
@@ -3897,7 +3955,7 @@
     </unit>
     <unit id="saved">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:177,178</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:214,215</note>
       </notes>
       <segment>
         <source>Gespeichert.</source>
@@ -3905,7 +3963,7 @@
     </unit>
     <unit id="settings.remindersLinkTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:182,183</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:219,220</note>
       </notes>
       <segment>
         <source>🔔 Erinnerungen</source>
@@ -3913,7 +3971,7 @@
     </unit>
     <unit id="settings.remindersLinkDesc">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:184,186</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:221,223</note>
       </notes>
       <segment>
         <source> Liegestütz-Erinnerungen und Push-Benachrichtigungen konfigurieren. </source>
@@ -3921,7 +3979,7 @@
     </unit>
     <unit id="settings.remindersLinkCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:191,193</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:228,230</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications</pc> Erinnerungen verwalten </source>
@@ -3929,7 +3987,7 @@
     </unit>
     <unit id="settings.dangerZoneTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:197,198</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:234,235</note>
       </notes>
       <segment>
         <source>Danger Zone</source>
@@ -3937,7 +3995,7 @@
     </unit>
     <unit id="settings.dangerZoneBody">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:199,201</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:236,238</note>
       </notes>
       <segment>
         <source> Konto löschen entfernt dein Konto. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -3945,7 +4003,7 @@
     </unit>
     <unit id="settings.deleteAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:210,212</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:247,249</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Konto löschen </source>
@@ -3953,7 +4011,7 @@
     </unit>
     <unit id="settings.deletingAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:215,218</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:252,255</note>
       </notes>
       <segment>
         <source>Konto wird gelöscht…</source>
@@ -3961,7 +4019,7 @@
     </unit>
     <unit id="settings.deleteDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:222,224</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:259,261</note>
       </notes>
       <segment>
         <source> Account wirklich löschen? </source>
@@ -3969,7 +4027,7 @@
     </unit>
     <unit id="settings.deleteDialogWarning">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:226,228</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:263,265</note>
       </notes>
       <segment>
         <source> Achtung: Diese Aktion ist nicht rückgängig. </source>
@@ -3977,7 +4035,7 @@
     </unit>
     <unit id="settings.deleteDialogInfo">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:229,231</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:266,268</note>
       </notes>
       <segment>
         <source> Dein Konto wird gelöscht. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -3985,7 +4043,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:234,236</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:271,273</note>
       </notes>
       <segment>
         <source>Bestätigungswort eingeben</source>
@@ -3993,7 +4051,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:243,245</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:280,282</note>
       </notes>
       <segment>
         <source>Bitte exakt „löscchen“ eingeben.</source>
@@ -4001,7 +4059,7 @@
     </unit>
     <unit id="settings.deleteConfirmFinal">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:260,262</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:297,299</note>
       </notes>
       <segment>
         <source> Final löschen </source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -691,7 +691,7 @@
     </unit>
     <unit id="reminder.quickLog.success">
       <notes>
-        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:66</note>
+        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:70</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="reps" disp="reps"/> Push-ups eingetragen ✓</source>
@@ -699,15 +699,15 @@
     </unit>
     <unit id="snackbar.close">
       <notes>
-        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:67</note>
-        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:73</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:507</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:535</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:551</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:566</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:585</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:604</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:626</note>
+        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:71</note>
+        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:77</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:509</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:537</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:553</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:568</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:587</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:606</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:628</note>
       </notes>
       <segment>
         <source>Schließen</source>
@@ -715,7 +715,7 @@
     </unit>
     <unit id="reminder.quickLog.error">
       <notes>
-        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:72</note>
+        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:76</note>
       </notes>
       <segment>
         <source>Eintrag konnte nicht gespeichert werden.</source>
@@ -2551,15 +2551,15 @@
     </unit>
     <unit id="reminder.quickLog.desc">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:164,166</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:164,167</note>
       </notes>
       <segment>
-        <source> Zeigt einen &quot;Eintragen&quot;-Button auf der Push-Benachrichtigung. Tippen speichert die konfigurierte Anzahl Liegestütze, ohne dass du die App öffnen musst. </source>
+        <source> Zeigt einen &quot;Eintragen&quot;-Button auf der Push-Benachrichtigung. Wenn die App schon geöffnet ist, wird der Eintrag im Hintergrund gespeichert; ansonsten öffnet sich kurz ein Tab, der den Eintrag automatisch anlegt. </source>
       </segment>
     </unit>
     <unit id="reminder.quickLog.toggle">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:175,176</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:177,178</note>
       </notes>
       <segment>
         <source> Schnell-Eintrag aktivieren </source>
@@ -2567,7 +2567,7 @@
     </unit>
     <unit id="reminder.quickLog.reps.label">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:183,185</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:185,187</note>
       </notes>
       <segment>
         <source>Anzahl Liegestütze</source>
@@ -2575,7 +2575,7 @@
     </unit>
     <unit id="reminder.quickLog.reps.hint">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:196,198</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:198,200</note>
       </notes>
       <segment>
         <source>1–500 Wiederholungen</source>
@@ -2583,7 +2583,7 @@
     </unit>
     <unit id="reminder.quietHours.label">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:205,206</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:207,208</note>
       </notes>
       <segment>
         <source> Ruhezeiten </source>
@@ -2591,7 +2591,7 @@
     </unit>
     <unit id="reminder.quietHours.from">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:211,213</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:213,215</note>
       </notes>
       <segment>
         <source>Von</source>
@@ -2599,7 +2599,7 @@
     </unit>
     <unit id="reminder.quietHours.to">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:229,230</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:231,232</note>
       </notes>
       <segment>
         <source>Bis</source>
@@ -2607,7 +2607,7 @@
     </unit>
     <unit id="reminder.quietHours.remove.aria">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:246,247</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:248,249</note>
       </notes>
       <segment>
         <source>Ruhezeit entfernen</source>
@@ -2615,7 +2615,7 @@
     </unit>
     <unit id="reminder.quietHours.add">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:260,262</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:262,264</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc> Ruhezeit hinzufügen </source>
@@ -2623,7 +2623,7 @@
     </unit>
     <unit id="reminder.save">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:275,277</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:277,279</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc> Erinnerungen speichern </source>
@@ -2631,7 +2631,7 @@
     </unit>
     <unit id="reminder.saved">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:279,281</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:281,283</note>
       </notes>
       <segment>
         <source>Gespeichert.</source>
@@ -2639,7 +2639,7 @@
     </unit>
     <unit id="push.section.title">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:286,287</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:288,289</note>
       </notes>
       <segment>
         <source>🔔 Erinnerungen</source>
@@ -2647,7 +2647,7 @@
     </unit>
     <unit id="push.section.desc">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:288,291</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:290,293</note>
       </notes>
       <segment>
         <source> Wir tippen dir auf die Schulter, wenn es Zeit für Liegestütze ist. </source>
@@ -2655,7 +2655,7 @@
     </unit>
     <unit id="push.status.unsupported">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:293,295</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:295,297</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">info</pc> Dein Browser unterstützt keine Push-Benachrichtigungen. </source>
@@ -2663,7 +2663,7 @@
     </unit>
     <unit id="push.status.denied">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:298,300</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:300,302</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Push-Benachrichtigungen sind blockiert. Bitte in den Browser-Einstellungen erlauben. </source>
@@ -2671,7 +2671,7 @@
     </unit>
     <unit id="push.status.browserInvalidated">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:307,312</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:309,314</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Dein Browser hat das Push-Abo für dieses Gerät als dauerhaft ungültig markiert. Bitte setze die Benachrichtigungs-Einstellungen für diese Seite in den Browser-Einstellungen zurück (Chrome → Einstellungen → Website-Einstellungen → Benachrichtigungen) und aktiviere Push danach erneut. </source>
@@ -2679,7 +2679,7 @@
     </unit>
     <unit id="push.status.subscribed">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:320,322</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:322,324</note>
       </notes>
       <segment>
         <source>Erinnerungen aktiv ✓</source>
@@ -2687,7 +2687,7 @@
     </unit>
     <unit id="push.unsubscribe">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:330,332</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:332,334</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications_off</pc> Deaktivieren </source>
@@ -2695,7 +2695,7 @@
     </unit>
     <unit id="push.device.count">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:338,339</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:340,341</note>
       </notes>
       <segment>
         <source> Aktiv auf <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}"/> Geräten </source>
@@ -2703,7 +2703,7 @@
     </unit>
     <unit id="push.cta.desc">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:344,345</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:346,347</note>
       </notes>
       <segment>
         <source> Nie wieder eine Einheit verpassen. </source>
@@ -2711,7 +2711,7 @@
     </unit>
     <unit id="push.subscribe">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:354,356</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:356,358</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications</pc> Push aktivieren </source>
@@ -2719,7 +2719,7 @@
     </unit>
     <unit id="unsubAll.section.title">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:362,363</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:364,365</note>
       </notes>
       <segment>
         <source>📵 Push auf allen Geräten</source>
@@ -2727,7 +2727,7 @@
     </unit>
     <unit id="unsubAll.section.desc">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:364,366</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:366,368</note>
       </notes>
       <segment>
         <source> Entfernt alle Push-Benachrichtigungs-Abos auf diesem und allen anderen Geräten. Du bleibst angemeldet und kannst Push jederzeit wieder aktivieren. </source>
@@ -2735,7 +2735,7 @@
     </unit>
     <unit id="unsubAll.button">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:377,379</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:379,381</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications_off</pc> Push auf allen Geräten deaktivieren </source>
@@ -2743,8 +2743,8 @@
     </unit>
     <unit id="push.subscribe.error">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:506</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:625</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:508</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:627</note>
       </notes>
       <segment>
         <source>Push konnte nicht aktiviert werden.</source>
@@ -2752,7 +2752,7 @@
     </unit>
     <unit id="unsubAll.error">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:534</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:536</note>
       </notes>
       <segment>
         <source>Entfernen der Push-Abos fehlgeschlagen.</source>
@@ -2760,7 +2760,7 @@
     </unit>
     <unit id="unsubAll.success">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:550</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:552</note>
       </notes>
       <segment>
         <source>Push-Abos aller Geräte entfernt.</source>
@@ -2768,7 +2768,7 @@
     </unit>
     <unit id="reminder.permission.snackbar">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:565</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:567</note>
       </notes>
       <segment>
         <source>Benachrichtigungen sind blockiert. Bitte in den Browser-Einstellungen erlauben.</source>
@@ -2776,8 +2776,8 @@
     </unit>
     <unit id="reminder.save.error">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:584</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:603</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:586</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:605</note>
       </notes>
       <segment>
         <source>Einstellungen konnten nicht gespeichert werden.</source>


### PR DESCRIPTION
## Summary

Adds a configurable one-tap "✅ N eintragen" button to the push reminder so the user can log a preset number of push-ups **without opening the app**. Pipeline (CF → SW → app):

- **Model:** `ReminderConfig.quickLogReps` (1–500) persists the preset count.
- **Cloud Function:** `dispatchPushReminders` includes a `quick-log` notification action and the count via `data.quickLogReps` when configured. Action builder + sanitizer extracted as pure helpers (`buildReminderActions`, `sanitizeQuickLogReps`) for unit testing.
- **Service Worker:** `sw-push/handlers.ts` routes `quick-log` clicks — posts `QUICK_LOG_PUSHUPS` to an open client (silent log) or opens `/app?quickLog=N` as fallback when no tab is open. Falls back to `?log=1` if the payload reps are missing/invalid.
- **App:** New `QuickLogListenerService` (in `@pu-reminders/reminders`) listens for `QUICK_LOG_PUSHUPS` SW messages and creates the entry via `StatsApiService` with a Material snackbar for feedback. Registered once at app boot alongside the existing SW message bridge.
- **Dashboard:** `StatsDashboardComponent` now also handles `?quickLog=N` deep-links to auto-create the entry on first render.
- **UI:** Reminders page exposes a slide-toggle + count input ("Schnell-Eintrag aktivieren"); EN translations added to `messages.en.xlf`.

## Test plan

- [x] `pnpm nx test sw-push` — 20/20 (handler routing for quick-log + fallbacks)
- [x] `pnpm nx test cloud-functions` — 258/258 (action builder DE/EN + sanitizer)
- [x] `pnpm nx test pus-reminders` — 67/67 (incl. new `QuickLogListenerService` spec)
- [x] `pnpm nx test web` — 300/300 (incl. `ReminderFormStore` quickLog cases)
- [x] `pnpm nx run-many -t lint -p pus-reminders,sw-push,cloud-functions,web` — only pre-existing warnings
- [x] `pnpm nx build web --configuration=development` — OK, no missing-translation warnings
- [x] `pnpm nx run web:extract-i18n` — `messages.xlf` regenerated; EN translations resolve cleanly
- [ ] Manual: configure quickLogReps, send test push (`dispatchPushReminders`), tap action — entry appears with `source: 'reminder'`
- [ ] Manual: tap quick-log action with no app tab open — `?quickLog=N` auto-creates entry on dashboard render

## Notes

- Service workers can't authenticate to Firestore directly, so "without opening" is best-effort: when an app tab is already open the log is silent (postMessage); otherwise the SW navigates to a deep-link and the dashboard creates the entry on render. A truly background log would need a signed-token pattern with a new HTTP-callable; deferred until there's demand.
- `setDoc({merge:true})` semantics for the `reminder` map are unchanged — the whole map is replaced, so toggling quickLog off cleanly removes the field.

https://claude.ai/code/session_017Xe4dTFspeNg55qX5EP4g4

---
_Generated by [Claude Code](https://claude.ai/code/session_017Xe4dTFspeNg55qX5EP4g4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * One-tap quick log action in push notifications with configurable repetition count (1–500)
  * New reminder settings toggle to enable quick logging functionality
  * URL-based quick log parameter support for direct logging
  * Full localization support for quick log notifications and UI (English & German)

* **Tests**
  * Comprehensive test coverage added for new quick log feature across all components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->