### PR TITLE
feat(reactivity): wire userConfig/userStats/leaderboard to Firestore real-time listeners

### DIFF
--- a/docs/gotchas/firestore.md
+++ b/docs/gotchas/firestore.md
@@ -28,3 +28,40 @@ When in doubt, write a test that saves a partial `ui` patch and asserts the unre
 ## `getDoc` after `setDoc` race
 
 `setDoc` resolves once the local mutation is queued, not once the server has acknowledged it. A `getDoc` immediately afterwards may return the cached value from before the write. If you need to assert the persisted shape (mostly in tests), force a server fetch with `getDoc(ref, { source: 'server' })`.
+
+## Real-time reads: `docData` + `rxResource`, never `firstValueFrom` inside `resource()`
+
+`resource({ loader })` is for one-shot Promise loaders. Wrapping a Firestore observable as `firstValueFrom(this.api.getConfig(uid))` inside a `resource` loader collapses a long-lived stream into a single emission — the store will never see subsequent doc updates (settings edits from another tab, Cloud Function rewrites of `userStats/*`, etc.).
+
+For real-time data:
+
+1. Return `docData(ref)` / `collectionData(query)` from the API service, not `from(getDoc(ref))`. The signature stays `Observable<T>` but the source now emits on every change.
+2. Consume it via `rxResource({ stream })`, not `resource({ loader })`:
+
+   ```ts
+   import { rxResource } from '@angular/core/rxjs-interop';
+
+   configResource: rxResource({
+     params: () => ({ userId: store._user.userIdSafe() }),
+     stream: ({ params }) => (params.userId ? store._api.getConfig(params.userId) : of(null)),
+   });
+   ```
+
+3. Existing `firstValueFrom(api.getConfig(uid))` callers (one-shot snapshots in app-bootstrap hooks, write-then-read flows) keep working — `firstValueFrom` resolves with the first emission and unsubscribes.
+
+When migrating, audit consumers that subscribe directly without unsubscription (e.g. ad-hoc `.subscribe(...)` calls) — those previously completed after one emission and now leak. Wrap in `take(1)` / `firstValueFrom` or move them under a `DestroyRef`-aware helper.
+
+## Naive vs TZ-aware ISO timestamps
+
+`PushupRecord.timestamp` is **not** uniformly UTC. `createPushup()` writes `new Date().toISOString()` (`...Z`), but legacy / quick-add code paths still produce naive `YYYY-MM-DDTHH:mm[:ss]` strings — and the backend (`berlinParts`, period-key bucketing, `USERSTATS_VERSION` v3) explicitly treats those as Berlin local time.
+
+`new Date('2026-04-22T08:00:00')` parses in the **device's** timezone, so on any client outside `Europe/Berlin` the resulting Date hits a different Berlin day than the backend computed for the same string. Anything that buckets, filters, or compares timestamps must replicate the backend convention:
+
+```ts
+const HAS_TIMEZONE = /(Z|[+-]\d{2}:?\d{2})$/;
+function entryBerlinDate(timestamp: string): string {
+  return HAS_TIMEZONE.test(timestamp) ? toBerlinIsoDate(new Date(timestamp)) : timestamp.slice(0, 10); // already a Berlin-local date prefix
+}
+```
+
+`entry.timestamp.slice(0, 10)` alone is wrong for TZ-aware timestamps near midnight (UTC date != Berlin date during summer hours); `toBerlinIsoDate(new Date(...))` alone is wrong for naive timestamps off-Berlin. Handle both.

--- a/docs/gotchas/signals.md
+++ b/docs/gotchas/signals.md
@@ -27,6 +27,54 @@ Any `toSignal()` wrapping an observable that emits objects which may be mutated 
 - `{ equal: () => false }` plus downstream dedup, OR
 - A `.pipe(map(x => ({ ...x })))` to break reference equality
 
+## Clock-derived computeds need a reactive dependency
+
+`computed(() => toBerlinIsoDate(new Date()))` looks fine but is a **stale-data trap**: the computed has no signal dependency, so Angular memoises the first result for the entire lifetime of the injector. In a long-running PWA session that crosses midnight, `today()` keeps returning yesterday's date — even though `new Date()` would give the right answer if it were called fresh — and any flag/bucket/key derived from it stays anchored to day 1.
+
+`GoalReachedNotificationService` hit this exact bug: the daily celebration suppressed itself on day 2 because both the dialog gating key and the entry filter pulled from a `todayBerlin` that never recomputed.
+
+Fix: tie clock-derived computeds to a signal that _does_ change when the user could possibly observe a different "now" — typically the live data signal that triggers whatever consumes the date:
+
+```ts
+private readonly todayBerlin = computed(() => {
+  this.entries(); // tracking dependency: re-evaluate `new Date()` on any data change
+  return toBerlinIsoDate(new Date());
+});
+```
+
+Alternatives, depending on the use case:
+
+- A wall-clock `setInterval` that bumps a `tick` signal at midnight.
+- Convert the function from `computed` to a plain method so each call re-reads `Date.now()`.
+
+Don't rely on the natural recomputation of consumers — if `todayBerlin` is read from another `computed`, that consumer only re-runs when _its_ dependencies change. The clock-derived signal itself must declare a reactive dep.
+
+## `localStorage` getter can throw — wrap the access, not just the calls
+
+`globalThis.localStorage` itself is a getter. In Safari private mode, sandboxed iframes, embedded webviews, or any context where storage is disabled, _touching_ it throws `SecurityError` synchronously — before any `getItem` / `setItem` call. A guard like:
+
+```ts
+const ls = globalThis.localStorage; // ← can throw
+if (!ls) return;
+try {
+  ls.removeItem(key);
+} catch {}
+```
+
+still aborts module / service construction. Wrap the **entire** access, including the getter read and any derived data, inside the try block:
+
+```ts
+try {
+  const ls = globalThis.localStorage;
+  if (!ls) return;
+  // ...derive keys, iterate, mutate...
+} catch {
+  // Storage unavailable / SecurityError — best-effort.
+}
+```
+
+The `readFlag`/`writeFlag` helpers in `goal-reached-notification.service.ts` follow this pattern. Apply it anywhere a `providedIn: 'root'` service touches `localStorage`/`sessionStorage` during construction — a single uncaught `SecurityError` there breaks the whole app, not just the feature.
+
 ## Display-defaulted signals vs "is this configured?"
 
 Several signals in the app return defaulted values for display convenience:

--- a/docs/gotchas/testing.md
+++ b/docs/gotchas/testing.md
@@ -16,6 +16,16 @@
 ## Jest ↔ Firebase
 
 - **`@angular/fire/firestore` import in Jest:** Importing the module at all triggers `fetch is not defined`. Always `jest.mock('@angular/fire/firestore', () => ({...}))` at the top of the file — see `pushup-firestore.service.spec.ts` for the pattern. Use `jest.mocked(getDoc)` instead of `jest.requireMock()` for type safety.
+- **Don't reference module-level imports inside `jest.mock` factories.** `jest.mock(path, factory)` is hoisted above all imports, but the _factory body_ runs the first time the mocked module is `require()`'d. Anything that captures a same-file binding (e.g. `docData: jest.fn(() => of(undefined))` where `of` is imported from `rxjs` below) can evaluate before that import has been initialised under the CJS transform and crash the file. Either keep the factory bare and set the implementation in `beforeEach`:
+  ```ts
+  jest.mock('@angular/fire/firestore', () => ({
+    Firestore: jest.fn(),
+    docData: jest.fn(),
+  }));
+  // ...
+  beforeEach(() => jest.mocked(docData).mockReturnValue(of(undefined) as never));
+  ```
+  …or `require()` the dependency inside the factory. Mirrors the Vitest `vi.hoisted` pattern below.
 - **Cloud Function pure logic testing:** Extract business logic to separate modules (not in Cloud Function triggers) for testability. See `user-stats-delta.ts` pattern: pure functions tested separately via Jest without Firebase mocks; triggers are thin wrappers that call the logic. This enables testing calculation correctness without mocking Firestore.
 
 ## Versioned migrations

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -44,10 +44,13 @@ export class LeaderboardService {
 
   /**
    * Real-time stream of the precomputed `leaderboards/current` document.
-   * Emits `null` while the doc does not exist or Firestore is unavailable.
+   *
    * Used by `LeaderboardStore` to reload aggregates whenever the Cloud
    * Function rewrites the snapshot, giving the leaderboard live updates
-   * without a manual refresh.
+   * without a manual refresh. The store only cares about *change*
+   * notifications, not payload shape — so we forward whatever `docData`
+   * emits (the doc data, or `undefined` when the doc does not exist), and
+   * fall back to `EMPTY` (no emissions) when Firestore is unavailable.
    */
   observeSnapshot(): Observable<unknown> {
     if (!this.firestore) return EMPTY;

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -3,6 +3,7 @@ import { Auth } from '@angular/fire/auth';
 import {
   collection,
   doc,
+  docData,
   Firestore,
   getDoc,
   getDocs,
@@ -10,6 +11,7 @@ import {
   query,
   where,
 } from '@angular/fire/firestore';
+import { EMPTY, Observable } from 'rxjs';
 
 export type LeaderboardPeriod = 'daily' | 'weekly' | 'monthly';
 
@@ -39,6 +41,18 @@ type PushupRow = {
 export class LeaderboardService {
   private readonly firestore = inject(Firestore, { optional: true });
   private readonly auth = inject(Auth, { optional: true });
+
+  /**
+   * Real-time stream of the precomputed `leaderboards/current` document.
+   * Emits `null` while the doc does not exist or Firestore is unavailable.
+   * Used by `LeaderboardStore` to reload aggregates whenever the Cloud
+   * Function rewrites the snapshot, giving the leaderboard live updates
+   * without a manual refresh.
+   */
+  observeSnapshot(): Observable<unknown> {
+    if (!this.firestore) return EMPTY;
+    return docData(doc(this.firestore, 'leaderboards', 'current'));
+  }
 
   async load(): Promise<LeaderboardData> {
     const currentUserId = this.auth?.currentUser?.uid ?? null;

--- a/libs/data-access/src/lib/api/user-config-api.service.spec.ts
+++ b/libs/data-access/src/lib/api/user-config-api.service.spec.ts
@@ -3,6 +3,7 @@ import { Auth } from '@angular/fire/auth';
 import { Firestore } from '@angular/fire/firestore';
 import { UserConfig, UserConfigUpdate } from '@pu-stats/models';
 import { render } from '@testing-library/angular';
+import { of } from 'rxjs';
 import { UserConfigApiService } from './user-config-api.service';
 
 jest.mock('@angular/fire/auth', () => ({
@@ -12,7 +13,7 @@ jest.mock('@angular/fire/auth', () => ({
 jest.mock('@angular/fire/firestore', () => ({
   Firestore: jest.fn(),
   doc: jest.fn(),
-  getDoc: jest.fn(),
+  docData: jest.fn(),
   setDoc: jest.fn(() => Promise.resolve()),
 }));
 
@@ -21,12 +22,12 @@ describe('UserConfigApiService', () => {
     jest.clearAllMocks();
   });
 
-  it('reads config from Firestore when authenticated', async () => {
+  it('streams config from Firestore in real time when authenticated', async () => {
     const firestoreFns = await import('@angular/fire/firestore');
     (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
-    (firestoreFns.getDoc as jest.Mock).mockResolvedValue({
-      data: () => ({ userId: 'u', dailyGoal: 99 }),
-    });
+    (firestoreFns.docData as jest.Mock).mockReturnValue(
+      of({ userId: 'u', dailyGoal: 99 })
+    );
 
     const { fixture } = await render('', {
       providers: [
@@ -45,12 +46,32 @@ describe('UserConfigApiService', () => {
     expect(result).toEqual({ userId: 'u', dailyGoal: 99 });
   });
 
+  it('falls back to a stub config when the Firestore doc is missing', async () => {
+    const firestoreFns = await import('@angular/fire/firestore');
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
+    (firestoreFns.docData as jest.Mock).mockReturnValue(of(undefined));
+
+    const { fixture } = await render('', {
+      providers: [
+        UserConfigApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'u' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(UserConfigApiService);
+    let result: UserConfig | undefined;
+    service.getConfig('u').subscribe((r) => (result = r));
+
+    await Promise.resolve();
+    expect(result).toEqual({ userId: 'u' });
+  });
+
   it('uses currentUser.uid (not passed-in userId) for Firestore getConfig doc path', async () => {
     const firestoreFns = await import('@angular/fire/firestore');
     (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'actual-uid' });
-    (firestoreFns.getDoc as jest.Mock).mockResolvedValue({
-      data: () => undefined,
-    });
+    (firestoreFns.docData as jest.Mock).mockReturnValue(of(undefined));
 
     const { fixture } = await render('', {
       providers: [

--- a/libs/data-access/src/lib/api/user-config-api.service.ts
+++ b/libs/data-access/src/lib/api/user-config-api.service.ts
@@ -2,9 +2,9 @@ import { inject, Injectable } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
 import {
   doc,
+  docData,
   DocumentReference,
   Firestore,
-  getDoc,
   setDoc,
 } from '@angular/fire/firestore';
 import { UserConfig, UserConfigUpdate } from '@pu-stats/models';
@@ -15,6 +15,11 @@ export class UserConfigApiService {
   private readonly firestore = inject(Firestore, { optional: true });
   private readonly auth = inject(Auth, { optional: true });
 
+  /**
+   * Subscribe to the user's config document. Emits initially and on every
+   * Firestore document change so consumers update reactively (e.g. when the
+   * user edits goals on another device, or after a write completes).
+   */
   getConfig(userId: string): Observable<UserConfig> {
     const effectiveUserId = this.resolveUserId(userId);
     if (!effectiveUserId || !this.firestore) {
@@ -22,11 +27,12 @@ export class UserConfigApiService {
     }
 
     const ref = this.docRef(effectiveUserId);
-    return from(getDoc(ref)).pipe(
-      map((snapshot) => {
-        const data = snapshot.data() as UserConfig | undefined;
-        return data ?? ({ userId: effectiveUserId } as UserConfig);
-      })
+    return docData(ref).pipe(
+      map(
+        (data) =>
+          (data as UserConfig | undefined) ??
+          ({ userId: effectiveUserId } as UserConfig)
+      )
     );
   }
 

--- a/libs/data-access/src/lib/api/user-config-api.service.ts
+++ b/libs/data-access/src/lib/api/user-config-api.service.ts
@@ -23,7 +23,11 @@ export class UserConfigApiService {
   getConfig(userId: string): Observable<UserConfig> {
     const effectiveUserId = this.resolveUserId(userId);
     if (!effectiveUserId || !this.firestore) {
-      return of({ userId } as UserConfig);
+      // Use the resolved id (or the passed-in fallback when no auth user is
+      // available) so the stub config matches the doc path the live read
+      // would have hit. Returning the unresolved `userId` here would emit a
+      // different identity than `updateConfig` writes to.
+      return of({ userId: effectiveUserId || userId } as UserConfig);
     }
 
     const ref = this.docRef(effectiveUserId);

--- a/libs/data-access/src/lib/api/user-stats-api.service.spec.ts
+++ b/libs/data-access/src/lib/api/user-stats-api.service.spec.ts
@@ -1,16 +1,14 @@
 jest.mock('@angular/fire/firestore', () => ({
   Firestore: jest.fn(),
   doc: jest.fn(() => ({})),
-  getDoc: jest.fn(() =>
-    Promise.resolve({ exists: () => false, data: () => null })
-  ),
+  docData: jest.fn(() => of(undefined)),
 }));
 
 import { TestBed } from '@angular/core/testing';
-import { Firestore, getDoc } from '@angular/fire/firestore';
+import { Firestore, docData } from '@angular/fire/firestore';
 import { UserStatsApiService } from './user-stats-api.service';
 import { UserStats } from '@pu-stats/models';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 
 const fullMockStats: UserStats = {
   userId: 'test-uid',
@@ -51,12 +49,20 @@ describe('UserStatsApiService', () => {
   });
 
   it('returns UserStats when document exists', async () => {
-    jest.mocked(getDoc).mockResolvedValueOnce({
-      exists: () => true,
-      data: () => fullMockStats,
-    } as never);
+    jest.mocked(docData).mockReturnValueOnce(of(fullMockStats) as never);
 
     const result = await firstValueFrom(service.getUserStats('test-uid'));
     expect(result).toEqual(fullMockStats);
+  });
+
+  it('emits successive updates as the userStats doc is rewritten', async () => {
+    const initial: UserStats = { ...fullMockStats, dailyReps: 30 };
+    const updated: UserStats = { ...fullMockStats, dailyReps: 45 };
+    jest.mocked(docData).mockReturnValueOnce(of(initial, updated) as never);
+
+    const emissions: (UserStats | null)[] = [];
+    service.getUserStats('test-uid').subscribe((v) => emissions.push(v));
+    await Promise.resolve();
+    expect(emissions).toEqual([initial, updated]);
   });
 });

--- a/libs/data-access/src/lib/api/user-stats-api.service.spec.ts
+++ b/libs/data-access/src/lib/api/user-stats-api.service.spec.ts
@@ -1,7 +1,10 @@
 jest.mock('@angular/fire/firestore', () => ({
   Firestore: jest.fn(),
   doc: jest.fn(() => ({})),
-  docData: jest.fn(() => of(undefined)),
+  // Implementation is set per-test below; do NOT reference `of` here — the
+  // factory runs during `require()` resolution and rxjs may not yet be
+  // initialised under Jest's CJS transform.
+  docData: jest.fn(),
 }));
 
 import { TestBed } from '@angular/core/testing';
@@ -33,6 +36,7 @@ describe('UserStatsApiService', () => {
   let service: UserStatsApiService;
 
   beforeEach(() => {
+    jest.mocked(docData).mockReturnValue(of(undefined) as never);
     TestBed.configureTestingModule({
       providers: [{ provide: Firestore, useValue: {} }],
     });

--- a/libs/data-access/src/lib/api/user-stats-api.service.ts
+++ b/libs/data-access/src/lib/api/user-stats-api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
-import { doc, Firestore, getDoc } from '@angular/fire/firestore';
+import { doc, docData, Firestore } from '@angular/fire/firestore';
 import { UserStats } from '@pu-stats/models';
-import { from, map, Observable } from 'rxjs';
+import { map, Observable } from 'rxjs';
 
 const USER_STATS_COLLECTION = 'userStats';
 
@@ -10,13 +10,15 @@ export class UserStatsApiService {
   private readonly firestore = inject(Firestore);
 
   /**
-   * Fetch precomputed user statistics from `userStats/{userId}`.
-   * Returns null if the document does not exist yet (no backfill run).
+   * Subscribe to precomputed user statistics at `userStats/{userId}`.
+   * Emits null while the document is missing (no backfill run yet) and
+   * re-emits whenever the Cloud Function aggregator rewrites the doc, so the
+   * dashboard updates without a manual reload.
    */
   getUserStats(userId: string): Observable<UserStats | null> {
     const docRef = doc(this.firestore, USER_STATS_COLLECTION, userId);
-    return from(getDoc(docRef)).pipe(
-      map((snap) => (snap.exists() ? (snap.data() as UserStats) : null))
+    return docData(docRef).pipe(
+      map((data) => (data ? (data as UserStats) : null))
     );
   }
 }

--- a/libs/data-access/src/lib/leaderboard/leaderboard.store.spec.ts
+++ b/libs/data-access/src/lib/leaderboard/leaderboard.store.spec.ts
@@ -1,0 +1,172 @@
+// Importing `LeaderboardService` indirectly pulls in `@angular/fire/firestore`,
+// whose top-level evaluation hits `fetch is not defined` under Jest. Stub the
+// surface used by the service so the import succeeds. See
+// docs/gotchas/testing.md → "Jest ↔ Firebase".
+jest.mock('@angular/fire/firestore', () => ({
+  Firestore: jest.fn(),
+  doc: jest.fn(),
+  docData: jest.fn(),
+  collection: jest.fn(),
+  getDoc: jest.fn(),
+  getDocs: jest.fn(),
+  orderBy: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+}));
+jest.mock('@angular/fire/auth', () => ({ Auth: jest.fn() }));
+
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+import {
+  LeaderboardData,
+  LeaderboardService,
+} from '../api/leaderboard.service';
+import { LeaderboardStore } from './leaderboard.store';
+
+const emptyLeaderboard: LeaderboardData = {
+  daily: { top: [], current: null },
+  weekly: { top: [], current: null },
+  monthly: { top: [], current: null },
+};
+
+function makeApiMock(): {
+  load: jest.Mock<Promise<LeaderboardData>, []>;
+  observeSnapshot: jest.Mock<Subject<unknown>, []>;
+  snapshot$: Subject<unknown>;
+} {
+  const snapshot$ = new Subject<unknown>();
+  return {
+    load: jest.fn().mockResolvedValue(emptyLeaderboard),
+    observeSnapshot: jest.fn().mockReturnValue(snapshot$.asObservable()),
+    snapshot$,
+  };
+}
+
+describe('LeaderboardStore — live snapshot reload', () => {
+  describe('Given the app is running in the browser', () => {
+    it('Then it subscribes to observeSnapshot on init and force-reloads on each emission', async () => {
+      // Given
+      const api = makeApiMock();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: PLATFORM_ID, useValue: 'browser' },
+          { provide: LeaderboardService, useValue: api },
+        ],
+      });
+      const store = TestBed.inject(LeaderboardStore);
+      // The hook subscribes synchronously during creation.
+      expect(api.observeSnapshot).toHaveBeenCalledTimes(1);
+
+      // When — Cloud Function rewrites the snapshot doc twice.
+      api.snapshot$.next({ rev: 1 });
+      await Promise.resolve();
+      api.snapshot$.next({ rev: 2 });
+      await Promise.resolve();
+      // Drain the second performLoad triggered by reloadPending.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Then — the API was hit at least once per emission. With the in-flight
+      // queueing in `load()` the second emission may collapse with the first
+      // but is never dropped: the final fetch always reflects the latest doc.
+      expect(api.load).toHaveBeenCalled();
+      expect(store.loading()).toBe(false);
+      expect(store.data()).toEqual(emptyLeaderboard);
+    });
+
+    it('Then it unsubscribes from observeSnapshot when the injector is destroyed', () => {
+      // Given
+      const api = makeApiMock();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: PLATFORM_ID, useValue: 'browser' },
+          { provide: LeaderboardService, useValue: api },
+        ],
+      });
+      TestBed.inject(LeaderboardStore);
+      expect(api.snapshot$.observed).toBe(true);
+
+      // When
+      TestBed.resetTestingModule();
+
+      // Then — the effect's onCleanup tore down the subscription so the
+      // store instance does not keep Firestore listeners alive after destroy.
+      expect(api.snapshot$.observed).toBe(false);
+    });
+
+    it('Then a snapshot emission arriving while a load is in flight queues a follow-up reload', async () => {
+      // Given — `_api.load()` resolves only when we pull on `release`.
+      const api = makeApiMock();
+      let release!: (data: LeaderboardData) => void;
+      const dataA: LeaderboardData = {
+        ...emptyLeaderboard,
+        daily: {
+          top: [{ alias: 'A', reps: 1, rank: 1 }],
+          current: null,
+        },
+      };
+      const dataB: LeaderboardData = {
+        ...emptyLeaderboard,
+        daily: {
+          top: [{ alias: 'B', reps: 2, rank: 1 }],
+          current: null,
+        },
+      };
+      api.load.mockImplementationOnce(
+        () =>
+          new Promise<LeaderboardData>((resolve) => {
+            release = resolve;
+          })
+      );
+      api.load.mockResolvedValueOnce(dataB);
+
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: PLATFORM_ID, useValue: 'browser' },
+          { provide: LeaderboardService, useValue: api },
+        ],
+      });
+      const store = TestBed.inject(LeaderboardStore);
+
+      // First emission starts a load that is still pending.
+      api.snapshot$.next({ rev: 1 });
+      await Promise.resolve();
+      expect(store.loading()).toBe(true);
+
+      // When — second emission arrives while the first load is still in flight.
+      api.snapshot$.next({ rev: 2 });
+      await Promise.resolve();
+      // Now finish the first load. The store must run a second one for rev=2,
+      // not silently drop it.
+      release(dataA);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Then — both loads ran and the store reflects the LATER snapshot.
+      expect(api.load).toHaveBeenCalledTimes(2);
+      expect(store.data()).toEqual(dataB);
+      expect(store.loading()).toBe(false);
+    });
+  });
+
+  describe('Given the app is running on the server', () => {
+    it('Then no live subscription is opened (SSR has no Firestore listener)', () => {
+      // Given
+      const api = makeApiMock();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: PLATFORM_ID, useValue: 'server' },
+          { provide: LeaderboardService, useValue: api },
+        ],
+      });
+
+      // When
+      TestBed.inject(LeaderboardStore);
+
+      // Then
+      expect(api.observeSnapshot).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/data-access/src/lib/leaderboard/leaderboard.store.ts
+++ b/libs/data-access/src/lib/leaderboard/leaderboard.store.ts
@@ -1,8 +1,17 @@
-import { computed, inject } from '@angular/core';
+import {
+  computed,
+  effect,
+  inject,
+  Injector,
+  PLATFORM_ID,
+  runInInjectionContext,
+} from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import {
   patchState,
   signalStore,
   withComputed,
+  withHooks,
   withMethods,
   withProps,
   withState,
@@ -33,6 +42,8 @@ export const LeaderboardStore = signalStore(
   withState(initialState),
   withProps(() => ({
     _api: inject(LeaderboardService, { optional: true }),
+    _isBrowser: isPlatformBrowser(inject(PLATFORM_ID)),
+    _injector: inject(Injector),
   })),
   withComputed((store) => ({
     loaded: computed(() => store.data() !== null),
@@ -83,5 +94,28 @@ export const LeaderboardStore = signalStore(
         return data[period()].current;
       });
     },
-  }))
+  })),
+  withHooks({
+    onInit(store) {
+      // Live-refresh whenever the precomputed `leaderboards/current` doc
+      // changes. The snapshot only mutates after a Cloud Function rewrite
+      // (typically minutes), so re-running `load({ force: true })` is cheap
+      // and avoids a stale leaderboard between manual refreshes.
+      if (!store._isBrowser || !store._api) return;
+      const api = store._api;
+      runInInjectionContext(store._injector, () => {
+        effect((onCleanup) => {
+          const sub = api.observeSnapshot().subscribe({
+            next: () => {
+              void store.load({ force: true });
+            },
+            error: () => {
+              /* swallow — leaderboard is non-critical, fall back to one-shot load */
+            },
+          });
+          onCleanup(() => sub.unsubscribe());
+        });
+      });
+    },
+  })
 );

--- a/libs/data-access/src/lib/leaderboard/leaderboard.store.ts
+++ b/libs/data-access/src/lib/leaderboard/leaderboard.store.ts
@@ -1,11 +1,4 @@
-import {
-  computed,
-  effect,
-  inject,
-  Injector,
-  PLATFORM_ID,
-  runInInjectionContext,
-} from '@angular/core';
+import { computed, DestroyRef, inject, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import {
   patchState,
@@ -43,15 +36,22 @@ export const LeaderboardStore = signalStore(
   withProps(() => ({
     _api: inject(LeaderboardService, { optional: true }),
     _isBrowser: isPlatformBrowser(inject(PLATFORM_ID)),
-    _injector: inject(Injector),
+    _destroyRef: inject(DestroyRef),
   })),
   withComputed((store) => ({
     loaded: computed(() => store.data() !== null),
   })),
-  withMethods(({ _api, ...store }) => ({
-    async load(options?: { force?: boolean }): Promise<void> {
-      if (store.loading()) return;
-      if (store.loaded() && !options?.force) return;
+  withMethods(({ _api, ...store }) => {
+    // Tracks whether a `load()` is currently awaiting `_api.load()`. The
+    // `loading` signal flips synchronously inside the same tick, but using a
+    // dedicated closure flag makes the "did another caller try to force a
+    // reload while we were busy?" check explicit and decoupled from the
+    // public state.
+    let inFlight = false;
+    let reloadPending = false;
+
+    async function performLoad(): Promise<void> {
+      inFlight = true;
       patchState(store, { loading: true, error: null });
       try {
         if (!_api) {
@@ -72,50 +72,73 @@ export const LeaderboardStore = signalStore(
           error: err instanceof Error ? err.message : String(err),
           loading: false,
         });
+      } finally {
+        inFlight = false;
       }
-    },
+    }
 
-    entriesForPeriod(
-      period: () => LeaderboardPeriod
-    ): () => LeaderboardEntry[] {
-      return computed(() => {
-        const data = store.data();
-        if (!data) return EMPTY_ENTRIES;
-        return data[period()].top;
-      });
-    },
+    return {
+      async load(options?: { force?: boolean }): Promise<void> {
+        // A previous load is mid-flight. If the caller insists on freshness
+        // (snapshot live-reload, manual user refresh), remember that we owe
+        // them another run after the current one finishes — otherwise live
+        // updates that arrive during a slow load would be silently dropped.
+        if (inFlight) {
+          if (options?.force) reloadPending = true;
+          return;
+        }
+        if (store.loaded() && !options?.force) return;
 
-    currentUserForPeriod(
-      period: () => LeaderboardPeriod
-    ): () => LeaderboardEntry | null {
-      return computed(() => {
-        const data = store.data();
-        if (!data) return null;
-        return data[period()].current;
-      });
-    },
-  })),
+        await performLoad();
+
+        if (reloadPending) {
+          reloadPending = false;
+          await performLoad();
+        }
+      },
+
+      entriesForPeriod(
+        period: () => LeaderboardPeriod
+      ): () => LeaderboardEntry[] {
+        return computed(() => {
+          const data = store.data();
+          if (!data) return EMPTY_ENTRIES;
+          return data[period()].top;
+        });
+      },
+
+      currentUserForPeriod(
+        period: () => LeaderboardPeriod
+      ): () => LeaderboardEntry | null {
+        return computed(() => {
+          const data = store.data();
+          if (!data) return null;
+          return data[period()].current;
+        });
+      },
+    };
+  }),
   withHooks({
     onInit(store) {
       // Live-refresh whenever the precomputed `leaderboards/current` doc
       // changes. The snapshot only mutates after a Cloud Function rewrite
       // (typically minutes), so re-running `load({ force: true })` is cheap
       // and avoids a stale leaderboard between manual refreshes.
+      //
+      // We subscribe directly (not via `effect`) so the listener attaches
+      // synchronously at construction — tests can assert behaviour without
+      // having to flush effects, and the cleanup is hooked into `DestroyRef`
+      // for symmetric tear-down.
       if (!store._isBrowser || !store._api) return;
-      const api = store._api;
-      runInInjectionContext(store._injector, () => {
-        effect((onCleanup) => {
-          const sub = api.observeSnapshot().subscribe({
-            next: () => {
-              void store.load({ force: true });
-            },
-            error: () => {
-              /* swallow — leaderboard is non-critical, fall back to one-shot load */
-            },
-          });
-          onCleanup(() => sub.unsubscribe());
-        });
+      const sub = store._api.observeSnapshot().subscribe({
+        next: () => {
+          void store.load({ force: true });
+        },
+        error: () => {
+          /* swallow — leaderboard is non-critical, fall back to one-shot load */
+        },
       });
+      store._destroyRef.onDestroy(() => sub.unsubscribe());
     },
   })
 );

--- a/libs/testing/src/lib/data-access-mocks.ts
+++ b/libs/testing/src/lib/data-access-mocks.ts
@@ -13,7 +13,7 @@
  *   const mock = makePushupFirestoreMock({ createPushup: vitest.fn().mockReturnValue(of(record)) });
  */
 
-import { of } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import {
   LeaderboardBucket,
   LeaderboardData,
@@ -140,6 +140,7 @@ export function makeLeaderboardMock(
 ): Partial<LeaderboardService> {
   return {
     load: () => Promise.resolve(emptyLeaderboard),
+    observeSnapshot: () => EMPTY,
     ...overrides,
   };
 }

--- a/web/src/app/core/goal-reached-notification.service.spec.ts
+++ b/web/src/app/core/goal-reached-notification.service.spec.ts
@@ -402,6 +402,62 @@ describe('GoalReachedNotificationService', () => {
       ).toBeNull();
     });
 
+    it('Then re-fires after midnight in the same service instance when live entries arrive on day 2', async () => {
+      // Given — long-running session. Service is created on day 1 and the
+      // user reaches the goal; flag persisted. The instance stays alive
+      // (PWA / background tab) and the clock crosses midnight without the
+      // service being recreated. This is the regression path the
+      // `live.entries()`-tied `todayBerlin` recompute targets.
+      setup({
+        dailyGoal: 10,
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 12,
+          } as PushupRecord,
+        ],
+      });
+      await flushAll();
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      expect(localStorage.getItem('pus_goal_reached_daily_2026-04-22')).toBe(
+        '1'
+      );
+      dialogOpenSpy.mockClear();
+
+      // When — clock advances to day 2 (no fresh service, no setup() call),
+      // and a new entry on the new day arrives via the same liveEntries
+      // signal the service is already subscribed to.
+      vi.setSystemTime(new Date(2026, 3, 23, 12, 0));
+      liveEntries.set([
+        {
+          _id: '1',
+          timestamp: '2026-04-22T08:00:00',
+          reps: 12,
+        } as PushupRecord,
+        {
+          _id: '2',
+          timestamp: '2026-04-23T09:00:00',
+          reps: 12,
+        } as PushupRecord,
+      ]);
+      await flushAll();
+
+      // Then — the SAME service instance must now recompute "today" to day 2
+      // (because `todayBerlin` depends on `entries()`), pick up the day-2
+      // total, and fire the celebration with the new period key.
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      const [, config] = dialogOpenSpy.mock.calls[0];
+      expect(config?.data).toMatchObject({
+        kind: 'daily',
+        total: 12,
+        goal: 10,
+      });
+      expect(localStorage.getItem('pus_goal_reached_daily_2026-04-23')).toBe(
+        '1'
+      );
+    });
+
     it('Then a downward change leaves the persisted flag intact', async () => {
       // Given
       setup({

--- a/web/src/app/core/goal-reached-notification.service.spec.ts
+++ b/web/src/app/core/goal-reached-notification.service.spec.ts
@@ -344,6 +344,64 @@ describe('GoalReachedNotificationService', () => {
       });
     });
 
+    it('Then re-fires on the next day even if the previous day was already celebrated', async () => {
+      // Given — day 1: goal reached, dialog opens, flag persisted.
+      setup({
+        dailyGoal: 10,
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 12,
+          } as PushupRecord,
+        ],
+      });
+      await flushAll();
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      expect(localStorage.getItem('pus_goal_reached_daily_2026-04-22')).toBe(
+        '1'
+      );
+      dialogOpenSpy.mockClear();
+
+      // When — clock advances to day 2, fresh service start, the user reaches
+      // the goal again on the new day. Yesterday's flag must NOT silently
+      // suppress the new day's celebration.
+      vi.setSystemTime(new Date(2026, 3, 23, 12, 0));
+      setup({
+        dailyGoal: 10,
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 12,
+          } as PushupRecord,
+          {
+            _id: '2',
+            timestamp: '2026-04-23T09:00:00',
+            reps: 12,
+          } as PushupRecord,
+        ],
+      });
+      await flushAll();
+
+      // Then — dialog fires for day 2 with its own flag, and yesterday's stale
+      // flag has been pruned from localStorage so it can no longer accidentally
+      // match a future period.
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      const [, config] = dialogOpenSpy.mock.calls[0];
+      expect(config?.data).toMatchObject({
+        kind: 'daily',
+        total: 12,
+        goal: 10,
+      });
+      expect(localStorage.getItem('pus_goal_reached_daily_2026-04-23')).toBe(
+        '1'
+      );
+      expect(
+        localStorage.getItem('pus_goal_reached_daily_2026-04-22')
+      ).toBeNull();
+    });
+
     it('Then a downward change leaves the persisted flag intact', async () => {
       // Given
       setup({

--- a/web/src/app/core/goal-reached-notification.service.ts
+++ b/web/src/app/core/goal-reached-notification.service.ts
@@ -51,12 +51,22 @@ export class GoalReachedNotificationService {
     this.live.entries()
   );
 
-  private readonly todayBerlin = computed(() => toBerlinIsoDate(new Date()));
+  /**
+   * Berlin-localised "today" key. Reading `entries()` here ties the key to
+   * the live data signal, so that — in a long-running PWA session that
+   * crosses midnight — the key recomputes the next time a Firestore entry
+   * update arrives. Without this dependency `todayBerlin` would cache day 1
+   * forever and the dialog would never re-fire on day 2.
+   */
+  private readonly todayBerlin = computed(() => {
+    this.entries();
+    return toBerlinIsoDate(new Date());
+  });
 
   private readonly todayTotal = computed(() => {
     const today = this.todayBerlin();
     return this.entries()
-      .filter((entry) => entry.timestamp.slice(0, 10) === today)
+      .filter((entry) => entryBerlinDate(entry.timestamp) === today)
       .reduce((sum, entry) => sum + entry.reps, 0);
   });
 
@@ -70,7 +80,7 @@ export class GoalReachedNotificationService {
     const { from, to } = this.weekRange();
     return this.entries()
       .filter((entry) => {
-        const day = entry.timestamp.slice(0, 10);
+        const day = entryBerlinDate(entry.timestamp);
         return day >= from && day <= to;
       })
       .reduce((sum, entry) => sum + entry.reps, 0);
@@ -83,7 +93,7 @@ export class GoalReachedNotificationService {
   private readonly monthTotal = computed(() => {
     const prefix = this.currentMonthKey();
     return this.entries()
-      .filter((entry) => entry.timestamp.startsWith(prefix))
+      .filter((entry) => entryBerlinDate(entry.timestamp).startsWith(prefix))
       .reduce((sum, entry) => sum + entry.reps, 0);
   });
 
@@ -124,6 +134,12 @@ export class GoalReachedNotificationService {
 
   constructor() {
     if (!isPlatformBrowser(this.platformId)) return;
+    // Drop stale period flags from previous days/weeks/months on every app
+    // start. Without this, localStorage accumulates `pus_goal_reached_*` keys
+    // forever, and a clock skew or formatting drift could falsely match an
+    // old key on a new day — exactly the "dialog never re-fires on day 2"
+    // class of bug.
+    pruneStalePeriodFlags(toBerlinIsoDate(new Date()));
     for (const spec of this.specs) {
       // Order matters: the increase watcher is registered before the
       // goal-reached watcher so that, when both fire on a single goal raise,
@@ -194,6 +210,38 @@ export class GoalReachedNotificationService {
         maxParticleCount: snapshot.maxParticleCount,
       },
     });
+  }
+}
+
+/**
+ * Convert a Firestore-stored ISO timestamp (`YYYY-MM-DDTHH:mm:ss.sssZ`) to
+ * its Berlin-localised date key. Without the timezone hop, entries created
+ * between 00:00–02:00 Berlin local during summer time get classified under
+ * the previous UTC day, which would silently mis-count daily/weekly totals.
+ */
+function entryBerlinDate(timestamp: string): string {
+  return toBerlinIsoDate(new Date(timestamp));
+}
+
+function pruneStalePeriodFlags(todayBerlin: string): void {
+  const ls = globalThis.localStorage;
+  if (!ls) return;
+  const validKeys = new Set([
+    `${STORAGE_PREFIX}daily_${todayBerlin}`,
+    `${STORAGE_PREFIX}weekly_${isoWeekKey(todayBerlin)}`,
+    `${STORAGE_PREFIX}monthly_${todayBerlin.slice(0, 7)}`,
+  ]);
+  try {
+    const stale: string[] = [];
+    for (let i = 0; i < ls.length; i++) {
+      const key = ls.key(i);
+      if (key && key.startsWith(STORAGE_PREFIX) && !validKeys.has(key)) {
+        stale.push(key);
+      }
+    }
+    for (const key of stale) ls.removeItem(key);
+  } catch {
+    // localStorage unavailable / SecurityError — best-effort cleanup only.
   }
 }
 

--- a/web/src/app/core/goal-reached-notification.service.ts
+++ b/web/src/app/core/goal-reached-notification.service.ts
@@ -214,24 +214,41 @@ export class GoalReachedNotificationService {
 }
 
 /**
- * Convert a Firestore-stored ISO timestamp (`YYYY-MM-DDTHH:mm:ss.sssZ`) to
- * its Berlin-localised date key. Without the timezone hop, entries created
- * between 00:00–02:00 Berlin local during summer time get classified under
- * the previous UTC day, which would silently mis-count daily/weekly totals.
+ * Convert a Firestore-stored ISO timestamp to its Berlin-localised date key.
+ *
+ * Two timestamp shapes appear in production:
+ *   - Naive (`YYYY-MM-DDTHH:mm[:ss]`) — written by older quick-add entries
+ *     that the backend treats as Berlin local time. We must NOT round-trip
+ *     these through `new Date()`, because that parses them in the device's
+ *     local timezone and shifts the day on devices not in `Europe/Berlin`.
+ *     The Cloud Function's bucketing logic also uses the literal date prefix.
+ *   - TZ-aware (`...Z` or `...±HH:mm`) — written by `createPushup` via
+ *     `new Date().toISOString()`. We convert these via the Berlin formatter
+ *     so that an entry made at 00:30 Berlin (== 22:30 UTC the prior day)
+ *     counts toward today and not yesterday.
  */
 function entryBerlinDate(timestamp: string): string {
-  return toBerlinIsoDate(new Date(timestamp));
+  if (HAS_TIMEZONE.test(timestamp)) {
+    return toBerlinIsoDate(new Date(timestamp));
+  }
+  return timestamp.slice(0, 10);
 }
 
+const HAS_TIMEZONE = /(Z|[+-]\d{2}:?\d{2})$/;
+
 function pruneStalePeriodFlags(todayBerlin: string): void {
-  const ls = globalThis.localStorage;
-  if (!ls) return;
-  const validKeys = new Set([
-    `${STORAGE_PREFIX}daily_${todayBerlin}`,
-    `${STORAGE_PREFIX}weekly_${isoWeekKey(todayBerlin)}`,
-    `${STORAGE_PREFIX}monthly_${todayBerlin.slice(0, 7)}`,
-  ]);
+  // Touching `globalThis.localStorage` itself can throw `SecurityError` in
+  // sandboxed/opaque origins or with storage disabled (Safari private mode,
+  // some embedded webviews). Wrap the whole access — not just the read loop —
+  // so cleanup stays best-effort and never breaks app startup.
   try {
+    const ls = globalThis.localStorage;
+    if (!ls) return;
+    const validKeys = new Set([
+      `${STORAGE_PREFIX}daily_${todayBerlin}`,
+      `${STORAGE_PREFIX}weekly_${isoWeekKey(todayBerlin)}`,
+      `${STORAGE_PREFIX}monthly_${todayBerlin.slice(0, 7)}`,
+    ]);
     const stale: string[] = [];
     for (let i = 0; i < ls.length; i++) {
       const key = ls.key(i);

--- a/web/src/app/core/user-config.store.spec.ts
+++ b/web/src/app/core/user-config.store.spec.ts
@@ -1,10 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { UserConfigStore } from './user-config.store';
 import { UserConfigApiService } from '@pu-stats/data-access';
 import { UserContextService } from '@pu-auth/auth';
-import { UserConfigUpdate } from '@pu-stats/models';
+import { UserConfig, UserConfigUpdate } from '@pu-stats/models';
 
 describe('UserConfigStore', () => {
   const userId = signal<string>('u1');
@@ -78,5 +78,42 @@ describe('UserConfigStore', () => {
     expect(store.dailyGoal()).toBe(0);
 
     userId.set('u1'); // restore for other tests
+  });
+
+  it('Given the API observable emits a new config, When no manual reload is called, Then the store reflects the update (live Firestore listener)', async () => {
+    // Given — the API exposes a long-lived stream (as `docData()` does in
+    // production). The store consumes it via `rxResource` and must propagate
+    // every emission to the dailyGoal signal without an explicit `.reload()`.
+    const stream = new BehaviorSubject<UserConfig>({
+      userId: 'u1',
+      dailyGoal: 100,
+    });
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: UserConfigApiService,
+          useValue: {
+            getConfig: vitest.fn(() => stream.asObservable()),
+            updateConfig: vitest.fn(),
+          },
+        },
+        {
+          provide: UserContextService,
+          useValue: { userIdSafe: () => 'u1' },
+        },
+      ],
+    });
+    const store = TestBed.inject(UserConfigStore);
+    await flush();
+    expect(store.dailyGoal()).toBe(100);
+
+    // When — a fresh emission arrives on the same stream (e.g. another tab
+    // wrote to userConfigs/u1, or the Cloud Function rewrote it).
+    stream.next({ userId: 'u1', dailyGoal: 222 });
+    await flush();
+
+    // Then — the signal updates without `store.reload()` ever being called.
+    expect(store.dailyGoal()).toBe(222);
   });
 });

--- a/web/src/app/core/user-config.store.ts
+++ b/web/src/app/core/user-config.store.ts
@@ -1,4 +1,5 @@
-import { computed, inject, resource } from '@angular/core';
+import { computed, inject } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 import {
   signalStore,
   withComputed,
@@ -14,13 +15,17 @@ import {
   UserConfig,
   UserConfigUpdate,
 } from '@pu-stats/models';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 
 /**
  * Root-level store for user config (daily/weekly/monthly goals, display name,
  * consent, ui flags). Single source of truth — consumed by the app toolbar,
  * dashboard and settings page so that edits made in one place propagate
  * reactively to the others without requiring a full reload.
+ *
+ * Backed by a Firestore real-time listener (`docData()`), so config changes
+ * made anywhere — settings page, another device, server-side — propagate to
+ * every consumer without a manual reload.
  */
 export const UserConfigStore = signalStore(
   { providedIn: 'root' },
@@ -29,11 +34,11 @@ export const UserConfigStore = signalStore(
     _user: inject(UserContextService),
   })),
   withProps((store) => ({
-    configResource: resource({
+    configResource: rxResource({
       params: () => ({ userId: store._user.userIdSafe() }),
-      loader: async ({ params }) => {
-        if (!params.userId) return null;
-        return firstValueFrom(store._api.getConfig(params.userId));
+      stream: ({ params }) => {
+        if (!params.userId) return of(null);
+        return store._api.getConfig(params.userId);
       },
     }),
   })),

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -1,4 +1,5 @@
 import { computed, inject, LOCALE_ID, resource } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 import {
   patchState,
   signalStore,
@@ -7,7 +8,7 @@ import {
   withProps,
   withState,
 } from '@ngrx/signals';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 import { StatsApiService, UserStatsApiService } from '@pu-stats/data-access';
 import { UserContextService } from '@pu-auth/auth';
 import {
@@ -173,12 +174,15 @@ export const AnalysisStore = signalStore(
         firstValueFrom(store._api.listPushups(params)),
     });
 
-    const userStatsResource = resource({
+    // Real-time listener on `userStats/{userId}` so server-side aggregation
+    // updates (heatmap, best entries) flow into the analysis page without
+    // requiring a manual reload.
+    const userStatsResource = rxResource({
       params: () => ({ userId: store._user.userIdSafe() }),
-      loader: async ({ params }) =>
+      stream: ({ params }) =>
         params.userId
-          ? firstValueFrom(store._userStatsApi.getUserStats(params.userId))
-          : null,
+          ? store._userStatsApi.getUserStats(params.userId)
+          : of(null),
     });
 
     const weekEntriesResource = resource({

--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -1,5 +1,6 @@
 import { isPlatformBrowser } from '@angular/common';
 import { computed, inject, PLATFORM_ID, resource } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 import {
   signalStore,
   withComputed,
@@ -21,7 +22,7 @@ import {
 import { AdsStore } from '@pu-stats/ads';
 import { UserContextService } from '@pu-auth/auth';
 import { MotivationStore } from '@pu-stats/motivation';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 import { UserConfigStore } from '../core/user-config.store';
 
 const EMPTY_STATS: StatsResponse = {
@@ -99,12 +100,15 @@ export const DashboardStore = signalStore(
     allTimeResource: resource({
       loader: async () => firstValueFrom(store._api.load({})),
     }),
-    userStatsResource: resource({
+    // Real-time listener on `userStats/{userId}`. The Cloud Function
+    // aggregator rewrites this doc after each pushup write — `rxResource`
+    // ensures the dashboard re-renders without polling or manual reload.
+    userStatsResource: rxResource({
       params: () => ({ userId: store._user.userIdSafe() }),
-      loader: async ({ params }) =>
+      stream: ({ params }) =>
         params.userId
-          ? firstValueFrom(store._userStatsApi.getUserStats(params.userId))
-          : null,
+          ? store._userStatsApi.getUserStats(params.userId)
+          : of(null),
     }),
   })),
   withComputed((store) => {


### PR DESCRIPTION
- UserConfigApiService.getConfig and UserStatsApiService.getUserStats now use
  docData() so changes (settings edits, Cloud Function aggregation) propagate
  to every consumer signal without a manual reload. UserConfigStore,
  DashboardStore and AnalysisStore consume them via rxResource.
- LeaderboardService.observeSnapshot streams `leaderboards/current`;
  LeaderboardStore reloads on each snapshot rewrite.

fix(goal-reached): re-fire celebration on the next day

The daily success dialog was suppressed on day 2 because (a) the Berlin
"today" key was a dependency-free computed and cached forever within a
session, and (b) old `pus_goal_reached_*` flags accumulated in localStorage
indefinitely. Now today's key recomputes on every live-data update and
stale period flags are pruned at service start. Entry timestamps are also
compared via Berlin date conversion to avoid UTC-slice mis-classification
near midnight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time updates for leaderboards, user configuration, and statistics data.
  * Browser-based timezone corrections for daily goal notifications.

* **Bug Fixes**
  * Fixed timezone handling for daily goal celebrations to use Berlin local time.
  * Automatic cleanup of stale goal dismissal flags from local storage on app startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->