### PR TITLE
feat(training-plans): add structured training plans with daily goal override

### DIFF
--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -86,6 +86,19 @@ service cloud.firestore {
       allow read, update, delete: if false;
     }
 
+    // Active training plan — owner-only. Single doc per user.
+    // The doc id IS the user id, and writes must keep `userId` aligned.
+    match /userTrainingPlans/{userId} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow create: if request.auth != null
+                    && request.auth.uid == userId
+                    && request.resource.data.userId == userId;
+      allow update: if request.auth != null
+                    && request.auth.uid == userId
+                    && request.resource.data.userId == userId;
+      allow delete: if request.auth != null && request.auth.uid == userId;
+    }
+
     // Deny everything else by default.
     match /{document=**} {
       allow read, write: if false;

--- a/libs/data-access/src/index.ts
+++ b/libs/data-access/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/api/stats-api.service';
 export * from './lib/api/user-config-api.service';
+export * from './lib/api/user-training-plan-api.service';
 export * from './lib/api/user-stats-api.service';
 export * from './lib/live/live-data.store';
 export * from './lib/api/pushup-firestore.service';

--- a/libs/data-access/src/lib/api/user-training-plan-api.service.spec.ts
+++ b/libs/data-access/src/lib/api/user-training-plan-api.service.spec.ts
@@ -1,0 +1,170 @@
+import { PLATFORM_ID } from '@angular/core';
+import { Auth } from '@angular/fire/auth';
+import { Firestore } from '@angular/fire/firestore';
+import { UserTrainingPlan } from '@pu-stats/models';
+import { render } from '@testing-library/angular';
+import { of } from 'rxjs';
+import { UserTrainingPlanApiService } from './user-training-plan-api.service';
+
+jest.mock('@angular/fire/auth', () => ({
+  Auth: jest.fn(),
+}));
+
+jest.mock('@angular/fire/firestore', () => ({
+  Firestore: jest.fn(),
+  doc: jest.fn(),
+  docData: jest.fn(),
+  setDoc: jest.fn(() => Promise.resolve()),
+}));
+
+describe('UserTrainingPlanApiService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('streams the active plan from Firestore', async () => {
+    const firestoreFns = await import('@angular/fire/firestore');
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
+    (firestoreFns.docData as jest.Mock).mockReturnValue(
+      of({
+        userId: 'u',
+        planId: 'challenge-30d-v1',
+        startDate: '2026-04-01',
+        status: 'active',
+        completedDays: [1, 2],
+      } satisfies UserTrainingPlan)
+    );
+
+    const { fixture } = await render('', {
+      providers: [
+        UserTrainingPlanApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'u' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(
+      UserTrainingPlanApiService
+    );
+    let result: UserTrainingPlan | null | undefined;
+    service.getActivePlan('u').subscribe((r) => (result = r));
+
+    await Promise.resolve();
+    expect(result?.planId).toBe('challenge-30d-v1');
+  });
+
+  it('returns null when the doc does not exist', async () => {
+    const firestoreFns = await import('@angular/fire/firestore');
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
+    (firestoreFns.docData as jest.Mock).mockReturnValue(of(undefined));
+
+    const { fixture } = await render('', {
+      providers: [
+        UserTrainingPlanApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'u' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(
+      UserTrainingPlanApiService
+    );
+    let result: UserTrainingPlan | null | undefined;
+    service.getActivePlan('u').subscribe((r) => (result = r));
+
+    await Promise.resolve();
+    expect(result).toBeNull();
+  });
+
+  it('uses the auth uid (not the passed-in userId) for the doc path', async () => {
+    const firestoreFns = await import('@angular/fire/firestore');
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'real' });
+    (firestoreFns.docData as jest.Mock).mockReturnValue(of(undefined));
+
+    const { fixture } = await render('', {
+      providers: [
+        UserTrainingPlanApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'real' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(
+      UserTrainingPlanApiService
+    );
+    service.getActivePlan('forged').subscribe();
+
+    await Promise.resolve();
+    expect(firestoreFns.doc).toHaveBeenCalledWith(
+      expect.anything(),
+      'userTrainingPlans',
+      'real'
+    );
+  });
+
+  it('writes a new active plan via setPlan (overwrites stale state)', async () => {
+    const firestoreFns = await import('@angular/fire/firestore');
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
+
+    const { fixture } = await render('', {
+      providers: [
+        UserTrainingPlanApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'u' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(
+      UserTrainingPlanApiService
+    );
+
+    let result: UserTrainingPlan | undefined;
+    service
+      .setPlan('u', {
+        planId: 'challenge-30d-v1',
+        startDate: '2026-05-01',
+        status: 'active',
+        completedDays: [],
+      })
+      .subscribe((r) => (result = r));
+
+    await Promise.resolve();
+    expect(firestoreFns.setDoc).toHaveBeenCalled();
+    expect(result?.planId).toBe('challenge-30d-v1');
+    expect(result?.userId).toBe('u');
+  });
+
+  it('merges patches via updatePlan', async () => {
+    const firestoreFns = await import('@angular/fire/firestore');
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
+
+    const { fixture } = await render('', {
+      providers: [
+        UserTrainingPlanApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'u' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(
+      UserTrainingPlanApiService
+    );
+
+    service.updatePlan('u', { completedDays: [1, 2, 3] }).subscribe();
+
+    await Promise.resolve();
+    expect(firestoreFns.setDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        completedDays: [1, 2, 3],
+        userId: 'u',
+      }),
+      { merge: true }
+    );
+  });
+});

--- a/libs/data-access/src/lib/api/user-training-plan-api.service.spec.ts
+++ b/libs/data-access/src/lib/api/user-training-plan-api.service.spec.ts
@@ -1,5 +1,6 @@
 import { PLATFORM_ID } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
+import * as firestoreFns from '@angular/fire/firestore';
 import { Firestore } from '@angular/fire/firestore';
 import { UserTrainingPlan } from '@pu-stats/models';
 import { render } from '@testing-library/angular';
@@ -23,7 +24,7 @@ describe('UserTrainingPlanApiService', () => {
   });
 
   it('streams the active plan from Firestore', async () => {
-    const firestoreFns = await import('@angular/fire/firestore');
+
     (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
     (firestoreFns.docData as jest.Mock).mockReturnValue(
       of({
@@ -55,7 +56,7 @@ describe('UserTrainingPlanApiService', () => {
   });
 
   it('returns null when the doc does not exist', async () => {
-    const firestoreFns = await import('@angular/fire/firestore');
+
     (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
     (firestoreFns.docData as jest.Mock).mockReturnValue(of(undefined));
 
@@ -79,7 +80,7 @@ describe('UserTrainingPlanApiService', () => {
   });
 
   it('uses the auth uid (not the passed-in userId) for the doc path', async () => {
-    const firestoreFns = await import('@angular/fire/firestore');
+
     (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'real' });
     (firestoreFns.docData as jest.Mock).mockReturnValue(of(undefined));
 
@@ -106,7 +107,7 @@ describe('UserTrainingPlanApiService', () => {
   });
 
   it('writes a new active plan via setPlan (overwrites stale state)', async () => {
-    const firestoreFns = await import('@angular/fire/firestore');
+
     (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
 
     const { fixture } = await render('', {
@@ -139,7 +140,7 @@ describe('UserTrainingPlanApiService', () => {
   });
 
   it('merges patches via updatePlan', async () => {
-    const firestoreFns = await import('@angular/fire/firestore');
+
     (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
 
     const { fixture } = await render('', {

--- a/libs/data-access/src/lib/api/user-training-plan-api.service.ts
+++ b/libs/data-access/src/lib/api/user-training-plan-api.service.ts
@@ -1,0 +1,116 @@
+import { inject, Injectable } from '@angular/core';
+import { Auth } from '@angular/fire/auth';
+import {
+  doc,
+  docData,
+  DocumentReference,
+  Firestore,
+  setDoc,
+} from '@angular/fire/firestore';
+import { UserTrainingPlan, UserTrainingPlanUpdate } from '@pu-stats/models';
+import { from, map, Observable, of } from 'rxjs';
+
+const COLLECTION = 'userTrainingPlans';
+
+/**
+ * Single-document-per-user store for the active training plan.
+ * Mirrors the pattern of `UserConfigApiService` (collection
+ * `userTrainingPlans/{userId}` keyed on the auth uid). Always uses
+ * `currentUser.uid` for the doc path so a forged `userId` parameter
+ * cannot redirect reads/writes.
+ */
+@Injectable({ providedIn: 'root' })
+export class UserTrainingPlanApiService {
+  private readonly firestore = inject(Firestore, { optional: true });
+  private readonly auth = inject(Auth, { optional: true });
+
+  getActivePlan(userId: string): Observable<UserTrainingPlan | null> {
+    const effectiveUserId = this.resolveUserId(userId);
+    if (!effectiveUserId || !this.firestore) {
+      return of(null);
+    }
+    const ref = this.docRef(effectiveUserId);
+    return docData(ref).pipe(
+      map((data) => (data as UserTrainingPlan | undefined) ?? null)
+    );
+  }
+
+  updatePlan(
+    userId: string,
+    patch: UserTrainingPlanUpdate
+  ): Observable<UserTrainingPlan> {
+    const effectiveUserId = this.resolveUserId(userId);
+    if (!effectiveUserId || !this.firestore) {
+      return of({
+        userId,
+        planId: '',
+        startDate: '',
+        status: 'active',
+        completedDays: [],
+        ...patch,
+      } as UserTrainingPlan);
+    }
+    const ref = this.docRef(effectiveUserId);
+    const nowIso = new Date().toISOString();
+    const payload: Partial<UserTrainingPlan> = {
+      ...patch,
+      userId: effectiveUserId,
+      updatedAt: nowIso,
+    };
+    return from(setDoc(ref, payload, { merge: true })).pipe(
+      map(
+        () =>
+          ({
+            userId: effectiveUserId,
+            planId: '',
+            startDate: '',
+            status: 'active',
+            completedDays: [],
+            ...patch,
+          }) as UserTrainingPlan
+      )
+    );
+  }
+
+  /**
+   * Replaces the doc atomically (used when starting a new plan so we
+   * don't merge stale `completedDays` from a previous activation).
+   */
+  setPlan(
+    userId: string,
+    plan: Omit<UserTrainingPlan, 'userId'>
+  ): Observable<UserTrainingPlan> {
+    const effectiveUserId = this.resolveUserId(userId);
+    if (!effectiveUserId || !this.firestore) {
+      return of({ ...plan, userId } as UserTrainingPlan);
+    }
+    const ref = this.docRef(effectiveUserId);
+    const nowIso = new Date().toISOString();
+    const payload: UserTrainingPlan = {
+      ...plan,
+      userId: effectiveUserId,
+      createdAt: plan.createdAt ?? nowIso,
+      updatedAt: nowIso,
+    };
+    return from(setDoc(ref, payload)).pipe(map(() => payload));
+  }
+
+  private resolveUserId(fallbackUserId: string): string {
+    return this.auth?.currentUser?.uid ?? fallbackUserId;
+  }
+
+  private docRef(userId: string): DocumentReference<UserTrainingPlan> {
+    return doc(
+      this.requireFirestore(),
+      COLLECTION,
+      userId
+    ) as DocumentReference<UserTrainingPlan>;
+  }
+
+  private requireFirestore(): Firestore {
+    if (!this.firestore) {
+      throw new Error('Firestore provider missing');
+    }
+    return this.firestore;
+  }
+}

--- a/libs/data-access/src/lib/api/user-training-plan-api.service.ts
+++ b/libs/data-access/src/lib/api/user-training-plan-api.service.ts
@@ -15,9 +15,15 @@ const COLLECTION = 'userTrainingPlans';
 /**
  * Single-document-per-user store for the active training plan.
  * Mirrors the pattern of `UserConfigApiService` (collection
- * `userTrainingPlans/{userId}` keyed on the auth uid). Always uses
- * `currentUser.uid` for the doc path so a forged `userId` parameter
- * cannot redirect reads/writes.
+ * `userTrainingPlans/{userId}` keyed on the auth uid).
+ *
+ * The doc path prefers `auth.currentUser.uid` over the `userId`
+ * argument, so a forged argument cannot redirect reads/writes for an
+ * authenticated session. When `auth.currentUser` is unavailable
+ * (e.g. SSR before auth resolves, or the optional `Auth` provider is
+ * missing in tests) we fall back to the passed-in `userId` so the
+ * stub path matches what callers expect — Firestore rules still
+ * reject any cross-user write.
  */
 @Injectable({ providedIn: 'root' })
 export class UserTrainingPlanApiService {

--- a/libs/stats/src/index.ts
+++ b/libs/stats/src/index.ts
@@ -1,4 +1,6 @@
 export * from './lib/models/stats.models';
+export * from './lib/models/training-plan.models';
+export * from './lib/models/training-plan.catalog';
 export * from './lib/date/parse-iso-date';
 export * from './lib/date/to-local-iso-date';
 export * from './lib/date/to-berlin-iso-date';

--- a/libs/stats/src/lib/models/training-plan.catalog.ts
+++ b/libs/stats/src/lib/models/training-plan.catalog.ts
@@ -1,0 +1,218 @@
+import {
+  TrainingPlan,
+  TrainingPlanDay,
+  TrainingPlanLevel,
+} from './training-plan.models';
+
+/**
+ * Curated training plans, derived from existing blog articles in
+ * `web/src/app/blog/blog-posts.data.ts`. The numeric targets are
+ * absolute baselines suitable for the stated audience — users whose
+ * current max differs significantly should treat them as anchors and
+ * adjust by `±20%`.
+ */
+
+const RECRUIT_DAYS: ReadonlyArray<TrainingPlanDay> = [
+  // Week 1 (Mon–Sun) — 3× full reps with 90s rest. Targets are
+  // suitable for someone whose max is roughly 10–15 reps.
+  d(1, 'main', 30, [10, 10, 10], '3×10 saubere Liegestütze, 90 s Pause', '3×10 clean push-ups, 90 s rest'),
+  d(2, 'rest', 0, undefined, 'Ruhetag — Stretching, Mobility', 'Rest day — stretching, mobility'),
+  d(3, 'main', 33, [12, 11, 10], '3×AMRAP, 90 s Pause (Ziel ≈12-11-10)', '3×AMRAP, 90 s rest (target ≈12-11-10)'),
+  d(4, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(5, 'main', 36, [13, 12, 11], '3×AMRAP, 90 s Pause', '3×AMRAP, 90 s rest'),
+  d(6, 'light', 20, [10, 10], 'Leichter Tag — 50 % vom Maximum', 'Light day — 50% of max'),
+  d(7, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  // Week 2 — same scheme, +10% volume.
+  d(8, 'main', 36, [13, 12, 11], '3×AMRAP', '3×AMRAP'),
+  d(9, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(10, 'main', 39, [14, 13, 12], '3×AMRAP', '3×AMRAP'),
+  d(11, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(12, 'main', 42, [15, 14, 13], '3×AMRAP', '3×AMRAP'),
+  d(13, 'light', 22, [11, 11], 'Leichter Tag', 'Light day'),
+  d(14, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  // Week 3 — 4 sets, shorter rest (60s).
+  d(15, 'main', 48, [14, 12, 12, 10], '4×AMRAP, 60 s Pause', '4×AMRAP, 60 s rest'),
+  d(16, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(17, 'main', 52, [15, 13, 12, 12], '4×AMRAP, 60 s Pause', '4×AMRAP, 60 s rest'),
+  d(18, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(19, 'main', 56, [16, 14, 13, 13], '4×AMRAP, 60 s Pause', '4×AMRAP, 60 s rest'),
+  d(20, 'light', 24, [12, 12], 'Leichter Tag', 'Light day'),
+  d(21, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  // Week 4 — 4 sets, slightly higher reps.
+  d(22, 'main', 60, [17, 15, 14, 14], '4×AMRAP', '4×AMRAP'),
+  d(23, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(24, 'main', 64, [18, 16, 15, 15], '4×AMRAP', '4×AMRAP'),
+  d(25, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(26, 'main', 68, [19, 17, 16, 16], '4×AMRAP', '4×AMRAP'),
+  d(27, 'light', 26, [13, 13], 'Leichter Tag', 'Light day'),
+  d(28, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  // Week 5 — 5 sets, target reps (descending).
+  d(29, 'main', 64, [15, 14, 13, 12, 10], '5 Sätze Zielwiederholungen', '5 sets target reps'),
+  d(30, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(31, 'main', 68, [16, 15, 14, 13, 10], '5 Sätze Zielwiederholungen', '5 sets target reps'),
+  d(32, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(33, 'main', 72, [17, 16, 15, 14, 10], '5 Sätze Zielwiederholungen', '5 sets target reps'),
+  d(34, 'light', 28, [14, 14], 'Leichter Tag', 'Light day'),
+  d(35, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  // Week 6 — peak + final test.
+  d(36, 'main', 76, [18, 17, 16, 14, 11], '5 Sätze, volle Bewegungsamplitude', '5 sets, full range of motion'),
+  d(37, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(38, 'main', 80, [19, 18, 16, 14, 13], '5 Sätze, kontrolliertes Tempo', '5 sets, controlled tempo'),
+  d(39, 'rest', 0, undefined, 'Ruhetag — Vorbereitung Endtest', 'Rest day — prepare for final test'),
+  d(40, 'main', 84, [20, 18, 17, 15, 14], '5 Sätze leicht', '5 sets light'),
+  d(41, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(42, 'test', 100, undefined, 'Endtest: Maximale Liegestütze ohne Pause', 'Final test: max push-ups without stopping'),
+];
+
+const CHALLENGE_30_DAYS: ReadonlyArray<TrainingPlanDay> = [
+  // Week 1 — Foundation. 3× AMRAP @ 90s on main days; light = 50% max.
+  d(1, 'test', 0, undefined, 'Maximaltest — als Ausgangswert eintragen', 'Max test — log as your baseline'),
+  d(2, 'main', 60, [20, 20, 20], '3×AMRAP, 90 s Pause', '3×AMRAP, 90 s rest'),
+  d(3, 'light', 20, [10, 10], 'Leichter Tag — 2×50 % vom Maximum', 'Light day — 2×50% of max'),
+  d(4, 'main', 63, [22, 21, 20], '3×AMRAP, 90 s Pause', '3×AMRAP, 90 s rest'),
+  d(5, 'light', 22, [11, 11], 'Leichter Tag', 'Light day'),
+  d(6, 'main', 66, [23, 22, 21], '3×AMRAP, 90 s Pause', '3×AMRAP, 90 s rest'),
+  d(7, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  // Week 2 — Volume. 4× AMRAP @ 60s; light = 60% max.
+  d(8, 'main', 80, [22, 20, 19, 19], '4×AMRAP, 60 s Pause', '4×AMRAP, 60 s rest'),
+  d(9, 'light', 30, [10, 10, 10], 'Leichter Tag — 3×60 % vom Maximum', 'Light day — 3×60% of max'),
+  d(10, 'main', 84, [23, 21, 20, 20], '4×AMRAP, 60 s Pause', '4×AMRAP, 60 s rest'),
+  d(11, 'light', 33, [11, 11, 11], 'Leichter Tag', 'Light day'),
+  d(12, 'main', 88, [24, 22, 21, 21], '4×AMRAP, 60 s Pause', '4×AMRAP, 60 s rest'),
+  d(13, 'light', 36, [12, 12, 12], 'Leichter Tag', 'Light day'),
+  d(14, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  // Week 3 — Intensity. 5× target reps (~80% max). No light days.
+  d(15, 'main', 100, [22, 20, 20, 20, 18], '5 Sätze à ~80 % vom Maximum', '5 sets at ~80% of max'),
+  d(16, 'rest', 0, undefined, 'Mobility & Brust-Stretching', 'Mobility & chest stretching'),
+  d(17, 'main', 105, [23, 22, 20, 20, 20], '5 Sätze Zielwiederholungen', '5 sets target reps'),
+  d(18, 'rest', 0, undefined, 'Mobility & Brust-Stretching', 'Mobility & chest stretching'),
+  d(19, 'main', 110, [24, 22, 22, 22, 20], '5 Sätze Zielwiederholungen', '5 sets target reps'),
+  d(20, 'rest', 0, undefined, 'Mobility & Brust-Stretching', 'Mobility & chest stretching'),
+  d(21, 'main', 115, [25, 23, 23, 22, 22], '5 Sätze Zielwiederholungen', '5 sets target reps'),
+  // Week 4 — Tapering & Peak. 3× 70% max, last 2 days active recovery.
+  d(22, 'main', 70, [25, 23, 22], '3 Sätze à 70 % — Qualität vor Quantität', '3 sets at 70% — quality over quantity'),
+  d(23, 'light', 30, [15, 15], 'Leichter Tag — 2×50 %', 'Light day — 2×50%'),
+  d(24, 'main', 75, [26, 25, 24], '3 Sätze à 70 %', '3 sets at 70%'),
+  d(25, 'light', 30, [15, 15], 'Leichter Tag — 2×50 %', 'Light day — 2×50%'),
+  d(26, 'main', 75, [26, 25, 24], '3 Sätze à 70 %', '3 sets at 70%'),
+  d(27, 'rest', 0, undefined, 'Aktive Erholung — Spaziergang, Mobility', 'Active recovery — walk, mobility'),
+  d(28, 'rest', 0, undefined, 'Aktive Erholung', 'Active recovery'),
+  d(29, 'rest', 0, undefined, 'Ruhe vor dem Endtest', 'Rest before the final test'),
+  d(30, 'test', 100, undefined, 'Endtest: Maximale Liegestütze ohne Pause', 'Final test: max push-ups without stopping'),
+];
+
+const OVER_40_DAYS: ReadonlyArray<TrainingPlanDay> = [
+  // Week 1 — Technique focus, low volume.
+  d(1, 'test', 0, undefined, 'Maximaltest mit sauberer Technik', 'Max test with clean form'),
+  d(2, 'main', 24, [8, 8, 8], '3×8 Knie- oder erhöhte Liegestütze', '3×8 knee or elevated push-ups'),
+  d(3, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(4, 'main', 27, [9, 9, 9], '3×9 saubere Liegestütze', '3×9 clean push-ups'),
+  d(5, 'rest', 0, undefined, 'Ruhetag — Schulter-Mobility', 'Rest day — shoulder mobility'),
+  d(6, 'main', 30, [10, 10, 10], '3×10 saubere Liegestütze', '3×10 clean push-ups'),
+  d(7, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  // Week 2 — slight volume increase.
+  d(8, 'main', 33, [11, 11, 11], '3×11', '3×11'),
+  d(9, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(10, 'main', 36, [12, 12, 12], '3×12', '3×12'),
+  d(11, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(12, 'main', 39, [13, 13, 13], '3×13', '3×13'),
+  d(13, 'light', 16, [8, 8], 'Leichter Tag', 'Light day'),
+  d(14, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  // Week 3 — 4 sets, more volume but still 90s rest.
+  d(15, 'main', 48, [13, 12, 12, 11], '4 Sätze, 90 s Pause', '4 sets, 90 s rest'),
+  d(16, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(17, 'main', 52, [14, 13, 13, 12], '4 Sätze, 90 s Pause', '4 sets, 90 s rest'),
+  d(18, 'rest', 0, undefined, 'Ruhetag — Mobility', 'Rest day — mobility'),
+  d(19, 'main', 56, [15, 14, 14, 13], '4 Sätze, 90 s Pause', '4 sets, 90 s rest'),
+  d(20, 'light', 18, [9, 9], 'Leichter Tag', 'Light day'),
+  d(21, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  // Week 4 — peak + final test (still gentle volume).
+  d(22, 'main', 60, [16, 15, 15, 14], '4 Sätze, kontrolliertes Tempo', '4 sets, controlled tempo'),
+  d(23, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(24, 'main', 64, [17, 16, 16, 15], '4 Sätze, langsame Exzentrik', '4 sets, slow eccentric'),
+  d(25, 'rest', 0, undefined, 'Ruhetag', 'Rest day'),
+  d(26, 'light', 20, [10, 10], 'Leichter Tag', 'Light day'),
+  d(27, 'rest', 0, undefined, 'Ruhetag — Vorbereitung Endtest', 'Rest day — prepare final test'),
+  d(28, 'test', 50, undefined, 'Endtest: Maximale Liegestütze', 'Final test: max push-ups'),
+];
+
+export const TRAINING_PLANS: ReadonlyArray<TrainingPlan> = [
+  {
+    id: 'recruit-6w-v1',
+    slug: 'recruit-6w',
+    title: 'Von 0 auf 100 — 6-Wochen-Aufbau',
+    titleEn: 'From 0 to 100 — 6-week buildup',
+    summary:
+      'Strukturierter Plan für Einsteiger: drei Trainingstage pro Woche, progressive Belastungssteigerung und ein Endtest in Woche 6.',
+    summaryEn:
+      'Beginner-friendly plan: three training days per week, progressive overload, and a final max test in week 6.',
+    level: 'beginner',
+    totalDays: 42,
+    blogSlugDe: 'liegestuetze-steigern',
+    blogSlugEn: 'pushup-progression',
+    days: RECRUIT_DAYS,
+  },
+  {
+    id: 'challenge-30d-v1',
+    slug: 'challenge-30d',
+    title: '30-Tage-Challenge',
+    titleEn: '30-day challenge',
+    summary:
+      'Dreißig Tage tägliches Training mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest.',
+    summaryEn:
+      'Thirty days of daily training with strategic rest days. Day 1 is the baseline test, Day 30 the final.',
+    level: 'intermediate',
+    totalDays: 30,
+    blogSlugDe: '30-tage-liegestuetze-challenge',
+    blogSlugEn: '30-day-pushup-challenge',
+    days: CHALLENGE_30_DAYS,
+  },
+  {
+    id: 'over-40-4w-v1',
+    slug: 'over-40-4w',
+    title: 'Liegestütze ab 40 — 4-Wochen-Plan',
+    titleEn: 'Push-ups after 40 — 4-week plan',
+    summary:
+      'Schonender 4-Wochen-Plan für Einsteiger ab 40: Fokus auf saubere Technik, ausreichend Pause und langsames Tempo.',
+    summaryEn:
+      'Gentle 4-week plan for beginners 40+: focus on clean technique, full recovery, and controlled tempo.',
+    level: 'beginner',
+    totalDays: 28,
+    blogSlugDe: 'liegestuetze-ab-40',
+    blogSlugEn: 'pushups-over-40',
+    days: OVER_40_DAYS,
+  },
+];
+
+const PLANS_BY_ID: ReadonlyMap<string, TrainingPlan> = new Map(
+  TRAINING_PLANS.map((plan) => [plan.id, plan])
+);
+
+const PLANS_BY_SLUG: ReadonlyMap<string, TrainingPlan> = new Map(
+  TRAINING_PLANS.map((plan) => [plan.slug, plan])
+);
+
+export function findPlanById(id: string): TrainingPlan | null {
+  return PLANS_BY_ID.get(id) ?? null;
+}
+
+export function findPlanBySlug(slug: string): TrainingPlan | null {
+  return PLANS_BY_SLUG.get(slug) ?? null;
+}
+
+export function plansByLevel(level: TrainingPlanLevel): TrainingPlan[] {
+  return TRAINING_PLANS.filter((p) => p.level === level);
+}
+
+function d(
+  dayIndex: number,
+  kind: TrainingPlanDay['kind'],
+  targetReps: number,
+  sets: number[] | undefined,
+  description: string,
+  descriptionEn: string
+): TrainingPlanDay {
+  return sets
+    ? { dayIndex, kind, targetReps, sets, description, descriptionEn }
+    : { dayIndex, kind, targetReps, description, descriptionEn };
+}

--- a/libs/stats/src/lib/models/training-plan.models.spec.ts
+++ b/libs/stats/src/lib/models/training-plan.models.spec.ts
@@ -1,6 +1,7 @@
 import {
   currentPlanDayIndex,
   isPlanCompleted,
+  localizePlan,
   planDayByIndex,
   TrainingPlan,
 } from './training-plan.models';
@@ -29,6 +30,12 @@ describe('training-plan models', () => {
     it('returns null on malformed dates', () => {
       expect(currentPlanDayIndex(plan, 'nope', '2026-04-01')).toBeNull();
       expect(currentPlanDayIndex(plan, '2026-04-01', '2026/04/01')).toBeNull();
+    });
+
+    it('returns null on impossible calendar dates', () => {
+      // 2026-02-30 doesn't exist; Date() would otherwise overflow.
+      expect(currentPlanDayIndex(plan, '2026-02-30', '2026-04-01')).toBeNull();
+      expect(currentPlanDayIndex(plan, '2026-04-01', '2026-13-01')).toBeNull();
     });
 
     it('crosses month and year boundaries via calendar diff', () => {
@@ -94,6 +101,62 @@ describe('training-plan models', () => {
     it('is false while any non-rest day is missing', () => {
       expect(isPlanCompleted(plan, [1, 4])).toBe(false);
       expect(isPlanCompleted(plan, [])).toBe(false);
+    });
+  });
+
+  describe('localizePlan', () => {
+    const plan: TrainingPlan = {
+      id: 'x',
+      slug: 'x',
+      title: 'Deutscher Titel',
+      titleEn: 'English title',
+      summary: 'Deutsche Beschreibung',
+      summaryEn: 'English summary',
+      level: 'beginner',
+      totalDays: 1,
+      days: [
+        {
+          dayIndex: 1,
+          kind: 'main',
+          targetReps: 10,
+          description: 'Deutsch',
+          descriptionEn: 'English',
+        },
+      ],
+    };
+
+    it('returns English fields when locale starts with "en"', () => {
+      const out = localizePlan(plan, 'en');
+      expect(out.title).toBe('English title');
+      expect(out.summary).toBe('English summary');
+      expect(out.days[0].description).toBe('English');
+    });
+
+    it('returns German fields for the source locale "de"', () => {
+      const out = localizePlan(plan, 'de');
+      expect(out.title).toBe('Deutscher Titel');
+      expect(out.days[0].description).toBe('Deutsch');
+    });
+
+    it('handles "en-US" the same as "en"', () => {
+      expect(localizePlan(plan, 'en-US').title).toBe('English title');
+    });
+
+    it('falls back to German description when descriptionEn is missing', () => {
+      const noEnDay: TrainingPlan = {
+        ...plan,
+        days: [
+          {
+            dayIndex: 1,
+            kind: 'main',
+            targetReps: 10,
+            description: 'Nur Deutsch',
+          },
+        ],
+      };
+      expect(localizePlan(noEnDay, 'en').days[0].description).toBe(
+        'Nur Deutsch'
+      );
     });
   });
 

--- a/libs/stats/src/lib/models/training-plan.models.spec.ts
+++ b/libs/stats/src/lib/models/training-plan.models.spec.ts
@@ -1,0 +1,149 @@
+import {
+  currentPlanDayIndex,
+  isPlanCompleted,
+  planDayByIndex,
+  TrainingPlan,
+} from './training-plan.models';
+import { findPlanById, TRAINING_PLANS } from './training-plan.catalog';
+
+describe('training-plan models', () => {
+  describe('currentPlanDayIndex', () => {
+    const plan = { totalDays: 30 };
+
+    it('returns 1 on the start date', () => {
+      expect(currentPlanDayIndex(plan, '2026-04-01', '2026-04-01')).toBe(1);
+    });
+
+    it('returns N+1 days after start', () => {
+      expect(currentPlanDayIndex(plan, '2026-04-01', '2026-04-08')).toBe(8);
+    });
+
+    it('caps at totalDays once the plan would have ended', () => {
+      expect(currentPlanDayIndex(plan, '2026-04-01', '2026-06-30')).toBe(30);
+    });
+
+    it('returns null when today is before the start date', () => {
+      expect(currentPlanDayIndex(plan, '2026-04-10', '2026-04-09')).toBeNull();
+    });
+
+    it('returns null on malformed dates', () => {
+      expect(currentPlanDayIndex(plan, 'nope', '2026-04-01')).toBeNull();
+      expect(currentPlanDayIndex(plan, '2026-04-01', '2026/04/01')).toBeNull();
+    });
+
+    it('crosses month and year boundaries via calendar diff', () => {
+      // 2025-12-31 -> 2026-01-02 = day 3
+      expect(currentPlanDayIndex(plan, '2025-12-31', '2026-01-02')).toBe(3);
+    });
+  });
+
+  describe('planDayByIndex', () => {
+    const plan: TrainingPlan = {
+      id: 'test',
+      slug: 'test',
+      title: '',
+      titleEn: '',
+      summary: '',
+      summaryEn: '',
+      level: 'beginner',
+      totalDays: 3,
+      days: [
+        { dayIndex: 1, kind: 'main', targetReps: 30, description: '' },
+        { dayIndex: 2, kind: 'rest', targetReps: 0, description: '' },
+        { dayIndex: 3, kind: 'main', targetReps: 33, description: '' },
+      ],
+    };
+
+    it('looks up by dayIndex', () => {
+      expect(planDayByIndex(plan, 2)?.kind).toBe('rest');
+      expect(planDayByIndex(plan, 3)?.targetReps).toBe(33);
+    });
+
+    it('returns null for out-of-range indexes', () => {
+      expect(planDayByIndex(plan, 0)).toBeNull();
+      expect(planDayByIndex(plan, 4)).toBeNull();
+    });
+  });
+
+  describe('isPlanCompleted', () => {
+    const plan: TrainingPlan = {
+      id: 'test',
+      slug: 'test',
+      title: '',
+      titleEn: '',
+      summary: '',
+      summaryEn: '',
+      level: 'beginner',
+      totalDays: 4,
+      days: [
+        { dayIndex: 1, kind: 'main', targetReps: 30, description: '' },
+        { dayIndex: 2, kind: 'rest', targetReps: 0, description: '' },
+        { dayIndex: 3, kind: 'main', targetReps: 33, description: '' },
+        { dayIndex: 4, kind: 'test', targetReps: 50, description: '' },
+      ],
+    };
+
+    it('is true once every non-rest day is completed', () => {
+      expect(isPlanCompleted(plan, [1, 3, 4])).toBe(true);
+    });
+
+    it('ignores rest days even if they are not in completedDays', () => {
+      expect(isPlanCompleted(plan, [1, 3, 4])).toBe(true);
+    });
+
+    it('is false while any non-rest day is missing', () => {
+      expect(isPlanCompleted(plan, [1, 4])).toBe(false);
+      expect(isPlanCompleted(plan, [])).toBe(false);
+    });
+  });
+
+  describe('catalog', () => {
+    it('exposes at least three plans', () => {
+      expect(TRAINING_PLANS.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('every plan has contiguous day indexes 1..totalDays', () => {
+      for (const plan of TRAINING_PLANS) {
+        const indexes = plan.days.map((d) => d.dayIndex);
+        const expected = Array.from(
+          { length: plan.totalDays },
+          (_, i) => i + 1
+        );
+        expect(indexes).toEqual(expected);
+      }
+    });
+
+    it('every plan has unique day indexes (no duplicates)', () => {
+      for (const plan of TRAINING_PLANS) {
+        const indexes = plan.days.map((d) => d.dayIndex);
+        expect(new Set(indexes).size).toBe(indexes.length);
+      }
+    });
+
+    it('rest days have targetReps === 0', () => {
+      for (const plan of TRAINING_PLANS) {
+        for (const day of plan.days) {
+          if (day.kind === 'rest') {
+            expect(day.targetReps).toBe(0);
+          }
+        }
+      }
+    });
+
+    it('main-day sets sum to targetReps when sets are defined', () => {
+      for (const plan of TRAINING_PLANS) {
+        for (const day of plan.days) {
+          if (day.sets && day.kind !== 'test') {
+            const sum = day.sets.reduce((a, b) => a + b, 0);
+            expect(sum).toBe(day.targetReps);
+          }
+        }
+      }
+    });
+
+    it('findPlanById returns the matching plan', () => {
+      expect(findPlanById('challenge-30d-v1')?.totalDays).toBe(30);
+      expect(findPlanById('does-not-exist')).toBeNull();
+    });
+  });
+});

--- a/libs/stats/src/lib/models/training-plan.models.ts
+++ b/libs/stats/src/lib/models/training-plan.models.ts
@@ -132,13 +132,51 @@ export function isPlanCompleted(
   return required.every((idx) => completedDays.includes(idx));
 }
 
+/**
+ * Returns plan fields adapted to the active Angular locale. We pick
+ * the English fields when `LOCALE_ID === 'en'` and otherwise fall
+ * back to the German source. The catalog stores both languages
+ * because plans are static curated data, not user-generated content.
+ */
+export function localizePlan(
+  plan: TrainingPlan,
+  locale: string
+): {
+  title: string;
+  summary: string;
+  days: ReadonlyArray<TrainingPlanDay & { description: string }>;
+} {
+  const isEnglish = locale.toLowerCase().startsWith('en');
+  return {
+    title: isEnglish ? plan.titleEn : plan.title,
+    summary: isEnglish ? plan.summaryEn : plan.summary,
+    days: plan.days.map((day) => ({
+      ...day,
+      description:
+        isEnglish && day.descriptionEn ? day.descriptionEn : day.description,
+    })),
+  };
+}
+
 function parseIsoDate(value: string): Date | null {
   // Accept `YYYY-MM-DD` (Berlin date string). Normalize to local
   // midnight so the day diff is calendar-based, not millisecond-based.
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
   if (!match) return null;
   const [, y, m, d] = match;
-  const date = new Date(Number(y), Number(m) - 1, Number(d));
+  const year = Number(y);
+  const month = Number(m);
+  const day = Number(d);
+  const date = new Date(year, month - 1, day);
+  // Reject impossible dates like 2026-02-30 — `Date()` would silently
+  // overflow into the next month. Round-trip the components.
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
   date.setHours(0, 0, 0, 0);
   return date;
 }

--- a/libs/stats/src/lib/models/training-plan.models.ts
+++ b/libs/stats/src/lib/models/training-plan.models.ts
@@ -1,0 +1,144 @@
+/**
+ * Training plans add structured day-by-day pushup goals on top of the
+ * free-form `dailyGoal` in `UserConfig`. A `TrainingPlan` is a static,
+ * curated catalog entry. A `UserTrainingPlan` is the live state of a
+ * user who has activated a plan: it tracks the start date and which
+ * days have been completed.
+ */
+
+/** Difficulty bucket for filtering and badge color in the UI. */
+export type TrainingPlanLevel = 'beginner' | 'intermediate' | 'advanced';
+
+/** Kind of training day. Drives icon, color, and goal-resolution rules. */
+export type TrainingDayKind = 'main' | 'light' | 'rest' | 'test';
+
+/**
+ * A single day in a plan. `dayIndex` is 1-based and contiguous from
+ * `1..plan.totalDays`. `targetReps === 0` is valid for `rest` days.
+ */
+export interface TrainingPlanDay {
+  /** 1-based day number in the plan. */
+  dayIndex: number;
+  kind: TrainingDayKind;
+  /**
+   * Total reps target for the day (sum of all sets). For `rest` days
+   * this is 0. For `test` days this is the recommended baseline; the
+   * user logs their actual max separately.
+   */
+  targetReps: number;
+  /**
+   * Optional set decomposition (e.g. `[15, 12, 10, 10]`). When omitted,
+   * the UI shows just the total target.
+   */
+  sets?: number[];
+  /** Short German description shown in the day card. */
+  description: string;
+  /** Short English description shown in the day card (en locale). */
+  descriptionEn?: string;
+}
+
+/**
+ * Static catalog entry. Versioned via `id` (slug + version suffix when
+ * we ever change targets) so old `UserTrainingPlan` documents keep
+ * resolving to the same numbers.
+ */
+export interface TrainingPlan {
+  id: string;
+  slug: string;
+  /** German-language title. */
+  title: string;
+  /** English-language title (used when `LOCALE_ID === 'en'`). */
+  titleEn: string;
+  /** German-language summary. */
+  summary: string;
+  /** English-language summary. */
+  summaryEn: string;
+  level: TrainingPlanLevel;
+  totalDays: number;
+  /** Optional blog slug pair (de/en) for "Read the article". */
+  blogSlugDe?: string;
+  blogSlugEn?: string;
+  days: ReadonlyArray<TrainingPlanDay>;
+}
+
+export type TrainingPlanStatus = 'active' | 'completed' | 'abandoned';
+
+/**
+ * Per-user state for an activated plan. Stored at
+ * `userTrainingPlans/{userId}` (single active doc per user — when a
+ * user starts another plan we overwrite it; previously completed
+ * plans live in a `history` subcollection later if we want to expose
+ * them).
+ */
+export interface UserTrainingPlan {
+  userId: string;
+  planId: string;
+  /** ISO date (YYYY-MM-DD, Berlin) when the user pressed "Start". */
+  startDate: string;
+  status: TrainingPlanStatus;
+  /**
+   * Day indexes the user has marked as done. Storing day indexes
+   * (rather than dates) makes the data robust against clock skew and
+   * skipped days.
+   */
+  completedDays: number[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export type UserTrainingPlanUpdate = Partial<
+  Pick<UserTrainingPlan, 'planId' | 'startDate' | 'status' | 'completedDays'>
+>;
+
+/**
+ * Compute the current 1-based day number of an active plan based on
+ * the calendar diff between `startDate` and `today`. Caps at
+ * `plan.totalDays`. Returns `null` when the plan hasn't started yet
+ * (today < startDate).
+ */
+export function currentPlanDayIndex(
+  plan: Pick<TrainingPlan, 'totalDays'>,
+  startDate: string,
+  today: string
+): number | null {
+  const start = parseIsoDate(startDate);
+  const now = parseIsoDate(today);
+  if (!start || !now) return null;
+  const diff = Math.round((now.getTime() - start.getTime()) / 86_400_000);
+  if (diff < 0) return null;
+  return Math.min(diff + 1, plan.totalDays);
+}
+
+/**
+ * Look up the day for a given 1-based index. Returns `null` if the
+ * plan doesn't define that day (out of range).
+ */
+export function planDayByIndex(
+  plan: Pick<TrainingPlan, 'days'>,
+  dayIndex: number
+): TrainingPlanDay | null {
+  return plan.days.find((d) => d.dayIndex === dayIndex) ?? null;
+}
+
+/** Returns true once every non-rest day is in `completedDays`. */
+export function isPlanCompleted(
+  plan: Pick<TrainingPlan, 'days'>,
+  completedDays: ReadonlyArray<number>
+): boolean {
+  const required = plan.days
+    .filter((d) => d.kind !== 'rest')
+    .map((d) => d.dayIndex);
+  if (required.length === 0) return false;
+  return required.every((idx) => completedDays.includes(idx));
+}
+
+function parseIsoDate(value: string): Date | null {
+  // Accept `YYYY-MM-DD` (Berlin date string). Normalize to local
+  // midnight so the day diff is calendar-based, not millisecond-based.
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const [, y, m, d] = match;
+  const date = new Date(Number(y), Number(m) - 1, Number(d));
+  date.setHours(0, 0, 0, 0);
+  return date;
+}

--- a/web/src/app/app.html
+++ b/web/src/app/app.html
@@ -66,6 +66,16 @@
       @if (isLoggedIn()) {
       <a
         mat-list-item
+        routerLink="/training-plans"
+        routerLinkActive="active"
+        (click)="navOpen.set(false)"
+      >
+        <mat-icon matListItemIcon>fitness_center</mat-icon>
+        <span matListItemTitle i18n="@@nav.trainingPlans">Trainingspläne</span>
+      </a>
+
+      <a
+        mat-list-item
         routerLink="/reminders"
         routerLinkActive="active"
         (click)="navOpen.set(false)"

--- a/web/src/app/app.routes.spec.ts
+++ b/web/src/app/app.routes.spec.ts
@@ -24,6 +24,8 @@ describe('appRoutes', () => {
       'history',
       'analysis',
       'settings',
+      'training-plans',
+      'training-plans/:slug',
       'reminders',
       'leaderboard',
       'blog',

--- a/web/src/app/app.routes.spec.ts
+++ b/web/src/app/app.routes.spec.ts
@@ -11,6 +11,8 @@ import { EntriesPageComponent } from './stats/shell/entries-page.component';
 import { SettingsPageComponent } from './stats/shell/settings-page.component';
 import { StatsDashboardComponent } from './stats/shell/stats-dashboard.component';
 import { LeaderboardPageComponent } from './leaderboard/shell/leaderboard-page.component';
+import { TrainingPlanDetailComponent } from './training-plans/training-plan-detail.component';
+import { TrainingPlansPageComponent } from './training-plans/training-plans-page.component';
 
 describe('appRoutes', () => {
   it('defines landing, app and feature routes', () => {
@@ -72,6 +74,18 @@ describe('appRoutes', () => {
     expect(component).toBe(LeaderboardPageComponent);
   });
 
+  it('lazy-loads training plans list and detail components', async () => {
+    const listRoute = appRoutes.find((r) => r.path === 'training-plans');
+    const listComponent = await listRoute?.loadComponent?.();
+    expect(listComponent).toBe(TrainingPlansPageComponent);
+
+    const detailRoute = appRoutes.find(
+      (r) => r.path === 'training-plans/:slug'
+    );
+    const detailComponent = await detailRoute?.loadComponent?.();
+    expect(detailComponent).toBe(TrainingPlanDetailComponent);
+  });
+
   it('statically loads login component', () => {
     const route = appRoutes.find((r) => r.path === 'login');
     expect(route?.component).toBe(LoginComponent);
@@ -94,7 +108,14 @@ describe('appRoutes', () => {
   });
 
   it('protects app routes and keeps landing/login/register public-only', () => {
-    const protectedPaths = ['app', 'history', 'analysis', 'settings'];
+    const protectedPaths = [
+      'app',
+      'history',
+      'analysis',
+      'settings',
+      'training-plans',
+      'training-plans/:slug',
+    ];
     for (const path of protectedPaths) {
       const route = appRoutes.find((r) => r.path === path);
       expect(route?.canActivate).toEqual([authGuard]);

--- a/web/src/app/app.routes.ts
+++ b/web/src/app/app.routes.ts
@@ -92,6 +92,26 @@ export const appRoutes: Routes = [
       ),
   },
   {
+    path: 'training-plans',
+    canActivate: [authGuard],
+    data: {
+      seoTitle: $localize`:@@seo.trainingPlans.title:Trainingspläne – Pushup Tracker`,
+      seoDescription: $localize`:@@seo.trainingPlans.description:Strukturierte Liegestütz-Trainingspläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung.`,
+    },
+    loadComponent: () =>
+      import('./training-plans/training-plans-page.component').then(
+        (m) => m.TrainingPlansPageComponent
+      ),
+  },
+  {
+    path: 'training-plans/:slug',
+    canActivate: [authGuard],
+    loadComponent: () =>
+      import('./training-plans/training-plan-detail.component').then(
+        (m) => m.TrainingPlanDetailComponent
+      ),
+  },
+  {
     path: 'reminders',
     canActivate: [authGuard],
     data: {

--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -24,6 +24,7 @@ import { UserContextService } from '@pu-auth/auth';
 import { MotivationStore } from '@pu-stats/motivation';
 import { firstValueFrom, of } from 'rxjs';
 import { UserConfigStore } from '../core/user-config.store';
+import { TrainingPlanStore } from '../training-plans/training-plan.store';
 
 const EMPTY_STATS: StatsResponse = {
   meta: {
@@ -87,6 +88,7 @@ export const DashboardStore = signalStore(
     _live: inject(LiveDataStore),
     _ads: inject(AdsStore),
     _motivation: inject(MotivationStore),
+    _trainingPlan: inject(TrainingPlanStore),
     _isBrowser: isPlatformBrowser(inject(PLATFORM_ID)),
   })),
   withProps((store) => ({
@@ -160,7 +162,30 @@ export const DashboardStore = signalStore(
       return liveTotal;
     });
 
-    const dailyGoal = computed(() => store._userConfig.dailyGoal() || 10);
+    /** Today's plan target — if a plan is active and today is not a
+     *  rest day, this overrides the user-configured `dailyGoal`. */
+    const planTodayTarget = computed(() => {
+      if (!store._trainingPlan.hasActivePlan()) return 0;
+      const day = store._trainingPlan.todayDay();
+      if (!day || day.kind === 'rest') return 0;
+      return day.targetReps;
+    });
+
+    const planActive = computed(() => store._trainingPlan.hasActivePlan());
+    const planTodayKind = computed(
+      () => store._trainingPlan.todayDay()?.kind ?? null
+    );
+    const planTitle = computed(
+      () => store._trainingPlan.activeCatalog()?.title ?? ''
+    );
+    const planDayIndex = computed(() => store._trainingPlan.currentDayIndex());
+    const planTotalDays = computed(
+      () => store._trainingPlan.activeCatalog()?.totalDays ?? 0
+    );
+
+    const dailyGoal = computed(
+      () => planTodayTarget() || store._userConfig.dailyGoal() || 10
+    );
     const weeklyGoal = computed(() => store._userConfig.weeklyGoal() || 50);
     const monthlyGoal = computed(() => store._userConfig.monthlyGoal() || 200);
 
@@ -180,7 +205,10 @@ export const DashboardStore = signalStore(
         : 0
     );
 
-    const configuredDailyGoal = computed(() => store._userConfig.dailyGoal());
+    /** Effective daily goal = plan target if active, else configured. */
+    const configuredDailyGoal = computed(
+      () => planTodayTarget() || store._userConfig.dailyGoal()
+    );
     const configuredWeeklyGoal = computed(() => store._userConfig.weeklyGoal());
     const configuredMonthlyGoal = computed(() =>
       store._userConfig.monthlyGoal()
@@ -362,6 +390,12 @@ export const DashboardStore = signalStore(
       adSlotDashboardInline,
       dashboardInlineAdsEnabled,
       todayQuote,
+      planActive,
+      planTodayTarget,
+      planTodayKind,
+      planTitle,
+      planDayIndex,
+      planTotalDays,
     };
   }),
   withMethods((store) => ({

--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -175,9 +175,6 @@ export const DashboardStore = signalStore(
     const planTodayKind = computed(
       () => store._trainingPlan.todayDay()?.kind ?? null
     );
-    const planTitle = computed(
-      () => store._trainingPlan.activeCatalog()?.title ?? ''
-    );
     const planDayIndex = computed(() => store._trainingPlan.currentDayIndex());
     const planTotalDays = computed(
       () => store._trainingPlan.activeCatalog()?.totalDays ?? 0
@@ -393,7 +390,6 @@ export const DashboardStore = signalStore(
       planActive,
       planTodayTarget,
       planTodayKind,
-      planTitle,
       planDayIndex,
       planTotalDays,
     };

--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -73,7 +73,7 @@
           </div>
           <a
             mat-stroked-button
-            routerLink="/training-plans"
+            [routerLink]="['/training-plans', planSlug()]"
             i18n="@@trainingPlans.openDetail"
           >
             Details öffnen

--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -48,6 +48,41 @@
     >
   </section>
 
+  @if (planActive()) {
+    <mat-card class="plan-banner">
+      <mat-card-content>
+        <div class="plan-banner-row">
+          <mat-icon>fitness_center</mat-icon>
+          <div class="plan-banner-text">
+            <strong>{{ planTitle() }}</strong>
+            <span class="plan-meta">
+              <span i18n="@@trainingPlans.day">Tag</span>
+              {{ planDayIndex() }} / {{ planTotalDays() }}
+              @if (planTodayKind() === 'rest') {
+                · <span i18n="@@trainingPlans.kind.rest">Ruhetag</span>
+              } @else if (planTodayKind() === 'light') {
+                ·
+                <span i18n="@@trainingPlans.kind.light">Leichter Tag</span>
+              } @else if (planTodayKind() === 'test') {
+                · <span i18n="@@trainingPlans.kind.test">Maximaltest</span>
+              } @else {
+                · {{ planTodayTarget() }}
+                <span i18n="@@trainingPlans.reps">Wdh.</span>
+              }
+            </span>
+          </div>
+          <a
+            mat-stroked-button
+            routerLink="/training-plans"
+            i18n="@@trainingPlans.openDetail"
+          >
+            Details öffnen
+          </a>
+        </div>
+      </mat-card-content>
+    </mat-card>
+  }
+
   <section
     class="today-focus"
     aria-label="Tagesfokus"

--- a/web/src/app/stats/shell/stats-dashboard.component.scss
+++ b/web/src/app/stats/shell/stats-dashboard.component.scss
@@ -3,6 +3,33 @@
   overflow-x: hidden;
 }
 
+.plan-banner {
+  border-left: 4px solid #7b9fff;
+}
+
+.plan-banner-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.plan-banner-row mat-icon {
+  color: #7b9fff;
+}
+
+.plan-banner-text {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.plan-banner-text .plan-meta {
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
 .container {
   max-width: 1200px;
   margin: 0 auto;

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -10,6 +10,9 @@ import {
   untracked,
 } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { LOCALE_ID, computed } from '@angular/core';
+import { localizePlan } from '@pu-stats/models';
+import { TrainingPlanStore } from '../../training-plans/training-plan.store';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
@@ -99,9 +102,16 @@ export class StatsDashboardComponent {
   readonly planActive = this.store.planActive;
   readonly planTodayTarget = this.store.planTodayTarget;
   readonly planTodayKind = this.store.planTodayKind;
-  readonly planTitle = this.store.planTitle;
   readonly planDayIndex = this.store.planDayIndex;
   readonly planTotalDays = this.store.planTotalDays;
+  private readonly trainingPlans = inject(TrainingPlanStore);
+  private readonly locale = inject(LOCALE_ID) as string;
+  /** Plan title in the active locale. Falls back to '' when no plan. */
+  readonly planTitle = computed(() => {
+    const cat = this.trainingPlans.activeCatalog();
+    if (!cat) return '';
+    return localizePlan(cat, this.locale).title;
+  });
   /** Counter that increments on every data refresh to trigger child component reloads. */
   readonly refreshCounter = signal(0);
 

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -112,6 +112,10 @@ export class StatsDashboardComponent {
     if (!cat) return '';
     return localizePlan(cat, this.locale).title;
   });
+  /** Active plan slug — used to deep-link the banner CTA. */
+  readonly planSlug = computed(
+    () => this.trainingPlans.activeCatalog()?.slug ?? ''
+  );
   /** Counter that increments on every data refresh to trigger child component reloads. */
   readonly refreshCounter = signal(0);
 

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -9,7 +9,7 @@ import {
   signal,
   untracked,
 } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
@@ -48,6 +48,7 @@ import { DashboardStore } from '../dashboard.store';
     PreviewBannerComponent,
     StatsTableComponent,
     AdSlotComponent,
+    RouterLink,
   ],
   providers: [DashboardStore],
   templateUrl: './stats-dashboard.component.html',
@@ -95,6 +96,12 @@ export class StatsDashboardComponent {
   readonly quickAddButtons = this.store.quickAddButtons;
   readonly adSlotDashboardInline = this.store.adSlotDashboardInline;
   readonly dashboardInlineAdsEnabled = this.store.dashboardInlineAdsEnabled;
+  readonly planActive = this.store.planActive;
+  readonly planTodayTarget = this.store.planTodayTarget;
+  readonly planTodayKind = this.store.planTodayKind;
+  readonly planTitle = this.store.planTitle;
+  readonly planDayIndex = this.store.planDayIndex;
+  readonly planTotalDays = this.store.planTotalDays;
   /** Counter that increments on every data refresh to trigger child component reloads. */
   readonly refreshCounter = signal(0);
 

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -135,11 +135,20 @@ interface DayRow {
                   </div>
                   <div class="day-body">
                     <div class="day-title">
-                      @if (row.day.targetReps > 0) {
+                      @if (row.day.kind === 'rest') {
+                        <span i18n="@@trainingPlans.kind.rest">Ruhetag</span>
+                      } @else if (row.day.kind === 'test') {
+                        <span i18n="@@trainingPlans.kind.test">Maximaltest</span>
+                      } @else if (row.day.kind === 'light') {
+                        <span i18n="@@trainingPlans.kind.light">Leichter Tag</span>
+                        @if (row.day.targetReps > 0) {
+                          <span class="muted">·</span>
+                          <strong>{{ row.day.targetReps }}</strong>
+                          <span i18n="@@trainingPlans.reps">Wdh.</span>
+                        }
+                      } @else if (row.day.targetReps > 0) {
                         <strong>{{ row.day.targetReps }}</strong>
                         <span i18n="@@trainingPlans.reps">Wdh.</span>
-                      } @else {
-                        <span i18n="@@trainingPlans.kind.rest">Ruhetag</span>
                       }
                       @if (row.day.sets && row.day.sets.length > 1) {
                         <span class="sets muted">{{ formatSets(row.day.sets) }}</span>

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -1,0 +1,355 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { findPlanBySlug, TrainingPlanDay } from '@pu-stats/models';
+import { TrainingPlanStore } from './training-plan.store';
+
+interface DayRow {
+  day: TrainingPlanDay;
+  weekIndex: number;
+  isToday: boolean;
+  isCompleted: boolean;
+  isFuture: boolean;
+}
+
+@Component({
+  selector: 'app-training-plan-detail',
+  imports: [
+    MatCardModule,
+    MatButtonModule,
+    MatChipsModule,
+    MatIconModule,
+    MatProgressBarModule,
+    MatSnackBarModule,
+    RouterLink,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (plan(); as p) {
+      <main class="page-wrap">
+        <header class="page-header">
+          <a mat-icon-button routerLink="/training-plans" aria-label="Zurück" i18n-aria-label="@@trainingPlans.back">
+            <mat-icon>arrow_back</mat-icon>
+          </a>
+          <div>
+            <h1>{{ p.title }}</h1>
+            <p class="muted">{{ p.summary }}</p>
+          </div>
+        </header>
+
+        <mat-chip-set class="meta-chips">
+          <mat-chip>{{ p.totalDays }} <span i18n="@@trainingPlans.daysSuffix">Tage</span></mat-chip>
+          <mat-chip>
+            @if (p.level === 'beginner') {
+              <span i18n="@@trainingPlans.level.beginner">Einsteiger</span>
+            } @else if (p.level === 'intermediate') {
+              <span i18n="@@trainingPlans.level.intermediate">Mittelstufe</span>
+            } @else {
+              <span i18n="@@trainingPlans.level.advanced">Fortgeschritten</span>
+            }
+          </mat-chip>
+        </mat-chip-set>
+
+        @if (isThisPlanActive()) {
+          <mat-card class="status-card">
+            <mat-card-content>
+              <div class="progress-row">
+                <span i18n="@@trainingPlans.progress">Fortschritt</span>
+                <strong>{{ store.completionPercent() }}%</strong>
+              </div>
+              <mat-progress-bar mode="determinate" [value]="store.completionPercent()" />
+              @if (store.currentDayIndex(); as idx) {
+                <p class="muted current-day">
+                  <span i18n="@@trainingPlans.currentDay">Aktueller Tag:</span>
+                  {{ idx }} / {{ p.totalDays }}
+                </p>
+              }
+            </mat-card-content>
+            <mat-card-actions align="end">
+              <button mat-stroked-button color="warn" (click)="abandon()" i18n="@@trainingPlans.abandon">
+                <mat-icon>cancel</mat-icon>
+                Plan beenden
+              </button>
+            </mat-card-actions>
+          </mat-card>
+        } @else {
+          <mat-card class="status-card">
+            <mat-card-content>
+              <p i18n="@@trainingPlans.startCta">
+                Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt.
+              </p>
+            </mat-card-content>
+            <mat-card-actions align="end">
+              @if (store.hasActivePlan()) {
+                <p class="muted warn-replace" i18n="@@trainingPlans.replaceWarn">
+                  Achtung: Dies ersetzt den aktuell aktiven Plan.
+                </p>
+              }
+              <button mat-flat-button color="primary" (click)="start()">
+                <mat-icon>play_arrow</mat-icon>
+                <span i18n="@@trainingPlans.start">Plan starten</span>
+              </button>
+            </mat-card-actions>
+          </mat-card>
+        }
+
+        @for (week of weeks(); track week.weekIndex) {
+          <section class="week">
+            <h2>
+              <span i18n="@@trainingPlans.week">Woche</span>
+              {{ week.weekIndex }}
+            </h2>
+            <ul class="day-list">
+              @for (row of week.rows; track row.day.dayIndex) {
+                <li
+                  class="day-row"
+                  [class.today]="row.isToday"
+                  [class.done]="row.isCompleted"
+                  [class.future]="row.isFuture"
+                >
+                  <div class="day-num">
+                    <strong>{{ row.day.dayIndex }}</strong>
+                  </div>
+                  <div class="day-icon">
+                    @if (row.day.kind === 'rest') {
+                      <mat-icon aria-hidden="true">self_improvement</mat-icon>
+                    } @else if (row.day.kind === 'light') {
+                      <mat-icon aria-hidden="true">directions_walk</mat-icon>
+                    } @else if (row.day.kind === 'test') {
+                      <mat-icon aria-hidden="true">local_fire_department</mat-icon>
+                    } @else {
+                      <mat-icon aria-hidden="true">fitness_center</mat-icon>
+                    }
+                  </div>
+                  <div class="day-body">
+                    <div class="day-title">
+                      @if (row.day.targetReps > 0) {
+                        <strong>{{ row.day.targetReps }}</strong>
+                        <span i18n="@@trainingPlans.reps">Wdh.</span>
+                      } @else {
+                        <span i18n="@@trainingPlans.kind.rest">Ruhetag</span>
+                      }
+                      @if (row.day.sets && row.day.sets.length > 1) {
+                        <span class="sets muted">{{ formatSets(row.day.sets) }}</span>
+                      }
+                    </div>
+                    <div class="day-desc muted">{{ row.day.description }}</div>
+                  </div>
+                  <div class="day-actions">
+                    @if (isThisPlanActive() && row.day.kind !== 'rest') {
+                      @if (row.isCompleted) {
+                        <button
+                          mat-icon-button
+                          (click)="unmark(row.day.dayIndex)"
+                          aria-label="Als nicht erledigt markieren"
+                          i18n-aria-label="@@trainingPlans.unmarkAria"
+                        >
+                          <mat-icon>check_circle</mat-icon>
+                        </button>
+                      } @else {
+                        <button
+                          mat-icon-button
+                          (click)="mark(row.day.dayIndex)"
+                          aria-label="Als erledigt markieren"
+                          i18n-aria-label="@@trainingPlans.markAria"
+                        >
+                          <mat-icon>radio_button_unchecked</mat-icon>
+                        </button>
+                      }
+                    }
+                  </div>
+                </li>
+              }
+            </ul>
+          </section>
+        }
+      </main>
+    } @else {
+      <main class="page-wrap">
+        <p i18n="@@trainingPlans.notFound">Plan nicht gefunden.</p>
+        <a mat-stroked-button routerLink="/training-plans">
+          <mat-icon>arrow_back</mat-icon>
+          <span i18n="@@trainingPlans.back">Zurück</span>
+        </a>
+      </main>
+    }
+  `,
+  styles: [
+    `
+      .page-wrap {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 16px;
+      }
+      .page-header {
+        display: flex;
+        gap: 8px;
+        align-items: flex-start;
+      }
+      .page-header h1 {
+        margin: 0;
+      }
+      .muted {
+        color: rgba(0, 0, 0, 0.6);
+      }
+      :host-context(.dark-theme) .muted {
+        color: rgba(255, 255, 255, 0.6);
+      }
+      .meta-chips {
+        margin: 12px 0;
+      }
+      .status-card {
+        margin: 16px 0;
+      }
+      .progress-row {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 6px;
+      }
+      .current-day {
+        margin-top: 8px;
+      }
+      .warn-replace {
+        margin: 0 8px 0 0;
+        color: var(--mat-sys-error, #d32f2f);
+      }
+      .week h2 {
+        margin: 24px 0 8px;
+      }
+      .day-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 8px;
+      }
+      .day-row {
+        display: grid;
+        grid-template-columns: 40px 36px 1fr 48px;
+        gap: 12px;
+        align-items: center;
+        padding: 10px 12px;
+        border-radius: 8px;
+        background: rgba(0, 0, 0, 0.04);
+      }
+      :host-context(.dark-theme) .day-row {
+        background: rgba(255, 255, 255, 0.04);
+      }
+      .day-row.today {
+        outline: 2px solid var(--mat-sys-primary, #3f51b5);
+      }
+      .day-row.done {
+        opacity: 0.7;
+      }
+      .day-row.done .day-actions mat-icon {
+        color: var(--mat-sys-primary, #3f51b5);
+      }
+      .day-row.future {
+        opacity: 0.85;
+      }
+      .day-num {
+        text-align: center;
+        font-variant-numeric: tabular-nums;
+      }
+      .day-title {
+        display: flex;
+        gap: 6px;
+        align-items: baseline;
+      }
+      .sets {
+        margin-left: 4px;
+        font-size: 0.85rem;
+      }
+      .day-desc {
+        font-size: 0.9rem;
+      }
+    `,
+  ],
+})
+export class TrainingPlanDetailComponent {
+  protected readonly store = inject(TrainingPlanStore);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly snackbar = inject(MatSnackBar);
+
+  private readonly slugSignal = toSignal(this.route.paramMap, {
+    initialValue: this.route.snapshot.paramMap,
+  });
+
+  readonly plan = computed(() => {
+    const slug = this.slugSignal().get('slug');
+    return slug ? findPlanBySlug(slug) : null;
+  });
+
+  readonly isThisPlanActive = computed(() => {
+    const p = this.plan();
+    const a = this.store.activePlan();
+    return !!p && !!a && a.planId === p.id && a.status === 'active';
+  });
+
+  readonly weeks = computed(() => {
+    const p = this.plan();
+    if (!p) return [];
+    const currentDay = this.isThisPlanActive() ? this.store.currentDayIndex() : null;
+    const completed = new Set(this.store.activePlan()?.completedDays ?? []);
+
+    const grouped = new Map<number, DayRow[]>();
+    for (const day of p.days) {
+      const weekIndex = Math.floor((day.dayIndex - 1) / 7) + 1;
+      const isToday = currentDay !== null && day.dayIndex === currentDay;
+      const row: DayRow = {
+        day,
+        weekIndex,
+        isToday,
+        isCompleted: completed.has(day.dayIndex),
+        isFuture: currentDay !== null && day.dayIndex > currentDay,
+      };
+      const list = grouped.get(weekIndex) ?? [];
+      list.push(row);
+      grouped.set(weekIndex, list);
+    }
+
+    return Array.from(grouped.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([weekIndex, rows]) => ({ weekIndex, rows }));
+  });
+
+  formatSets(sets: number[]): string {
+    return `(${sets.join(' · ')})`;
+  }
+
+  async start(): Promise<void> {
+    const p = this.plan();
+    if (!p) return;
+    await this.store.start(p.id);
+    this.snackbar.open(
+      $localize`:@@trainingPlans.started:Plan gestartet — viel Erfolg!`,
+      undefined,
+      { duration: 3000 }
+    );
+  }
+
+  async abandon(): Promise<void> {
+    await this.store.abandon();
+    this.snackbar.open(
+      $localize`:@@trainingPlans.abandoned:Plan beendet.`,
+      undefined,
+      { duration: 3000 }
+    );
+    void this.router.navigate(['/training-plans']);
+  }
+
+  async mark(dayIndex: number): Promise<void> {
+    await this.store.markDayDone(dayIndex);
+  }
+
+  async unmark(dayIndex: number): Promise<void> {
+    await this.store.unmarkDayDone(dayIndex);
+  }
+}

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -297,7 +297,9 @@ export class TrainingPlanDetailComponent {
     const p = this.plan();
     if (!p) return [];
     const currentDay = this.isThisPlanActive() ? this.store.currentDayIndex() : null;
-    const completed = new Set(this.store.activePlan()?.completedDays ?? []);
+    const completed = this.isThisPlanActive()
+      ? new Set(this.store.activePlan()?.completedDays ?? [])
+      : new Set<number>();
 
     const grouped = new Map<number, DayRow[]>();
     for (const day of p.days) {

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  LOCALE_ID,
+} from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
@@ -7,7 +13,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
-import { findPlanBySlug, TrainingPlanDay } from '@pu-stats/models';
+import { findPlanBySlug, localizePlan, TrainingPlanDay } from '@pu-stats/models';
 import { TrainingPlanStore } from './training-plan.store';
 
 interface DayRow {
@@ -38,8 +44,8 @@ interface DayRow {
             <mat-icon>arrow_back</mat-icon>
           </a>
           <div>
-            <h1>{{ p.title }}</h1>
-            <p class="muted">{{ p.summary }}</p>
+            <h1>{{ localized()?.title }}</h1>
+            <p class="muted">{{ localized()?.summary }}</p>
           </div>
         </header>
 
@@ -277,6 +283,7 @@ export class TrainingPlanDetailComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly snackbar = inject(MatSnackBar);
+  private readonly locale = inject(LOCALE_ID) as string;
 
   private readonly slugSignal = toSignal(this.route.paramMap, {
     initialValue: this.route.snapshot.paramMap,
@@ -287,6 +294,12 @@ export class TrainingPlanDetailComponent {
     return slug ? findPlanBySlug(slug) : null;
   });
 
+  /** Plan with title/summary/day descriptions in the active locale. */
+  readonly localized = computed(() => {
+    const p = this.plan();
+    return p ? localizePlan(p, this.locale) : null;
+  });
+
   readonly isThisPlanActive = computed(() => {
     const p = this.plan();
     const a = this.store.activePlan();
@@ -294,15 +307,15 @@ export class TrainingPlanDetailComponent {
   });
 
   readonly weeks = computed(() => {
-    const p = this.plan();
-    if (!p) return [];
+    const localized = this.localized();
+    if (!localized) return [];
     const currentDay = this.isThisPlanActive() ? this.store.currentDayIndex() : null;
     const completed = this.isThisPlanActive()
       ? new Set(this.store.activePlan()?.completedDays ?? [])
       : new Set<number>();
 
     const grouped = new Map<number, DayRow[]>();
-    for (const day of p.days) {
+    for (const day of localized.days) {
       const weekIndex = Math.floor((day.dayIndex - 1) / 7) + 1;
       const isToday = currentDay !== null && day.dayIndex === currentDay;
       const row: DayRow = {

--- a/web/src/app/training-plans/training-plan.store.spec.ts
+++ b/web/src/app/training-plans/training-plan.store.spec.ts
@@ -1,0 +1,202 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { UserContextService } from '@pu-auth/auth';
+import { UserTrainingPlanApiService } from '@pu-stats/data-access';
+import {
+  toBerlinIsoDate,
+  TRAINING_PLANS,
+  UserTrainingPlan,
+} from '@pu-stats/models';
+import { TrainingPlanStore } from './training-plan.store';
+
+const PLAN = TRAINING_PLANS.find(
+  (p) => p.id === 'challenge-30d-v1'
+) as (typeof TRAINING_PLANS)[number];
+
+interface Mocks {
+  apiMock: {
+    getActivePlan: ReturnType<typeof vitest.fn>;
+    setPlan: ReturnType<typeof vitest.fn>;
+    updatePlan: ReturnType<typeof vitest.fn>;
+  };
+  stream: BehaviorSubject<UserTrainingPlan | null>;
+  current: UserTrainingPlan | null;
+}
+
+describe('TrainingPlanStore', () => {
+  const userId = signal<string>('u1');
+
+  function setup(initial: UserTrainingPlan | null = null): {
+    store: InstanceType<typeof TrainingPlanStore>;
+    mocks: Mocks;
+  } {
+    const stream = new BehaviorSubject<UserTrainingPlan | null>(initial);
+    const mocks: Mocks = {
+      stream,
+      current: initial,
+      apiMock: {
+        getActivePlan: vitest.fn(() => stream.asObservable()),
+        setPlan: vitest.fn((_uid: string, plan: UserTrainingPlan) => {
+          mocks.current = { ...plan, userId: _uid };
+          stream.next(mocks.current);
+          return new BehaviorSubject(mocks.current).asObservable();
+        }),
+        updatePlan: vitest.fn(
+          (_uid: string, patch: Partial<UserTrainingPlan>) => {
+            mocks.current = { ...(mocks.current as UserTrainingPlan), ...patch };
+            stream.next(mocks.current);
+            return new BehaviorSubject(mocks.current).asObservable();
+          }
+        ),
+      },
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: UserTrainingPlanApiService, useValue: mocks.apiMock },
+        {
+          provide: UserContextService,
+          useValue: { userIdSafe: () => userId() },
+        },
+      ],
+    });
+    const store = TestBed.inject(TrainingPlanStore);
+    return { store, mocks };
+  }
+
+  async function flush(): Promise<void> {
+    TestBed.tick();
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+    TestBed.tick();
+  }
+
+  it('starts with no active plan when the doc is missing', async () => {
+    const { store } = setup(null);
+    await flush();
+    expect(store.activePlan()).toBeNull();
+    expect(store.hasActivePlan()).toBe(false);
+    expect(store.todayTarget()).toBe(0);
+  });
+
+  it('exposes today\'s target reps once a plan is active', async () => {
+    const today = toBerlinIsoDate(new Date());
+    const { store } = setup({
+      userId: 'u1',
+      planId: PLAN.id,
+      startDate: today,
+      status: 'active',
+      completedDays: [],
+    });
+    await flush();
+
+    expect(store.hasActivePlan()).toBe(true);
+    expect(store.activeCatalog()?.id).toBe(PLAN.id);
+    expect(store.currentDayIndex()).toBe(1);
+    expect(store.todayDay()?.kind).toBe(PLAN.days[0].kind);
+    expect(store.todayTarget()).toBe(PLAN.days[0].targetReps);
+  });
+
+  it('marks today as done and updates completedDays via the API', async () => {
+    const today = toBerlinIsoDate(new Date());
+    const { store, mocks } = setup({
+      userId: 'u1',
+      planId: PLAN.id,
+      startDate: today,
+      status: 'active',
+      completedDays: [],
+    });
+    await flush();
+
+    await store.markTodayDone();
+    await flush();
+
+    expect(mocks.apiMock.updatePlan).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ completedDays: [1] })
+    );
+    expect(store.todayDone()).toBe(true);
+  });
+
+  it('start() overwrites the active plan with a fresh start date and empty completedDays', async () => {
+    const { store, mocks } = setup({
+      userId: 'u1',
+      planId: 'recruit-6w-v1',
+      startDate: '2026-01-01',
+      status: 'active',
+      completedDays: [1, 2, 3],
+    });
+    await flush();
+
+    await store.start(PLAN.id);
+    await flush();
+
+    expect(mocks.apiMock.setPlan).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({
+        planId: PLAN.id,
+        completedDays: [],
+        status: 'active',
+      })
+    );
+    expect(store.activePlan()?.planId).toBe(PLAN.id);
+    expect(store.activePlan()?.completedDays).toEqual([]);
+  });
+
+  it('abandon() flips status to abandoned without clearing progress', async () => {
+    const today = toBerlinIsoDate(new Date());
+    const { store, mocks } = setup({
+      userId: 'u1',
+      planId: PLAN.id,
+      startDate: today,
+      status: 'active',
+      completedDays: [1, 2],
+    });
+    await flush();
+
+    await store.abandon();
+    await flush();
+
+    expect(mocks.apiMock.updatePlan).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ status: 'abandoned' })
+    );
+    expect(store.hasActivePlan()).toBe(false);
+  });
+
+  it('completionPercent counts non-rest days', async () => {
+    const today = toBerlinIsoDate(new Date());
+    const { store } = setup({
+      userId: 'u1',
+      planId: PLAN.id,
+      startDate: today,
+      status: 'active',
+      completedDays: [1, 2, 4],
+    });
+    await flush();
+
+    const total = PLAN.days.filter((d) => d.kind !== 'rest').length;
+    expect(store.completionPercent()).toBe(Math.round((3 / total) * 100));
+  });
+
+  it('unmarkDayDone removes a day from completedDays', async () => {
+    const today = toBerlinIsoDate(new Date());
+    const { store, mocks } = setup({
+      userId: 'u1',
+      planId: PLAN.id,
+      startDate: today,
+      status: 'active',
+      completedDays: [1, 2, 3],
+    });
+    await flush();
+
+    await store.unmarkDayDone(2);
+    await flush();
+
+    expect(mocks.apiMock.updatePlan).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ completedDays: [1, 3] })
+    );
+  });
+});

--- a/web/src/app/training-plans/training-plan.store.spec.ts
+++ b/web/src/app/training-plans/training-plan.store.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { signal } from '@angular/core';
+import { PLATFORM_ID, signal } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { UserContextService } from '@pu-auth/auth';
 import { UserTrainingPlanApiService } from '@pu-stats/data-access';
@@ -55,6 +55,9 @@ describe('TrainingPlanStore', () => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       providers: [
+        // Treat tests as SSR so the midnight-tick setInterval doesn't
+        // start (otherwise it would leak across `resetTestingModule`).
+        { provide: PLATFORM_ID, useValue: 'server' },
         { provide: UserTrainingPlanApiService, useValue: mocks.apiMock },
         {
           provide: UserContextService,
@@ -178,6 +181,64 @@ describe('TrainingPlanStore', () => {
 
     const total = PLAN.days.filter((d) => d.kind !== 'rest').length;
     expect(store.completionPercent()).toBe(Math.round((3 / total) * 100));
+  });
+
+  it('completionPercent ignores stray rest-day entries and clamps at 100', async () => {
+    const today = toBerlinIsoDate(new Date());
+    // Find a rest-day index inside the catalog so we can plant it
+    // into completedDays as if a stale write leaked one in.
+    const restDay = PLAN.days.find((d) => d.kind === 'rest');
+    if (!restDay) throw new Error('catalog invariant: plan has a rest day');
+    const restDayIdx = restDay.dayIndex;
+    const allNonRest = PLAN.days
+      .filter((d) => d.kind !== 'rest')
+      .map((d) => d.dayIndex);
+
+    const { store } = setup({
+      userId: 'u1',
+      planId: PLAN.id,
+      startDate: today,
+      status: 'active',
+      // every non-rest day completed + a phantom rest day
+      completedDays: [...allNonRest, restDayIdx],
+    });
+    await flush();
+
+    expect(store.completionPercent()).toBe(100);
+  });
+
+  it('markTodayDone does nothing on a rest day', async () => {
+    // Recruit-6w day 2 is a rest day. Start it 1 day ago so today is
+    // the rest day in the plan.
+    const recruit = TRAINING_PLANS.find(
+      (p) => p.id === 'recruit-6w-v1'
+    ) as (typeof TRAINING_PLANS)[number];
+    expect(recruit.days[1].kind).toBe('rest');
+    const todayIso = toBerlinIsoDate(new Date());
+    const yesterday = toBerlinIsoDate(
+      new Date(Date.now() - 86_400_000)
+    );
+
+    const { store, mocks } = setup({
+      userId: 'u1',
+      planId: recruit.id,
+      startDate: yesterday,
+      status: 'active',
+      completedDays: [],
+    });
+    await flush();
+
+    // sanity: the resolver believes today is plan-day 2 (a rest day)
+    expect(store.currentDayIndex()).toBe(2);
+    expect(store.todayDay()?.kind).toBe('rest');
+
+    await store.markTodayDone();
+    await flush();
+
+    expect(mocks.apiMock.updatePlan).not.toHaveBeenCalled();
+    expect(store.activePlan()?.completedDays).toEqual([]);
+    // Reference unused param to keep tsc happy.
+    void todayIso;
   });
 
   it('unmarkDayDone removes a day from completedDays', async () => {

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -1,8 +1,16 @@
-import { computed, inject } from '@angular/core';
+import {
+  computed,
+  DestroyRef,
+  inject,
+  PLATFORM_ID,
+  signal,
+} from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { rxResource } from '@angular/core/rxjs-interop';
 import {
   signalStore,
   withComputed,
+  withHooks,
   withMethods,
   withProps,
 } from '@ngrx/signals';
@@ -36,6 +44,16 @@ export const TrainingPlanStore = signalStore(
   withProps(() => ({
     _api: inject(UserTrainingPlanApiService),
     _user: inject(UserContextService),
+    _isBrowser: isPlatformBrowser(inject(PLATFORM_ID)),
+    /**
+     * Coarse daily tick. The Berlin date used by `currentDayIndex`
+     * has no signal dependencies of its own, so without this signal
+     * a long-running tab stays on the previous calendar day after
+     * midnight until something else triggers recomputation. We
+     * update once a minute (cheap; covers the midnight crossover
+     * within 60 s).
+     */
+    _dayTick: signal(0),
   })),
   withProps((store) => ({
     activeResource: rxResource({
@@ -56,7 +74,12 @@ export const TrainingPlanStore = signalStore(
       return a ? findPlanById(a.planId) : null;
     });
 
-    const today = computed(() => toBerlinIsoDate(new Date()));
+    const today = computed(() => {
+      // Establish a dependency on the day tick so `currentDayIndex`
+      // re-evaluates after midnight.
+      store._dayTick();
+      return toBerlinIsoDate(new Date());
+    });
 
     /** Current 1-based day for today, or null if not started/no plan. */
     const currentDayIndex = computed<number | null>(() => {
@@ -87,9 +110,20 @@ export const TrainingPlanStore = signalStore(
       const a = activePlan();
       const c = activeCatalog();
       if (!a || !c) return 0;
-      const total = c.days.filter((d) => d.kind !== 'rest').length;
-      if (total === 0) return 0;
-      return Math.round((a.completedDays.length / total) * 100);
+      const nonRestDayIndexes = new Set(
+        c.days.filter((d) => d.kind !== 'rest').map((d) => d.dayIndex)
+      );
+      if (nonRestDayIndexes.size === 0) return 0;
+      // Filter `completedDays` to only count non-rest days. Rest-day
+      // entries can otherwise leak progress > 100% (e.g. via direct
+      // API writes or future UI changes that mark rest days done).
+      const completedNonRest = a.completedDays.filter((idx) =>
+        nonRestDayIndexes.has(idx)
+      ).length;
+      return Math.min(
+        100,
+        Math.round((completedNonRest / nonRestDayIndexes.size) * 100)
+      );
     });
 
     const isCompleted = computed(() => {
@@ -142,11 +176,15 @@ export const TrainingPlanStore = signalStore(
       store.activeResource.reload();
     },
 
-    /** Mark today's plan day as done. Idempotent. */
+    /** Mark today's plan day as done. Idempotent. No-op on rest days. */
     async markTodayDone(): Promise<void> {
       const a = store.activePlan();
       const idx = store.currentDayIndex();
-      if (!a || idx === null) return;
+      const day = store.todayDay();
+      if (!a || idx === null || !day) return;
+      // Rest days are not part of the completion set — silently skip
+      // so a generic "mark today done" callback can't skew progress.
+      if (day.kind === 'rest') return;
       if (a.completedDays.includes(idx)) return;
       const next = [...a.completedDays, idx].sort((x, y) => x - y);
       const userId = store._user.userIdSafe();
@@ -159,7 +197,12 @@ export const TrainingPlanStore = signalStore(
     /** Mark a specific day as done (used from the plan detail page). */
     async markDayDone(dayIndex: number): Promise<void> {
       const a = store.activePlan();
-      if (!a) return;
+      const c = store.activeCatalog();
+      if (!a || !c) return;
+      // Reject out-of-range or rest-day indexes — those should never
+      // count toward completion progress.
+      const day = planDayByIndex(c, dayIndex);
+      if (!day || day.kind === 'rest') return;
       if (a.completedDays.includes(dayIndex)) return;
       const next = [...a.completedDays, dayIndex].sort((x, y) => x - y);
       const userId = store._user.userIdSafe();
@@ -196,5 +239,19 @@ export const TrainingPlanStore = signalStore(
     reload(): void {
       store.activeResource.reload();
     },
-  }))
+  })),
+  withHooks({
+    onInit(store) {
+      // Browser-only: tick the day signal once a minute so the
+      // Berlin-date-based `currentDayIndex` updates within ~60 s of
+      // midnight even if no Firestore activity refreshes the
+      // `activePlan` resource.
+      if (!store._isBrowser) return;
+      const handle = setInterval(
+        () => store._dayTick.update((n) => n + 1),
+        60_000
+      );
+      inject(DestroyRef).onDestroy(() => clearInterval(handle));
+    },
+  })
 );

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -1,0 +1,200 @@
+import { computed, inject } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import {
+  signalStore,
+  withComputed,
+  withMethods,
+  withProps,
+} from '@ngrx/signals';
+import { UserContextService } from '@pu-auth/auth';
+import { UserTrainingPlanApiService } from '@pu-stats/data-access';
+import {
+  currentPlanDayIndex,
+  findPlanById,
+  isPlanCompleted,
+  planDayByIndex,
+  toBerlinIsoDate,
+  TrainingPlan,
+  TrainingPlanDay,
+  TRAINING_PLANS,
+  UserTrainingPlan,
+} from '@pu-stats/models';
+import { firstValueFrom, of } from 'rxjs';
+
+/**
+ * Active-plan store. Keeps the live `UserTrainingPlan` doc in sync
+ * via a Firestore real-time listener and exposes derived state for
+ * the dashboard goal pill, the plan detail page and the training
+ * plans list.
+ *
+ * Single active plan per user — starting a new plan replaces the
+ * existing doc. (We can move the previous doc into a `history`
+ * subcollection later if we want to surface completed plans.)
+ */
+export const TrainingPlanStore = signalStore(
+  { providedIn: 'root' },
+  withProps(() => ({
+    _api: inject(UserTrainingPlanApiService),
+    _user: inject(UserContextService),
+  })),
+  withProps((store) => ({
+    activeResource: rxResource({
+      params: () => ({ userId: store._user.userIdSafe() }),
+      stream: ({ params }) => {
+        if (!params.userId) return of(null);
+        return store._api.getActivePlan(params.userId);
+      },
+    }),
+  })),
+  withComputed((store) => {
+    const activePlan = computed<UserTrainingPlan | null>(
+      () => store.activeResource.value() ?? null
+    );
+
+    const activeCatalog = computed<TrainingPlan | null>(() => {
+      const a = activePlan();
+      return a ? findPlanById(a.planId) : null;
+    });
+
+    const today = computed(() => toBerlinIsoDate(new Date()));
+
+    /** Current 1-based day for today, or null if not started/no plan. */
+    const currentDayIndex = computed<number | null>(() => {
+      const a = activePlan();
+      const c = activeCatalog();
+      if (!a || !c) return null;
+      return currentPlanDayIndex(c, a.startDate, today());
+    });
+
+    /** Today's `TrainingPlanDay` (null when no plan or pre-start). */
+    const todayDay = computed<TrainingPlanDay | null>(() => {
+      const c = activeCatalog();
+      const idx = currentDayIndex();
+      if (!c || idx === null) return null;
+      return planDayByIndex(c, idx);
+    });
+
+    const todayTarget = computed(() => todayDay()?.targetReps ?? 0);
+
+    const todayDone = computed(() => {
+      const idx = currentDayIndex();
+      const a = activePlan();
+      if (!a || idx === null) return false;
+      return a.completedDays.includes(idx);
+    });
+
+    const completionPercent = computed(() => {
+      const a = activePlan();
+      const c = activeCatalog();
+      if (!a || !c) return 0;
+      const total = c.days.filter((d) => d.kind !== 'rest').length;
+      if (total === 0) return 0;
+      return Math.round((a.completedDays.length / total) * 100);
+    });
+
+    const isCompleted = computed(() => {
+      const a = activePlan();
+      const c = activeCatalog();
+      if (!a || !c) return false;
+      return isPlanCompleted(c, a.completedDays);
+    });
+
+    const hasActivePlan = computed(
+      () => activePlan() !== null && activePlan()?.status === 'active'
+    );
+
+    return {
+      activePlan,
+      activeCatalog,
+      currentDayIndex,
+      todayDay,
+      todayTarget,
+      todayDone,
+      completionPercent,
+      isCompleted,
+      hasActivePlan,
+    };
+  }),
+  withMethods((store) => ({
+    /** All curated plans (re-exposed for component templates). */
+    allPlans(): ReadonlyArray<TrainingPlan> {
+      return TRAINING_PLANS;
+    },
+
+    /**
+     * Activate a plan starting today (Berlin date). Overwrites any
+     * existing active plan — that is intentional: only one active
+     * plan at a time, and the user has confirmed the switch.
+     */
+    async start(planId: string): Promise<void> {
+      const userId = store._user.userIdSafe();
+      if (!userId) return;
+      const plan = findPlanById(planId);
+      if (!plan) return;
+      await firstValueFrom(
+        store._api.setPlan(userId, {
+          planId: plan.id,
+          startDate: toBerlinIsoDate(new Date()),
+          status: 'active',
+          completedDays: [],
+        })
+      );
+      store.activeResource.reload();
+    },
+
+    /** Mark today's plan day as done. Idempotent. */
+    async markTodayDone(): Promise<void> {
+      const a = store.activePlan();
+      const idx = store.currentDayIndex();
+      if (!a || idx === null) return;
+      if (a.completedDays.includes(idx)) return;
+      const next = [...a.completedDays, idx].sort((x, y) => x - y);
+      const userId = store._user.userIdSafe();
+      await firstValueFrom(
+        store._api.updatePlan(userId, { completedDays: next })
+      );
+      store.activeResource.reload();
+    },
+
+    /** Mark a specific day as done (used from the plan detail page). */
+    async markDayDone(dayIndex: number): Promise<void> {
+      const a = store.activePlan();
+      if (!a) return;
+      if (a.completedDays.includes(dayIndex)) return;
+      const next = [...a.completedDays, dayIndex].sort((x, y) => x - y);
+      const userId = store._user.userIdSafe();
+      await firstValueFrom(
+        store._api.updatePlan(userId, { completedDays: next })
+      );
+      store.activeResource.reload();
+    },
+
+    /** Undo a day completion. */
+    async unmarkDayDone(dayIndex: number): Promise<void> {
+      const a = store.activePlan();
+      if (!a) return;
+      if (!a.completedDays.includes(dayIndex)) return;
+      const next = a.completedDays.filter((d) => d !== dayIndex);
+      const userId = store._user.userIdSafe();
+      await firstValueFrom(
+        store._api.updatePlan(userId, { completedDays: next })
+      );
+      store.activeResource.reload();
+    },
+
+    /** Abandon the current plan (status → abandoned). */
+    async abandon(): Promise<void> {
+      const a = store.activePlan();
+      if (!a) return;
+      const userId = store._user.userIdSafe();
+      await firstValueFrom(
+        store._api.updatePlan(userId, { status: 'abandoned' })
+      );
+      store.activeResource.reload();
+    },
+
+    reload(): void {
+      store.activeResource.reload();
+    },
+  }))
+);

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -133,8 +133,18 @@ export const TrainingPlanStore = signalStore(
       return isPlanCompleted(c, a.completedDays);
     });
 
+    /**
+     * Active iff the user doc says so AND we can still resolve the
+     * catalog entry. A stale `planId` (e.g. a plan was retired or
+     * the doc was hand-edited) should fall back to the user's normal
+     * goal rather than rendering an "active plan" with empty
+     * title/totalDays in the dashboard banner.
+     */
     const hasActivePlan = computed(
-      () => activePlan() !== null && activePlan()?.status === 'active'
+      () =>
+        activePlan() !== null &&
+        activePlan()?.status === 'active' &&
+        activeCatalog() !== null
     );
 
     return {

--- a/web/src/app/training-plans/training-plans-page.component.ts
+++ b/web/src/app/training-plans/training-plans-page.component.ts
@@ -1,0 +1,221 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { RouterLink } from '@angular/router';
+import { TrainingPlanStore } from './training-plan.store';
+
+@Component({
+  selector: 'app-training-plans-page',
+  imports: [
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatChipsModule,
+    MatProgressBarModule,
+    RouterLink,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <main class="page-wrap">
+      <header class="page-header">
+        <h1 i18n="@@trainingPlans.title">Trainingspläne</h1>
+        <p class="muted" i18n="@@trainingPlans.intro">
+          Strukturierte Pläne mit Tagesziel, Sätzen und automatischer
+          Fortschrittsverfolgung. Starte einen Plan, und dein Tagesziel im
+          Dashboard wird automatisch gesetzt.
+        </p>
+      </header>
+
+      @if (store.hasActivePlan() && store.activeCatalog(); as active) {
+        <mat-card class="active-plan">
+          <mat-card-header>
+            <mat-card-title i18n="@@trainingPlans.active.title">
+              Aktiver Plan
+            </mat-card-title>
+            <mat-card-subtitle>{{ active.title }}</mat-card-subtitle>
+          </mat-card-header>
+          <mat-card-content>
+            <p class="muted">{{ active.summary }}</p>
+
+            @if (store.currentDayIndex(); as idx) {
+              <div class="progress-row">
+                <span i18n="@@trainingPlans.day">Tag</span>
+                <strong>{{ idx }} / {{ active.totalDays }}</strong>
+              </div>
+              <mat-progress-bar
+                mode="determinate"
+                [value]="store.completionPercent()"
+              />
+            }
+
+            @if (store.todayDay(); as today) {
+              <div class="today-card">
+                <div class="today-kind">
+                  @if (today.kind === 'rest') {
+                    <mat-icon>self_improvement</mat-icon>
+                    <span i18n="@@trainingPlans.kind.rest">Ruhetag</span>
+                  } @else if (today.kind === 'light') {
+                    <mat-icon>directions_walk</mat-icon>
+                    <span i18n="@@trainingPlans.kind.light">Leichter Tag</span>
+                  } @else if (today.kind === 'test') {
+                    <mat-icon>local_fire_department</mat-icon>
+                    <span i18n="@@trainingPlans.kind.test">Maximaltest</span>
+                  } @else {
+                    <mat-icon>fitness_center</mat-icon>
+                    <span i18n="@@trainingPlans.kind.main">Trainingstag</span>
+                  }
+                </div>
+                @if (today.targetReps > 0) {
+                  <div class="today-target">
+                    <span i18n="@@trainingPlans.todayTarget"
+                      >Heute geplant:</span
+                    >
+                    <strong>{{ today.targetReps }}</strong>
+                    <span i18n="@@trainingPlans.reps">Wdh.</span>
+                  </div>
+                }
+                <p class="muted today-desc">{{ today.description }}</p>
+              </div>
+            }
+          </mat-card-content>
+          <mat-card-actions align="end">
+            <button
+              mat-stroked-button
+              type="button"
+              color="warn"
+              (click)="abandon()"
+              i18n="@@trainingPlans.abandon"
+            >
+              <mat-icon>cancel</mat-icon>
+              Plan beenden
+            </button>
+            <a
+              mat-flat-button
+              color="primary"
+              [routerLink]="['/training-plans', active.slug]"
+            >
+              <mat-icon>open_in_full</mat-icon>
+              <span i18n="@@trainingPlans.openDetail">Details öffnen</span>
+            </a>
+          </mat-card-actions>
+        </mat-card>
+      }
+
+      <section class="plan-grid">
+        @for (plan of store.allPlans(); track plan.id) {
+          <mat-card class="plan-card">
+            <mat-card-header>
+              <mat-card-title>{{ plan.title }}</mat-card-title>
+              <mat-card-subtitle>
+                <mat-chip-set>
+                  <mat-chip [highlighted]="true">
+                    {{ plan.totalDays }}
+                    <span i18n="@@trainingPlans.daysSuffix">Tage</span>
+                  </mat-chip>
+                  <mat-chip>
+                    @if (plan.level === 'beginner') {
+                      <span i18n="@@trainingPlans.level.beginner"
+                        >Einsteiger</span
+                      >
+                    } @else if (plan.level === 'intermediate') {
+                      <span i18n="@@trainingPlans.level.intermediate"
+                        >Mittelstufe</span
+                      >
+                    } @else {
+                      <span i18n="@@trainingPlans.level.advanced"
+                        >Fortgeschritten</span
+                      >
+                    }
+                  </mat-chip>
+                </mat-chip-set>
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <p>{{ plan.summary }}</p>
+            </mat-card-content>
+            <mat-card-actions align="end">
+              <a
+                mat-stroked-button
+                [routerLink]="['/training-plans', plan.slug]"
+              >
+                <mat-icon>visibility</mat-icon>
+                <span i18n="@@trainingPlans.viewPlan">Plan ansehen</span>
+              </a>
+            </mat-card-actions>
+          </mat-card>
+        }
+      </section>
+    </main>
+  `,
+  styles: [
+    `
+      .page-wrap {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 16px;
+      }
+      .page-header h1 {
+        margin: 0 0 4px;
+      }
+      .muted {
+        color: rgba(0, 0, 0, 0.6);
+      }
+      :host-context(.dark-theme) .muted {
+        color: rgba(255, 255, 255, 0.6);
+      }
+      .active-plan {
+        margin-bottom: 24px;
+        border-left: 4px solid var(--mat-sys-primary, #3f51b5);
+      }
+      .progress-row {
+        display: flex;
+        gap: 8px;
+        align-items: baseline;
+        margin: 12px 0 4px;
+      }
+      .today-card {
+        margin-top: 16px;
+        padding: 12px 16px;
+        border-radius: 8px;
+        background: rgba(0, 0, 0, 0.04);
+      }
+      :host-context(.dark-theme) .today-card {
+        background: rgba(255, 255, 255, 0.05);
+      }
+      .today-kind {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 500;
+      }
+      .today-target {
+        margin-top: 8px;
+        font-size: 1.2rem;
+        display: flex;
+        gap: 6px;
+        align-items: baseline;
+      }
+      .today-desc {
+        margin: 6px 0 0;
+      }
+      .plan-grid {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      }
+      .plan-card mat-card-content {
+        min-height: 64px;
+      }
+    `,
+  ],
+})
+export class TrainingPlansPageComponent {
+  readonly store = inject(TrainingPlanStore);
+
+  abandon(): void {
+    void this.store.abandon();
+  }
+}

--- a/web/src/app/training-plans/training-plans-page.component.ts
+++ b/web/src/app/training-plans/training-plans-page.component.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  LOCALE_ID,
+} from '@angular/core';
+import { localizePlan, TrainingPlanDay } from '@pu-stats/models';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatChipsModule } from '@angular/material/chips';
@@ -29,7 +36,7 @@ import { TrainingPlanStore } from './training-plan.store';
         </p>
       </header>
 
-      @if (store.hasActivePlan() && store.activeCatalog(); as active) {
+      @if (activeView(); as active) {
         <mat-card class="active-plan">
           <mat-card-header>
             <mat-card-title i18n="@@trainingPlans.active.title">
@@ -51,7 +58,7 @@ import { TrainingPlanStore } from './training-plan.store';
               />
             }
 
-            @if (store.todayDay(); as today) {
+            @if (todayLocalized(); as today) {
               <div class="today-card">
                 <div class="today-kind">
                   @if (today.kind === 'rest') {
@@ -95,7 +102,7 @@ import { TrainingPlanStore } from './training-plan.store';
             <a
               mat-flat-button
               color="primary"
-              [routerLink]="['/training-plans', active.slug]"
+              [routerLink]="['/training-plans', store.activeCatalog()?.slug]"
             >
               <mat-icon>open_in_full</mat-icon>
               <span i18n="@@trainingPlans.openDetail">Details öffnen</span>
@@ -105,7 +112,7 @@ import { TrainingPlanStore } from './training-plan.store';
       }
 
       <section class="plan-grid">
-        @for (plan of store.allPlans(); track plan.id) {
+        @for (plan of localizedPlans(); track plan.id) {
           <mat-card class="plan-card">
             <mat-card-header>
               <mat-card-title>{{ plan.title }}</mat-card-title>
@@ -214,6 +221,45 @@ import { TrainingPlanStore } from './training-plan.store';
 })
 export class TrainingPlansPageComponent {
   readonly store = inject(TrainingPlanStore);
+  private readonly locale = inject(LOCALE_ID) as string;
+
+  /** Catalog with `title`/`summary` fields swapped to the active locale. */
+  readonly localizedPlans = computed(() =>
+    this.store.allPlans().map((p) => {
+      const localized = localizePlan(p, this.locale);
+      return {
+        id: p.id,
+        slug: p.slug,
+        level: p.level,
+        totalDays: p.totalDays,
+        title: localized.title,
+        summary: localized.summary,
+      };
+    })
+  );
+
+  /** Active plan card view-model — null when no plan is active. */
+  readonly activeView = computed(() => {
+    const cat = this.store.activeCatalog();
+    if (!cat || !this.store.hasActivePlan()) return null;
+    const localized = localizePlan(cat, this.locale);
+    return {
+      title: localized.title,
+      summary: localized.summary,
+      totalDays: cat.totalDays,
+    };
+  });
+
+  /** Today's day with localized description. */
+  readonly todayLocalized = computed<TrainingPlanDay | null>(() => {
+    const day = this.store.todayDay();
+    const cat = this.store.activeCatalog();
+    if (!day || !cat) return null;
+    const localized = localizePlan(cat, this.locale).days.find(
+      (d) => d.dayIndex === day.dayIndex
+    );
+    return localized ?? day;
+  });
 
   abandon(): void {
     void this.store.abandon();

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -5550,5 +5550,197 @@ Deine Position: # ·  Reps        </source>
         <target>push-ups</target>
       </segment>
     </unit>
+    <unit id="nav.trainingPlans">
+      <segment state="translated">
+        <source>Trainingspläne</source>
+        <target>Training plans</target>
+      </segment>
+    </unit>
+    <unit id="seo.trainingPlans.title">
+      <segment state="translated">
+        <source>Trainingspläne – Pushup Tracker</source>
+        <target>Training plans – Pushup Tracker</target>
+      </segment>
+    </unit>
+    <unit id="seo.trainingPlans.description">
+      <segment state="translated">
+        <source>Strukturierte Liegestütz-Trainingspläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung.</source>
+        <target>Structured push-up training plans with daily goals, sets, and automatic progress tracking.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.title">
+      <segment state="translated">
+        <source>Trainingspläne</source>
+        <target>Training plans</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.intro">
+      <segment state="translated">
+        <source>Strukturierte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Starte einen Plan, und dein Tagesziel im Dashboard wird automatisch gesetzt.</source>
+        <target>Structured plans with daily goals, sets, and automatic progress tracking. Start a plan and your daily goal on the dashboard will be set automatically.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.active.title">
+      <segment state="translated">
+        <source>Aktiver Plan</source>
+        <target>Active plan</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.day">
+      <segment state="translated">
+        <source>Tag</source>
+        <target>Day</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.week">
+      <segment state="translated">
+        <source>Woche</source>
+        <target>Week</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.todayTarget">
+      <segment state="translated">
+        <source>Heute geplant:</source>
+        <target>Today's target:</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.reps">
+      <segment state="translated">
+        <source>Wdh.</source>
+        <target>reps</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.daysSuffix">
+      <segment state="translated">
+        <source>Tage</source>
+        <target>days</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.kind.rest">
+      <segment state="translated">
+        <source>Ruhetag</source>
+        <target>Rest day</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.kind.light">
+      <segment state="translated">
+        <source>Leichter Tag</source>
+        <target>Light day</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.kind.test">
+      <segment state="translated">
+        <source>Maximaltest</source>
+        <target>Max test</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.kind.main">
+      <segment state="translated">
+        <source>Trainingstag</source>
+        <target>Training day</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.level.beginner">
+      <segment state="translated">
+        <source>Einsteiger</source>
+        <target>Beginner</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.level.intermediate">
+      <segment state="translated">
+        <source>Mittelstufe</source>
+        <target>Intermediate</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.level.advanced">
+      <segment state="translated">
+        <source>Fortgeschritten</source>
+        <target>Advanced</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.openDetail">
+      <segment state="translated">
+        <source>Details öffnen</source>
+        <target>Open details</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.viewPlan">
+      <segment state="translated">
+        <source>Plan ansehen</source>
+        <target>View plan</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.start">
+      <segment state="translated">
+        <source>Plan starten</source>
+        <target>Start plan</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.startCta">
+      <segment state="translated">
+        <source>Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt.</source>
+        <target>Start the plan and the dashboard's daily goal will follow this plan automatically.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.replaceWarn">
+      <segment state="translated">
+        <source>Achtung: Dies ersetzt den aktuell aktiven Plan.</source>
+        <target>Heads up: this replaces the currently active plan.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.abandon">
+      <segment state="translated">
+        <source>Plan beenden</source>
+        <target>End plan</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.started">
+      <segment state="translated">
+        <source>Plan gestartet — viel Erfolg!</source>
+        <target>Plan started — good luck!</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.abandoned">
+      <segment state="translated">
+        <source>Plan beendet.</source>
+        <target>Plan ended.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.progress">
+      <segment state="translated">
+        <source>Fortschritt</source>
+        <target>Progress</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.currentDay">
+      <segment state="translated">
+        <source>Aktueller Tag:</source>
+        <target>Current day:</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.markAria">
+      <segment state="translated">
+        <source>Als erledigt markieren</source>
+        <target>Mark as done</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unmarkAria">
+      <segment state="translated">
+        <source>Als nicht erledigt markieren</source>
+        <target>Mark as not done</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.back">
+      <segment state="translated">
+        <source>Zurück</source>
+        <target>Back</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.notFound">
+      <segment state="translated">
+        <source>Plan nicht gefunden.</source>
+        <target>Plan not found.</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -1132,7 +1132,7 @@
     <unit id="app.title">
       <notes>
         <note category="location">web/src/app/app.html:11,12</note>
-        <note category="location">web/src/app/app.html:133,134</note>
+        <note category="location">web/src/app/app.html:143,144</note>
       </notes>
       <segment>
         <source>Pushups</source>
@@ -1141,8 +1141,8 @@
     <unit id="nav.dashboard">
       <notes>
         <note category="location">web/src/app/app.html:23,26</note>
-        <note category="location">web/src/app/app.html:164,166</note>
-        <note category="location">web/src/app/app.html:213,215</note>
+        <note category="location">web/src/app/app.html:174,176</note>
+        <note category="location">web/src/app/app.html:223,225</note>
       </notes>
       <segment>
         <source>Dashboard</source>
@@ -1151,8 +1151,8 @@
     <unit id="nav.analysis">
       <notes>
         <note category="location">web/src/app/app.html:33,36</note>
-        <note category="location">web/src/app/app.html:168,170</note>
-        <note category="location">web/src/app/app.html:217,219</note>
+        <note category="location">web/src/app/app.html:178,180</note>
+        <note category="location">web/src/app/app.html:227,229</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -1161,8 +1161,8 @@
     <unit id="nav.leaderboard">
       <notes>
         <note category="location">web/src/app/app.html:43,47</note>
-        <note category="location">web/src/app/app.html:172,174</note>
-        <note category="location">web/src/app/app.html:221,223</note>
+        <note category="location">web/src/app/app.html:182,184</note>
+        <note category="location">web/src/app/app.html:231,233</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -1171,8 +1171,8 @@
     <unit id="nav.blog">
       <notes>
         <note category="location">web/src/app/app.html:53,56</note>
-        <note category="location">web/src/app/app.html:176,178</note>
-        <note category="location">web/src/app/app.html:225,227</note>
+        <note category="location">web/src/app/app.html:186,188</note>
+        <note category="location">web/src/app/app.html:235,237</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -1186,9 +1186,17 @@
         <source>Historie</source>
       </segment>
     </unit>
-    <unit id="nav.reminders">
+    <unit id="nav.trainingPlans">
       <notes>
         <note category="location">web/src/app/app.html:74,78</note>
+      </notes>
+      <segment>
+        <source>Trainingspläne</source>
+      </segment>
+    </unit>
+    <unit id="nav.reminders">
+      <notes>
+        <note category="location">web/src/app/app.html:84,88</note>
       </notes>
       <segment>
         <source>Erinnerungen</source>
@@ -1196,7 +1204,7 @@
     </unit>
     <unit id="nav.language">
       <notes>
-        <note category="location">web/src/app/app.html:85,88</note>
+        <note category="location">web/src/app/app.html:95,98</note>
       </notes>
       <segment>
         <source> Sprache </source>
@@ -1204,7 +1212,7 @@
     </unit>
     <unit id="nav.lang.de">
       <notes>
-        <note category="location">web/src/app/app.html:94,97</note>
+        <note category="location">web/src/app/app.html:104,107</note>
       </notes>
       <segment>
         <source>Deutsch</source>
@@ -1212,7 +1220,7 @@
     </unit>
     <unit id="nav.lang.en">
       <notes>
-        <note category="location">web/src/app/app.html:103,105</note>
+        <note category="location">web/src/app/app.html:113,115</note>
       </notes>
       <segment>
         <source>English</source>
@@ -1220,7 +1228,7 @@
     </unit>
     <unit id="nav.aria">
       <notes>
-        <note category="location">web/src/app/app.html:112,113</note>
+        <note category="location">web/src/app/app.html:122,123</note>
       </notes>
       <segment>
         <source>Pushup Navigation</source>
@@ -1228,7 +1236,7 @@
     </unit>
     <unit id="nav.openMenu">
       <notes>
-        <note category="location">web/src/app/app.html:118,119</note>
+        <note category="location">web/src/app/app.html:128,129</note>
       </notes>
       <segment>
         <source>Menü öffnen</source>
@@ -1236,7 +1244,7 @@
     </unit>
     <unit id="nav.toLanding">
       <notes>
-        <note category="location">web/src/app/app.html:128,129</note>
+        <note category="location">web/src/app/app.html:138,139</note>
       </notes>
       <segment>
         <source>Zur Landingpage</source>
@@ -1244,7 +1252,7 @@
     </unit>
     <unit id="toolbarDailyGoal">
       <notes>
-        <note category="location">web/src/app/app.html:136,137</note>
+        <note category="location">web/src/app/app.html:146,147</note>
       </notes>
       <segment>
         <source>Tagesziel</source>
@@ -1252,7 +1260,7 @@
     </unit>
     <unit id="nav.admin">
       <notes>
-        <note category="location">web/src/app/app.html:144,145</note>
+        <note category="location">web/src/app/app.html:154,155</note>
       </notes>
       <segment>
         <source>Admin-Bereich</source>
@@ -1260,7 +1268,7 @@
     </unit>
     <unit id="nav.desktop.aria">
       <notes>
-        <note category="location">web/src/app/app.html:155,156</note>
+        <note category="location">web/src/app/app.html:165,166</note>
       </notes>
       <segment>
         <source>Hauptnavigation</source>
@@ -1268,7 +1276,7 @@
     </unit>
     <unit id="footer.aria">
       <notes>
-        <note category="location">web/src/app/app.html:185</note>
+        <note category="location">web/src/app/app.html:195</note>
       </notes>
       <segment>
         <source>Rechtliches</source>
@@ -1276,7 +1284,7 @@
     </unit>
     <unit id="footer.impressum">
       <notes>
-        <note category="location">web/src/app/app.html:187,189</note>
+        <note category="location">web/src/app/app.html:197,199</note>
       </notes>
       <segment>
         <source>Impressum</source>
@@ -1284,7 +1292,7 @@
     </unit>
     <unit id="footer.datenschutz">
       <notes>
-        <note category="location">web/src/app/app.html:190,193</note>
+        <note category="location">web/src/app/app.html:200,203</note>
       </notes>
       <segment>
         <source>Datenschutz</source>
@@ -1292,7 +1300,7 @@
     </unit>
     <unit id="footer.cookies">
       <notes>
-        <note category="location">web/src/app/app.html:197,199</note>
+        <note category="location">web/src/app/app.html:207,209</note>
       </notes>
       <segment>
         <source> Cookie-Einstellungen </source>
@@ -1300,7 +1308,7 @@
     </unit>
     <unit id="nav.bottom.aria">
       <notes>
-        <note category="location">web/src/app/app.html:204,205</note>
+        <note category="location">web/src/app/app.html:214,215</note>
       </notes>
       <segment>
         <source>Mobile-Navigation</source>
@@ -1418,9 +1426,25 @@
         <source>Verwalte Profil, Leaderboard-Sichtbarkeit und Tagesziel-Einstellungen.</source>
       </segment>
     </unit>
-    <unit id="seo.reminders.title">
+    <unit id="seo.trainingPlans.title">
       <notes>
         <note category="location">web/src/app/app.routes.ts:98</note>
+      </notes>
+      <segment>
+        <source>Trainingspläne – Pushup Tracker</source>
+      </segment>
+    </unit>
+    <unit id="seo.trainingPlans.description">
+      <notes>
+        <note category="location">web/src/app/app.routes.ts:99</note>
+      </notes>
+      <segment>
+        <source>Strukturierte Liegestütz-Trainingspläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung.</source>
+      </segment>
+    </unit>
+    <unit id="seo.reminders.title">
+      <notes>
+        <note category="location">web/src/app/app.routes.ts:118</note>
       </notes>
       <segment>
         <source>Erinnerungen – Pushup Tracker</source>
@@ -1428,7 +1452,7 @@
     </unit>
     <unit id="seo.reminders.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:99</note>
+        <note category="location">web/src/app/app.routes.ts:119</note>
       </notes>
       <segment>
         <source>Konfiguriere Liegestütz-Erinnerungen und Push-Benachrichtigungen.</source>
@@ -1436,7 +1460,7 @@
     </unit>
     <unit id="seo.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:109</note>
+        <note category="location">web/src/app/app.routes.ts:129</note>
       </notes>
       <segment>
         <source>Bestenliste – Pushup Tracker</source>
@@ -1444,7 +1468,7 @@
     </unit>
     <unit id="seo.leaderboard.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:110</note>
+        <note category="location">web/src/app/app.routes.ts:130</note>
       </notes>
       <segment>
         <source>Öffentliche Bestenliste für tägliche, wöchentliche und monatliche Pushup-Reps.</source>
@@ -1452,7 +1476,7 @@
     </unit>
     <unit id="seo.blog.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:124</note>
+        <note category="location">web/src/app/app.routes.ts:144</note>
       </notes>
       <segment>
         <source>Blog – Liegestütze Tipps &amp; Guides | Pushup Tracker</source>
@@ -1460,7 +1484,7 @@
     </unit>
     <unit id="seo.blog.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:125</note>
+        <note category="location">web/src/app/app.routes.ts:145</note>
       </notes>
       <segment>
         <source>Tipps, Trainingspläne und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten.</source>
@@ -1468,7 +1492,7 @@
     </unit>
     <unit id="seo.impressum.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:142</note>
+        <note category="location">web/src/app/app.routes.ts:162</note>
       </notes>
       <segment>
         <source>Impressum – Pushup Tracker</source>
@@ -1476,7 +1500,7 @@
     </unit>
     <unit id="seo.impressum.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:143</note>
+        <note category="location">web/src/app/app.routes.ts:163</note>
       </notes>
       <segment>
         <source>Impressum und Anbieterkennzeichnung von Pushup Tracker.</source>
@@ -1484,7 +1508,7 @@
     </unit>
     <unit id="seo.datenschutz.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:153</note>
+        <note category="location">web/src/app/app.routes.ts:173</note>
       </notes>
       <segment>
         <source>Datenschutzerklärung – Pushup Tracker</source>
@@ -1492,7 +1516,7 @@
     </unit>
     <unit id="seo.datenschutz.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:154</note>
+        <note category="location">web/src/app/app.routes.ts:174</note>
       </notes>
       <segment>
         <source>Datenschutzerklärung von Pushup Tracker – Informationen zu Datenverarbeitung, Cookies und Ihren Rechten.</source>
@@ -4097,81 +4121,9 @@
         <source> Live: <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;verbunden&apos; : &apos;getrennt&apos; }}"/> </source>
       </segment>
     </unit>
-    <unit id="todayFocusAria">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:30,31</note>
-      </notes>
-      <segment>
-        <source>Tagesfokus</source>
-      </segment>
-    </unit>
-    <unit id="dashboard.todayTotal">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:36,38</note>
-      </notes>
-      <segment>
-        <source>Heute Gesamt</source>
-      </segment>
-    </unit>
-    <unit id="goalProgressTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:47,49</note>
-      </notes>
-      <segment>
-        <source>Zielfortschritt</source>
-      </segment>
-    </unit>
-    <unit id="dashboard.dailyGoalLabel">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:52,53</note>
-      </notes>
-      <segment>
-        <source>Tag</source>
-      </segment>
-    </unit>
-    <unit id="dashboard.weeklyGoalLabel">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:61,62</note>
-      </notes>
-      <segment>
-        <source>Woche</source>
-      </segment>
-    </unit>
-    <unit id="dashboard.monthlyGoalLabel">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:70,71</note>
-      </notes>
-      <segment>
-        <source>Monat</source>
-      </segment>
-    </unit>
-    <unit id="lastEntryTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:89,90</note>
-      </notes>
-      <segment>
-        <source>Letzter Eintrag</source>
-      </segment>
-    </unit>
-    <unit id="latEntryReps">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:94,96</note>
-      </notes>
-      <segment>
-        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/> </source>
-      </segment>
-    </unit>
-    <unit id="dashboard.noEntryYet">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:98,100</note>
-      </notes>
-      <segment>
-        <source>Noch kein Eintrag.</source>
-      </segment>
-    </unit>
     <unit id="allTimeSummaryAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:106,107</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:30,31</note>
       </notes>
       <segment>
         <source>All-Time Kurzübersicht</source>
@@ -4179,7 +4131,7 @@
     </unit>
     <unit id="allTimeTotal">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:110,111</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:34,35</note>
       </notes>
       <segment>
         <source>All-Time Gesamt</source>
@@ -4187,7 +4139,7 @@
     </unit>
     <unit id="allTimeDays">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:114,115</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:38,39</note>
       </notes>
       <segment>
         <source>All-Time Tage</source>
@@ -4195,7 +4147,7 @@
     </unit>
     <unit id="allTimeEntries">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:118,119</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:42,43</note>
       </notes>
       <segment>
         <source>All-Time Einträge</source>
@@ -4203,15 +4155,143 @@
     </unit>
     <unit id="allTimeAvg">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:122,123</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:46,47</note>
       </notes>
       <segment>
         <source>All-Time Ø/Tag</source>
       </segment>
     </unit>
+    <unit id="trainingPlans.day">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:59,60</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:45,46</note>
+      </notes>
+      <segment>
+        <source>Tag</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.kind.rest">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:62,63</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:136,138</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:59,60</note>
+      </notes>
+      <segment>
+        <source>Ruhetag</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.kind.light">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:65,66</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:62,63</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.kind.test">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:67,69</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:65,67</note>
+      </notes>
+      <segment>
+        <source>Maximaltest</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.reps">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:70,72</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:134,135</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:77,79</note>
+      </notes>
+      <segment>
+        <source>Wdh.</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.openDetail">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:79,81</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:101,103</note>
+      </notes>
+      <segment>
+        <source> Details öffnen </source>
+      </segment>
+    </unit>
+    <unit id="todayFocusAria">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:88,89</note>
+      </notes>
+      <segment>
+        <source>Tagesfokus</source>
+      </segment>
+    </unit>
+    <unit id="dashboard.todayTotal">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:94,96</note>
+      </notes>
+      <segment>
+        <source>Heute Gesamt</source>
+      </segment>
+    </unit>
+    <unit id="goalProgressTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:105,107</note>
+      </notes>
+      <segment>
+        <source>Zielfortschritt</source>
+      </segment>
+    </unit>
+    <unit id="dashboard.dailyGoalLabel">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:110,111</note>
+      </notes>
+      <segment>
+        <source>Tag</source>
+      </segment>
+    </unit>
+    <unit id="dashboard.weeklyGoalLabel">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:119,120</note>
+      </notes>
+      <segment>
+        <source>Woche</source>
+      </segment>
+    </unit>
+    <unit id="dashboard.monthlyGoalLabel">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:128,129</note>
+      </notes>
+      <segment>
+        <source>Monat</source>
+      </segment>
+    </unit>
+    <unit id="lastEntryTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:147,148</note>
+      </notes>
+      <segment>
+        <source>Letzter Eintrag</source>
+      </segment>
+    </unit>
+    <unit id="latEntryReps">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:152,154</note>
+      </notes>
+      <segment>
+        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/> </source>
+      </segment>
+    </unit>
+    <unit id="dashboard.noEntryYet">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:156,158</note>
+      </notes>
+      <segment>
+        <source>Noch kein Eintrag.</source>
+      </segment>
+    </unit>
     <unit id="quickActionsTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:130,132</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:165,167</note>
       </notes>
       <segment>
         <source>Schnellaktionen</source>
@@ -4219,7 +4299,7 @@
     </unit>
     <unit id="quickActionsSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:133,135</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:168,170</note>
       </notes>
       <segment>
         <source>Schnell eintragen ohne Dialog</source>
@@ -4227,7 +4307,7 @@
     </unit>
     <unit id="quickActions.edit.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:140,141</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:175,176</note>
       </notes>
       <segment>
         <source>Schnellaktionen bearbeiten</source>
@@ -4235,7 +4315,7 @@
     </unit>
     <unit id="dashboard.quickAdd.button">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:162,163</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:197,198</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
@@ -4243,7 +4323,7 @@
     </unit>
     <unit id="dashboard.goalFill.reached">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:176,178</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:211,213</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -4251,7 +4331,7 @@
     </unit>
     <unit id="dashboard.goalFill.fill">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:179,180</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:214,215</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> bis zum Ziel</source>
@@ -4259,7 +4339,7 @@
     </unit>
     <unit id="quickAddNew">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:191,193</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:226,228</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">edit_note</pc> Neu </source>
@@ -4267,7 +4347,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:210,214</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:245,249</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -4275,7 +4355,7 @@
     </unit>
     <unit id="dashboard.latestEntriesLinkAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:214,224</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:256,257</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -4283,7 +4363,7 @@
     </unit>
     <unit id="dashboard.latestEntries">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:225,226</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:259,260</note>
       </notes>
       <segment>
         <source>Letzte Einträge</source>
@@ -4291,7 +4371,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:230,231</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:266,267</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -4299,7 +4379,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:234,236</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:270,273</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -4307,10 +4387,200 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:220</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:276</note>
       </notes>
       <segment>
         <source>Werbung</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.back">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:37</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:178,180</note>
+      </notes>
+      <segment>
+        <source>Zurück</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.daysSuffix">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:47,48</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:116,118</note>
+      </notes>
+      <segment>
+        <source>Tage</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.level.beginner">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:50,51</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:121,123</note>
+      </notes>
+      <segment>
+        <source>Einsteiger</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.level.intermediate">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:52,54</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:125,127</note>
+      </notes>
+      <segment>
+        <source>Mittelstufe</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.level.advanced">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:54,56</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:129,131</note>
+      </notes>
+      <segment>
+        <source>Fortgeschritten</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.progress">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:63,64</note>
+      </notes>
+      <segment>
+        <source>Fortschritt</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.currentDay">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:69,70</note>
+      </notes>
+      <segment>
+        <source>Aktueller Tag:</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.abandon">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:76,78</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:92,94</note>
+      </notes>
+      <segment>
+        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">cancel</pc> Plan beenden </source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.startCta">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:85,87</note>
+      </notes>
+      <segment>
+        <source> Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt. </source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.replaceWarn">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:91,93</note>
+      </notes>
+      <segment>
+        <source> Achtung: Dies ersetzt den aktuell aktiven Plan. </source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.start">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:96,98</note>
+      </notes>
+      <segment>
+        <source>Plan starten</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.week">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:105,106</note>
+      </notes>
+      <segment>
+        <source>Woche</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unmarkAria">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:150,151</note>
+      </notes>
+      <segment>
+        <source>Als nicht erledigt markieren</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.markAria">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:159,160</note>
+      </notes>
+      <segment>
+        <source>Als erledigt markieren</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.notFound">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:175,176</note>
+      </notes>
+      <segment>
+        <source>Plan nicht gefunden.</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.started">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:332</note>
+      </notes>
+      <segment>
+        <source>Plan gestartet — viel Erfolg!</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.abandoned">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:341</note>
+      </notes>
+      <segment>
+        <source>Plan beendet.</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.title">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:24,25</note>
+      </notes>
+      <segment>
+        <source>Trainingspläne</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.intro">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:26,29</note>
+      </notes>
+      <segment>
+        <source> Strukturierte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Starte einen Plan, und dein Tagesziel im Dashboard wird automatisch gesetzt. </source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.active.title">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:36,37</note>
+      </notes>
+      <segment>
+        <source> Aktiver Plan </source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.kind.main">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:68,70</note>
+      </notes>
+      <segment>
+        <source>Trainingstag</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.todayTarget">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:74,76</note>
+      </notes>
+      <segment>
+        <source>Heute geplant:</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.viewPlan">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:145,147</note>
+      </notes>
+      <segment>
+        <source>Plan ansehen</source>
       </segment>
     </unit>
   </file>


### PR DESCRIPTION
Three curated plans (6-week buildup, 30-day challenge, 4-week over-40)
with per-day target reps, sets, and a `kind` (main/light/rest/test)
that drives the dashboard goal pill and the plan detail page.
Day targets are anchored on the existing blog articles so users land
on a plan they have already read about.

Active-plan state lives at `userTrainingPlans/{userId}` and is exposed
via a real-time `TrainingPlanStore`. When a plan is active, the
dashboard's daily goal follows the plan's day; otherwise the
user-configured goal stays in effect. Single active plan per user —
starting another replaces the doc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Training Plans" section accessible from main navigation
  * Browse predefined training plans with summaries, duration, and difficulty levels
  * Start a plan and track daily progress directly on the dashboard
  * Mark individual workouts complete or incomplete as you progress
  * Abandon plans anytime to switch between training programs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->