### PR TITLE
feat(training-plans): log pushup entry when completing a plan day

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,8 @@ When making changes, always write or update relevant tests as part of the same c
 - **Never** instantiate Angular services, guards, or components with `new` when they depend on DI. Use `TestBed` or `@testing-library/angular`'s `render`.
 - **Guards** must be tested in a real Angular router/TestBed context, not as plain functions.
 - **Mock providers via Angular DI** (`{ provide: ..., useValue: ... }`), not by patching `inject()` directly.
-- **External functions** (e.g. `deleteUser` from Firebase) are mocked on the imported module — never with dynamic `import()` or `require()`.
+- **External functions** (e.g. `deleteUser` from Firebase) are mocked on the imported module — never with dynamic `import()` or `require()`. Use a static `import * as ns from '@angular/fire/firestore'` and reference `ns.doc`/`ns.docData` after `jest.mock(...)`; avoid repeating `await import(...)` per test.
+- **`PLATFORM_ID: 'server'` in tests for stores that start a `setInterval` / browser-only timer** in `withHooks`. Otherwise the timer leaks across `TestBed.resetTestingModule()` and tests pile up wall-clock work.
 - **Given-When-Then** style tests are preferred.
 
 ## Tech Stack
@@ -81,9 +82,10 @@ When making changes, always write or update relevant tests as part of the same c
   - `MotivationStore` - quote cache with user-keyed localStorage (motivation module)
   - `LiveDataStore` - Firestore real-time entries + tick (data-access, browser-only)
   - `LeaderboardStore` - shared leaderboard data with `load({ force })` (data-access)
+  - `TrainingPlanStore` - active training plan, derived "today" state, plan-day mutation methods (app-level)
   - `AuthStore`, `ReminderStore`, `PushSubscriptionStore`, `ThemeService` (existing)
 - **Feature/form state:** signalStore with component-level DI
-  - `DashboardStore` - stats, goals, ads, motivation for dashboard page
+  - `DashboardStore` - stats, goals, ads, motivation, plan-day target override for dashboard page
   - `AnalysisStore` - date filters, trends, breakdowns for analysis page
   - `EntriesStore` - CRUD, filters, browser/SSR hybrid for entries page
   - `ReminderFormStore`, `LoginUiStore`, `RegisterUiStore` (existing)
@@ -120,6 +122,15 @@ UI Component  →  Signal Store  →  API Service
 - Both modes return `CreateEntryResult` on submit. The stats table's `openEditDialog()` maps the result back to an update emission.
 - **Sets UX:** Starts with a single "Reps" field. A "+" button adds sets (pre-filled from previous value). Multi-set mode shows "Set 1", "Set 2", etc. with remove buttons and a total display.
 
+**Training Plans (curated catalog + active-plan state):**
+
+- **Catalog** (`libs/stats/src/lib/models/training-plan.catalog.ts`): static, versioned plan definitions with per-day `kind` (`main`/`light`/`rest`/`test`), `targetReps`, optional `sets[]`, and bilingual descriptions (`description` / `descriptionEn`). Plan IDs carry a `-vN` suffix so old `UserTrainingPlan` docs keep resolving when targets change.
+- **Per-user state** (`userTrainingPlans/{userId}` in Firestore): `planId`, `startDate`, `status`, `completedDays[]`. Single active plan per user; starting another overwrites the doc.
+- **Locale-aware rendering:** `localizePlan(plan, LOCALE_ID)` swaps title/summary/description fields. The catalog stores both languages because plans are structured curated data — putting them in XLIFF would lose the per-day pairing.
+- **Single source of truth = `pushups` collection:** the `completedDays` flag is a UI shortcut. `logPlanDay(idx)` writes a real `pushups` entry (with `source: 'plan'`, plan-prescribed sets, noon timestamp on the plan day's calendar date) AND flips the flag. Without the entry, stats/streaks/leaderboard wouldn't reflect the workout.
+- **Auto-mark via `effect()` in `withHooks`:** when `LiveDataStore.entries()` push today's reps past the plan target, today's flag flips automatically — read-only, never creates a new entry. Lets the existing Quick-Add/dialog flows propagate plan progress without an explicit button click.
+- **Day-tick signal:** Berlin-date-based `currentDayIndex()` has no inherent signal dependency, so a long-running browser tab caches the previous calendar day past midnight. The store ticks an internal `_dayTick` signal once a minute (browser-only) so derived day state recomputes within ~60 s of midnight.
+
 ### Module Boundary Rules
 
 Enforced via `@nx/enforce-module-boundaries` in `eslint.config.mjs`:
@@ -141,6 +152,8 @@ Split into focused files under `libs/stats/src/lib/models/`:
 - `user-config.models.ts` - UserConfig, UserConfigUpdate
 - `reminder-config.models.ts` - ReminderConfig
 - `user-stats.models.ts` - UserStats (server-side precomputed), emptyUserStats, USERSTATS_VERSION
+- `training-plan.models.ts` - TrainingPlan, TrainingPlanDay, UserTrainingPlan, `localizePlan()`, `currentPlanDayIndex()`, `planDayByIndex()`, `isPlanCompleted()`. `parseIsoDate` round-trips Y/M/D after `new Date()` to reject impossible dates like `2026-02-30`.
+- `training-plan.catalog.ts` - curated `TRAINING_PLANS` array + `findPlanById()` / `findPlanBySlug()` lookups. Test invariant: every plan's day indexes form a contiguous `1..totalDays` sequence and rest days have `targetReps === 0`.
   - UserStats includes a `version` field for migration support. See [`docs/gotchas/cloud-functions.md`](docs/gotchas/cloud-functions.md) for the versioning strategy.
 
 ## Commands
@@ -201,6 +214,22 @@ A separate Firebase project (`pushup-stats-staging-867b7`) provides full isolati
 - **Firestore region:** `europe-west3` (Frankfurt). Must match when creating the database in Firebase Console.
 - **Firestore rules & indexes** are shared source files (`data-store/firestore.rules`, `data-store/firestore.indexes.json`) deployed to both projects.
 - **Infra scripts:** `infra/setup-staging.sh` automates full project setup (APIs, SA, IAM, secrets); `infra/teardown-staging.sh` removes deploy resources. Both support `--dry-run`.
+
+### Firestore Rules — adding a new collection
+
+`data-store/firestore.rules` ends with a deny-all fallback (`match /{document=**} { allow read, write: if false; }`). **Every new collection a client reads or writes needs a matching `match` block** — without it, authenticated users hit `permission-denied` in production. Both PR preview and merge deploy run `firebase deploy --only functions,firestore`, so the rules ship together with the code, but propagation can lag the hosting deploy by 10–30 s; staging-preview testers may briefly see permission errors on the first request after a redeploy.
+
+Default pattern for owner-only single-doc-per-user collections (e.g. `userTrainingPlans`):
+
+```
+match /userTrainingPlans/{userId} {
+  allow read: if request.auth != null && request.auth.uid == userId;
+  allow create, update: if request.auth != null
+                        && request.auth.uid == userId
+                        && request.resource.data.userId == userId;
+  allow delete: if request.auth != null && request.auth.uid == userId;
+}
+```
 
 ## Pre-Push Checklist
 

--- a/libs/data-access/src/lib/api/user-training-plan-api.service.spec.ts
+++ b/libs/data-access/src/lib/api/user-training-plan-api.service.spec.ts
@@ -16,6 +16,15 @@ jest.mock('@angular/fire/firestore', () => ({
   doc: jest.fn(),
   docData: jest.fn(),
   setDoc: jest.fn(() => Promise.resolve()),
+  updateDoc: jest.fn(() => Promise.resolve()),
+  arrayUnion: jest.fn((...values: unknown[]) => ({
+    __type: 'arrayUnion',
+    values,
+  })),
+  arrayRemove: jest.fn((...values: unknown[]) => ({
+    __type: 'arrayRemove',
+    values,
+  })),
 }));
 
 describe('UserTrainingPlanApiService', () => {
@@ -161,6 +170,60 @@ describe('UserTrainingPlanApiService', () => {
         userId: 'u',
       }),
       { merge: true }
+    );
+  });
+
+  it('uses arrayUnion for addCompletedDay so concurrent writes merge atomically', async () => {
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
+
+    const { fixture } = await render('', {
+      providers: [
+        UserTrainingPlanApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'u' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(
+      UserTrainingPlanApiService
+    );
+    service.addCompletedDay('u', 5).subscribe();
+
+    await Promise.resolve();
+    expect(firestoreFns.arrayUnion).toHaveBeenCalledWith(5);
+    expect(firestoreFns.updateDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        completedDays: expect.objectContaining({ __type: 'arrayUnion' }),
+      })
+    );
+  });
+
+  it('uses arrayRemove for removeCompletedDay', async () => {
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
+
+    const { fixture } = await render('', {
+      providers: [
+        UserTrainingPlanApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'u' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(
+      UserTrainingPlanApiService
+    );
+    service.removeCompletedDay('u', 2).subscribe();
+
+    await Promise.resolve();
+    expect(firestoreFns.arrayRemove).toHaveBeenCalledWith(2);
+    expect(firestoreFns.updateDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        completedDays: expect.objectContaining({ __type: 'arrayRemove' }),
+      })
     );
   });
 });

--- a/libs/data-access/src/lib/api/user-training-plan-api.service.ts
+++ b/libs/data-access/src/lib/api/user-training-plan-api.service.ts
@@ -1,11 +1,14 @@
 import { inject, Injectable } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
 import {
+  arrayRemove,
+  arrayUnion,
   doc,
   docData,
   DocumentReference,
   Firestore,
   setDoc,
+  updateDoc,
 } from '@angular/fire/firestore';
 import { UserTrainingPlan, UserTrainingPlanUpdate } from '@pu-stats/models';
 import { from, map, Observable, of } from 'rxjs';
@@ -76,6 +79,39 @@ export class UserTrainingPlanApiService {
           }) as UserTrainingPlan
       )
     );
+  }
+
+  /**
+   * Atomic add/remove for `completedDays`. The default `updatePlan`
+   * path overwrites the whole array via `setDoc({merge:true})`, so
+   * two concurrent in-flight writes (e.g. auto-mark for today racing
+   * with a manual `logPlanDay(yesterday)`) can drop a completion.
+   * `arrayUnion`/`arrayRemove` work at the field-element level, so
+   * concurrent writes to *different* day indexes are merged
+   * correctly server-side.
+   */
+  addCompletedDay(userId: string, dayIndex: number): Observable<void> {
+    const effectiveUserId = this.resolveUserId(userId);
+    if (!effectiveUserId || !this.firestore) return of(void 0);
+    const ref = this.docRef(effectiveUserId);
+    return from(
+      updateDoc(ref, {
+        completedDays: arrayUnion(dayIndex),
+        updatedAt: new Date().toISOString(),
+      })
+    ).pipe(map(() => void 0));
+  }
+
+  removeCompletedDay(userId: string, dayIndex: number): Observable<void> {
+    const effectiveUserId = this.resolveUserId(userId);
+    if (!effectiveUserId || !this.firestore) return of(void 0);
+    const ref = this.docRef(effectiveUserId);
+    return from(
+      updateDoc(ref, {
+        completedDays: arrayRemove(dayIndex),
+        updatedAt: new Date().toISOString(),
+      })
+    ).pipe(map(() => void 0));
   }
 
   /**

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -18,7 +18,7 @@ import {
   localizePlan,
   TrainingPlanDay,
 } from '@pu-stats/models';
-import { TrainingPlanStore } from './training-plan.store';
+import { LogPlanDayResult, TrainingPlanStore } from './training-plan.store';
 
 interface DayRow {
   day: TrainingPlanDay;
@@ -200,15 +200,17 @@ interface DayRow {
                           <mat-icon>check_circle</mat-icon>
                         </button>
                       } @else {
-                        <button
-                          mat-icon-button
-                          color="primary"
-                          (click)="logPlanDay(row.day.dayIndex)"
-                          aria-label="Plan-Sätze eintragen und als erledigt markieren"
-                          i18n-aria-label="@@trainingPlans.logAria"
-                        >
-                          <mat-icon>play_circle</mat-icon>
-                        </button>
+                        @if (row.day.targetReps > 0) {
+                          <button
+                            mat-icon-button
+                            color="primary"
+                            (click)="logPlanDay(row.day.dayIndex)"
+                            aria-label="Plan-Sätze eintragen und als erledigt markieren"
+                            i18n-aria-label="@@trainingPlans.logAria"
+                          >
+                            <mat-icon>play_circle</mat-icon>
+                          </button>
+                        }
                         <button
                           mat-icon-button
                           (click)="mark(row.day.dayIndex)"
@@ -421,11 +423,24 @@ export class TrainingPlanDetailComponent {
   }
 
   async logPlanDay(dayIndex: number): Promise<void> {
-    await this.store.logPlanDay(dayIndex);
-    this.snackbar.open(
-      $localize`:@@trainingPlans.logged:Plan-Sätze wurden eingetragen.`,
-      undefined,
-      { duration: 3000 }
-    );
+    const result = await this.store.logPlanDay(dayIndex);
+    const message = this.messageForLogResult(result);
+    if (message) {
+      this.snackbar.open(message, undefined, { duration: 3000 });
+    }
+  }
+
+  private messageForLogResult(result: LogPlanDayResult): string | null {
+    switch (result) {
+      case 'logged':
+        return $localize`:@@trainingPlans.logged:Plan-Sätze wurden eingetragen.`;
+      case 'already-logged':
+        return $localize`:@@trainingPlans.alreadyLogged:Tag war schon eingetragen — als erledigt markiert.`;
+      case 'not-ready':
+        return $localize`:@@trainingPlans.notReady:Daten werden noch geladen, bitte gleich noch einmal versuchen.`;
+      case 'in-flight':
+      case 'noop':
+        return null;
+    }
   }
 }

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -202,8 +202,17 @@ interface DayRow {
                       } @else {
                         <button
                           mat-icon-button
+                          color="primary"
+                          (click)="logPlanDay(row.day.dayIndex)"
+                          aria-label="Plan-Sätze eintragen und als erledigt markieren"
+                          i18n-aria-label="@@trainingPlans.logAria"
+                        >
+                          <mat-icon>play_circle</mat-icon>
+                        </button>
+                        <button
+                          mat-icon-button
                           (click)="mark(row.day.dayIndex)"
-                          aria-label="Als erledigt markieren"
+                          aria-label="Nur als erledigt markieren (ohne Eintrag)"
                           i18n-aria-label="@@trainingPlans.markAria"
                         >
                           <mat-icon>radio_button_unchecked</mat-icon>
@@ -409,5 +418,14 @@ export class TrainingPlanDetailComponent {
 
   async unmark(dayIndex: number): Promise<void> {
     await this.store.unmarkDayDone(dayIndex);
+  }
+
+  async logPlanDay(dayIndex: number): Promise<void> {
+    await this.store.logPlanDay(dayIndex);
+    this.snackbar.open(
+      $localize`:@@trainingPlans.logged:Plan-Sätze wurden eingetragen.`,
+      undefined,
+      { duration: 3000 }
+    );
   }
 }

--- a/web/src/app/training-plans/training-plan.store.spec.ts
+++ b/web/src/app/training-plans/training-plan.store.spec.ts
@@ -281,26 +281,24 @@ describe('TrainingPlanStore', () => {
 
   describe('logPlanDay', () => {
     it('creates a pushup entry with the plan sets and marks the day done', async () => {
-      const today = toBerlinIsoDate(new Date());
+      // Day 2 is a main day with sets [20, 20, 20] and target 60.
+      // We seed startDate one day in the past so day 2 == today
+      // (logPlanDay rejects future days).
+      const yesterdayIso = toBerlinIsoDate(
+        new Date(Date.now() - 86_400_000)
+      );
       const { store, mocks } = setup({
         userId: 'u1',
         planId: PLAN.id,
-        startDate: today,
+        startDate: yesterdayIso,
         status: 'active',
         completedDays: [],
       });
       await flush();
 
-      // Day 2 is a main day with sets [20, 20, 20] and target 60.
       const day2 = PLAN.days[1];
       expect(day2.kind).toBe('main');
       expect(day2.targetReps).toBeGreaterThan(0);
-
-      // Day 2 = startDate + 1
-      const yesterday = toBerlinIsoDate(new Date());
-      void yesterday;
-      // (we just need the create call; date computation is verified
-      // implicitly by the timestamp passed to createPushup)
 
       await store.logPlanDay(2);
       await flush();

--- a/web/src/app/training-plans/training-plan.store.spec.ts
+++ b/web/src/app/training-plans/training-plan.store.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { PLATFORM_ID, signal } from '@angular/core';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, from, map, of } from 'rxjs';
 import { UserContextService } from '@pu-auth/auth';
 import {
   LiveDataStore,
@@ -25,6 +25,8 @@ interface Mocks {
     getActivePlan: ReturnType<typeof vitest.fn>;
     setPlan: ReturnType<typeof vitest.fn>;
     updatePlan: ReturnType<typeof vitest.fn>;
+    addCompletedDay: ReturnType<typeof vitest.fn>;
+    removeCompletedDay: ReturnType<typeof vitest.fn>;
   };
   statsApiMock: {
     createPushup: ReturnType<typeof vitest.fn>;
@@ -70,6 +72,30 @@ describe('TrainingPlanStore', () => {
             return new BehaviorSubject(mocks.current).asObservable();
           }
         ),
+        addCompletedDay: vitest.fn((_uid: string, dayIndex: number) => {
+          const cur = mocks.current as UserTrainingPlan;
+          if (!cur.completedDays.includes(dayIndex)) {
+            mocks.current = {
+              ...cur,
+              completedDays: [...cur.completedDays, dayIndex].sort(
+                (x, y) => x - y
+              ),
+            };
+            stream.next(mocks.current);
+          }
+          return of(void 0);
+        }),
+        removeCompletedDay: vitest.fn((_uid: string, dayIndex: number) => {
+          const cur = mocks.current as UserTrainingPlan;
+          if (cur.completedDays.includes(dayIndex)) {
+            mocks.current = {
+              ...cur,
+              completedDays: cur.completedDays.filter((d) => d !== dayIndex),
+            };
+            stream.next(mocks.current);
+          }
+          return of(void 0);
+        }),
       },
       statsApiMock: {
         createPushup: vitest.fn((payload: PushupCreate) =>
@@ -155,10 +181,7 @@ describe('TrainingPlanStore', () => {
     await store.markTodayDone();
     await flush();
 
-    expect(mocks.apiMock.updatePlan).toHaveBeenCalledWith(
-      'u1',
-      expect.objectContaining({ completedDays: [1] })
-    );
+    expect(mocks.apiMock.addCompletedDay).toHaveBeenCalledWith('u1', 1);
     expect(store.todayDone()).toBe(true);
   });
 
@@ -273,7 +296,7 @@ describe('TrainingPlanStore', () => {
     await store.markTodayDone();
     await flush();
 
-    expect(mocks.apiMock.updatePlan).not.toHaveBeenCalled();
+    expect(mocks.apiMock.addCompletedDay).not.toHaveBeenCalled();
     expect(store.activePlan()?.completedDays).toEqual([]);
     // Reference unused param to keep tsc happy.
     void todayIso;
@@ -309,10 +332,7 @@ describe('TrainingPlanStore', () => {
       expect(call.sets).toEqual(day2.sets);
       expect(call.source).toBe('plan');
 
-      expect(mocks.apiMock.updatePlan).toHaveBeenCalledWith(
-        'u1',
-        expect.objectContaining({ completedDays: [2] })
-      );
+      expect(mocks.apiMock.addCompletedDay).toHaveBeenCalledWith('u1', 2);
     });
 
     it('skips the pushup write when the day is already covered by existing entries', async () => {
@@ -348,10 +368,7 @@ describe('TrainingPlanStore', () => {
       // Pushup write skipped — user already had enough reps.
       expect(mocks.statsApiMock.createPushup).not.toHaveBeenCalled();
       // Plan day still gets marked done.
-      expect(mocks.apiMock.updatePlan).toHaveBeenCalledWith(
-        'u1',
-        expect.objectContaining({ completedDays: [2] })
-      );
+      expect(mocks.apiMock.addCompletedDay).toHaveBeenCalledWith('u1', 2);
     });
 
     it('tops up only the remainder when partially logged', async () => {
@@ -406,7 +423,136 @@ describe('TrainingPlanStore', () => {
       await flush();
 
       expect(mocks.statsApiMock.createPushup).not.toHaveBeenCalled();
-      expect(mocks.apiMock.updatePlan).not.toHaveBeenCalled();
+      expect(mocks.apiMock.addCompletedDay).not.toHaveBeenCalled();
+    });
+
+    it("returns 'not-ready' when LiveDataStore hasn't connected yet (no writes)", async () => {
+      // Browser PLATFORM_ID is required for the connected check. We
+      // build the store without the SSR shortcut and then assert no
+      // writes happen even though target would otherwise be reached.
+      const today = toBerlinIsoDate(new Date());
+      const target = PLAN.days[1].targetReps;
+      const startDate = toBerlinIsoDate(new Date(Date.now() - 86_400_000));
+      const stream = new BehaviorSubject<UserTrainingPlan | null>({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate,
+        status: 'active',
+        completedDays: [],
+      });
+      const apiMock = {
+        getActivePlan: vitest.fn(() => stream.asObservable()),
+        setPlan: vitest.fn(),
+        updatePlan: vitest.fn(),
+        addCompletedDay: vitest.fn(() => of(void 0)),
+        removeCompletedDay: vitest.fn(() => of(void 0)),
+      };
+      const statsApiMock = { createPushup: vitest.fn() };
+      // Pre-existing entry that DOES cover the target — but
+      // `connected: false` means we shouldn't trust it.
+      const liveEntries = signal<PushupRecord[]>([
+        {
+          _id: 'existing',
+          timestamp: `${today}T08:00:00.000+02:00`,
+          reps: target,
+          source: 'web',
+        },
+      ]);
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: PLATFORM_ID, useValue: 'browser' },
+          { provide: UserTrainingPlanApiService, useValue: apiMock },
+          { provide: StatsApiService, useValue: statsApiMock },
+          {
+            provide: LiveDataStore,
+            useValue: {
+              entries: liveEntries,
+              connected: signal(false),
+              updateTick: signal(0),
+            },
+          },
+          { provide: UserContextService, useValue: { userIdSafe: () => 'u1' } },
+        ],
+      });
+      const store = TestBed.inject(TrainingPlanStore);
+      await flush();
+
+      const result = await store.logPlanDay(2);
+      await flush();
+
+      expect(result).toBe('not-ready');
+      expect(statsApiMock.createPushup).not.toHaveBeenCalled();
+      expect(apiMock.addCompletedDay).not.toHaveBeenCalled();
+      TestBed.resetTestingModule();
+    });
+
+    it("returns 'in-flight' on a concurrent call for the same day (no duplicate writes)", async () => {
+      // Resolver we control to keep the first call hanging until
+      // the second one has had a chance to short-circuit.
+      let releaseFirst: (value: void) => void = () => undefined;
+      const firstWrite = new Promise<void>((res) => (releaseFirst = res));
+      const today = toBerlinIsoDate(new Date());
+      const startDate = toBerlinIsoDate(new Date(Date.now() - 86_400_000));
+      const stream = new BehaviorSubject<UserTrainingPlan | null>({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate,
+        status: 'active',
+        completedDays: [],
+      });
+      const apiMock = {
+        getActivePlan: vitest.fn(() => stream.asObservable()),
+        setPlan: vitest.fn(),
+        updatePlan: vitest.fn(),
+        addCompletedDay: vitest.fn(() => of(void 0)),
+        removeCompletedDay: vitest.fn(() => of(void 0)),
+      };
+      const statsApiMock = {
+        createPushup: vitest.fn(() => from(firstWrite).pipe(map(() => ({})))),
+      };
+      const liveEntries = signal<PushupRecord[]>([]);
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          // SSR PLATFORM_ID so we don't need to also handle the
+          // setInterval. The 'not-ready' branch relies on
+          // _isBrowser, so we explicitly pass through that gate by
+          // setting `connected: true`.
+          { provide: PLATFORM_ID, useValue: 'server' },
+          { provide: UserTrainingPlanApiService, useValue: apiMock },
+          { provide: StatsApiService, useValue: statsApiMock },
+          {
+            provide: LiveDataStore,
+            useValue: {
+              entries: liveEntries,
+              connected: signal(true),
+              updateTick: signal(0),
+            },
+          },
+          { provide: UserContextService, useValue: { userIdSafe: () => 'u1' } },
+        ],
+      });
+      const store = TestBed.inject(TrainingPlanStore);
+      await flush();
+      void today;
+
+      // Kick off two parallel calls. The first is parked inside
+      // createPushup; the second hits the in-flight lock.
+      const firstPromise = store.logPlanDay(2);
+      // Yield so the lock has been acquired.
+      await Promise.resolve();
+      const secondPromise = store.logPlanDay(2);
+
+      const secondResult = await secondPromise;
+      expect(secondResult).toBe('in-flight');
+      expect(statsApiMock.createPushup).toHaveBeenCalledTimes(1);
+
+      releaseFirst();
+      const firstResult = await firstPromise;
+      await flush();
+      expect(firstResult).toBe('logged');
+      expect(apiMock.addCompletedDay).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -437,6 +583,17 @@ describe('TrainingPlanStore', () => {
             return new BehaviorSubject(next).asObservable();
           }
         ),
+        addCompletedDay: vitest.fn((_uid: string, dayIndex: number) => {
+          const cur = stream.value!;
+          stream.next({
+            ...cur,
+            completedDays: [...cur.completedDays, dayIndex].sort(
+              (x, y) => x - y
+            ),
+          });
+          return of(void 0);
+        }),
+        removeCompletedDay: vitest.fn(() => of(void 0)),
       };
       const statsApiMock = {
         createPushup: vitest.fn(),
@@ -466,7 +623,7 @@ describe('TrainingPlanStore', () => {
       await flush();
 
       // Initially no entries — the effect should not have fired.
-      expect(apiMock.updatePlan).not.toHaveBeenCalled();
+      expect(apiMock.addCompletedDay).not.toHaveBeenCalled();
 
       // Simulate the dashboard logging today's reps.
       liveEntries.set([
@@ -479,10 +636,7 @@ describe('TrainingPlanStore', () => {
       ]);
       await flush();
 
-      expect(apiMock.updatePlan).toHaveBeenCalledWith(
-        'u1',
-        expect.objectContaining({ completedDays: [2] })
-      );
+      expect(apiMock.addCompletedDay).toHaveBeenCalledWith('u1', 2);
       // No pushup created — the auto-mark NEVER writes a new entry.
       expect(statsApiMock.createPushup).not.toHaveBeenCalled();
 
@@ -505,9 +659,6 @@ describe('TrainingPlanStore', () => {
     await store.unmarkDayDone(2);
     await flush();
 
-    expect(mocks.apiMock.updatePlan).toHaveBeenCalledWith(
-      'u1',
-      expect.objectContaining({ completedDays: [1, 3] })
-    );
+    expect(mocks.apiMock.removeCompletedDay).toHaveBeenCalledWith('u1', 2);
   });
 });

--- a/web/src/app/training-plans/training-plan.store.spec.ts
+++ b/web/src/app/training-plans/training-plan.store.spec.ts
@@ -1,9 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 import { PLATFORM_ID, signal } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { UserContextService } from '@pu-auth/auth';
-import { UserTrainingPlanApiService } from '@pu-stats/data-access';
 import {
+  LiveDataStore,
+  StatsApiService,
+  UserTrainingPlanApiService,
+} from '@pu-stats/data-access';
+import {
+  PushupCreate,
+  PushupRecord,
   toBerlinIsoDate,
   TRAINING_PLANS,
   UserTrainingPlan,
@@ -20,6 +26,14 @@ interface Mocks {
     setPlan: ReturnType<typeof vitest.fn>;
     updatePlan: ReturnType<typeof vitest.fn>;
   };
+  statsApiMock: {
+    createPushup: ReturnType<typeof vitest.fn>;
+  };
+  liveMock: {
+    entries: ReturnType<typeof signal<PushupRecord[]>>;
+    connected: ReturnType<typeof signal<boolean>>;
+    updateTick: ReturnType<typeof signal<number>>;
+  };
   stream: BehaviorSubject<UserTrainingPlan | null>;
   current: UserTrainingPlan | null;
 }
@@ -27,11 +41,15 @@ interface Mocks {
 describe('TrainingPlanStore', () => {
   const userId = signal<string>('u1');
 
-  function setup(initial: UserTrainingPlan | null = null): {
+  function setup(
+    initial: UserTrainingPlan | null = null,
+    initialEntries: PushupRecord[] = []
+  ): {
     store: InstanceType<typeof TrainingPlanStore>;
     mocks: Mocks;
   } {
     const stream = new BehaviorSubject<UserTrainingPlan | null>(initial);
+    const liveEntries = signal<PushupRecord[]>(initialEntries);
     const mocks: Mocks = {
       stream,
       current: initial,
@@ -53,6 +71,23 @@ describe('TrainingPlanStore', () => {
           }
         ),
       },
+      statsApiMock: {
+        createPushup: vitest.fn((payload: PushupCreate) =>
+          of({
+            _id: 'new',
+            timestamp: payload.timestamp,
+            reps: payload.reps,
+            sets: payload.sets,
+            source: payload.source ?? 'plan',
+            type: payload.type ?? 'Standard',
+          } satisfies PushupRecord)
+        ),
+      },
+      liveMock: {
+        entries: liveEntries,
+        connected: signal(true),
+        updateTick: signal(0),
+      },
     };
 
     TestBed.resetTestingModule();
@@ -62,6 +97,8 @@ describe('TrainingPlanStore', () => {
         // start (otherwise it would leak across `resetTestingModule`).
         { provide: PLATFORM_ID, useValue: 'server' },
         { provide: UserTrainingPlanApiService, useValue: mocks.apiMock },
+        { provide: StatsApiService, useValue: mocks.statsApiMock },
+        { provide: LiveDataStore, useValue: mocks.liveMock },
         {
           provide: UserContextService,
           useValue: { userIdSafe: () => userId() },
@@ -240,6 +277,220 @@ describe('TrainingPlanStore', () => {
     expect(store.activePlan()?.completedDays).toEqual([]);
     // Reference unused param to keep tsc happy.
     void todayIso;
+  });
+
+  describe('logPlanDay', () => {
+    it('creates a pushup entry with the plan sets and marks the day done', async () => {
+      const today = toBerlinIsoDate(new Date());
+      const { store, mocks } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate: today,
+        status: 'active',
+        completedDays: [],
+      });
+      await flush();
+
+      // Day 2 is a main day with sets [20, 20, 20] and target 60.
+      const day2 = PLAN.days[1];
+      expect(day2.kind).toBe('main');
+      expect(day2.targetReps).toBeGreaterThan(0);
+
+      // Day 2 = startDate + 1
+      const yesterday = toBerlinIsoDate(new Date());
+      void yesterday;
+      // (we just need the create call; date computation is verified
+      // implicitly by the timestamp passed to createPushup)
+
+      await store.logPlanDay(2);
+      await flush();
+
+      expect(mocks.statsApiMock.createPushup).toHaveBeenCalledTimes(1);
+      const call = mocks.statsApiMock.createPushup.mock.calls[0][0];
+      expect(call.reps).toBe(day2.targetReps);
+      expect(call.sets).toEqual(day2.sets);
+      expect(call.source).toBe('plan');
+
+      expect(mocks.apiMock.updatePlan).toHaveBeenCalledWith(
+        'u1',
+        expect.objectContaining({ completedDays: [2] })
+      );
+    });
+
+    it('skips the pushup write when the day is already covered by existing entries', async () => {
+      const today = toBerlinIsoDate(new Date());
+      // Day 1 of challenge-30d is a `test` day with target 0 — pick
+      // a main day instead. Day 2 has target 60.
+      const day2Target = PLAN.days[1].targetReps;
+      const startDate = toBerlinIsoDate(
+        new Date(Date.now() - 86_400_000) // start one day ago → today is day 2
+      );
+      const { store, mocks } = setup(
+        {
+          userId: 'u1',
+          planId: PLAN.id,
+          startDate,
+          status: 'active',
+          completedDays: [],
+        },
+        [
+          {
+            _id: 'a',
+            timestamp: `${today}T08:00:00.000+02:00`,
+            reps: day2Target,
+            source: 'web',
+          },
+        ]
+      );
+      await flush();
+
+      await store.logPlanDay(2);
+      await flush();
+
+      // Pushup write skipped — user already had enough reps.
+      expect(mocks.statsApiMock.createPushup).not.toHaveBeenCalled();
+      // Plan day still gets marked done.
+      expect(mocks.apiMock.updatePlan).toHaveBeenCalledWith(
+        'u1',
+        expect.objectContaining({ completedDays: [2] })
+      );
+    });
+
+    it('tops up only the remainder when partially logged', async () => {
+      const today = toBerlinIsoDate(new Date());
+      const day2Target = PLAN.days[1].targetReps;
+      const startDate = toBerlinIsoDate(
+        new Date(Date.now() - 86_400_000)
+      );
+      const { store, mocks } = setup(
+        {
+          userId: 'u1',
+          planId: PLAN.id,
+          startDate,
+          status: 'active',
+          completedDays: [],
+        },
+        [
+          {
+            _id: 'a',
+            timestamp: `${today}T08:00:00.000+02:00`,
+            reps: 20,
+            source: 'web',
+          },
+        ]
+      );
+      await flush();
+
+      await store.logPlanDay(2);
+      await flush();
+
+      const call = mocks.statsApiMock.createPushup.mock.calls[0][0];
+      expect(call.reps).toBe(day2Target - 20);
+      expect(call.sets).toEqual([day2Target - 20]);
+    });
+
+    it('does nothing on rest days', async () => {
+      const today = toBerlinIsoDate(new Date());
+      const { store, mocks } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate: today,
+        status: 'active',
+        completedDays: [],
+      });
+      await flush();
+
+      // challenge-30d day 7 is rest
+      const restDay = PLAN.days.find((d) => d.kind === 'rest');
+      if (!restDay) throw new Error('catalog invariant: rest day exists');
+
+      await store.logPlanDay(restDay.dayIndex);
+      await flush();
+
+      expect(mocks.statsApiMock.createPushup).not.toHaveBeenCalled();
+      expect(mocks.apiMock.updatePlan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('auto-mark effect', () => {
+    it('marks today as done once daily reps reach the plan target', async () => {
+      // We need a browser PLATFORM_ID for the effect to run. But
+      // that would also start the setInterval — so we control the
+      // setup carefully and resetTestingModule at the end.
+      const today = toBerlinIsoDate(new Date());
+      const target = PLAN.days[1].targetReps;
+      const startDate = toBerlinIsoDate(new Date(Date.now() - 86_400_000));
+      const initial: UserTrainingPlan = {
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate,
+        status: 'active',
+        completedDays: [],
+      };
+      const stream = new BehaviorSubject<UserTrainingPlan | null>(initial);
+      const liveEntries = signal<PushupRecord[]>([]);
+      const apiMock = {
+        getActivePlan: vitest.fn(() => stream.asObservable()),
+        setPlan: vitest.fn(),
+        updatePlan: vitest.fn(
+          (_uid: string, patch: Partial<UserTrainingPlan>) => {
+            const next = { ...stream.value!, ...patch };
+            stream.next(next);
+            return new BehaviorSubject(next).asObservable();
+          }
+        ),
+      };
+      const statsApiMock = {
+        createPushup: vitest.fn(),
+      };
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: PLATFORM_ID, useValue: 'browser' },
+          { provide: UserTrainingPlanApiService, useValue: apiMock },
+          { provide: StatsApiService, useValue: statsApiMock },
+          {
+            provide: LiveDataStore,
+            useValue: {
+              entries: liveEntries,
+              connected: signal(true),
+              updateTick: signal(0),
+            },
+          },
+          {
+            provide: UserContextService,
+            useValue: { userIdSafe: () => 'u1' },
+          },
+        ],
+      });
+      TestBed.inject(TrainingPlanStore);
+      await flush();
+
+      // Initially no entries — the effect should not have fired.
+      expect(apiMock.updatePlan).not.toHaveBeenCalled();
+
+      // Simulate the dashboard logging today's reps.
+      liveEntries.set([
+        {
+          _id: 'x',
+          timestamp: `${today}T10:00:00.000+02:00`,
+          reps: target,
+          source: 'web',
+        },
+      ]);
+      await flush();
+
+      expect(apiMock.updatePlan).toHaveBeenCalledWith(
+        'u1',
+        expect.objectContaining({ completedDays: [2] })
+      );
+      // No pushup created — the auto-mark NEVER writes a new entry.
+      expect(statsApiMock.createPushup).not.toHaveBeenCalled();
+
+      // Tear down the implicit setInterval started by withHooks.
+      TestBed.resetTestingModule();
+    });
   });
 
   it('unmarkDayDone removes a day from completedDays', async () => {

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -37,6 +37,18 @@ import {
 import { firstValueFrom, of } from 'rxjs';
 
 /**
+ * Result of `logPlanDay` / `logTodayPlanDay`. Lets callers tailor
+ * UI feedback (snackbar message) to what actually happened: a
+ * fresh write, an idempotent skip, or a rejected request.
+ */
+export type LogPlanDayResult =
+  | 'logged' // pushup entry created + day marked done
+  | 'already-logged' // day was already covered by existing reps; only marked
+  | 'noop' // pre-conditions failed (no plan, rest day, future day, …)
+  | 'in-flight' // a concurrent call for the same day is still running
+  | 'not-ready'; // LiveDataStore hasn't finished its first sync yet
+
+/**
  * Active-plan store. Keeps the live `UserTrainingPlan` doc in sync
  * via a Firestore real-time listener and exposes derived state for
  * the dashboard goal pill, the plan detail page and the training
@@ -63,6 +75,14 @@ export const TrainingPlanStore = signalStore(
      * within 60 s).
      */
     _dayTick: signal(0),
+    /**
+     * Day indexes with an in-flight write. Both `logPlanDay` and
+     * the auto-mark effect read pre-write state from
+     * `LiveDataStore.entries()`/`activePlan()`, so back-to-back
+     * invocations could otherwise race and produce duplicate
+     * pushup entries or `updatePlan` writes for the same day.
+     */
+    _writingDays: signal<ReadonlySet<number>>(new Set()),
   })),
   withProps((store) => ({
     activeResource: rxResource({
@@ -195,6 +215,24 @@ export const TrainingPlanStore = signalStore(
         .filter((e) => e.timestamp.slice(0, 10) === dateIso)
         .reduce((sum, e) => sum + e.reps, 0);
     },
+
+    /** Acquire an in-flight lock for a day. Returns false if already held. */
+    _acquireWriteLock(dayIndex: number): boolean {
+      const set = store._writingDays();
+      if (set.has(dayIndex)) return false;
+      const next = new Set(set);
+      next.add(dayIndex);
+      store._writingDays.set(next);
+      return true;
+    },
+
+    _releaseWriteLock(dayIndex: number): void {
+      const set = store._writingDays();
+      if (!set.has(dayIndex)) return;
+      const next = new Set(set);
+      next.delete(dayIndex);
+      store._writingDays.set(next);
+    },
   })),
   withMethods((store) => ({
     /** All curated plans (re-exposed for component templates). */
@@ -245,10 +283,10 @@ export const TrainingPlanStore = signalStore(
      * Log today's plan-prescribed reps and mark today as done. Thin
      * wrapper around `logPlanDay(currentDayIndex)`.
      */
-    async logTodayPlanDay(): Promise<void> {
+    async logTodayPlanDay(): Promise<LogPlanDayResult> {
       const idx = store.currentDayIndex();
-      if (idx === null) return;
-      await this.logPlanDay(idx);
+      if (idx === null) return 'noop';
+      return this.logPlanDay(idx);
     },
 
     /**
@@ -276,53 +314,80 @@ export const TrainingPlanStore = signalStore(
 
     /**
      * Log the plan-prescribed reps for a day AND mark the day as
-     * done. Skips the pushup write if the user has already logged
-     * enough reps for that calendar day (so the auto-mark effect
-     * and a manual button click both stay idempotent).
+     * done. Idempotent: skips the pushup write if the calendar day
+     * is already covered by existing entries.
      *
      * The pushup entry is timestamped at noon (12:00) on the plan
      * day's calendar date so a backfill for an earlier day still
      * lands in the correct daily bucket.
+     *
+     * Guards (in order):
+     * - Plan must be active (status === 'active') and resolvable.
+     * - Day must be a non-rest, non-zero-target day in the plan.
+     * - Day must not be in the future relative to today.
+     * - `LiveDataStore` must have synced at least once, otherwise
+     *   `_repsLoggedOn` returns 0 and we'd duplicate-write existing
+     *   entries on day-2 reload.
+     * - No concurrent call for the same day index (in-flight lock).
      */
-    async logPlanDay(dayIndex: number): Promise<void> {
+    async logPlanDay(dayIndex: number): Promise<LogPlanDayResult> {
       const a = store.activePlan();
       const c = store.activeCatalog();
-      if (!a || !c) return;
+      if (!a || !c || a.status !== 'active') return 'noop';
       const day = planDayByIndex(c, dayIndex);
-      if (!day || day.kind === 'rest' || day.targetReps <= 0) return;
+      if (!day || day.kind === 'rest' || day.targetReps <= 0) return 'noop';
 
-      const dateIso = store._planDayDate(dayIndex);
-      const alreadyLogged = store._repsLoggedOn(dateIso);
+      const currentIdx = store.currentDayIndex();
+      if (currentIdx === null || dayIndex > currentIdx) return 'noop';
 
-      if (alreadyLogged < day.targetReps) {
-        const remaining = day.targetReps - alreadyLogged;
-        // If the user has logged nothing yet, persist the full
-        // prescribed sets so the breakdown is preserved. If they
-        // logged some reps already, just top up the remainder as a
-        // single set — we don't try to second-guess their split.
-        const sets = alreadyLogged === 0
-          ? day.sets ?? [day.targetReps]
-          : [remaining];
-        const reps = alreadyLogged === 0 ? day.targetReps : remaining;
-        await firstValueFrom(
-          store._statsApi.createPushup({
-            timestamp: appendLocalOffset(`${dateIso}T12:00`),
-            reps,
-            sets,
-            source: 'plan',
-            type: 'Standard',
-          })
-        );
+      // `_live.entries()` is empty until the Firestore listener has
+      // emitted at least once. Don't make a write decision off
+      // pre-sync data — it would top-up a day that's already
+      // covered as soon as the listener catches up.
+      if (store._isBrowser && !store._live.connected()) return 'not-ready';
+
+      if (!store._acquireWriteLock(dayIndex)) return 'in-flight';
+
+      try {
+        const dateIso = store._planDayDate(dayIndex);
+        const alreadyLogged = store._repsLoggedOn(dateIso);
+        let result: LogPlanDayResult;
+
+        if (alreadyLogged < day.targetReps) {
+          const remaining = day.targetReps - alreadyLogged;
+          // If the user has logged nothing yet, persist the full
+          // prescribed sets so the breakdown is preserved. If they
+          // logged some reps already, just top up the remainder as
+          // a single set — we don't try to second-guess their split.
+          const sets =
+            alreadyLogged === 0 ? day.sets ?? [day.targetReps] : [remaining];
+          const reps = alreadyLogged === 0 ? day.targetReps : remaining;
+          await firstValueFrom(
+            store._statsApi.createPushup({
+              timestamp: appendLocalOffset(`${dateIso}T12:00`),
+              reps,
+              sets,
+              source: 'plan',
+              type: 'Standard',
+            })
+          );
+          result = 'logged';
+        } else {
+          result = 'already-logged';
+        }
+
+        if (!a.completedDays.includes(dayIndex)) {
+          const next = [...a.completedDays, dayIndex].sort((x, y) => x - y);
+          const userId = store._user.userIdSafe();
+          await firstValueFrom(
+            store._api.updatePlan(userId, { completedDays: next })
+          );
+        }
+        store.activeResource.reload();
+        return result;
+      } finally {
+        store._releaseWriteLock(dayIndex);
       }
-
-      if (!a.completedDays.includes(dayIndex)) {
-        const next = [...a.completedDays, dayIndex].sort((x, y) => x - y);
-        const userId = store._user.userIdSafe();
-        await firstValueFrom(
-          store._api.updatePlan(userId, { completedDays: next })
-        );
-      }
-      store.activeResource.reload();
     },
 
     /** Undo a day completion. */
@@ -375,8 +440,15 @@ export const TrainingPlanStore = signalStore(
         const idx = store.currentDayIndex();
         const day = store.todayDay();
         if (!a || !day || idx === null) return;
+        // Skip on abandoned/completed plans — the doc still exists,
+        // but writes against it are noise (plus they'd drift the
+        // status-based banner state in the UI).
+        if (a.status !== 'active') return;
         if (day.kind === 'rest' || day.targetReps <= 0) return;
         if (a.completedDays.includes(idx)) return;
+        // The same in-flight lock guards manual logPlanDay calls,
+        // so a fast Quick-Add + auto-mark can't double-write.
+        if (store._writingDays().has(idx)) return;
         // `_live.entries()` is the same source the dashboard uses;
         // it streams from Firestore in real time so manual logs
         // propagate here without polling.
@@ -385,14 +457,14 @@ export const TrainingPlanStore = signalStore(
         store._dayTick();
         const todayReps = store._repsLoggedOn(todayIso);
         if (todayReps >= day.targetReps) {
-          // Fire-and-forget: the resulting `activePlan` reload will
-          // re-trigger this effect, which then short-circuits via
-          // the `completedDays.includes(idx)` guard above.
+          if (!store._acquireWriteLock(idx)) return;
           const next = [...a.completedDays, idx].sort((x, y) => x - y);
           const userId = store._user.userIdSafe();
           firstValueFrom(
             store._api.updatePlan(userId, { completedDays: next })
-          ).then(() => store.activeResource.reload());
+          )
+            .then(() => store.activeResource.reload())
+            .finally(() => store._releaseWriteLock(idx));
         }
       });
     },

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -200,8 +200,21 @@ export const TrainingPlanStore = signalStore(
       if (!a) return toBerlinIsoDate(new Date());
       const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(a.startDate);
       if (!m) return toBerlinIsoDate(new Date());
-      const [, y, mo, d] = m;
-      const start = new Date(Number(y), Number(mo) - 1, Number(d));
+      const year = Number(m[1]);
+      const month = Number(m[2]);
+      const day = Number(m[3]);
+      const start = new Date(year, month - 1, day);
+      // Round-trip: `new Date(2026, 1, 30)` silently overflows to
+      // March 2 instead of failing on Feb-30. Reject impossible
+      // dates so a corrupt `startDate` can't shift logging into
+      // the wrong calendar day.
+      if (
+        start.getFullYear() !== year ||
+        start.getMonth() !== month - 1 ||
+        start.getDate() !== day
+      ) {
+        return toBerlinIsoDate(new Date());
+      }
       start.setHours(0, 0, 0, 0);
       const target = new Date(start);
       target.setDate(start.getDate() + (dayIndex - 1));
@@ -271,11 +284,11 @@ export const TrainingPlanStore = signalStore(
       // so a generic "mark today done" callback can't skew progress.
       if (day.kind === 'rest') return;
       if (a.completedDays.includes(idx)) return;
-      const next = [...a.completedDays, idx].sort((x, y) => x - y);
       const userId = store._user.userIdSafe();
-      await firstValueFrom(
-        store._api.updatePlan(userId, { completedDays: next })
-      );
+      // `arrayUnion` so concurrent writes to *different* day indexes
+      // (e.g. auto-mark today + manual mark for yesterday in another
+      // tab) merge correctly server-side instead of clobbering.
+      await firstValueFrom(store._api.addCompletedDay(userId, idx));
       store.activeResource.reload();
     },
 
@@ -304,11 +317,8 @@ export const TrainingPlanStore = signalStore(
       const day = planDayByIndex(c, dayIndex);
       if (!day || day.kind === 'rest') return;
       if (a.completedDays.includes(dayIndex)) return;
-      const next = [...a.completedDays, dayIndex].sort((x, y) => x - y);
       const userId = store._user.userIdSafe();
-      await firstValueFrom(
-        store._api.updatePlan(userId, { completedDays: next })
-      );
+      await firstValueFrom(store._api.addCompletedDay(userId, dayIndex));
       store.activeResource.reload();
     },
 
@@ -377,11 +387,8 @@ export const TrainingPlanStore = signalStore(
         }
 
         if (!a.completedDays.includes(dayIndex)) {
-          const next = [...a.completedDays, dayIndex].sort((x, y) => x - y);
           const userId = store._user.userIdSafe();
-          await firstValueFrom(
-            store._api.updatePlan(userId, { completedDays: next })
-          );
+          await firstValueFrom(store._api.addCompletedDay(userId, dayIndex));
         }
         store.activeResource.reload();
         return result;
@@ -395,11 +402,8 @@ export const TrainingPlanStore = signalStore(
       const a = store.activePlan();
       if (!a) return;
       if (!a.completedDays.includes(dayIndex)) return;
-      const next = a.completedDays.filter((d) => d !== dayIndex);
       const userId = store._user.userIdSafe();
-      await firstValueFrom(
-        store._api.updatePlan(userId, { completedDays: next })
-      );
+      await firstValueFrom(store._api.removeCompletedDay(userId, dayIndex));
       store.activeResource.reload();
     },
 
@@ -446,6 +450,10 @@ export const TrainingPlanStore = signalStore(
         if (a.status !== 'active') return;
         if (day.kind === 'rest' || day.targetReps <= 0) return;
         if (a.completedDays.includes(idx)) return;
+        // Same readiness guard as `logPlanDay` — without this, a
+        // pre-sync `_live.entries()` could appear to satisfy the
+        // target on stale state and trigger a false auto-mark.
+        if (!store._live.connected()) return;
         // The same in-flight lock guards manual logPlanDay calls,
         // so a fast Quick-Add + auto-mark can't double-write.
         if (store._writingDays().has(idx)) return;
@@ -458,12 +466,21 @@ export const TrainingPlanStore = signalStore(
         const todayReps = store._repsLoggedOn(todayIso);
         if (todayReps >= day.targetReps) {
           if (!store._acquireWriteLock(idx)) return;
-          const next = [...a.completedDays, idx].sort((x, y) => x - y);
           const userId = store._user.userIdSafe();
-          firstValueFrom(
-            store._api.updatePlan(userId, { completedDays: next })
-          )
+          // Use the atomic `arrayUnion` write so a concurrent
+          // manual mark for a different day index (e.g. from
+          // another tab) doesn't get clobbered. `effect()` is
+          // synchronous, so handle errors explicitly — an
+          // unhandled rejection here would surface in the
+          // browser console without context.
+          firstValueFrom(store._api.addCompletedDay(userId, idx))
             .then(() => store.activeResource.reload())
+            .catch((error) => {
+              console.error(
+                'Failed to auto-mark training plan day as completed.',
+                { error, planId: a.planId, dayIndex: idx }
+              );
+            })
             .finally(() => store._releaseWriteLock(idx));
         }
       });

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -1,6 +1,7 @@
 import {
   computed,
   DestroyRef,
+  effect,
   inject,
   PLATFORM_ID,
   signal,
@@ -15,13 +16,19 @@ import {
   withProps,
 } from '@ngrx/signals';
 import { UserContextService } from '@pu-auth/auth';
-import { UserTrainingPlanApiService } from '@pu-stats/data-access';
 import {
+  LiveDataStore,
+  StatsApiService,
+  UserTrainingPlanApiService,
+} from '@pu-stats/data-access';
+import {
+  appendLocalOffset,
   currentPlanDayIndex,
   findPlanById,
   isPlanCompleted,
   planDayByIndex,
   toBerlinIsoDate,
+  toLocalIsoDate,
   TrainingPlan,
   TrainingPlanDay,
   TRAINING_PLANS,
@@ -43,6 +50,8 @@ export const TrainingPlanStore = signalStore(
   { providedIn: 'root' },
   withProps(() => ({
     _api: inject(UserTrainingPlanApiService),
+    _statsApi: inject(StatsApiService),
+    _live: inject(LiveDataStore),
     _user: inject(UserContextService),
     _isBrowser: isPlatformBrowser(inject(PLATFORM_ID)),
     /**
@@ -160,6 +169,34 @@ export const TrainingPlanStore = signalStore(
     };
   }),
   withMethods((store) => ({
+    /**
+     * Calendar date (`YYYY-MM-DD`) for a 1-based plan day. Falls
+     * back to today's Berlin date if the plan is missing or the
+     * start date can't be parsed (defensive — caller already
+     * checks).
+     */
+    _planDayDate(dayIndex: number): string {
+      const a = store.activePlan();
+      if (!a) return toBerlinIsoDate(new Date());
+      const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(a.startDate);
+      if (!m) return toBerlinIsoDate(new Date());
+      const [, y, mo, d] = m;
+      const start = new Date(Number(y), Number(mo) - 1, Number(d));
+      start.setHours(0, 0, 0, 0);
+      const target = new Date(start);
+      target.setDate(start.getDate() + (dayIndex - 1));
+      return toLocalIsoDate(target);
+    },
+
+    /** Sum of reps already logged on a given local date. */
+    _repsLoggedOn(dateIso: string): number {
+      return store
+        ._live.entries()
+        .filter((e) => e.timestamp.slice(0, 10) === dateIso)
+        .reduce((sum, e) => sum + e.reps, 0);
+    },
+  })),
+  withMethods((store) => ({
     /** All curated plans (re-exposed for component templates). */
     allPlans(): ReadonlyArray<TrainingPlan> {
       return TRAINING_PLANS;
@@ -204,7 +241,22 @@ export const TrainingPlanStore = signalStore(
       store.activeResource.reload();
     },
 
-    /** Mark a specific day as done (used from the plan detail page). */
+    /**
+     * Log today's plan-prescribed reps and mark today as done. Thin
+     * wrapper around `logPlanDay(currentDayIndex)`.
+     */
+    async logTodayPlanDay(): Promise<void> {
+      const idx = store.currentDayIndex();
+      if (idx === null) return;
+      await this.logPlanDay(idx);
+    },
+
+    /**
+     * Mark a specific day as done WITHOUT creating a pushup entry.
+     * Use this for "I already logged elsewhere" flows. For the
+     * common case (mark done + log the plan-prescribed reps) call
+     * `logPlanDay()` instead.
+     */
     async markDayDone(dayIndex: number): Promise<void> {
       const a = store.activePlan();
       const c = store.activeCatalog();
@@ -219,6 +271,57 @@ export const TrainingPlanStore = signalStore(
       await firstValueFrom(
         store._api.updatePlan(userId, { completedDays: next })
       );
+      store.activeResource.reload();
+    },
+
+    /**
+     * Log the plan-prescribed reps for a day AND mark the day as
+     * done. Skips the pushup write if the user has already logged
+     * enough reps for that calendar day (so the auto-mark effect
+     * and a manual button click both stay idempotent).
+     *
+     * The pushup entry is timestamped at noon (12:00) on the plan
+     * day's calendar date so a backfill for an earlier day still
+     * lands in the correct daily bucket.
+     */
+    async logPlanDay(dayIndex: number): Promise<void> {
+      const a = store.activePlan();
+      const c = store.activeCatalog();
+      if (!a || !c) return;
+      const day = planDayByIndex(c, dayIndex);
+      if (!day || day.kind === 'rest' || day.targetReps <= 0) return;
+
+      const dateIso = store._planDayDate(dayIndex);
+      const alreadyLogged = store._repsLoggedOn(dateIso);
+
+      if (alreadyLogged < day.targetReps) {
+        const remaining = day.targetReps - alreadyLogged;
+        // If the user has logged nothing yet, persist the full
+        // prescribed sets so the breakdown is preserved. If they
+        // logged some reps already, just top up the remainder as a
+        // single set — we don't try to second-guess their split.
+        const sets = alreadyLogged === 0
+          ? day.sets ?? [day.targetReps]
+          : [remaining];
+        const reps = alreadyLogged === 0 ? day.targetReps : remaining;
+        await firstValueFrom(
+          store._statsApi.createPushup({
+            timestamp: appendLocalOffset(`${dateIso}T12:00`),
+            reps,
+            sets,
+            source: 'plan',
+            type: 'Standard',
+          })
+        );
+      }
+
+      if (!a.completedDays.includes(dayIndex)) {
+        const next = [...a.completedDays, dayIndex].sort((x, y) => x - y);
+        const userId = store._user.userIdSafe();
+        await firstValueFrom(
+          store._api.updatePlan(userId, { completedDays: next })
+        );
+      }
       store.activeResource.reload();
     },
 
@@ -262,6 +365,36 @@ export const TrainingPlanStore = signalStore(
         60_000
       );
       inject(DestroyRef).onDestroy(() => clearInterval(handle));
+
+      // Auto-mark today as done when reps logged via Quick-Add /
+      // dialog reach the plan target. Read-only — never creates a
+      // pushup entry, just flips the `completedDays` flag so users
+      // who track in their own way still see plan progress.
+      effect(() => {
+        const a = store.activePlan();
+        const idx = store.currentDayIndex();
+        const day = store.todayDay();
+        if (!a || !day || idx === null) return;
+        if (day.kind === 'rest' || day.targetReps <= 0) return;
+        if (a.completedDays.includes(idx)) return;
+        // `_live.entries()` is the same source the dashboard uses;
+        // it streams from Firestore in real time so manual logs
+        // propagate here without polling.
+        const todayIso = toBerlinIsoDate(new Date());
+        // Establish a tick dependency so this re-runs at midnight.
+        store._dayTick();
+        const todayReps = store._repsLoggedOn(todayIso);
+        if (todayReps >= day.targetReps) {
+          // Fire-and-forget: the resulting `activePlan` reload will
+          // re-trigger this effect, which then short-circuits via
+          // the `completedDays.includes(idx)` guard above.
+          const next = [...a.completedDays, idx].sort((x, y) => x - y);
+          const userId = store._user.userIdSafe();
+          firstValueFrom(
+            store._api.updatePlan(userId, { completedDays: next })
+          ).then(() => store.activeResource.reload());
+        }
+      });
     },
   })
 );

--- a/web/src/app/training-plans/training-plans-page.component.ts
+++ b/web/src/app/training-plans/training-plans-page.component.ts
@@ -99,9 +99,26 @@ import { TrainingPlanStore } from './training-plan.store';
               <mat-icon>cancel</mat-icon>
               Plan beenden
             </button>
+            @if (
+              todayLocalized();
+              as today
+            ) {
+              @if (today.kind !== 'rest' && !store.todayDone()) {
+                <button
+                  mat-flat-button
+                  type="button"
+                  color="primary"
+                  (click)="logToday()"
+                >
+                  <mat-icon>play_circle</mat-icon>
+                  <span i18n="@@trainingPlans.logToday"
+                    >Heute eintragen</span
+                  >
+                </button>
+              }
+            }
             <a
               mat-flat-button
-              color="primary"
               [routerLink]="['/training-plans', store.activeCatalog()?.slug]"
             >
               <mat-icon>open_in_full</mat-icon>
@@ -263,5 +280,9 @@ export class TrainingPlansPageComponent {
 
   abandon(): void {
     void this.store.abandon();
+  }
+
+  logToday(): void {
+    void this.store.logTodayPlanDay();
   }
 }

--- a/web/src/app/training-plans/training-plans-page.component.ts
+++ b/web/src/app/training-plans/training-plans-page.component.ts
@@ -11,8 +11,9 @@ import { MatCardModule } from '@angular/material/card';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterLink } from '@angular/router';
-import { TrainingPlanStore } from './training-plan.store';
+import { LogPlanDayResult, TrainingPlanStore } from './training-plan.store';
 
 @Component({
   selector: 'app-training-plans-page',
@@ -22,6 +23,7 @@ import { TrainingPlanStore } from './training-plan.store';
     MatIconModule,
     MatChipsModule,
     MatProgressBarModule,
+    MatSnackBarModule,
     RouterLink,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -103,7 +105,11 @@ import { TrainingPlanStore } from './training-plan.store';
               todayLocalized();
               as today
             ) {
-              @if (today.kind !== 'rest' && !store.todayDone()) {
+              @if (
+                today.kind !== 'rest' &&
+                today.targetReps > 0 &&
+                !store.todayDone()
+              ) {
                 <button
                   mat-flat-button
                   type="button"
@@ -238,6 +244,7 @@ import { TrainingPlanStore } from './training-plan.store';
 })
 export class TrainingPlansPageComponent {
   readonly store = inject(TrainingPlanStore);
+  private readonly snackbar = inject(MatSnackBar);
   private readonly locale = inject(LOCALE_ID) as string;
 
   /** Catalog with `title`/`summary` fields swapped to the active locale. */
@@ -282,7 +289,25 @@ export class TrainingPlansPageComponent {
     void this.store.abandon();
   }
 
-  logToday(): void {
-    void this.store.logTodayPlanDay();
+  async logToday(): Promise<void> {
+    const result = await this.store.logTodayPlanDay();
+    const message = this.messageForLogResult(result);
+    if (message) {
+      this.snackbar.open(message, undefined, { duration: 3000 });
+    }
+  }
+
+  private messageForLogResult(result: LogPlanDayResult): string | null {
+    switch (result) {
+      case 'logged':
+        return $localize`:@@trainingPlans.logged:Plan-Sätze wurden eingetragen.`;
+      case 'already-logged':
+        return $localize`:@@trainingPlans.alreadyLogged:Tag war schon eingetragen — als erledigt markiert.`;
+      case 'not-ready':
+        return $localize`:@@trainingPlans.notReady:Daten werden noch geladen, bitte gleich noch einmal versuchen.`;
+      case 'in-flight':
+      case 'noop':
+        return null;
+    }
   }
 }

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -5720,8 +5720,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="trainingPlans.markAria">
       <segment state="translated">
-        <source>Als erledigt markieren</source>
-        <target>Mark as done</target>
+        <source>Nur als erledigt markieren (ohne Eintrag)</source>
+        <target>Mark as done only (no entry created)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.unmarkAria">
@@ -5848,6 +5848,18 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source>Plan-Sätze wurden eingetragen.</source>
         <target>Plan sets were logged.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.alreadyLogged">
+      <segment state="translated">
+        <source>Tag war schon eingetragen — als erledigt markiert.</source>
+        <target>Day was already logged — marked as done.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.notReady">
+      <segment state="translated">
+        <source>Daten werden noch geladen, bitte gleich noch einmal versuchen.</source>
+        <target>Data still loading, please try again in a moment.</target>
       </segment>
     </unit>
   </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -5832,5 +5832,23 @@ Deine Position: # ·  Reps        </source>
         <target>Sharing is not available on this device.</target>
       </segment>
     </unit>
+    <unit id="trainingPlans.logToday">
+      <segment state="translated">
+        <source>Heute eintragen</source>
+        <target>Log today</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.logAria">
+      <segment state="translated">
+        <source>Plan-Sätze eintragen und als erledigt markieren</source>
+        <target>Log plan sets and mark as done</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.logged">
+      <segment state="translated">
+        <source>Plan-Sätze wurden eingetragen.</source>
+        <target>Plan sets were logged.</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -3590,6 +3590,30 @@
         <source>Keine Daten</source>
       </segment>
     </unit>
+    <unit id="dashboard.share.text.streak">
+      <notes>
+        <note category="location">web/src/app/stats/dashboard.store.ts:413</note>
+      </notes>
+      <segment>
+        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
+      </segment>
+    </unit>
+    <unit id="dashboard.share.text.simple">
+      <notes>
+        <note category="location">web/src/app/stats/dashboard.store.ts:414</note>
+      </notes>
+      <segment>
+        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
+      </segment>
+    </unit>
+    <unit id="dashboard.share.title">
+      <notes>
+        <note category="location">web/src/app/stats/dashboard.store.ts:416</note>
+      </notes>
+      <segment>
+        <source>Pushup Tracker</source>
+      </segment>
+    </unit>
     <unit id="analysis.weekTrendTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:66,68</note>
@@ -4254,7 +4278,7 @@
     <unit id="trainingPlans.kind.rest">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:73,74</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:139,140</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:165,166</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:66,67</note>
       </notes>
       <segment>
@@ -4264,7 +4288,7 @@
     <unit id="trainingPlans.kind.light">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:76,77</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:143,144</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:172,174</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:69,70</note>
       </notes>
       <segment>
@@ -4274,7 +4298,7 @@
     <unit id="trainingPlans.kind.test">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:78,80</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:141,142</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:168,170</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:72,74</note>
       </notes>
       <segment>
@@ -4284,8 +4308,8 @@
     <unit id="trainingPlans.reps">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:81,83</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:147,148</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:151,153</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:177,178</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:181,183</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:84,86</note>
       </notes>
       <segment>
@@ -4295,7 +4319,7 @@
     <unit id="trainingPlans.openDetail">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:90,92</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:108,110</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:125,127</note>
       </notes>
       <segment>
         <source> Details öffnen </source>
@@ -4479,7 +4503,7 @@
     </unit>
     <unit id="dashboard.share.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:73</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:71</note>
       </notes>
       <segment>
         <source>Tagesleistung teilen</source>
@@ -4487,40 +4511,16 @@
     </unit>
     <unit id="dashboard.share">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:74</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:72</note>
       </notes>
       <segment>
         <source>Teilen</source>
       </segment>
     </unit>
-    <unit id="dashboard.share.text.streak">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:195</note>
-      </notes>
-      <segment>
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
-      </segment>
-    </unit>
-    <unit id="dashboard.share.text.simple">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:196</note>
-      </notes>
-      <segment>
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
-      </segment>
-    </unit>
-    <unit id="dashboard.share.title">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:198</note>
-      </notes>
-      <segment>
-        <source>Pushup Tracker</source>
-      </segment>
-    </unit>
     <unit id="trainingPlans.back">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:43</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:193,195</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:51</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:234,236</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -4528,8 +4528,8 @@
     </unit>
     <unit id="trainingPlans.daysSuffix">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:53,54</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:123,125</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:64,66</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:140,142</note>
       </notes>
       <segment>
         <source>Tage</source>
@@ -4537,8 +4537,8 @@
     </unit>
     <unit id="trainingPlans.level.beginner">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:56,57</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:128,130</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:68,69</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:145,147</note>
       </notes>
       <segment>
         <source>Einsteiger</source>
@@ -4546,8 +4546,8 @@
     </unit>
     <unit id="trainingPlans.level.intermediate">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:58,60</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:132,134</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:70,72</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:149,151</note>
       </notes>
       <segment>
         <source>Mittelstufe</source>
@@ -4555,8 +4555,8 @@
     </unit>
     <unit id="trainingPlans.level.advanced">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:60,62</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:136,138</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:72,74</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:153,155</note>
       </notes>
       <segment>
         <source>Fortgeschritten</source>
@@ -4564,7 +4564,7 @@
     </unit>
     <unit id="trainingPlans.progress">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:69,70</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:81,82</note>
       </notes>
       <segment>
         <source>Fortschritt</source>
@@ -4572,7 +4572,7 @@
     </unit>
     <unit id="trainingPlans.currentDay">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:75,76</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:90,91</note>
       </notes>
       <segment>
         <source>Aktueller Tag:</source>
@@ -4580,7 +4580,7 @@
     </unit>
     <unit id="trainingPlans.abandon">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:82,84</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:102,104</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:99,101</note>
       </notes>
       <segment>
@@ -4589,7 +4589,7 @@
     </unit>
     <unit id="trainingPlans.startCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:91,93</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:111,113</note>
       </notes>
       <segment>
         <source> Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt. </source>
@@ -4597,7 +4597,7 @@
     </unit>
     <unit id="trainingPlans.replaceWarn">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:97,99</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:121,123</note>
       </notes>
       <segment>
         <source> Achtung: Dies ersetzt den aktuell aktiven Plan. </source>
@@ -4605,7 +4605,7 @@
     </unit>
     <unit id="trainingPlans.start">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:102,104</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:126,128</note>
       </notes>
       <segment>
         <source>Plan starten</source>
@@ -4613,7 +4613,7 @@
     </unit>
     <unit id="trainingPlans.week">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:111,112</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:135,136</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -4621,23 +4621,31 @@
     </unit>
     <unit id="trainingPlans.unmarkAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:165,166</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:197,198</note>
       </notes>
       <segment>
         <source>Als nicht erledigt markieren</source>
       </segment>
     </unit>
-    <unit id="trainingPlans.markAria">
+    <unit id="trainingPlans.logAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:174,175</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:207,208</note>
       </notes>
       <segment>
-        <source>Als erledigt markieren</source>
+        <source>Plan-Sätze eintragen und als erledigt markieren</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.markAria">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:215,216</note>
+      </notes>
+      <segment>
+        <source>Nur als erledigt markieren (ohne Eintrag)</source>
       </segment>
     </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:190,191</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:231,232</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -4645,7 +4653,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:356</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:399</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -4653,10 +4661,18 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:365</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:408</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.logged">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:426</note>
+      </notes>
+      <segment>
+        <source>Plan-Sätze wurden eingetragen.</source>
       </segment>
     </unit>
     <unit id="trainingPlans.title">
@@ -4699,9 +4715,17 @@
         <source>Heute geplant:</source>
       </segment>
     </unit>
+    <unit id="trainingPlans.logToday">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:115,117</note>
+      </notes>
+      <segment>
+        <source>Heute eintragen</source>
+      </segment>
+    </unit>
     <unit id="trainingPlans.viewPlan">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:152,154</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:169,171</note>
       </notes>
       <segment>
         <source>Plan ansehen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4675,6 +4675,24 @@
         <source>Plan-Sätze wurden eingetragen.</source>
       </segment>
     </unit>
+    <unit id="trainingPlans.alreadyLogged">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts</note>
+      </notes>
+      <segment>
+        <source>Tag war schon eingetragen — als erledigt markiert.</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.notReady">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts</note>
+      </notes>
+      <segment>
+        <source>Daten werden noch geladen, bitte gleich noch einmal versuchen.</source>
+      </segment>
+    </unit>
     <unit id="trainingPlans.title">
       <notes>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:31,32</note>


### PR DESCRIPTION
Previously `markDayDone` only flipped `completedDays` in
`userTrainingPlans/{uid}` — it never wrote to the `pushups`
collection. Users who used the Done-toggle to "finish today's
challenge" saw a green checkmark in the plan detail page, but their
stats, streak and leaderboard entry stayed unchanged.

Three coordinated fixes:

1. New `logPlanDay(dayIndex)` store method creates a pushup entry
   with the plan day's prescribed sets (e.g. `[20, 20, 20]`,
   `source: 'plan'`) AND flips `completedDays`. Idempotent: if
   reps already logged for that calendar day cover the target it
   skips the write; if they cover it partially, it tops up only
   the remainder. Timestamps land at noon on the plan day's date,
   so backfilling an earlier day keeps the daily bucket correct.

2. Auto-mark effect: when entries from `LiveDataStore` push today's
   reps past the plan target, today flips to "done" automatically.
   Read-only — never creates a pushup entry. Quick-Add and dialog
   logging now move plan progress without an explicit button click.

3. UI: the day-row toggle in the detail page now has two icons —
   a primary `play_circle` ("Plan-Sätze eintragen") that calls
   `logPlanDay`, and the existing `radio_button_unchecked` for the
   "I logged elsewhere" flow. The active-plan card on the list
   page also gains a "Heute eintragen" CTA.

Fixes the lost-day issue: re-open the plan detail page, click the
new primary button on yesterday's row → a pushup entry will be
created with that day's date and the prescribed sets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "log today" button for quick logging of today's training plan.
  * Added a play-circle button to log individual training days directly from the plan detail view.
  * Implemented smart duplicate-prevention: avoids creating entries if the day's target reps are already logged.
  * Auto-marks days as complete when live entries reach the plan target.

* **Improvements**
  * Clarified button labels to distinguish between logging entries and marking days done.

* **Documentation**
  * Added translations for new logging UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->