### PR TITLE
feat(public-profile): add /u/:uid public profile route

### DIFF
--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -26,7 +26,13 @@ import {
   FALLBACK_QUOTES_EN,
   QUOTE_CACHE_HOURS,
 } from './motivation';
-import { UserProfile } from './profile';
+import {
+  buildPublicProfile,
+  isValidUid,
+  type UserConfigForPublicProfile,
+  type UserStatsForPublicProfile,
+  UserProfile,
+} from './profile';
 import type { ReminderConfig } from './push';
 import {
   buildNotificationPayload,
@@ -620,6 +626,46 @@ export const refreshLeaderboardsOnPushupWrite = onDocumentWritten(
   },
   async () => {
     await rebuildLeaderboardsCore();
+  }
+);
+
+// ─── getPublicProfile (anonymous-callable, opt-in only) ──────────────────────
+// Returns a sanitized projection of `userConfigs/{uid}` + `userStats/{uid}`
+// for users who explicitly set `ui.publicProfile = true`. Anyone else returns
+// `not-found` so existence of a private user can't be probed by walking UIDs.
+//
+// This callable runs UNAUTHENTICATED on purpose — it backs the `/u/:uid`
+// public route and the dynamic OG image endpoint. Do NOT add side effects
+// here; only sanctioned read-only projection.
+
+export const getPublicProfile = onCall(
+  { region: 'europe-west3', invoker: 'public' },
+  async (request) => {
+    const uid = String(request.data?.uid ?? '').trim();
+    if (!isValidUid(uid)) {
+      throw new HttpsError('invalid-argument', 'Invalid uid');
+    }
+
+    const db = admin.firestore();
+    const [cfgSnap, statsSnap] = await Promise.all([
+      db.collection('userConfigs').doc(uid).get(),
+      db.collection('userStats').doc(uid).get(),
+    ]);
+
+    const config = cfgSnap.exists
+      ? (cfgSnap.data() as UserConfigForPublicProfile)
+      : null;
+    const stats = statsSnap.exists
+      ? (statsSnap.data() as UserStatsForPublicProfile)
+      : null;
+
+    const projection = buildPublicProfile(uid, config, stats);
+    if (!projection) {
+      // Same response shape for "user does not exist" and "user is private"
+      // so an attacker can't enumerate accounts.
+      throw new HttpsError('not-found', 'Profile not available');
+    }
+    return projection;
   }
 );
 

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -642,8 +642,12 @@ export const getPublicProfile = onCall(
   { region: 'europe-west3', invoker: 'public' },
   async (request) => {
     const uid = String(request.data?.uid ?? '').trim();
+    // Collapse malformed UIDs into the same `not-found` response we use for
+    // missing / opted-out users, so /u/<bad-slug> hits the same UX/privacy
+    // path as /u/<missing-but-valid> instead of bouncing into a generic
+    // error state on the client.
     if (!isValidUid(uid)) {
-      throw new HttpsError('invalid-argument', 'Invalid uid');
+      throw new HttpsError('not-found', 'Profile not available');
     }
 
     const db = admin.firestore();

--- a/data-store/functions/src/profile/index.ts
+++ b/data-store/functions/src/profile/index.ts
@@ -1,1 +1,2 @@
 export * from './logic';
+export * from './public-profile';

--- a/data-store/functions/src/profile/public-profile.spec.ts
+++ b/data-store/functions/src/profile/public-profile.spec.ts
@@ -1,0 +1,202 @@
+import {
+  buildPublicProfile,
+  isPublicProfileAllowed,
+  isValidUid,
+} from './public-profile';
+
+describe('isValidUid', () => {
+  it.each([
+    ['', false],
+    ['short', false],
+    ['valid-uid-1234567890', true],
+    ['ALongIshUidWithMixedCase_-09', true],
+    ['has spaces', false],
+    ['has/slash', false],
+    ['has..dot', false],
+    ['x'.repeat(8), true],
+    ['x'.repeat(7), false],
+    ['x'.repeat(128), true],
+    ['x'.repeat(129), false],
+  ])('isValidUid(%j) => %s', (input, expected) => {
+    expect(isValidUid(input)).toBe(expected);
+  });
+
+  it('rejects non-string inputs', () => {
+    expect(isValidUid(undefined)).toBe(false);
+    expect(isValidUid(null)).toBe(false);
+    expect(isValidUid(123)).toBe(false);
+    expect(isValidUid({})).toBe(false);
+  });
+});
+
+describe('isPublicProfileAllowed', () => {
+  it('Given missing config, Then returns false', () => {
+    expect(isPublicProfileAllowed(undefined)).toBe(false);
+    expect(isPublicProfileAllowed(null)).toBe(false);
+  });
+
+  it('Given config without ui.publicProfile, Then returns false', () => {
+    expect(isPublicProfileAllowed({ displayName: 'Wolfi' })).toBe(false);
+    expect(isPublicProfileAllowed({ displayName: 'Wolfi', ui: {} })).toBe(
+      false
+    );
+  });
+
+  it('Given ui.publicProfile=false, Then returns false', () => {
+    expect(
+      isPublicProfileAllowed({
+        displayName: 'Wolfi',
+        ui: { publicProfile: false },
+      })
+    ).toBe(false);
+  });
+
+  it('Given ui.publicProfile=true, Then returns true', () => {
+    expect(
+      isPublicProfileAllowed({
+        displayName: 'Wolfi',
+        ui: { publicProfile: true },
+      })
+    ).toBe(true);
+  });
+
+  it('Defaults to private even when other ui flags are set', () => {
+    // Regression: leaderboard opt-in should NOT auto-grant a public profile.
+    expect(
+      isPublicProfileAllowed({
+        displayName: 'Wolfi',
+        ui: { hideFromLeaderboard: false },
+      })
+    ).toBe(false);
+  });
+});
+
+describe('buildPublicProfile', () => {
+  const uid = 'abcdef1234567890';
+
+  it('Given user has not opted in, Then returns null', () => {
+    expect(buildPublicProfile(uid, null, null)).toBeNull();
+    expect(
+      buildPublicProfile(uid, { displayName: 'Wolfi', ui: {} }, null)
+    ).toBeNull();
+    expect(
+      buildPublicProfile(
+        uid,
+        { displayName: 'Wolfi', ui: { publicProfile: false } },
+        null
+      )
+    ).toBeNull();
+  });
+
+  it('Given opt-in but no stats yet, Then returns zeros for numeric fields', () => {
+    const result = buildPublicProfile(
+      uid,
+      { displayName: 'Wolfi', ui: { publicProfile: true } },
+      null
+    );
+    expect(result).toEqual({
+      uid,
+      displayName: 'Wolfi',
+      total: 0,
+      totalEntries: 0,
+      totalDays: 0,
+      currentStreak: 0,
+      bestSingleEntry: null,
+      bestDayTotal: null,
+      updatedAt: '',
+    });
+  });
+
+  it('Given opt-in and full stats, Then projects whitelisted fields only', () => {
+    const result = buildPublicProfile(
+      uid,
+      { displayName: 'Wolfi', ui: { publicProfile: true } },
+      {
+        total: 5000,
+        totalEntries: 200,
+        totalDays: 90,
+        currentStreak: 14,
+        bestSingleEntry: { reps: 50, timestamp: '2026-04-01T12:00:00Z' },
+        bestDay: { date: '2026-04-15', total: 250 },
+        updatedAt: '2026-04-29T08:30:00.000Z',
+      }
+    );
+    expect(result).toEqual({
+      uid,
+      displayName: 'Wolfi',
+      total: 5000,
+      totalEntries: 200,
+      totalDays: 90,
+      currentStreak: 14,
+      bestSingleEntry: 50,
+      bestDayTotal: 250,
+      updatedAt: '2026-04-29T08:30:00.000Z',
+    });
+  });
+
+  it('Falls back to anonymous label when displayName is missing', () => {
+    const result = buildPublicProfile(
+      uid,
+      { ui: { publicProfile: true } },
+      null
+    );
+    expect(result?.displayName).toBe('anonym');
+  });
+
+  it('Coerces non-numeric stats fields to 0', () => {
+    const result = buildPublicProfile(
+      uid,
+      { displayName: 'Wolfi', ui: { publicProfile: true } },
+      {
+        total: NaN,
+        totalEntries: undefined,
+        totalDays: 'oops' as unknown as number,
+        currentStreak: Infinity,
+      }
+    );
+    expect(result).toMatchObject({
+      total: 0,
+      totalEntries: 0,
+      totalDays: 0,
+      currentStreak: 0,
+    });
+  });
+
+  // Privacy regression — explicit list of fields a future careless edit
+  // could leak. If anyone adds a property to this projection, this spec
+  // forces them to acknowledge it.
+  it('Never leaks privacy-sensitive fields from the source documents', () => {
+    const result = buildPublicProfile(
+      uid,
+      {
+        displayName: 'Wolfi',
+        ui: { publicProfile: true, hideFromLeaderboard: false },
+        // Hypothetical future field — must not appear in projection.
+        ...({ email: 'leak@example.com' } as Record<string, unknown>),
+      },
+      {
+        total: 1,
+        totalEntries: 1,
+        totalDays: 1,
+        currentStreak: 1,
+        // Sensitive timestamps and full heatmap must not pass through.
+        ...({ heatmap: { 'Mo-08': 100 } } as Record<string, unknown>),
+        updatedAt: '2026-04-29T00:00:00Z',
+      } as never
+    );
+    const allowed = new Set([
+      'uid',
+      'displayName',
+      'total',
+      'totalEntries',
+      'totalDays',
+      'currentStreak',
+      'bestSingleEntry',
+      'bestDayTotal',
+      'updatedAt',
+    ]);
+    for (const key of Object.keys(result ?? {})) {
+      expect(allowed.has(key)).toBe(true);
+    }
+  });
+});

--- a/data-store/functions/src/profile/public-profile.spec.ts
+++ b/data-store/functions/src/profile/public-profile.spec.ts
@@ -7,14 +7,16 @@ import {
 describe('isValidUid', () => {
   it.each([
     ['', false],
-    ['short', false],
+    // Firebase allows UIDs from 1 to 128 chars; custom-token / fixture UIDs
+    // can be shorter than the 28-char anonymous default, so the validator
+    // must accept the full range.
+    ['x', true],
+    ['short', true],
     ['valid-uid-1234567890', true],
     ['ALongIshUidWithMixedCase_-09', true],
     ['has spaces', false],
     ['has/slash', false],
     ['has..dot', false],
-    ['x'.repeat(8), true],
-    ['x'.repeat(7), false],
     ['x'.repeat(128), true],
     ['x'.repeat(129), false],
   ])('isValidUid(%j) => %s', (input, expected) => {

--- a/data-store/functions/src/profile/public-profile.ts
+++ b/data-store/functions/src/profile/public-profile.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure logic for projecting a user's private stats + config into the
+ * sanitized {@link PublicProfileProjection} shape returned by the
+ * `getPublicProfile` Cloud Function.
+ *
+ * Kept Firebase-free so it can be unit-tested without an emulator and so
+ * the projection rules stay in one auditable place — every leak risk
+ * (email, goals, reminder config, raw entries) is whitelisted by absence.
+ */
+
+import { toPublicDisplayName, type UserProfile } from './logic';
+
+/** Subset of `UserConfig` this projection actually reads. */
+export interface UserConfigForPublicProfile extends UserProfile {
+  ui?: { publicProfile?: boolean; hideFromLeaderboard?: boolean };
+}
+
+/** Subset of `UserStats` this projection actually reads. */
+export interface UserStatsForPublicProfile {
+  total?: number;
+  totalEntries?: number;
+  totalDays?: number;
+  currentStreak?: number;
+  bestSingleEntry?: { reps: number; timestamp: string } | null;
+  bestDay?: { date: string; total: number } | null;
+  updatedAt?: string;
+}
+
+export interface PublicProfileProjection {
+  uid: string;
+  displayName: string;
+  total: number;
+  totalEntries: number;
+  totalDays: number;
+  currentStreak: number;
+  bestSingleEntry: number | null;
+  bestDayTotal: number | null;
+  updatedAt: string;
+}
+
+/**
+ * Returns true iff the user has explicitly opted in to a public profile.
+ * Defaults to private — undefined / missing fields = false.
+ */
+export function isPublicProfileAllowed(
+  config: UserConfigForPublicProfile | undefined | null
+): boolean {
+  return config?.ui?.publicProfile === true;
+}
+
+/**
+ * Validates a Firebase UID input. Real Firebase UIDs are URL-safe characters
+ * up to 128 chars long (anonymous: 28 chars). Reject anything outside a
+ * conservative range so a malformed slug never reaches Firestore.
+ */
+export function isValidUid(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length >= 8 &&
+    value.length <= 128 &&
+    /^[A-Za-z0-9_-]+$/.test(value)
+  );
+}
+
+/**
+ * Build the public projection. Returns `null` when the requested user has
+ * not opted in — callers MUST surface this as `not-found` to anonymous
+ * callers so existence of a private user can't be probed.
+ */
+export function buildPublicProfile(
+  uid: string,
+  config: UserConfigForPublicProfile | null,
+  stats: UserStatsForPublicProfile | null
+): PublicProfileProjection | null {
+  if (!config || !isPublicProfileAllowed(config)) return null;
+
+  return {
+    uid,
+    displayName: toPublicDisplayName(config),
+    total: numberOrZero(stats?.total),
+    totalEntries: numberOrZero(stats?.totalEntries),
+    totalDays: numberOrZero(stats?.totalDays),
+    currentStreak: numberOrZero(stats?.currentStreak),
+    bestSingleEntry:
+      typeof stats?.bestSingleEntry?.reps === 'number'
+        ? stats.bestSingleEntry.reps
+        : null,
+    bestDayTotal:
+      typeof stats?.bestDay?.total === 'number' ? stats.bestDay.total : null,
+    updatedAt: typeof stats?.updatedAt === 'string' ? stats.updatedAt : '',
+  };
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}

--- a/data-store/functions/src/profile/public-profile.ts
+++ b/data-store/functions/src/profile/public-profile.ts
@@ -49,14 +49,18 @@ export function isPublicProfileAllowed(
 }
 
 /**
- * Validates a Firebase UID input. Real Firebase UIDs are URL-safe characters
- * up to 128 chars long (anonymous: 28 chars). Reject anything outside a
- * conservative range so a malformed slug never reaches Firestore.
+ * Validates a Firebase UID input. The Auth API allows UIDs of 1-128
+ * characters; the Admin SDK accepts arbitrary strings, but in practice every
+ * shipped UID we see is URL-safe (A-Z, a-z, 0-9, `_`, `-`).
+ *
+ * We restrict the charset rather than the length so projects with custom
+ * short UIDs (e.g. test fixtures) still work, while a malformed slug like a
+ * path traversal (`..`) or a slash never reaches Firestore.
  */
 export function isValidUid(value: unknown): value is string {
   return (
     typeof value === 'string' &&
-    value.length >= 8 &&
+    value.length >= 1 &&
     value.length <= 128 &&
     /^[A-Za-z0-9_-]+$/.test(value)
   );
@@ -82,11 +86,15 @@ export function buildPublicProfile(
     totalDays: numberOrZero(stats?.totalDays),
     currentStreak: numberOrZero(stats?.currentStreak),
     bestSingleEntry:
-      typeof stats?.bestSingleEntry?.reps === 'number'
+      typeof stats?.bestSingleEntry?.reps === 'number' &&
+      Number.isFinite(stats.bestSingleEntry.reps)
         ? stats.bestSingleEntry.reps
         : null,
     bestDayTotal:
-      typeof stats?.bestDay?.total === 'number' ? stats.bestDay.total : null,
+      typeof stats?.bestDay?.total === 'number' &&
+      Number.isFinite(stats.bestDay.total)
+        ? stats.bestDay.total
+        : null,
     updatedAt: typeof stats?.updatedAt === 'string' ? stats.updatedAt : '',
   };
 }

--- a/libs/data-access/src/index.ts
+++ b/libs/data-access/src/index.ts
@@ -2,6 +2,7 @@ export * from './lib/api/stats-api.service';
 export * from './lib/api/user-config-api.service';
 export * from './lib/api/user-training-plan-api.service';
 export * from './lib/api/user-stats-api.service';
+export * from './lib/api/public-profile-api.service';
 export * from './lib/live/live-data.store';
 export * from './lib/api/pushup-firestore.service';
 export * from './lib/provide-firestore';

--- a/libs/data-access/src/lib/api/public-profile-api.service.spec.ts
+++ b/libs/data-access/src/lib/api/public-profile-api.service.spec.ts
@@ -1,0 +1,96 @@
+jest.mock('@angular/fire/functions', () => ({
+  Functions: jest.fn(),
+  // Implementation is set per-test below.
+  httpsCallable: jest.fn(),
+}));
+
+import { TestBed } from '@angular/core/testing';
+import { Functions, httpsCallable } from '@angular/fire/functions';
+import { type PublicProfile } from '@pu-stats/models';
+import { PublicProfileApiService } from './public-profile-api.service';
+
+const sampleProfile: PublicProfile = {
+  uid: 'abcdef1234567890',
+  displayName: 'Wolfi',
+  total: 5000,
+  totalEntries: 200,
+  totalDays: 90,
+  currentStreak: 14,
+  bestSingleEntry: 50,
+  bestDayTotal: 250,
+  updatedAt: '2026-04-29T08:30:00.000Z',
+};
+
+describe('PublicProfileApiService', () => {
+  function setup(callableImpl: (data: unknown) => Promise<unknown>): {
+    service: PublicProfileApiService;
+    spy: jest.Mock;
+  } {
+    const spy = jest.fn(callableImpl);
+    (httpsCallable as unknown as jest.Mock).mockReturnValue(spy);
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        PublicProfileApiService,
+        { provide: Functions, useValue: {} },
+      ],
+    });
+    return { service: TestBed.inject(PublicProfileApiService), spy };
+  }
+
+  describe('getProfile', () => {
+    it('Given the callable resolves with a projection, Then returns it', async () => {
+      const { service, spy } = setup(async () => ({ data: sampleProfile }));
+
+      const result = await service.getProfile('abcdef1234567890');
+
+      expect(result).toEqual(sampleProfile);
+      expect(spy).toHaveBeenCalledWith({ uid: 'abcdef1234567890' });
+    });
+
+    it('Given the callable rejects with functions/not-found, Then returns null', async () => {
+      const err = Object.assign(new Error('private'), {
+        code: 'functions/not-found',
+      });
+      const { service } = setup(async () => {
+        throw err;
+      });
+
+      const result = await service.getProfile('abcdef1234567890');
+
+      expect(result).toBeNull();
+    });
+
+    it('Given the callable rejects with bare not-found code, Then returns null', async () => {
+      // Some Firebase Functions SDK versions strip the `functions/` prefix.
+      const err = Object.assign(new Error('private'), { code: 'not-found' });
+      const { service } = setup(async () => {
+        throw err;
+      });
+
+      const result = await service.getProfile('abcdef1234567890');
+
+      expect(result).toBeNull();
+    });
+
+    it('Given the callable rejects with another error code, Then re-throws', async () => {
+      const err = Object.assign(new Error('boom'), {
+        code: 'functions/internal',
+      });
+      const { service } = setup(async () => {
+        throw err;
+      });
+
+      await expect(service.getProfile('abcdef1234567890')).rejects.toBe(err);
+    });
+
+    it('Given the callable resolves with no data, Then returns null', async () => {
+      const { service } = setup(async () => ({}));
+
+      const result = await service.getProfile('abcdef1234567890');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/libs/data-access/src/lib/api/public-profile-api.service.ts
+++ b/libs/data-access/src/lib/api/public-profile-api.service.ts
@@ -1,0 +1,43 @@
+import { inject, Injectable } from '@angular/core';
+import { Functions, httpsCallable } from '@angular/fire/functions';
+import { type PublicProfile } from '@pu-stats/models';
+
+/**
+ * Thin wrapper around the `getPublicProfile` callable Cloud Function.
+ *
+ * The function is intentionally invokable without auth: it powers the
+ * `/u/:uid` public route and the dynamic OG image endpoint. Privacy is
+ * enforced server-side — only users with `ui.publicProfile === true` get
+ * a projection back; everyone else surfaces as `not-found`.
+ */
+@Injectable({ providedIn: 'root' })
+export class PublicProfileApiService {
+  private readonly functions = inject(Functions);
+
+  /**
+   * Fetches the public profile projection. Returns `null` when the requested
+   * user does not exist or has not opted in — callers MUST treat both as a
+   * 404 to avoid leaking account existence.
+   */
+  async getProfile(uid: string): Promise<PublicProfile | null> {
+    const callable = httpsCallable<{ uid: string }, PublicProfile>(
+      this.functions,
+      'getPublicProfile'
+    );
+    try {
+      const result = await callable({ uid });
+      return result.data ?? null;
+    } catch (err) {
+      // Distinguish opt-out / nonexistent (treat as null) from other errors.
+      if (isNotFoundError(err)) return null;
+      throw err;
+    }
+  }
+}
+
+function isNotFoundError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const code = (err as { code?: unknown }).code;
+  // FirebaseError carries `functions/not-found`; also accept the bare HttpsError code.
+  return code === 'functions/not-found' || code === 'not-found';
+}

--- a/libs/stats/src/lib/models/public-profile.models.ts
+++ b/libs/stats/src/lib/models/public-profile.models.ts
@@ -1,0 +1,28 @@
+/**
+ * Sanitized projection of a user's stats for the public profile route.
+ *
+ * Only fields safe to expose to anonymous visitors live here. Anything that
+ * touches privacy (email, goals, reminder config, raw entries, leaderboard
+ * opt-in) MUST stay behind owner-only Firestore rules and never leak into
+ * this shape.
+ */
+export interface PublicProfile {
+  /** Firebase UID — used as the canonical permalink slug `/u/:uid`. */
+  readonly uid: string;
+  /** Public display name (anonymous fallback when none was set). */
+  readonly displayName: string;
+  /** Total reps across all time. */
+  readonly total: number;
+  /** Total number of recorded entries. */
+  readonly totalEntries: number;
+  /** Total number of unique days with at least one entry. */
+  readonly totalDays: number;
+  /** Current consecutive-day streak. */
+  readonly currentStreak: number;
+  /** Best single-entry rep count (null until any entries exist). */
+  readonly bestSingleEntry: number | null;
+  /** Best single-day total reps (null until any entries exist). */
+  readonly bestDayTotal: number | null;
+  /** ISO timestamp of the last stats update. */
+  readonly updatedAt: string;
+}

--- a/libs/stats/src/lib/models/stats.models.ts
+++ b/libs/stats/src/lib/models/stats.models.ts
@@ -34,3 +34,4 @@ export * from './pushup.models';
 export * from './user-config.models';
 export * from './reminder-config.models';
 export * from './user-stats.models';
+export * from './public-profile.models';

--- a/libs/stats/src/lib/models/user-config.models.ts
+++ b/libs/stats/src/lib/models/user-config.models.ts
@@ -36,6 +36,12 @@ export interface UserConfig {
   ui?: {
     showSourceColumn?: boolean;
     hideFromLeaderboard?: boolean;
+    /**
+     * Public-profile opt-in. When `true`, the `getPublicProfile(uid)` Cloud
+     * Function returns a sanitized projection of this user's stats; otherwise
+     * it returns `not-found`. Defaults to `false` (private).
+     */
+    publicProfile?: boolean;
     dayChartMode?: '24h' | '14h';
     quickAdds?: QuickAddConfig[];
     snapQuality?: SnapQuality;

--- a/web/src/app/app.routes.server.ts
+++ b/web/src/app/app.routes.server.ts
@@ -47,6 +47,12 @@ export const serverRoutes: ServerRoute[] = [
     path: 'leaderboard',
     renderMode: RenderMode.Server,
   },
+  // Public profile pages: dynamic per UID, server-rendered so social-card
+  // crawlers see populated meta tags without running client JS.
+  {
+    path: 'u/:uid',
+    renderMode: RenderMode.Server,
+  },
   {
     path: 'app',
     renderMode: RenderMode.Server,

--- a/web/src/app/app.routes.spec.ts
+++ b/web/src/app/app.routes.spec.ts
@@ -30,6 +30,7 @@ describe('appRoutes', () => {
       'training-plans/:slug',
       'reminders',
       'leaderboard',
+      'u/:uid',
       'blog',
       'impressum',
       'datenschutz',

--- a/web/src/app/app.routes.ts
+++ b/web/src/app/app.routes.ts
@@ -135,6 +135,17 @@ export const appRoutes: Routes = [
       ),
   },
   {
+    path: 'u/:uid',
+    data: {
+      seoTitle: $localize`:@@seo.publicProfile.title:Profil – Pushup Tracker`,
+      seoDescription: $localize`:@@seo.publicProfile.description:Öffentliches Pushup-Profil mit Reps, Streak und Bestleistungen.`,
+    },
+    loadComponent: () =>
+      import('./public-profile/public-profile-page.component').then(
+        (m) => m.PublicProfilePageComponent
+      ),
+  },
+  {
     path: 'blog',
     children: [
       {

--- a/web/src/app/public-profile/public-profile-page.component.html
+++ b/web/src/app/public-profile/public-profile-page.component.html
@@ -1,0 +1,111 @@
+<main class="container" data-testid="public-profile-page">
+  @switch (state().kind) {
+    @case ('loading') {
+      <div class="status-card" role="status" aria-live="polite">
+        <mat-spinner diameter="36"></mat-spinner>
+      </div>
+    }
+    @case ('not-found') {
+      <mat-card class="status-card" data-testid="public-profile-not-found">
+        <mat-card-header>
+          <mat-card-title>{{ notFoundTitle }}</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <p>{{ notFoundBody }}</p>
+        </mat-card-content>
+        <mat-card-actions>
+          <a mat-stroked-button routerLink="/">{{ homeLabel }}</a>
+        </mat-card-actions>
+      </mat-card>
+    }
+    @case ('error') {
+      <mat-card class="status-card" data-testid="public-profile-error">
+        <mat-card-header>
+          <mat-card-title>{{ errorTitle }}</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <p>{{ errorBody }}</p>
+        </mat-card-content>
+        <mat-card-actions>
+          <button mat-stroked-button type="button" (click)="reload()">
+            {{ retryLabel }}
+          </button>
+        </mat-card-actions>
+      </mat-card>
+    }
+    @case ('ready') {
+      @if (profile(); as p) {
+        <header class="profile-header">
+          <div class="avatar" aria-hidden="true">
+            <mat-icon>fitness_center</mat-icon>
+          </div>
+          <div class="header-text">
+            <h1 data-testid="public-profile-name">{{ p.displayName }}</h1>
+            <p class="subtitle">Pushup Tracker</p>
+          </div>
+          <button
+            mat-stroked-button
+            type="button"
+            class="share-btn"
+            data-testid="public-profile-share"
+            [attr.aria-label]="shareAriaLabel"
+            (click)="shareProfile()"
+          >
+            <mat-icon>share</mat-icon>
+            <span>{{ shareLabel }}</span>
+          </button>
+        </header>
+
+        <section class="stats-grid" [attr.aria-label]="statsLabel">
+          <mat-card class="stat-card">
+            <mat-card-content>
+              <small>{{ totalLabel }}</small>
+              <b data-testid="public-profile-total">{{ p.total }}</b>
+            </mat-card-content>
+          </mat-card>
+          <mat-card class="stat-card">
+            <mat-card-content>
+              <small>{{ streakLabel }}</small>
+              <b data-testid="public-profile-streak">{{ p.currentStreak }}</b>
+            </mat-card-content>
+          </mat-card>
+          <mat-card class="stat-card">
+            <mat-card-content>
+              <small>{{ daysLabel }}</small>
+              <b>{{ p.totalDays }}</b>
+            </mat-card-content>
+          </mat-card>
+          <mat-card class="stat-card">
+            <mat-card-content>
+              <small>{{ entriesLabel }}</small>
+              <b>{{ p.totalEntries }}</b>
+            </mat-card-content>
+          </mat-card>
+          @if (p.bestSingleEntry !== null) {
+            <mat-card class="stat-card">
+              <mat-card-content>
+                <small>{{ bestSetLabel }}</small>
+                <b>{{ p.bestSingleEntry }}</b>
+              </mat-card-content>
+            </mat-card>
+          }
+          @if (p.bestDayTotal !== null) {
+            <mat-card class="stat-card">
+              <mat-card-content>
+                <small>{{ bestDayLabel }}</small>
+                <b>{{ p.bestDayTotal }}</b>
+              </mat-card-content>
+            </mat-card>
+          }
+        </section>
+
+        <section class="cta">
+          <a mat-flat-button color="primary" routerLink="/">
+            <mat-icon>fitness_center</mat-icon>
+            <span>{{ ctaLabel }}</span>
+          </a>
+        </section>
+      }
+    }
+  }
+</main>

--- a/web/src/app/public-profile/public-profile-page.component.html
+++ b/web/src/app/public-profile/public-profile-page.component.html
@@ -41,7 +41,9 @@
           </div>
           <div class="header-text">
             <h1 data-testid="public-profile-name">{{ p.displayName }}</h1>
-            <p class="subtitle">Pushup Tracker</p>
+            <p class="subtitle" i18n="@@publicProfile.subtitle">
+              Pushup Tracker
+            </p>
           </div>
           <button
             mat-stroked-button
@@ -60,32 +62,36 @@
           <mat-card class="stat-card">
             <mat-card-content>
               <small>{{ totalLabel }}</small>
-              <b data-testid="public-profile-total">{{ p.total }}</b>
+              <b data-testid="public-profile-total">{{
+                p.total | number: '1.0-0'
+              }}</b>
             </mat-card-content>
           </mat-card>
           <mat-card class="stat-card">
             <mat-card-content>
               <small>{{ streakLabel }}</small>
-              <b data-testid="public-profile-streak">{{ p.currentStreak }}</b>
+              <b data-testid="public-profile-streak">{{
+                p.currentStreak | number: '1.0-0'
+              }}</b>
             </mat-card-content>
           </mat-card>
           <mat-card class="stat-card">
             <mat-card-content>
               <small>{{ daysLabel }}</small>
-              <b>{{ p.totalDays }}</b>
+              <b>{{ p.totalDays | number: '1.0-0' }}</b>
             </mat-card-content>
           </mat-card>
           <mat-card class="stat-card">
             <mat-card-content>
               <small>{{ entriesLabel }}</small>
-              <b>{{ p.totalEntries }}</b>
+              <b>{{ p.totalEntries | number: '1.0-0' }}</b>
             </mat-card-content>
           </mat-card>
           @if (p.bestSingleEntry !== null) {
             <mat-card class="stat-card">
               <mat-card-content>
                 <small>{{ bestSetLabel }}</small>
-                <b>{{ p.bestSingleEntry }}</b>
+                <b>{{ p.bestSingleEntry | number: '1.0-0' }}</b>
               </mat-card-content>
             </mat-card>
           }
@@ -93,7 +99,7 @@
             <mat-card class="stat-card">
               <mat-card-content>
                 <small>{{ bestDayLabel }}</small>
-                <b>{{ p.bestDayTotal }}</b>
+                <b>{{ p.bestDayTotal | number: '1.0-0' }}</b>
               </mat-card-content>
             </mat-card>
           }

--- a/web/src/app/public-profile/public-profile-page.component.scss
+++ b/web/src/app/public-profile/public-profile-page.component.scss
@@ -1,0 +1,167 @@
+:host {
+  display: block;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: clamp(18px, 3vw, 36px);
+  display: grid;
+  gap: 20px;
+  color: #e6edf9;
+}
+
+.status-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  padding: 24px;
+}
+
+.profile-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: clamp(16px, 2vw, 24px);
+  border: 1px solid rgba(123, 159, 255, 0.25);
+  border-radius: 20px;
+  background: linear-gradient(
+    150deg,
+    rgba(26, 35, 58, 0.9),
+    rgba(13, 18, 32, 0.9)
+  );
+}
+
+.avatar {
+  flex-shrink: 0;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(
+    135deg,
+    rgba(63, 128, 255, 0.92),
+    rgba(58, 92, 213, 0.92)
+  );
+  color: #f4f8ff;
+
+  mat-icon {
+    font-size: 36px;
+    width: 36px;
+    height: 36px;
+  }
+}
+
+.header-text {
+  flex: 1 1 auto;
+  min-width: 0;
+
+  h1 {
+    margin: 0;
+    font-size: clamp(1.4rem, 3vw, 2rem);
+  }
+
+  .subtitle {
+    margin: 4px 0 0;
+    color: #9fb3de;
+    font-size: 0.85rem;
+  }
+}
+
+.share-btn {
+  flex-shrink: 0;
+  align-self: center;
+
+  mat-icon {
+    margin-right: 4px;
+  }
+}
+
+.stats-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.stat-card {
+  border: 1px solid rgba(123, 159, 255, 0.24);
+  background: linear-gradient(
+    170deg,
+    rgba(22, 30, 49, 0.86),
+    rgba(14, 19, 33, 0.9)
+  );
+
+  mat-card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  small {
+    color: #9fb3de;
+    font-size: 0.74rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  b {
+    font-size: 1.6rem;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.cta {
+  display: flex;
+  justify-content: center;
+
+  a mat-icon {
+    margin-right: 8px;
+  }
+}
+
+@media (max-width: 600px) {
+  .profile-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .share-btn {
+    align-self: stretch;
+  }
+}
+
+:host-context(html.light-theme) {
+  .container {
+    color: #1e293b;
+  }
+
+  .profile-header {
+    border-color: rgba(59, 130, 246, 0.25);
+    background: linear-gradient(
+      150deg,
+      rgba(248, 250, 252, 0.95),
+      rgba(241, 245, 249, 0.95)
+    );
+  }
+
+  .header-text .subtitle {
+    color: #64748b;
+  }
+
+  .stat-card {
+    border-color: rgba(59, 130, 246, 0.25);
+    background: linear-gradient(
+      170deg,
+      rgba(255, 255, 255, 0.95),
+      rgba(248, 250, 252, 0.98)
+    );
+
+    small {
+      color: #64748b;
+    }
+  }
+}

--- a/web/src/app/public-profile/public-profile-page.component.spec.ts
+++ b/web/src/app/public-profile/public-profile-page.component.spec.ts
@@ -1,0 +1,160 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, ParamMap } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+import { PublicProfileApiService } from '@pu-stats/data-access';
+import { type PublicProfile } from '@pu-stats/models';
+import { PublicProfilePageComponent } from './public-profile-page.component';
+import { ShareService } from '../core/share.service';
+import { SeoService } from '../core/seo.service';
+
+const sampleProfile: PublicProfile = {
+  uid: 'abcdef1234567890',
+  displayName: 'Wolfi',
+  total: 5000,
+  totalEntries: 200,
+  totalDays: 90,
+  currentStreak: 14,
+  bestSingleEntry: 50,
+  bestDayTotal: 250,
+  updatedAt: '2026-04-29T08:30:00.000Z',
+};
+
+describe('PublicProfilePageComponent', () => {
+  let fixture: ComponentFixture<PublicProfilePageComponent>;
+  const apiMock = {
+    getProfile: vitest.fn<(uid: string) => Promise<PublicProfile | null>>(),
+  };
+  const shareMock = { share: vitest.fn().mockResolvedValue('native') };
+  const seoMock = { update: vitest.fn() };
+
+  function makeRoute(uid: string | null): ActivatedRoute {
+    const params = uid ? { uid } : {};
+    const map = convertToParamMap(params);
+    return {
+      paramMap: new BehaviorSubject<ParamMap>(map).asObservable(),
+      snapshot: { paramMap: map },
+    } as unknown as ActivatedRoute;
+  }
+
+  async function setup(
+    options: {
+      uid?: string | null;
+      resolve?: PublicProfile | null;
+      reject?: unknown;
+    } = {}
+  ): Promise<void> {
+    vitest.clearAllMocks();
+    if (options.reject !== undefined) {
+      apiMock.getProfile.mockRejectedValue(options.reject);
+    } else {
+      apiMock.getProfile.mockResolvedValue(options.resolve ?? null);
+    }
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [PublicProfilePageComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: makeRoute(
+            options.uid === undefined ? sampleProfile.uid : options.uid
+          ),
+        },
+        { provide: PublicProfileApiService, useValue: apiMock },
+        { provide: ShareService, useValue: shareMock },
+        { provide: SeoService, useValue: seoMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PublicProfilePageComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  describe('Given the API returns a profile', () => {
+    it('Then it renders the displayName, total reps and streak', async () => {
+      await setup({ resolve: sampleProfile });
+
+      const root = fixture.nativeElement as HTMLElement;
+      expect(
+        root.querySelector('[data-testid="public-profile-name"]')?.textContent
+      ).toContain('Wolfi');
+      expect(
+        root.querySelector('[data-testid="public-profile-total"]')?.textContent
+      ).toContain('5000');
+      expect(
+        root.querySelector('[data-testid="public-profile-streak"]')?.textContent
+      ).toContain('14');
+    });
+
+    it('Then it sets SEO meta tags including the displayName', async () => {
+      await setup({ resolve: sampleProfile });
+
+      expect(seoMock.update).toHaveBeenCalled();
+      const args = seoMock.update.mock.calls.at(-1)!;
+      expect(args[0]).toContain('Wolfi');
+      expect(args[2]).toBe('/u/abcdef1234567890');
+    });
+
+    it('Then clicking share forwards the profile URL to ShareService', async () => {
+      await setup({ resolve: sampleProfile });
+
+      const button = fixture.nativeElement.querySelector(
+        '[data-testid="public-profile-share"]'
+      ) as HTMLButtonElement;
+      button.click();
+      await fixture.whenStable();
+
+      expect(shareMock.share).toHaveBeenCalledTimes(1);
+      const payload = shareMock.share.mock.calls[0][0];
+      expect(payload.url).toBe('https://pushup-stats.de/u/abcdef1234567890');
+      expect(payload.text).toContain('Wolfi');
+      expect(payload.text).toContain('5000');
+    });
+  });
+
+  describe('Given the API returns null (private/unknown user)', () => {
+    it('Then it shows the not-found state', async () => {
+      await setup({ resolve: null });
+
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="public-profile-not-found"]'
+        )
+      ).toBeTruthy();
+      // Privacy regression: never display the queried UID, so an attacker
+      // can't confirm whether the user exists.
+      expect(fixture.nativeElement.textContent).not.toContain(
+        sampleProfile.uid
+      );
+    });
+  });
+
+  describe('Given the API rejects with an error', () => {
+    it('Then it shows the error state with a retry button', async () => {
+      await setup({ reject: new Error('boom') });
+
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="public-profile-error"]'
+        )
+      ).toBeTruthy();
+    });
+  });
+
+  describe('Given the route has no uid param', () => {
+    it('Then it shows not-found without calling the API', async () => {
+      await setup({ uid: null });
+
+      expect(apiMock.getProfile).not.toHaveBeenCalled();
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="public-profile-not-found"]'
+        )
+      ).toBeTruthy();
+    });
+  });
+});

--- a/web/src/app/public-profile/public-profile-page.component.spec.ts
+++ b/web/src/app/public-profile/public-profile-page.component.spec.ts
@@ -82,8 +82,13 @@ describe('PublicProfilePageComponent', () => {
       expect(
         root.querySelector('[data-testid="public-profile-name"]')?.textContent
       ).toContain('Wolfi');
+      // The number pipe formats with the active LOCALE_ID (en-US in tests),
+      // so 5000 renders as "5,000". Match the digits regardless of grouping
+      // separator so changing LOCALE_ID for tests doesn't break the assertion.
       expect(
-        root.querySelector('[data-testid="public-profile-total"]')?.textContent
+        root
+          .querySelector('[data-testid="public-profile-total"]')
+          ?.textContent?.replace(/[,.\s]/g, '')
       ).toContain('5000');
       expect(
         root.querySelector('[data-testid="public-profile-streak"]')?.textContent

--- a/web/src/app/public-profile/public-profile-page.component.ts
+++ b/web/src/app/public-profile/public-profile-page.component.ts
@@ -1,0 +1,136 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { PublicProfileApiService } from '@pu-stats/data-access';
+import { type PublicProfile } from '@pu-stats/models';
+import { ShareService } from '../core/share.service';
+import { SeoService } from '../core/seo.service';
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; profile: PublicProfile }
+  | { kind: 'not-found' }
+  | { kind: 'error' };
+
+const SHARE_URL_BASE = 'https://pushup-stats.de';
+
+@Component({
+  selector: 'app-public-profile-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink,
+    MatCardModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './public-profile-page.component.html',
+  styleUrl: './public-profile-page.component.scss',
+})
+export class PublicProfilePageComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly api = inject(PublicProfileApiService);
+  private readonly seo = inject(SeoService);
+  private readonly shareService = inject(ShareService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly state = signal<LoadState>({ kind: 'loading' });
+  protected readonly profile = computed(() => {
+    const s = this.state();
+    return s.kind === 'ready' ? s.profile : null;
+  });
+
+  protected readonly notFoundTitle = $localize`:@@publicProfile.notFound.title:Profil nicht gefunden`;
+  protected readonly notFoundBody = $localize`:@@publicProfile.notFound.body:Dieses Profil existiert nicht oder wurde nicht öffentlich freigegeben.`;
+  protected readonly errorTitle = $localize`:@@publicProfile.error.title:Profil konnte nicht geladen werden`;
+  protected readonly errorBody = $localize`:@@publicProfile.error.body:Bitte versuche es später erneut.`;
+  protected readonly retryLabel = $localize`:@@publicProfile.retry:Erneut versuchen`;
+  protected readonly homeLabel = $localize`:@@publicProfile.toHome:Zur Startseite`;
+  protected readonly statsLabel = $localize`:@@publicProfile.stats:Statistik`;
+  protected readonly totalLabel = $localize`:@@publicProfile.total:Gesamte Reps`;
+  protected readonly streakLabel = $localize`:@@publicProfile.streak:Aktuelle Streak`;
+  protected readonly daysLabel = $localize`:@@publicProfile.days:Aktive Tage`;
+  protected readonly entriesLabel = $localize`:@@publicProfile.entries:Einträge`;
+  protected readonly bestSetLabel = $localize`:@@publicProfile.bestSet:Bester Einzel-Eintrag`;
+  protected readonly bestDayLabel = $localize`:@@publicProfile.bestDay:Bester Tag`;
+  protected readonly shareAriaLabel = $localize`:@@publicProfile.share.aria:Profil teilen`;
+  protected readonly shareLabel = $localize`:@@publicProfile.share:Teilen`;
+  protected readonly ctaLabel = $localize`:@@publicProfile.cta:Selbst tracken – pushup-stats.de`;
+
+  constructor() {
+    this.route.paramMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((params) => {
+        const uid = (params.get('uid') ?? '').trim();
+        if (!uid) {
+          this.state.set({ kind: 'not-found' });
+          this.applySeo(null);
+          return;
+        }
+        void this.load(uid);
+      });
+  }
+
+  protected reload(): void {
+    const uid = this.route.snapshot.paramMap.get('uid')?.trim();
+    if (uid) void this.load(uid);
+  }
+
+  protected shareProfile(): void {
+    const profile = this.profile();
+    if (!profile) return;
+    const text = $localize`:@@publicProfile.share.text:${profile.displayName}:name: hat ${profile.total}:total: Liegestütze auf Pushup Tracker geschafft 💪 Schau's dir an:`;
+    void this.shareService.share({
+      title: $localize`:@@publicProfile.share.title:Pushup Tracker Profil`,
+      text,
+      url: `${SHARE_URL_BASE}/u/${profile.uid}`,
+    });
+  }
+
+  private async load(uid: string): Promise<void> {
+    this.state.set({ kind: 'loading' });
+    try {
+      const profile = await this.api.getProfile(uid);
+      if (!profile) {
+        this.state.set({ kind: 'not-found' });
+        this.applySeo(null);
+        return;
+      }
+      this.state.set({ kind: 'ready', profile });
+      this.applySeo(profile);
+    } catch {
+      this.state.set({ kind: 'error' });
+      this.applySeo(null);
+    }
+  }
+
+  private applySeo(profile: PublicProfile | null): void {
+    if (!profile) {
+      this.seo.update(
+        $localize`:@@publicProfile.seo.notFound.title:Profil nicht verfügbar – Pushup Tracker`,
+        $localize`:@@publicProfile.seo.notFound.description:Dieses Profil existiert nicht oder ist nicht öffentlich.`,
+        '/u/'
+      );
+      return;
+    }
+    this.seo.update(
+      $localize`:@@publicProfile.seo.title:${profile.displayName}:name: – Pushup Tracker Profil`,
+      $localize`:@@publicProfile.seo.description:${profile.displayName}:name: hat ${profile.total}:total: Liegestütze und eine ${profile.currentStreak}:streak:-Tage-Streak auf Pushup Tracker.`,
+      `/u/${profile.uid}`
+    );
+  }
+}

--- a/web/src/app/public-profile/public-profile-page.component.ts
+++ b/web/src/app/public-profile/public-profile-page.component.ts
@@ -71,12 +71,21 @@ export class PublicProfilePageComponent {
   protected readonly shareLabel = $localize`:@@publicProfile.share:Teilen`;
   protected readonly ctaLabel = $localize`:@@publicProfile.cta:Selbst tracken – pushup-stats.de`;
 
+  /**
+   * Monotonic request token. Increments on every route emission AND every
+   * `load()` start; only the most recent token is allowed to commit state /
+   * SEO. Without this, navigating quickly between two `/u/:uid` pages can
+   * let the slower request finish last and overwrite the newer profile.
+   */
+  private loadVersion = 0;
+
   constructor() {
     this.route.paramMap
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((params) => {
         const uid = (params.get('uid') ?? '').trim();
         if (!uid) {
+          this.loadVersion++;
           this.state.set({ kind: 'not-found' });
           this.applySeo(null);
           return;
@@ -102,9 +111,11 @@ export class PublicProfilePageComponent {
   }
 
   private async load(uid: string): Promise<void> {
+    const version = ++this.loadVersion;
     this.state.set({ kind: 'loading' });
     try {
       const profile = await this.api.getProfile(uid);
+      if (version !== this.loadVersion) return;
       if (!profile) {
         this.state.set({ kind: 'not-found' });
         this.applySeo(null);
@@ -113,17 +124,25 @@ export class PublicProfilePageComponent {
       this.state.set({ kind: 'ready', profile });
       this.applySeo(profile);
     } catch {
+      if (version !== this.loadVersion) return;
       this.state.set({ kind: 'error' });
       this.applySeo(null);
     }
   }
 
+  private currentPath(): string {
+    const uid = this.route.snapshot.paramMap.get('uid')?.trim();
+    return uid ? `/u/${uid}` : '/u/';
+  }
+
   private applySeo(profile: PublicProfile | null): void {
     if (!profile) {
+      // Use the actual requested path so canonical / og:url stay in sync
+      // with the URL the visitor sees, even on the not-found state.
       this.seo.update(
         $localize`:@@publicProfile.seo.notFound.title:Profil nicht verfügbar – Pushup Tracker`,
         $localize`:@@publicProfile.seo.notFound.description:Dieses Profil existiert nicht oder ist nicht öffentlich.`,
-        '/u/'
+        this.currentPath()
       );
       return;
     }

--- a/web/src/app/stats/shell/settings-page.component.ts
+++ b/web/src/app/stats/shell/settings-page.component.ts
@@ -22,6 +22,7 @@ import { Analytics, logEvent } from '@angular/fire/analytics';
 import { PushSubscriptionService } from '@pu-reminders/reminders';
 import { DEFAULT_SNAP_QUALITY, SnapQuality } from '@pu-stats/models';
 import { UserConfigStore } from '../../core/user-config.store';
+import { ShareService } from '../../core/share.service';
 
 @Component({
   selector: 'app-settings-page',
@@ -90,6 +91,39 @@ import { UserConfigStore } from '../../core/user-config.store';
               Wenn deaktiviert, wird dein Profil in der Bestenliste nicht
               angezeigt.
             </p>
+
+            <mat-slide-toggle
+              [checked]="publicProfileDraft()"
+              (change)="publicProfileDraft.set($event.checked)"
+              data-testid="settings-public-profile-toggle"
+              i18n="@@settings.publicProfile.toggle"
+            >
+              Öffentliches Profil aktivieren
+            </mat-slide-toggle>
+
+            <p class="muted" i18n="@@settings.publicProfile.hint">
+              Erlaubt jedem mit dem Link den Zugriff auf deine Reps, Streak und
+              Bestleistungen. Dein Anzeigename ist sichtbar; E-Mail, Ziele und
+              Erinnerungen bleiben privat.
+            </p>
+
+            @if (publicProfileDraft() && profileUrl()) {
+              <div
+                class="profile-link-row"
+                data-testid="settings-public-profile-link"
+              >
+                <code class="profile-link">{{ profileUrl() }}</code>
+                <button
+                  type="button"
+                  mat-stroked-button
+                  (click)="shareMyProfile()"
+                  i18n="@@settings.publicProfile.shareCta"
+                >
+                  <mat-icon>share</mat-icon>
+                  Profil teilen
+                </button>
+              </div>
+            }
 
             <mat-slide-toggle
               [checked]="adsConsentDraft()"
@@ -327,6 +361,23 @@ import { UserConfigStore } from '../../core/user-config.store';
       font-size: 0.9rem;
       margin: 0;
     }
+    .profile-link-row {
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+      padding: 10px 12px;
+      border-radius: 10px;
+      background: rgba(123, 159, 255, 0.12);
+      border: 1px solid rgba(123, 159, 255, 0.28);
+    }
+    .profile-link {
+      flex: 1 1 auto;
+      min-width: 0;
+      font-family: ui-monospace, monospace;
+      font-size: 0.85rem;
+      overflow-wrap: anywhere;
+    }
     .reminders-link-section {
       margin-top: 16px;
       padding-top: 12px;
@@ -397,16 +448,24 @@ export class SettingsPageComponent {
   private readonly snackBar = inject(MatSnackBar);
   private readonly pushService = inject(PushSubscriptionService);
   private readonly userConfigStore = inject(UserConfigStore);
+  private readonly shareService = inject(ShareService);
 
   readonly isGuest = this.user.isGuest;
+  readonly userId = this.user.userIdSafe;
 
   readonly displayNameDraft = signal('');
   readonly dailyGoalDraft = signal<number>(10);
   readonly weeklyGoalDraft = signal<number>(50);
   readonly monthlyGoalDraft = signal<number>(200);
   readonly leaderboardOptOutDraft = signal(false);
+  readonly publicProfileDraft = signal(false);
   readonly adsConsentDraft = signal(false);
   readonly snapQualityDraft = signal<SnapQuality>(DEFAULT_SNAP_QUALITY);
+
+  readonly profileUrl = computed(() => {
+    const uid = this.userId();
+    return uid ? `https://pushup-stats.de/u/${uid}` : '';
+  });
 
   readonly saving = signal(false);
   readonly saved = signal(false);
@@ -424,6 +483,7 @@ export class SettingsPageComponent {
         weeklyGoal: 50,
         monthlyGoal: 200,
         hideFromLeaderboard: false,
+        publicProfile: false,
         consent: { targetedAds: true },
         snapQuality: DEFAULT_SNAP_QUALITY,
       };
@@ -444,6 +504,9 @@ export class SettingsPageComponent {
       hideFromLeaderboard:
         (val as { ui?: { hideFromLeaderboard?: boolean } }).ui
           ?.hideFromLeaderboard ?? false,
+      publicProfile:
+        (val as { ui?: { publicProfile?: boolean } }).ui?.publicProfile ??
+        false,
       consent: (val as { consent?: { targetedAds?: boolean } }).consent ?? {
         targetedAds: true,
       },
@@ -462,8 +525,19 @@ export class SettingsPageComponent {
       this.weeklyGoalDraft.set(cfg.weeklyGoal);
       this.monthlyGoalDraft.set(cfg.monthlyGoal);
       this.leaderboardOptOutDraft.set(cfg.hideFromLeaderboard);
+      this.publicProfileDraft.set(cfg.publicProfile);
       this.adsConsentDraft.set(cfg.consent?.targetedAds ?? true);
       this.snapQualityDraft.set(cfg.snapQuality);
+    });
+  }
+
+  shareMyProfile(): void {
+    const url = this.profileUrl();
+    if (!url) return;
+    void this.shareService.share({
+      title: $localize`:@@settings.publicProfile.share.title:Mein Pushup Tracker Profil`,
+      text: $localize`:@@settings.publicProfile.share.text:Schau dir mein Pushup-Profil an:`,
+      url,
     });
   }
 
@@ -498,12 +572,14 @@ export class SettingsPageComponent {
         },
         ui: {
           hideFromLeaderboard: this.leaderboardOptOutDraft(),
+          publicProfile: this.publicProfileDraft(),
           snapQuality: this.snapQualityDraft(),
         },
       });
       this.saved.set(true);
       this.trackAnalytics('settings_saved', {
         hideFromLeaderboard: this.leaderboardOptOutDraft(),
+        publicProfile: this.publicProfileDraft(),
         dailyGoal,
         weeklyGoal,
         monthlyGoal,

--- a/web/src/app/stats/shell/settings-page.component.ts
+++ b/web/src/app/stats/shell/settings-page.component.ts
@@ -107,7 +107,12 @@ import { ShareService } from '../../core/share.service';
               Erinnerungen bleiben privat.
             </p>
 
-            @if (publicProfileDraft() && profileUrl()) {
+            <!-- Gate the share CTA on the persisted setting (not the draft).
+                 If we showed the link as soon as the toggle flipped, a user
+                 could tap "Profil teilen" before save() has written
+                 ui.publicProfile to Firestore and end up sharing a link that
+                 the backend will 404. -->
+            @if (config().publicProfile && profileUrl()) {
               <div
                 class="profile-link-row"
                 data-testid="settings-public-profile-link"

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -5832,5 +5832,179 @@ Deine Position: # ·  Reps        </source>
         <target>Sharing is not available on this device.</target>
       </segment>
     </unit>
+    <unit id="seo.publicProfile.title">
+      <segment state="translated">
+        <source>Profil – Pushup Tracker</source>
+        <target>Profile – Pushup Tracker</target>
+      </segment>
+    </unit>
+    <unit id="seo.publicProfile.description">
+      <segment state="translated">
+        <source>Öffentliches Pushup-Profil mit Reps, Streak und Bestleistungen.</source>
+        <target>Public push-up profile with reps, streak and personal bests.</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.notFound.title">
+      <segment state="translated">
+        <source>Profil nicht gefunden</source>
+        <target>Profile not found</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.notFound.body">
+      <segment state="translated">
+        <source>Dieses Profil existiert nicht oder wurde nicht öffentlich freigegeben.</source>
+        <target>This profile does not exist or has not been made public.</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.error.title">
+      <segment state="translated">
+        <source>Profil konnte nicht geladen werden</source>
+        <target>Could not load profile</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.error.body">
+      <segment state="translated">
+        <source>Bitte versuche es später erneut.</source>
+        <target>Please try again later.</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.retry">
+      <segment state="translated">
+        <source>Erneut versuchen</source>
+        <target>Try again</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.toHome">
+      <segment state="translated">
+        <source>Zur Startseite</source>
+        <target>Go to homepage</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.stats">
+      <segment state="translated">
+        <source>Statistik</source>
+        <target>Stats</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.total">
+      <segment state="translated">
+        <source>Gesamte Reps</source>
+        <target>Total reps</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.streak">
+      <segment state="translated">
+        <source>Aktuelle Streak</source>
+        <target>Current streak</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.days">
+      <segment state="translated">
+        <source>Aktive Tage</source>
+        <target>Active days</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.entries">
+      <segment state="translated">
+        <source>Einträge</source>
+        <target>Entries</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.bestSet">
+      <segment state="translated">
+        <source>Bester Einzel-Eintrag</source>
+        <target>Best single entry</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.bestDay">
+      <segment state="translated">
+        <source>Bester Tag</source>
+        <target>Best day</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.share.aria">
+      <segment state="translated">
+        <source>Profil teilen</source>
+        <target>Share profile</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.share">
+      <segment state="translated">
+        <source>Teilen</source>
+        <target>Share</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.cta">
+      <segment state="translated">
+        <source>Selbst tracken – pushup-stats.de</source>
+        <target>Track your own – pushup-stats.de</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.share.text">
+      <segment state="translated">
+        <source><ph id="0" equiv="name" disp="name"/> hat <ph id="1" equiv="total" disp="total"/> Liegestütze auf Pushup Tracker geschafft 💪 Schau's dir an:</source>
+        <target><ph id="0" equiv="name" disp="name"/> hit <ph id="1" equiv="total" disp="total"/> push-ups on Pushup Tracker 💪 Check it out:</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.share.title">
+      <segment state="translated">
+        <source>Pushup Tracker Profil</source>
+        <target>Pushup Tracker profile</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.seo.notFound.title">
+      <segment state="translated">
+        <source>Profil nicht verfügbar – Pushup Tracker</source>
+        <target>Profile not available – Pushup Tracker</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.seo.notFound.description">
+      <segment state="translated">
+        <source>Dieses Profil existiert nicht oder ist nicht öffentlich.</source>
+        <target>This profile does not exist or is not public.</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.seo.title">
+      <segment state="translated">
+        <source><ph id="0" equiv="name" disp="name"/> – Pushup Tracker Profil</source>
+        <target><ph id="0" equiv="name" disp="name"/> – Pushup Tracker profile</target>
+      </segment>
+    </unit>
+    <unit id="publicProfile.seo.description">
+      <segment state="translated">
+        <source><ph id="0" equiv="name" disp="name"/> hat <ph id="1" equiv="total" disp="total"/> Liegestütze und eine <ph id="2" equiv="streak" disp="streak"/>-Tage-Streak auf Pushup Tracker.</source>
+        <target><ph id="0" equiv="name" disp="name"/> has <ph id="1" equiv="total" disp="total"/> push-ups and a <ph id="2" equiv="streak" disp="streak"/>-day streak on Pushup Tracker.</target>
+      </segment>
+    </unit>
+    <unit id="settings.publicProfile.toggle">
+      <segment state="translated">
+        <source>Öffentliches Profil aktivieren</source>
+        <target>Enable public profile</target>
+      </segment>
+    </unit>
+    <unit id="settings.publicProfile.hint">
+      <segment state="translated">
+        <source>Erlaubt jedem mit dem Link den Zugriff auf deine Reps, Streak und Bestleistungen. Dein Anzeigename ist sichtbar; E-Mail, Ziele und Erinnerungen bleiben privat.</source>
+        <target>Anyone with the link can see your reps, streak and personal bests. Your display name is visible; email, goals and reminders stay private.</target>
+      </segment>
+    </unit>
+    <unit id="settings.publicProfile.shareCta">
+      <segment state="translated">
+        <source>Profil teilen</source>
+        <target>Share profile</target>
+      </segment>
+    </unit>
+    <unit id="settings.publicProfile.share.title">
+      <segment state="translated">
+        <source>Mein Pushup Tracker Profil</source>
+        <target>My Pushup Tracker profile</target>
+      </segment>
+    </unit>
+    <unit id="settings.publicProfile.share.text">
+      <segment state="translated">
+        <source>Schau dir mein Pushup-Profil an:</source>
+        <target>Check out my push-up profile:</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -5844,6 +5844,12 @@ Deine Position: # ·  Reps        </source>
         <target>Public push-up profile with reps, streak and personal bests.</target>
       </segment>
     </unit>
+    <unit id="publicProfile.subtitle">
+      <segment state="translated">
+        <source>Pushup Tracker</source>
+        <target>Pushup Tracker</target>
+      </segment>
+    </unit>
     <unit id="publicProfile.notFound.title">
       <segment state="translated">
         <source>Profil nicht gefunden</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -237,7 +237,7 @@
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:199,200</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:289,290</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:323,324</note>
       </notes>
       <segment>
         <source> Abbrechen </source>
@@ -1474,9 +1474,25 @@
         <source>Öffentliche Bestenliste für tägliche, wöchentliche und monatliche Pushup-Reps.</source>
       </segment>
     </unit>
+    <unit id="seo.publicProfile.title">
+      <notes>
+        <note category="location">web/src/app/app.routes.ts:140</note>
+      </notes>
+      <segment>
+        <source>Profil – Pushup Tracker</source>
+      </segment>
+    </unit>
+    <unit id="seo.publicProfile.description">
+      <notes>
+        <note category="location">web/src/app/app.routes.ts:141</note>
+      </notes>
+      <segment>
+        <source>Öffentliches Pushup-Profil mit Reps, Streak und Bestleistungen.</source>
+      </segment>
+    </unit>
     <unit id="seo.blog.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:144</note>
+        <note category="location">web/src/app/app.routes.ts:155</note>
       </notes>
       <segment>
         <source>Blog – Liegestütze Tipps &amp; Guides | Pushup Tracker</source>
@@ -1484,7 +1500,7 @@
     </unit>
     <unit id="seo.blog.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:145</note>
+        <note category="location">web/src/app/app.routes.ts:156</note>
       </notes>
       <segment>
         <source>Tipps, Trainingspläne und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten.</source>
@@ -1492,7 +1508,7 @@
     </unit>
     <unit id="seo.impressum.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:162</note>
+        <note category="location">web/src/app/app.routes.ts:173</note>
       </notes>
       <segment>
         <source>Impressum – Pushup Tracker</source>
@@ -1500,7 +1516,7 @@
     </unit>
     <unit id="seo.impressum.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:163</note>
+        <note category="location">web/src/app/app.routes.ts:174</note>
       </notes>
       <segment>
         <source>Impressum und Anbieterkennzeichnung von Pushup Tracker.</source>
@@ -1508,7 +1524,7 @@
     </unit>
     <unit id="seo.datenschutz.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:173</note>
+        <note category="location">web/src/app/app.routes.ts:184</note>
       </notes>
       <segment>
         <source>Datenschutzerklärung – Pushup Tracker</source>
@@ -1516,7 +1532,7 @@
     </unit>
     <unit id="seo.datenschutz.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:174</note>
+        <note category="location">web/src/app/app.routes.ts:185</note>
       </notes>
       <segment>
         <source>Datenschutzerklärung von Pushup Tracker – Informationen zu Datenverarbeitung, Cookies und Ihren Rechten.</source>
@@ -2428,6 +2444,182 @@
       </notes>
       <segment>
         <source>Zum Blog</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.notFound.title">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:57</note>
+      </notes>
+      <segment>
+        <source>Profil nicht gefunden</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.notFound.body">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:58</note>
+      </notes>
+      <segment>
+        <source>Dieses Profil existiert nicht oder wurde nicht öffentlich freigegeben.</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.error.title">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:59</note>
+      </notes>
+      <segment>
+        <source>Profil konnte nicht geladen werden</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.error.body">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:60</note>
+      </notes>
+      <segment>
+        <source>Bitte versuche es später erneut.</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.retry">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:61</note>
+      </notes>
+      <segment>
+        <source>Erneut versuchen</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.toHome">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:62</note>
+      </notes>
+      <segment>
+        <source>Zur Startseite</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.stats">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:63</note>
+      </notes>
+      <segment>
+        <source>Statistik</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.total">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:64</note>
+      </notes>
+      <segment>
+        <source>Gesamte Reps</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.streak">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:65</note>
+      </notes>
+      <segment>
+        <source>Aktuelle Streak</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.days">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:66</note>
+      </notes>
+      <segment>
+        <source>Aktive Tage</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.entries">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:67</note>
+      </notes>
+      <segment>
+        <source>Einträge</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.bestSet">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:68</note>
+      </notes>
+      <segment>
+        <source>Bester Einzel-Eintrag</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.bestDay">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:69</note>
+      </notes>
+      <segment>
+        <source>Bester Tag</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.share.aria">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:70</note>
+      </notes>
+      <segment>
+        <source>Profil teilen</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.share">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:71</note>
+      </notes>
+      <segment>
+        <source>Teilen</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.cta">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:72</note>
+      </notes>
+      <segment>
+        <source>Selbst tracken – pushup-stats.de</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.share.text">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:96</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze auf Pushup Tracker geschafft 💪 Schau&apos;s dir an:</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.share.title">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:98</note>
+      </notes>
+      <segment>
+        <source>Pushup Tracker Profil</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.seo.notFound.title">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:124</note>
+      </notes>
+      <segment>
+        <source>Profil nicht verfügbar – Pushup Tracker</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.seo.notFound.description">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:125</note>
+      </notes>
+      <segment>
+        <source>Dieses Profil existiert nicht oder ist nicht öffentlich.</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.seo.title">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:131</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="name" disp="profile.displayName"/> – Pushup Tracker Profil</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.seo.description">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:132</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze und eine <ph id="2" equiv="streak" disp="profile.currentStreak"/>-Tage-Streak auf Pushup Tracker.</source>
       </segment>
     </unit>
     <unit id="reminders.page.title">
@@ -3590,6 +3782,30 @@
         <source>Keine Daten</source>
       </segment>
     </unit>
+    <unit id="dashboard.share.text.streak">
+      <notes>
+        <note category="location">web/src/app/stats/dashboard.store.ts:413</note>
+      </notes>
+      <segment>
+        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
+      </segment>
+    </unit>
+    <unit id="dashboard.share.text.simple">
+      <notes>
+        <note category="location">web/src/app/stats/dashboard.store.ts:414</note>
+      </notes>
+      <segment>
+        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
+      </segment>
+    </unit>
+    <unit id="dashboard.share.title">
+      <notes>
+        <note category="location">web/src/app/stats/dashboard.store.ts:416</note>
+      </notes>
+      <segment>
+        <source>Pushup Tracker</source>
+      </segment>
+    </unit>
     <unit id="analysis.weekTrendTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:66,68</note>
@@ -3844,7 +4060,7 @@
     </unit>
     <unit id="settingsTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:44,45</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:45,46</note>
       </notes>
       <segment>
         <source>Einstellungen</source>
@@ -3852,7 +4068,7 @@
     </unit>
     <unit id="settingsSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:46,47</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:47,48</note>
       </notes>
       <segment>
         <source>User-Profil &amp; Tagesziel</source>
@@ -3860,7 +4076,7 @@
     </unit>
     <unit id="guest.banner.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:55,57</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:56,58</note>
       </notes>
       <segment>
         <source>Du nutzt die App als Gast. Erstelle ein Konto um alle Funktionen zu nutzen.</source>
@@ -3868,7 +4084,7 @@
     </unit>
     <unit id="guest.banner.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:62,64</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:63,65</note>
       </notes>
       <segment>
         <source>Konto erstellen</source>
@@ -3876,7 +4092,7 @@
     </unit>
     <unit id="displayNameLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:68,69</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:69,70</note>
       </notes>
       <segment>
         <source>Anzeigename</source>
@@ -3884,7 +4100,7 @@
     </unit>
     <unit id="displayNamePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:74</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:75</note>
       </notes>
       <segment>
         <source>Wolf</source>
@@ -3892,7 +4108,7 @@
     </unit>
     <unit id="settings.displayNameHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:77,79</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:78,80</note>
       </notes>
       <segment>
         <source>Kann in der Bestenliste angezeigt werden.</source>
@@ -3900,7 +4116,7 @@
     </unit>
     <unit id="settings.leaderboardOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:86,87</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:87,88</note>
       </notes>
       <segment>
         <source> In Bestenliste anzeigen </source>
@@ -3908,15 +4124,39 @@
     </unit>
     <unit id="settings.leaderboardOptOutHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:90,93</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:91,94</note>
       </notes>
       <segment>
         <source> Wenn deaktiviert, wird dein Profil in der Bestenliste nicht angezeigt. </source>
       </segment>
     </unit>
+    <unit id="settings.publicProfile.toggle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:101,102</note>
+      </notes>
+      <segment>
+        <source> Öffentliches Profil aktivieren </source>
+      </segment>
+    </unit>
+    <unit id="settings.publicProfile.hint">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:105,108</note>
+      </notes>
+      <segment>
+        <source> Erlaubt jedem mit dem Link den Zugriff auf deine Reps, Streak und Bestleistungen. Dein Anzeigename ist sichtbar; E-Mail, Ziele und Erinnerungen bleiben privat. </source>
+      </segment>
+    </unit>
+    <unit id="settings.publicProfile.shareCta">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:122,124</note>
+      </notes>
+      <segment>
+        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">share</pc> Profil teilen </source>
+      </segment>
+    </unit>
     <unit id="settings.adsConsentOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:99,100</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:133,134</note>
       </notes>
       <segment>
         <source> Personalisierte Werbung aktivieren </source>
@@ -3924,7 +4164,7 @@
     </unit>
     <unit id="settings.adsConsentHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:103,106</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:137,140</note>
       </notes>
       <segment>
         <source> Steuert, ob Werbe-Slots im Dashboard geladen werden dürfen. </source>
@@ -3932,7 +4172,7 @@
     </unit>
     <unit id="dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:107,108</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:141,142</note>
       </notes>
       <segment>
         <source>Tagesziel (Reps)</source>
@@ -3940,7 +4180,7 @@
     </unit>
     <unit id="dailyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:117</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:151</note>
       </notes>
       <segment>
         <source>10</source>
@@ -3948,7 +4188,7 @@
     </unit>
     <unit id="settings.goalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:120,122</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:154,156</note>
       </notes>
       <segment>
         <source>Wird prominent in der Toolbar angezeigt.</source>
@@ -3956,7 +4196,7 @@
     </unit>
     <unit id="weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:125,126</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:159,160</note>
       </notes>
       <segment>
         <source>Wochenziel (Reps)</source>
@@ -3964,7 +4204,7 @@
     </unit>
     <unit id="weeklyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:135</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:169</note>
       </notes>
       <segment>
         <source>50</source>
@@ -3972,7 +4212,7 @@
     </unit>
     <unit id="settings.weeklyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:138,140</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:172,174</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Woche (Mo–So).</source>
@@ -3980,7 +4220,7 @@
     </unit>
     <unit id="monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:143,144</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:177,178</note>
       </notes>
       <segment>
         <source>Monatsziel (Reps)</source>
@@ -3988,7 +4228,7 @@
     </unit>
     <unit id="monthlyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:153</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:187</note>
       </notes>
       <segment>
         <source>200</source>
@@ -3996,7 +4236,7 @@
     </unit>
     <unit id="settings.monthlyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:156,158</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:190,192</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Monat.</source>
@@ -4004,7 +4244,7 @@
     </unit>
     <unit id="settings.snapQualityLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:165,167</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:199,201</note>
       </notes>
       <segment>
         <source>Snap-Animation Qualität</source>
@@ -4012,7 +4252,7 @@
     </unit>
     <unit id="settings.snapQuality.low">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:175,177</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:209,211</note>
       </notes>
       <segment>
         <source>Niedrig</source>
@@ -4020,7 +4260,7 @@
     </unit>
     <unit id="settings.snapQuality.middle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:180,182</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:214,216</note>
       </notes>
       <segment>
         <source>Mittel</source>
@@ -4028,7 +4268,7 @@
     </unit>
     <unit id="settings.snapQuality.high">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:185,187</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:219,221</note>
       </notes>
       <segment>
         <source>Hoch</source>
@@ -4036,7 +4276,7 @@
     </unit>
     <unit id="settings.snapQualityHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:189,191</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:223,225</note>
       </notes>
       <segment>
         <source> Steuert die Partikelanzahl der „Ziel erreicht“-Animation (40k / 120k / 200k). </source>
@@ -4044,7 +4284,7 @@
     </unit>
     <unit id="saveSettings">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:207,209</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:241,243</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc> Speichern </source>
@@ -4052,7 +4292,7 @@
     </unit>
     <unit id="saving">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:211,212</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:245,246</note>
       </notes>
       <segment>
         <source>Speichert…</source>
@@ -4060,7 +4300,7 @@
     </unit>
     <unit id="saved">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:214,215</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:248,249</note>
       </notes>
       <segment>
         <source>Gespeichert.</source>
@@ -4068,7 +4308,7 @@
     </unit>
     <unit id="settings.remindersLinkTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:219,220</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:253,254</note>
       </notes>
       <segment>
         <source>🔔 Erinnerungen</source>
@@ -4076,7 +4316,7 @@
     </unit>
     <unit id="settings.remindersLinkDesc">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:221,223</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:255,257</note>
       </notes>
       <segment>
         <source> Liegestütz-Erinnerungen und Push-Benachrichtigungen konfigurieren. </source>
@@ -4084,7 +4324,7 @@
     </unit>
     <unit id="settings.remindersLinkCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:228,230</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:262,264</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications</pc> Erinnerungen verwalten </source>
@@ -4092,7 +4332,7 @@
     </unit>
     <unit id="settings.dangerZoneTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:234,235</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:268,269</note>
       </notes>
       <segment>
         <source>Danger Zone</source>
@@ -4100,7 +4340,7 @@
     </unit>
     <unit id="settings.dangerZoneBody">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:236,238</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:270,272</note>
       </notes>
       <segment>
         <source> Konto löschen entfernt dein Konto. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -4108,7 +4348,7 @@
     </unit>
     <unit id="settings.deleteAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:247,249</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:281,283</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Konto löschen </source>
@@ -4116,7 +4356,7 @@
     </unit>
     <unit id="settings.deletingAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:252,255</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:286,289</note>
       </notes>
       <segment>
         <source>Konto wird gelöscht…</source>
@@ -4124,7 +4364,7 @@
     </unit>
     <unit id="settings.deleteDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:259,261</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:293,295</note>
       </notes>
       <segment>
         <source> Account wirklich löschen? </source>
@@ -4132,7 +4372,7 @@
     </unit>
     <unit id="settings.deleteDialogWarning">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:263,265</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:297,299</note>
       </notes>
       <segment>
         <source> Achtung: Diese Aktion ist nicht rückgängig. </source>
@@ -4140,7 +4380,7 @@
     </unit>
     <unit id="settings.deleteDialogInfo">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:266,268</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:300,302</note>
       </notes>
       <segment>
         <source> Dein Konto wird gelöscht. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -4148,7 +4388,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:271,273</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:305,307</note>
       </notes>
       <segment>
         <source>Bestätigungswort eingeben</source>
@@ -4156,7 +4396,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:280,282</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:314,316</note>
       </notes>
       <segment>
         <source>Bitte exakt „löscchen“ eingeben.</source>
@@ -4164,10 +4404,26 @@
     </unit>
     <unit id="settings.deleteConfirmFinal">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:297,299</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:331,333</note>
       </notes>
       <segment>
         <source> Final löschen </source>
+      </segment>
+    </unit>
+    <unit id="settings.publicProfile.share.title">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:538</note>
+      </notes>
+      <segment>
+        <source>Mein Pushup Tracker Profil</source>
+      </segment>
+    </unit>
+    <unit id="settings.publicProfile.share.text">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:539</note>
+      </notes>
+      <segment>
+        <source>Schau dir mein Pushup-Profil an:</source>
       </segment>
     </unit>
     <unit id="eyebrowTitle">
@@ -4254,7 +4510,7 @@
     <unit id="trainingPlans.kind.rest">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:73,74</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:139,140</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:165,166</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:66,67</note>
       </notes>
       <segment>
@@ -4264,7 +4520,7 @@
     <unit id="trainingPlans.kind.light">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:76,77</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:143,144</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:172,174</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:69,70</note>
       </notes>
       <segment>
@@ -4274,7 +4530,7 @@
     <unit id="trainingPlans.kind.test">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:78,80</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:141,142</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:168,170</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:72,74</note>
       </notes>
       <segment>
@@ -4284,8 +4540,8 @@
     <unit id="trainingPlans.reps">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:81,83</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:147,148</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:151,153</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:177,178</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:181,183</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:84,86</note>
       </notes>
       <segment>
@@ -4479,7 +4735,7 @@
     </unit>
     <unit id="dashboard.share.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:73</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:71</note>
       </notes>
       <segment>
         <source>Tagesleistung teilen</source>
@@ -4487,40 +4743,16 @@
     </unit>
     <unit id="dashboard.share">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:74</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:72</note>
       </notes>
       <segment>
         <source>Teilen</source>
       </segment>
     </unit>
-    <unit id="dashboard.share.text.streak">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:195</note>
-      </notes>
-      <segment>
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
-      </segment>
-    </unit>
-    <unit id="dashboard.share.text.simple">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:196</note>
-      </notes>
-      <segment>
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
-      </segment>
-    </unit>
-    <unit id="dashboard.share.title">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:198</note>
-      </notes>
-      <segment>
-        <source>Pushup Tracker</source>
-      </segment>
-    </unit>
     <unit id="trainingPlans.back">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:43</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:193,195</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:51</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:225,227</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -4528,7 +4760,7 @@
     </unit>
     <unit id="trainingPlans.daysSuffix">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:53,54</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:64,66</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:123,125</note>
       </notes>
       <segment>
@@ -4537,7 +4769,7 @@
     </unit>
     <unit id="trainingPlans.level.beginner">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:56,57</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:68,69</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:128,130</note>
       </notes>
       <segment>
@@ -4546,7 +4778,7 @@
     </unit>
     <unit id="trainingPlans.level.intermediate">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:58,60</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:70,72</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:132,134</note>
       </notes>
       <segment>
@@ -4555,7 +4787,7 @@
     </unit>
     <unit id="trainingPlans.level.advanced">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:60,62</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:72,74</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:136,138</note>
       </notes>
       <segment>
@@ -4564,7 +4796,7 @@
     </unit>
     <unit id="trainingPlans.progress">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:69,70</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:81,82</note>
       </notes>
       <segment>
         <source>Fortschritt</source>
@@ -4572,7 +4804,7 @@
     </unit>
     <unit id="trainingPlans.currentDay">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:75,76</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:90,91</note>
       </notes>
       <segment>
         <source>Aktueller Tag:</source>
@@ -4580,7 +4812,7 @@
     </unit>
     <unit id="trainingPlans.abandon">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:82,84</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:102,104</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:99,101</note>
       </notes>
       <segment>
@@ -4589,7 +4821,7 @@
     </unit>
     <unit id="trainingPlans.startCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:91,93</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:111,113</note>
       </notes>
       <segment>
         <source> Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt. </source>
@@ -4597,7 +4829,7 @@
     </unit>
     <unit id="trainingPlans.replaceWarn">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:97,99</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:121,123</note>
       </notes>
       <segment>
         <source> Achtung: Dies ersetzt den aktuell aktiven Plan. </source>
@@ -4605,7 +4837,7 @@
     </unit>
     <unit id="trainingPlans.start">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:102,104</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:126,128</note>
       </notes>
       <segment>
         <source>Plan starten</source>
@@ -4613,7 +4845,7 @@
     </unit>
     <unit id="trainingPlans.week">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:111,112</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:135,136</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -4621,7 +4853,7 @@
     </unit>
     <unit id="trainingPlans.unmarkAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:165,166</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:197,198</note>
       </notes>
       <segment>
         <source>Als nicht erledigt markieren</source>
@@ -4629,7 +4861,7 @@
     </unit>
     <unit id="trainingPlans.markAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:174,175</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:206,207</note>
       </notes>
       <segment>
         <source>Als erledigt markieren</source>
@@ -4637,7 +4869,7 @@
     </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:190,191</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:222,223</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -4645,7 +4877,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:356</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:390</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -4653,7 +4885,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:365</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:399</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -237,7 +237,7 @@
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:199,200</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:323,324</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:328,329</note>
       </notes>
       <segment>
         <source> Abbrechen </source>
@@ -2446,6 +2446,14 @@
         <source>Zum Blog</source>
       </segment>
     </unit>
+    <unit id="publicProfile.subtitle">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.html:44,46</note>
+      </notes>
+      <segment>
+        <source>Pushup Tracker</source>
+      </segment>
+    </unit>
     <unit id="publicProfile.notFound.title">
       <notes>
         <note category="location">web/src/app/public-profile/public-profile-page.component.ts:57</note>
@@ -2576,7 +2584,7 @@
     </unit>
     <unit id="publicProfile.share.text">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:96</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:105</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze auf Pushup Tracker geschafft 💪 Schau&apos;s dir an:</source>
@@ -2584,7 +2592,7 @@
     </unit>
     <unit id="publicProfile.share.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:98</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:107</note>
       </notes>
       <segment>
         <source>Pushup Tracker Profil</source>
@@ -2592,7 +2600,7 @@
     </unit>
     <unit id="publicProfile.seo.notFound.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:124</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:143</note>
       </notes>
       <segment>
         <source>Profil nicht verfügbar – Pushup Tracker</source>
@@ -2600,7 +2608,7 @@
     </unit>
     <unit id="publicProfile.seo.notFound.description">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:125</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:144</note>
       </notes>
       <segment>
         <source>Dieses Profil existiert nicht oder ist nicht öffentlich.</source>
@@ -2608,7 +2616,7 @@
     </unit>
     <unit id="publicProfile.seo.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:131</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:150</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> – Pushup Tracker Profil</source>
@@ -2616,7 +2624,7 @@
     </unit>
     <unit id="publicProfile.seo.description">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:132</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:151</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze und eine <ph id="2" equiv="streak" disp="profile.currentStreak"/>-Tage-Streak auf Pushup Tracker.</source>
@@ -4148,7 +4156,7 @@
     </unit>
     <unit id="settings.publicProfile.shareCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:122,124</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:127,129</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">share</pc> Profil teilen </source>
@@ -4156,7 +4164,7 @@
     </unit>
     <unit id="settings.adsConsentOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:133,134</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:138,139</note>
       </notes>
       <segment>
         <source> Personalisierte Werbung aktivieren </source>
@@ -4164,7 +4172,7 @@
     </unit>
     <unit id="settings.adsConsentHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:137,140</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:142,145</note>
       </notes>
       <segment>
         <source> Steuert, ob Werbe-Slots im Dashboard geladen werden dürfen. </source>
@@ -4172,7 +4180,7 @@
     </unit>
     <unit id="dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:141,142</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:146,147</note>
       </notes>
       <segment>
         <source>Tagesziel (Reps)</source>
@@ -4180,7 +4188,7 @@
     </unit>
     <unit id="dailyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:151</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:156</note>
       </notes>
       <segment>
         <source>10</source>
@@ -4188,7 +4196,7 @@
     </unit>
     <unit id="settings.goalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:154,156</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:159,161</note>
       </notes>
       <segment>
         <source>Wird prominent in der Toolbar angezeigt.</source>
@@ -4196,7 +4204,7 @@
     </unit>
     <unit id="weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:159,160</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:164,165</note>
       </notes>
       <segment>
         <source>Wochenziel (Reps)</source>
@@ -4204,7 +4212,7 @@
     </unit>
     <unit id="weeklyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:169</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:174</note>
       </notes>
       <segment>
         <source>50</source>
@@ -4212,7 +4220,7 @@
     </unit>
     <unit id="settings.weeklyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:172,174</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:177,179</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Woche (Mo–So).</source>
@@ -4220,7 +4228,7 @@
     </unit>
     <unit id="monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:177,178</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:182,183</note>
       </notes>
       <segment>
         <source>Monatsziel (Reps)</source>
@@ -4228,7 +4236,7 @@
     </unit>
     <unit id="monthlyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:187</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:192</note>
       </notes>
       <segment>
         <source>200</source>
@@ -4236,7 +4244,7 @@
     </unit>
     <unit id="settings.monthlyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:190,192</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:195,197</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Monat.</source>
@@ -4244,7 +4252,7 @@
     </unit>
     <unit id="settings.snapQualityLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:199,201</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:204,206</note>
       </notes>
       <segment>
         <source>Snap-Animation Qualität</source>
@@ -4252,7 +4260,7 @@
     </unit>
     <unit id="settings.snapQuality.low">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:209,211</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:214,216</note>
       </notes>
       <segment>
         <source>Niedrig</source>
@@ -4260,7 +4268,7 @@
     </unit>
     <unit id="settings.snapQuality.middle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:214,216</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:219,221</note>
       </notes>
       <segment>
         <source>Mittel</source>
@@ -4268,7 +4276,7 @@
     </unit>
     <unit id="settings.snapQuality.high">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:219,221</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:224,226</note>
       </notes>
       <segment>
         <source>Hoch</source>
@@ -4276,7 +4284,7 @@
     </unit>
     <unit id="settings.snapQualityHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:223,225</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:228,230</note>
       </notes>
       <segment>
         <source> Steuert die Partikelanzahl der „Ziel erreicht“-Animation (40k / 120k / 200k). </source>
@@ -4284,7 +4292,7 @@
     </unit>
     <unit id="saveSettings">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:241,243</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:246,248</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc> Speichern </source>
@@ -4292,7 +4300,7 @@
     </unit>
     <unit id="saving">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:245,246</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:250,251</note>
       </notes>
       <segment>
         <source>Speichert…</source>
@@ -4300,7 +4308,7 @@
     </unit>
     <unit id="saved">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:248,249</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:253,254</note>
       </notes>
       <segment>
         <source>Gespeichert.</source>
@@ -4308,7 +4316,7 @@
     </unit>
     <unit id="settings.remindersLinkTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:253,254</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:258,259</note>
       </notes>
       <segment>
         <source>🔔 Erinnerungen</source>
@@ -4316,7 +4324,7 @@
     </unit>
     <unit id="settings.remindersLinkDesc">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:255,257</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:260,262</note>
       </notes>
       <segment>
         <source> Liegestütz-Erinnerungen und Push-Benachrichtigungen konfigurieren. </source>
@@ -4324,7 +4332,7 @@
     </unit>
     <unit id="settings.remindersLinkCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:262,264</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:267,269</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications</pc> Erinnerungen verwalten </source>
@@ -4332,7 +4340,7 @@
     </unit>
     <unit id="settings.dangerZoneTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:268,269</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:273,274</note>
       </notes>
       <segment>
         <source>Danger Zone</source>
@@ -4340,7 +4348,7 @@
     </unit>
     <unit id="settings.dangerZoneBody">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:270,272</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:275,277</note>
       </notes>
       <segment>
         <source> Konto löschen entfernt dein Konto. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -4348,7 +4356,7 @@
     </unit>
     <unit id="settings.deleteAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:281,283</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:286,288</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Konto löschen </source>
@@ -4356,7 +4364,7 @@
     </unit>
     <unit id="settings.deletingAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:286,289</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:291,294</note>
       </notes>
       <segment>
         <source>Konto wird gelöscht…</source>
@@ -4364,7 +4372,7 @@
     </unit>
     <unit id="settings.deleteDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:293,295</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:298,300</note>
       </notes>
       <segment>
         <source> Account wirklich löschen? </source>
@@ -4372,7 +4380,7 @@
     </unit>
     <unit id="settings.deleteDialogWarning">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:297,299</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:302,304</note>
       </notes>
       <segment>
         <source> Achtung: Diese Aktion ist nicht rückgängig. </source>
@@ -4380,7 +4388,7 @@
     </unit>
     <unit id="settings.deleteDialogInfo">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:300,302</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:305,307</note>
       </notes>
       <segment>
         <source> Dein Konto wird gelöscht. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -4388,7 +4396,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:305,307</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:310,312</note>
       </notes>
       <segment>
         <source>Bestätigungswort eingeben</source>
@@ -4396,7 +4404,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:314,316</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:319,321</note>
       </notes>
       <segment>
         <source>Bitte exakt „löscchen“ eingeben.</source>
@@ -4404,7 +4412,7 @@
     </unit>
     <unit id="settings.deleteConfirmFinal">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:331,333</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:336,338</note>
       </notes>
       <segment>
         <source> Final löschen </source>
@@ -4412,7 +4420,7 @@
     </unit>
     <unit id="settings.publicProfile.share.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:538</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:543</note>
       </notes>
       <segment>
         <source>Mein Pushup Tracker Profil</source>
@@ -4420,7 +4428,7 @@
     </unit>
     <unit id="settings.publicProfile.share.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:539</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:544</note>
       </notes>
       <segment>
         <source>Schau dir mein Pushup-Profil an:</source>


### PR DESCRIPTION
## Summary
- New SSR-rendered route `/u/:uid` that surfaces a sanitized public profile (total reps, current streak, active days, entries, personal bests).
- Privacy: explicit opt-in via `userConfigs.ui.publicProfile` (defaults to `false`). Without opt-in, the API returns `not-found` — same response as a non-existent user, so account existence cannot be probed.
- Cloud Function `getPublicProfile` (anonymous-callable) reads `userConfigs` + `userStats` via Admin SDK and returns a whitelisted projection. Pure projection logic lives in `data-store/functions/src/profile/public-profile.ts` with a privacy-regression spec asserting only known-safe keys can leak.
- Settings page: opt-in toggle + share-link row with a "Profil teilen" CTA (reuses the existing `ShareService`).
- Frontend: `PublicProfileApiService` (httpsCallable wrapper, treats `functions/not-found` as `null`) + `PublicProfilePageComponent` with loading / not-found / error / ready states, share button, and CTA back to home.
- Full de + en i18n. SSR meta tags include the display name + total reps so social cards (FB, X, LinkedIn) get a real preview.

## Why
This is the third virality lever in the discoverability roadmap (after Web Share entry-points). Public profiles give users a permalink they can drop into bios / chats so each shared link is a SEO-indexable, crawlable surface that points back to the app.

## Privacy notes
- UID-based URLs (no slug system) → no squatting, no namespace conflicts.
- Owner-only Firestore rules untouched; the projection happens in a CF that uses Admin SDK, so the public path doesn't widen any read rules.
- Whitelist enforced at projection time + asserted by the regression test in `public-profile.spec.ts`.

## Test plan
- [x] `pnpm nx affected -t=lint,test,build -c=production --parallel=3` — 11 projects passed locally.
- [ ] Verify `/u/:uid` loads the profile of an opted-in user on staging preview.
- [ ] Verify it surfaces the not-found state for an opted-out / unknown UID.
- [ ] Verify Settings toggle persists to Firestore (`ui.publicProfile`).
- [ ] Verify the "Profil teilen" button in Settings copies / shares the canonical `https://pushup-stats.de/u/<uid>` URL.
- [ ] Verify SSR meta tags (view-source on the staging URL) include the display name.

## Follow-up (not in this PR)
- Slice 3b: dynamic OG image rendered by a Cloud Function (Satori + resvg) so social cards show a per-user preview instead of the static site image.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGKDZpVUBj489VTNAshbXo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Share your workout stats publicly by enabling a public profile in settings
  * View others' public profiles via shareable profile pages with key statistics
  * Built-in share functionality to easily distribute your profile URL
  * Public profiles display totals, streaks, best entries, and workout history
  * Added multi-language localization support for the public profile feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->