### PR TITLE
feat(og-image): dynamic OpenGraph cards for public profiles

### DIFF
--- a/data-store/functions/package.json
+++ b/data-store/functions/package.json
@@ -14,8 +14,10 @@
     "@google-cloud/functions-framework": "^3.5.0",
     "@google-cloud/recaptcha-enterprise": "^6.4.0",
     "@google/generative-ai": "^0.21.0",
+    "@resvg/resvg-wasm": "^2.6.2",
     "firebase-admin": "^13.5.0",
     "firebase-functions": "^7.2.3",
+    "satori": "^0.26.0",
     "web-push": "^3.6.7"
   }
 }

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -8,6 +8,7 @@ import { logger } from 'firebase-functions';
 import { defineSecret } from 'firebase-functions/params';
 import { onDocumentWritten } from 'firebase-functions/v2/firestore';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { onRequest } from 'firebase-functions/v2/https';
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import webpush from 'web-push';
 import {
@@ -29,6 +30,7 @@ import {
 import {
   buildPublicProfile,
   isValidUid,
+  renderProfileOg,
   type UserConfigForPublicProfile,
   type UserStatsForPublicProfile,
   UserProfile,
@@ -670,6 +672,71 @@ export const getPublicProfile = onCall(
       throw new HttpsError('not-found', 'Profile not available');
     }
     return projection;
+  }
+);
+
+// ─── ogProfile (HTTP, dynamic OpenGraph card) ────────────────────────────────
+// `GET /og/profile?uid=<uid>` — renders a 1200×630 PNG via satori + resvg
+// for the profile's current stats. Returns 404 PNG-of-nothing for users who
+// haven't opted in (same shape as `getPublicProfile`'s privacy guarantee).
+//
+// Cache headers let Firebase Hosting / the function's own CDN do most of
+// the work — full re-render is amortised across hours per user.
+
+export const ogProfile = onRequest(
+  {
+    region: 'europe-west3',
+    invoker: 'public',
+    cors: true,
+    memory: '512MiB',
+    timeoutSeconds: 30,
+  },
+  async (req, res) => {
+    const uidRaw = String(req.query['uid'] ?? '').trim();
+    if (!isValidUid(uidRaw)) {
+      res.status(400).send('invalid uid');
+      return;
+    }
+
+    try {
+      const db = admin.firestore();
+      const [cfgSnap, statsSnap] = await Promise.all([
+        db.collection('userConfigs').doc(uidRaw).get(),
+        db.collection('userStats').doc(uidRaw).get(),
+      ]);
+      const config = cfgSnap.exists
+        ? (cfgSnap.data() as UserConfigForPublicProfile)
+        : null;
+      const stats = statsSnap.exists
+        ? (statsSnap.data() as UserStatsForPublicProfile)
+        : null;
+      const projection = buildPublicProfile(uidRaw, config, stats);
+      if (!projection) {
+        // Same fingerprint as a non-existent UID. Cache the 404 briefly so
+        // a hot-linked card from a private user doesn't hammer Firestore.
+        res.setHeader('Cache-Control', 'public, max-age=60, s-maxage=300');
+        res.status(404).send('Profile not available');
+        return;
+      }
+
+      const png = await renderProfileOg(projection);
+      res.setHeader('Content-Type', 'image/png');
+      res.setHeader('Content-Length', String(png.byteLength));
+      // 5 min browser, 1 h CDN, 1 day stale-while-revalidate so a slow
+      // delta-aggregation pipeline behind userStats doesn't stall a request.
+      res.setHeader(
+        'Cache-Control',
+        'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400'
+      );
+      res.status(200).send(png);
+    } catch (err) {
+      Sentry.captureException(err);
+      logger.error('ogProfile render failed', {
+        uid: uidRaw,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      res.status(500).send('OG render failed');
+    }
   }
 );
 

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -30,11 +30,14 @@ import {
 import {
   buildPublicProfile,
   isValidUid,
-  renderProfileOg,
   type UserConfigForPublicProfile,
   type UserStatsForPublicProfile,
   UserProfile,
 } from './profile';
+// `renderProfileOg` lives behind a dynamic `import()` call inside the
+// `ogProfile` handler below — pulling satori + @resvg/resvg-wasm (~15 MB
+// + WASM init) eagerly here would slow cold-start for every unrelated
+// function in this bundle (leaderboards, motivation, push, …).
 import type { ReminderConfig } from './push';
 import {
   buildNotificationPayload,
@@ -693,8 +696,12 @@ export const ogProfile = onRequest(
   },
   async (req, res) => {
     const uidRaw = String(req.query['uid'] ?? '').trim();
+    // Privacy parity with `getPublicProfile`: malformed UIDs surface as the
+    // same 404 + short-TTL cache as missing/opted-out profiles, so the OG
+    // endpoint can't be used to enumerate which UID strings are well-formed.
     if (!isValidUid(uidRaw)) {
-      res.status(400).send('invalid uid');
+      res.setHeader('Cache-Control', 'public, max-age=60, s-maxage=300');
+      res.status(404).send('Profile not available');
       return;
     }
 
@@ -719,6 +726,11 @@ export const ogProfile = onRequest(
         return;
       }
 
+      // Lazy-load the renderer so satori + @resvg/resvg-wasm only initialise
+      // on the first OG request (and stay cached in module scope across warm
+      // invocations) — keeps cold-start of unrelated functions in this
+      // bundle unaffected by the heavy renderer deps.
+      const { renderProfileOg } = await import('./profile/og-render');
       const png = await renderProfileOg(projection);
       res.setHeader('Content-Type', 'image/png');
       res.setHeader('Content-Length', String(png.byteLength));

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -634,6 +634,28 @@ export const refreshLeaderboardsOnPushupWrite = onDocumentWritten(
   }
 );
 
+// ─── Shared lookup ────────────────────────────────────────────────────────────
+// Both `getPublicProfile` (callable) and `ogProfile` (HTTP) need the same
+// validation → Firestore reads → projection chain with identical privacy
+// semantics. Centralising the lookup here keeps the 404-parity contract
+// from drifting between the two wrappers and matches the project's "trigger
+// functions in `index.ts` are thin wrappers" rule.
+async function fetchPublicProfileProjection(uid: string) {
+  if (!isValidUid(uid)) return null;
+  const db = admin.firestore();
+  const [cfgSnap, statsSnap] = await Promise.all([
+    db.collection('userConfigs').doc(uid).get(),
+    db.collection('userStats').doc(uid).get(),
+  ]);
+  const config = cfgSnap.exists
+    ? (cfgSnap.data() as UserConfigForPublicProfile)
+    : null;
+  const stats = statsSnap.exists
+    ? (statsSnap.data() as UserStatsForPublicProfile)
+    : null;
+  return buildPublicProfile(uid, config, stats);
+}
+
 // ─── getPublicProfile (anonymous-callable, opt-in only) ──────────────────────
 // Returns a sanitized projection of `userConfigs/{uid}` + `userStats/{uid}`
 // for users who explicitly set `ui.publicProfile = true`. Anyone else returns
@@ -647,31 +669,10 @@ export const getPublicProfile = onCall(
   { region: 'europe-west3', invoker: 'public' },
   async (request) => {
     const uid = String(request.data?.uid ?? '').trim();
-    // Collapse malformed UIDs into the same `not-found` response we use for
-    // missing / opted-out users, so /u/<bad-slug> hits the same UX/privacy
-    // path as /u/<missing-but-valid> instead of bouncing into a generic
-    // error state on the client.
-    if (!isValidUid(uid)) {
-      throw new HttpsError('not-found', 'Profile not available');
-    }
-
-    const db = admin.firestore();
-    const [cfgSnap, statsSnap] = await Promise.all([
-      db.collection('userConfigs').doc(uid).get(),
-      db.collection('userStats').doc(uid).get(),
-    ]);
-
-    const config = cfgSnap.exists
-      ? (cfgSnap.data() as UserConfigForPublicProfile)
-      : null;
-    const stats = statsSnap.exists
-      ? (statsSnap.data() as UserStatsForPublicProfile)
-      : null;
-
-    const projection = buildPublicProfile(uid, config, stats);
+    const projection = await fetchPublicProfileProjection(uid);
     if (!projection) {
-      // Same response shape for "user does not exist" and "user is private"
-      // so an attacker can't enumerate accounts.
+      // Same response for "malformed UID", "user does not exist", and
+      // "user is private" so an attacker can't enumerate accounts.
       throw new HttpsError('not-found', 'Profile not available');
     }
     return projection;
@@ -679,9 +680,10 @@ export const getPublicProfile = onCall(
 );
 
 // ─── ogProfile (HTTP, dynamic OpenGraph card) ────────────────────────────────
-// `GET /og/profile?uid=<uid>` — renders a 1200×630 PNG via satori + resvg
-// for the profile's current stats. Returns 404 PNG-of-nothing for users who
-// haven't opted in (same shape as `getPublicProfile`'s privacy guarantee).
+// `GET /ogProfile?uid=<uid>&lang=<de|en>` — renders a 1200×630 PNG via
+// satori + resvg for the profile's current stats. Returns a 404 with the
+// plain-text body `Profile not available` for users who haven't opted in
+// (or for malformed UIDs), matching `getPublicProfile`'s privacy guarantee.
 //
 // Cache headers let Firebase Hosting / the function's own CDN do most of
 // the work — full re-render is amortised across hours per user.
@@ -696,28 +698,11 @@ export const ogProfile = onRequest(
   },
   async (req, res) => {
     const uidRaw = String(req.query['uid'] ?? '').trim();
-    // Privacy parity with `getPublicProfile`: malformed UIDs surface as the
-    // same 404 + short-TTL cache as missing/opted-out profiles, so the OG
-    // endpoint can't be used to enumerate which UID strings are well-formed.
-    if (!isValidUid(uidRaw)) {
-      res.setHeader('Cache-Control', 'public, max-age=60, s-maxage=300');
-      res.status(404).send('Profile not available');
-      return;
-    }
+    const lang = String(req.query['lang'] ?? 'de').toLowerCase();
+    const locale = lang === 'en' ? 'en' : 'de';
 
     try {
-      const db = admin.firestore();
-      const [cfgSnap, statsSnap] = await Promise.all([
-        db.collection('userConfigs').doc(uidRaw).get(),
-        db.collection('userStats').doc(uidRaw).get(),
-      ]);
-      const config = cfgSnap.exists
-        ? (cfgSnap.data() as UserConfigForPublicProfile)
-        : null;
-      const stats = statsSnap.exists
-        ? (statsSnap.data() as UserStatsForPublicProfile)
-        : null;
-      const projection = buildPublicProfile(uidRaw, config, stats);
+      const projection = await fetchPublicProfileProjection(uidRaw);
       if (!projection) {
         // Same fingerprint as a non-existent UID. Cache the 404 briefly so
         // a hot-linked card from a private user doesn't hammer Firestore.
@@ -731,7 +716,7 @@ export const ogProfile = onRequest(
       // invocations) — keeps cold-start of unrelated functions in this
       // bundle unaffected by the heavy renderer deps.
       const { renderProfileOg } = await import('./profile/og-render');
-      const png = await renderProfileOg(projection);
+      const png = await renderProfileOg(projection, locale);
       res.setHeader('Content-Type', 'image/png');
       res.setHeader('Content-Length', String(png.byteLength));
       // 5 min browser, 1 h CDN, 1 day stale-while-revalidate so a slow

--- a/data-store/functions/src/profile/index.ts
+++ b/data-store/functions/src/profile/index.ts
@@ -1,2 +1,3 @@
 export * from './logic';
 export * from './public-profile';
+export * from './og-render';

--- a/data-store/functions/src/profile/index.ts
+++ b/data-store/functions/src/profile/index.ts
@@ -1,3 +1,9 @@
 export * from './logic';
 export * from './public-profile';
-export * from './og-render';
+// `og-render` is intentionally NOT re-exported here. It pulls in
+// satori + @resvg/resvg-wasm (~15 MB + WASM init), and re-exporting from
+// the shared barrel would force every other Cloud Function (leaderboards,
+// motivation, push, etc.) to eagerly load those modules at boot — blowing
+// up cold-start latency and making any renderer load failure crash unrelated
+// triggers. Import `renderProfileOg` directly from `./profile/og-render`
+// in the one place that needs it.

--- a/data-store/functions/src/profile/og-render.spec.ts
+++ b/data-store/functions/src/profile/og-render.spec.ts
@@ -96,6 +96,25 @@ describe('buildOgTree', () => {
     expect(text).toMatch(/Reps\s*·\s*Streak/);
     expect(text).toMatch(/Streak\s*\d+\s*·\s*\d+\s*Tage/);
   });
+
+  it('Renders English copy and en-US grouping when locale=en', () => {
+    const text = flatten(buildOgTree(profile, 'en'));
+    // en-US uses ',' grouping for 5000.
+    expect(text).toContain('5,000');
+    expect(text).toContain('90 days');
+    expect(text).not.toContain('Tage');
+  });
+
+  it('Defaults to German copy when no locale is supplied', () => {
+    const text = flatten(buildOgTree(profile));
+    expect(text).toContain('5.000');
+    expect(text).toContain('Tage');
+  });
+
+  it('Falls back to German copy for unknown locale strings', () => {
+    const text = flatten(buildOgTree(profile, 'fr'));
+    expect(text).toContain('Tage');
+  });
 });
 
 describe('_resetOgCachesForTesting', () => {

--- a/data-store/functions/src/profile/og-render.spec.ts
+++ b/data-store/functions/src/profile/og-render.spec.ts
@@ -1,0 +1,85 @@
+// Test the pure tree-builder. The satori/resvg integration is verified at
+// HTTP-handler integration level — pulling the WASM into Jest would slow
+// every spec run by ~1s for no extra coverage.
+jest.mock('satori', () => ({ default: jest.fn() }));
+jest.mock('@resvg/resvg-wasm', () => ({
+  Resvg: jest.fn(),
+  initWasm: jest.fn(),
+}));
+
+import { buildOgTree } from './og-render';
+import type { PublicProfileProjection } from './public-profile';
+
+describe('buildOgTree', () => {
+  const profile: PublicProfileProjection = {
+    uid: 'abcdef1234567890',
+    displayName: 'Wolfi',
+    total: 5000,
+    totalEntries: 200,
+    totalDays: 90,
+    currentStreak: 14,
+    bestSingleEntry: 50,
+    bestDayTotal: 250,
+    updatedAt: '2026-04-29T08:30:00.000Z',
+  };
+
+  function flatten(node: unknown): string {
+    if (typeof node === 'string') return node;
+    if (typeof node === 'number') return String(node);
+    if (Array.isArray(node)) return node.map(flatten).join(' ');
+    if (
+      node &&
+      typeof node === 'object' &&
+      'props' in node &&
+      typeof (node as { props: { children?: unknown } }).props === 'object'
+    ) {
+      const children = (node as { props: { children?: unknown } }).props
+        .children;
+      return children === undefined ? '' : flatten(children);
+    }
+    return '';
+  }
+
+  it('Renders the displayName, formatted total reps, streak and active days', () => {
+    const tree = buildOgTree(profile);
+    const text = flatten(tree);
+
+    expect(text).toContain('Wolfi');
+    // German thousands separator (de-DE locale).
+    expect(text).toContain('5.000');
+    expect(text).toContain('Streak 14');
+    expect(text).toContain('90 Tage');
+  });
+
+  it('Always renders the brand mark and canonical URL', () => {
+    const text = flatten(buildOgTree(profile));
+    expect(text).toContain('Pushup Tracker');
+    expect(text).toContain('pushup-stats.de');
+  });
+
+  it('Survives anonymous profiles with zero stats', () => {
+    const empty: PublicProfileProjection = {
+      ...profile,
+      displayName: 'anonym',
+      total: 0,
+      totalDays: 0,
+      currentStreak: 0,
+    };
+    const text = flatten(buildOgTree(empty));
+    expect(text).toContain('anonym');
+    expect(text).toContain('0 Reps');
+    expect(text).toContain('Streak 0');
+  });
+
+  it('Card dimensions and brand colours stay 1200×630 and dark', () => {
+    // OG cards are aspect-locked at 1.91:1 (1200×630). Anything else gets
+    // letter-boxed or cropped by Twitter/FB; assert the wrapper inherits
+    // the full root frame so the wrapper layout is unambiguous.
+    const tree = buildOgTree(profile) as unknown as {
+      props: { style: { width: string; height: string; background: string } };
+    };
+    expect(tree.props.style.width).toBe('100%');
+    expect(tree.props.style.height).toBe('100%');
+    expect(String(tree.props.style.background)).toContain('linear-gradient');
+  });
+});

--- a/data-store/functions/src/profile/og-render.spec.ts
+++ b/data-store/functions/src/profile/og-render.spec.ts
@@ -7,7 +7,7 @@ jest.mock('@resvg/resvg-wasm', () => ({
   initWasm: jest.fn(),
 }));
 
-import { buildOgTree } from './og-render';
+import { buildOgTree, _resetOgCachesForTesting } from './og-render';
 import type { PublicProfileProjection } from './public-profile';
 
 describe('buildOgTree', () => {
@@ -81,5 +81,29 @@ describe('buildOgTree', () => {
     expect(tree.props.style.width).toBe('100%');
     expect(tree.props.style.height).toBe('100%');
     expect(String(tree.props.style.background)).toContain('linear-gradient');
+  });
+
+  it('Returns an element of type div at the root', () => {
+    const tree = buildOgTree(profile) as unknown as { type: string };
+    expect(tree.type).toBe('div');
+  });
+
+  it('Renders the stats string with the separator dot between streak and days', () => {
+    // Regression: the combined stats line reads "N Reps · Streak M · D Tage".
+    // The separator must always be present so the three stat groups
+    // stay visually distinct regardless of locale or number value.
+    const text = flatten(buildOgTree(profile));
+    expect(text).toMatch(/Reps\s*·\s*Streak/);
+    expect(text).toMatch(/Streak\s*\d+\s*·\s*\d+\s*Tage/);
+  });
+});
+
+describe('_resetOgCachesForTesting', () => {
+  it('is callable and idempotent so specs can clear module-level caches between runs', () => {
+    expect(typeof _resetOgCachesForTesting).toBe('function');
+    expect(() => {
+      _resetOgCachesForTesting();
+      _resetOgCachesForTesting();
+    }).not.toThrow();
   });
 });

--- a/data-store/functions/src/profile/og-render.ts
+++ b/data-store/functions/src/profile/og-render.ts
@@ -19,31 +19,60 @@ import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import type { PublicProfileProjection } from './public-profile';
 
+// Direct CDN URL (no GitHub redirect), pinned to a release tag for stability.
 const FONT_URL =
-  'https://github.com/rsms/inter/raw/v4.0/docs/font-files/Inter-Bold.woff';
+  'https://raw.githubusercontent.com/rsms/inter/v4.0/docs/font-files/Inter-Bold.woff';
+const FONT_FETCH_TIMEOUT_MS = 5_000;
 
-let fontCache: ArrayBuffer | null = null;
-let wasmInitialised = false;
+// Cloud Functions Gen2 instances handle concurrent requests, so a plain
+// boolean / `null` check around the awaited work would let two cold-start
+// requests both run `initWasm()` (corrupting the global WASM state) or both
+// fetch the font twice. Cache the in-flight Promise instead so every caller
+// awaits the same work; on rejection clear the slot so the next attempt
+// retries from scratch.
+let fontPromise: Promise<ArrayBuffer> | null = null;
+let wasmPromise: Promise<void> | null = null;
 
 async function loadFont(): Promise<ArrayBuffer> {
-  if (fontCache) return fontCache;
-  const res = await fetch(FONT_URL);
-  if (!res.ok) {
-    throw new Error(`OG font fetch failed: ${res.status} ${res.statusText}`);
+  if (!fontPromise) {
+    fontPromise = (async () => {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), FONT_FETCH_TIMEOUT_MS);
+      try {
+        const res = await fetch(FONT_URL, { signal: ctrl.signal });
+        if (!res.ok) {
+          throw new Error(
+            `OG font fetch failed: ${res.status} ${res.statusText}`
+          );
+        }
+        return await res.arrayBuffer();
+      } finally {
+        clearTimeout(timer);
+      }
+    })().catch((err) => {
+      // Don't poison future attempts with a rejected cached promise.
+      fontPromise = null;
+      throw err;
+    });
   }
-  fontCache = await res.arrayBuffer();
-  return fontCache;
+  return fontPromise;
 }
 
 async function ensureResvgInitialised(): Promise<void> {
-  if (wasmInitialised) return;
-  // Locate the WASM binary inside the deployed bundle's node_modules.
-  // createRequire so it works from a CJS bundle without import.meta.
-  const require = createRequire(__filename);
-  const wasmPath = require.resolve('@resvg/resvg-wasm/index_bg.wasm');
-  const wasmBytes = await readFile(wasmPath);
-  await initWasm(wasmBytes);
-  wasmInitialised = true;
+  if (!wasmPromise) {
+    wasmPromise = (async () => {
+      // Locate the WASM binary inside the deployed bundle's node_modules.
+      // createRequire so it works from a CJS bundle without import.meta.
+      const require = createRequire(__filename);
+      const wasmPath = require.resolve('@resvg/resvg-wasm/index_bg.wasm');
+      const wasmBytes = await readFile(wasmPath);
+      await initWasm(wasmBytes);
+    })().catch((err) => {
+      wasmPromise = null;
+      throw err;
+    });
+  }
+  return wasmPromise;
 }
 
 const WIDTH = 1200;
@@ -61,8 +90,30 @@ function el(type: string, props: SatoriElement['props']): SatoriElement {
   return { type, props };
 }
 
+export type OgLocale = 'de' | 'en';
+
+interface OgCopy {
+  /** Intl locale tag for `toLocaleString` number formatting. */
+  numberLocale: string;
+  /** Suffix label between the streak count and active-day count (e.g. "Tage" / "days"). */
+  daysLabel: string;
+}
+
+const OG_COPY: Readonly<Record<OgLocale, OgCopy>> = {
+  de: { numberLocale: 'de-DE', daysLabel: 'Tage' },
+  en: { numberLocale: 'en-US', daysLabel: 'days' },
+};
+
+function copyFor(locale: OgLocale | string | undefined): OgCopy {
+  return OG_COPY[locale === 'en' ? 'en' : 'de'];
+}
+
 /** Build the satori-friendly element tree for the profile OG card. */
-export function buildOgTree(profile: PublicProfileProjection): SatoriElement {
+export function buildOgTree(
+  profile: PublicProfileProjection,
+  locale: OgLocale | string | undefined = 'de'
+): SatoriElement {
+  const copy = copyFor(locale);
   return el('div', {
     style: {
       width: '100%',
@@ -106,7 +157,7 @@ export function buildOgTree(profile: PublicProfileProjection): SatoriElement {
               fontSize: '36px',
               color: '#dbe7ff',
             },
-            children: `${profile.total.toLocaleString('de-DE')} Reps · Streak ${profile.currentStreak} · ${profile.totalDays} Tage`,
+            children: `${profile.total.toLocaleString(copy.numberLocale)} Reps · Streak ${profile.currentStreak} · ${profile.totalDays} ${copy.daysLabel}`,
           }),
         ],
       }),
@@ -126,13 +177,18 @@ export function buildOgTree(profile: PublicProfileProjection): SatoriElement {
 /**
  * Render a public-profile projection to a PNG buffer (1200×630).
  * Throws on font/resvg failures so callers can return a 500 explicitly.
+ *
+ * `locale` controls number formatting and copy ("Tage" vs "days") so the
+ * card renders in the language matching the share-link source page.
+ * Defaults to `'de'` (the source locale).
  */
 export async function renderProfileOg(
-  profile: PublicProfileProjection
+  profile: PublicProfileProjection,
+  locale: OgLocale | string | undefined = 'de'
 ): Promise<Buffer> {
   const [font] = await Promise.all([loadFont(), ensureResvgInitialised()]);
 
-  const svg = await satori(buildOgTree(profile) as never, {
+  const svg = await satori(buildOgTree(profile, locale) as never, {
     width: WIDTH,
     height: HEIGHT,
     fonts: [
@@ -154,6 +210,6 @@ export async function renderProfileOg(
 
 /** Test-only helper to flush the in-memory caches between specs. */
 export function _resetOgCachesForTesting(): void {
-  fontCache = null;
-  wasmInitialised = false;
+  fontPromise = null;
+  wasmPromise = null;
 }

--- a/data-store/functions/src/profile/og-render.ts
+++ b/data-store/functions/src/profile/og-render.ts
@@ -1,0 +1,159 @@
+/**
+ * Renders the OpenGraph card for `/u/:uid`.
+ *
+ * Decoupled from Firebase: takes a `PublicProfileProjection`, returns a PNG
+ * Buffer. This way the heavy bits (satori SVG layout + resvg WASM rasterise)
+ * stay testable in isolation and the HTTP wrapper in `index.ts` is a thin
+ * request-shaping shim.
+ *
+ * The font is fetched once at first call and cached in module scope. Cold
+ * start adds ~150ms for the woff fetch; warm starts pay nothing extra.
+ * Falling back to satori's empty-font path is not an option — the library
+ * throws without a font, so a fetch failure here surfaces as an HTTP 500
+ * upstream rather than a silently broken card.
+ */
+
+import satori from 'satori';
+import { Resvg, initWasm } from '@resvg/resvg-wasm';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import type { PublicProfileProjection } from './public-profile';
+
+const FONT_URL =
+  'https://github.com/rsms/inter/raw/v4.0/docs/font-files/Inter-Bold.woff';
+
+let fontCache: ArrayBuffer | null = null;
+let wasmInitialised = false;
+
+async function loadFont(): Promise<ArrayBuffer> {
+  if (fontCache) return fontCache;
+  const res = await fetch(FONT_URL);
+  if (!res.ok) {
+    throw new Error(`OG font fetch failed: ${res.status} ${res.statusText}`);
+  }
+  fontCache = await res.arrayBuffer();
+  return fontCache;
+}
+
+async function ensureResvgInitialised(): Promise<void> {
+  if (wasmInitialised) return;
+  // Locate the WASM binary inside the deployed bundle's node_modules.
+  // createRequire so it works from a CJS bundle without import.meta.
+  const require = createRequire(__filename);
+  const wasmPath = require.resolve('@resvg/resvg-wasm/index_bg.wasm');
+  const wasmBytes = await readFile(wasmPath);
+  await initWasm(wasmBytes);
+  wasmInitialised = true;
+}
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+interface SatoriElement {
+  type: string;
+  props: {
+    style?: Record<string, unknown>;
+    children?: SatoriElement | SatoriElement[] | string | number;
+  };
+}
+
+function el(type: string, props: SatoriElement['props']): SatoriElement {
+  return { type, props };
+}
+
+/** Build the satori-friendly element tree for the profile OG card. */
+export function buildOgTree(profile: PublicProfileProjection): SatoriElement {
+  return el('div', {
+    style: {
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+      padding: '64px 72px',
+      background:
+        'linear-gradient(135deg, rgb(11, 17, 31) 0%, rgb(31, 47, 84) 60%, rgb(63, 128, 255) 140%)',
+      color: '#f4f8ff',
+      fontFamily: 'Inter',
+    },
+    children: [
+      el('div', {
+        style: {
+          display: 'flex',
+          alignItems: 'center',
+          fontSize: '32px',
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: '#9fb3de',
+        },
+        children: 'Pushup Tracker',
+      }),
+      el('div', {
+        style: { display: 'flex', flexDirection: 'column', gap: '12px' },
+        children: [
+          el('div', {
+            style: {
+              fontSize: '88px',
+              fontWeight: 700,
+              lineHeight: 1.1,
+              maxWidth: '90%',
+              overflow: 'hidden',
+            },
+            children: profile.displayName,
+          }),
+          el('div', {
+            style: {
+              fontSize: '36px',
+              color: '#dbe7ff',
+            },
+            children: `${profile.total.toLocaleString('de-DE')} Reps · Streak ${profile.currentStreak} · ${profile.totalDays} Tage`,
+          }),
+        ],
+      }),
+      el('div', {
+        style: {
+          display: 'flex',
+          alignItems: 'center',
+          fontSize: '28px',
+          color: '#8ca8e8',
+        },
+        children: 'pushup-stats.de',
+      }),
+    ],
+  });
+}
+
+/**
+ * Render a public-profile projection to a PNG buffer (1200×630).
+ * Throws on font/resvg failures so callers can return a 500 explicitly.
+ */
+export async function renderProfileOg(
+  profile: PublicProfileProjection
+): Promise<Buffer> {
+  const [font] = await Promise.all([loadFont(), ensureResvgInitialised()]);
+
+  const svg = await satori(buildOgTree(profile) as never, {
+    width: WIDTH,
+    height: HEIGHT,
+    fonts: [
+      {
+        name: 'Inter',
+        data: font,
+        weight: 700,
+        style: 'normal',
+      },
+    ],
+  });
+
+  const resvg = new Resvg(svg, {
+    background: 'rgb(11, 17, 31)',
+    fitTo: { mode: 'width', value: WIDTH },
+  });
+  return Buffer.from(resvg.render().asPng());
+}
+
+/** Test-only helper to flush the in-memory caches between specs. */
+export function _resetOgCachesForTesting(): void {
+  fontCache = null;
+  wasmInitialised = false;
+}

--- a/data-store/functions/src/profile/public-profile.spec.ts
+++ b/data-store/functions/src/profile/public-profile.spec.ts
@@ -164,6 +164,53 @@ describe('buildPublicProfile', () => {
     });
   });
 
+  it('Returns null for bestSingleEntry when reps is Infinity', () => {
+    const result = buildPublicProfile(
+      uid,
+      { displayName: 'Wolfi', ui: { publicProfile: true } },
+      {
+        bestSingleEntry: { reps: Infinity, timestamp: '2026-04-01T12:00:00Z' },
+        updatedAt: '2026-04-29T00:00:00Z',
+      }
+    );
+    expect(result?.bestSingleEntry).toBeNull();
+  });
+
+  it('Returns null for bestDayTotal when total is NaN', () => {
+    const result = buildPublicProfile(
+      uid,
+      { displayName: 'Wolfi', ui: { publicProfile: true } },
+      {
+        bestDay: { date: '2026-04-15', total: NaN },
+        updatedAt: '2026-04-29T00:00:00Z',
+      }
+    );
+    expect(result?.bestDayTotal).toBeNull();
+  });
+
+  it('Falls back to empty string for updatedAt when value is not a string', () => {
+    const result = buildPublicProfile(
+      uid,
+      { displayName: 'Wolfi', ui: { publicProfile: true } },
+      {
+        total: 100,
+        // @ts-expect-error – intentionally testing bad runtime data
+        updatedAt: 1714383600000,
+      }
+    );
+    expect(result?.updatedAt).toBe('');
+  });
+
+  it('Returns bestSingleEntry and bestDayTotal as null when both are absent', () => {
+    const result = buildPublicProfile(
+      uid,
+      { displayName: 'Wolfi', ui: { publicProfile: true } },
+      { total: 100 }
+    );
+    expect(result?.bestSingleEntry).toBeNull();
+    expect(result?.bestDayTotal).toBeNull();
+  });
+
   // Privacy regression — explicit list of fields a future careless edit
   // could leak. If anyone adds a property to this projection, this spec
   // forces them to acknowledge it.

--- a/docs/gotchas/cloud-functions.md
+++ b/docs/gotchas/cloud-functions.md
@@ -76,3 +76,28 @@ When you need to expose a sanitized subset of an owner-only Firestore doc to ano
 `@nx/esbuild` with `thirdParty: false` keeps `node_modules` external; with `generatePackageJson: true` new deps just get registered in the emitted `package.json` and Cloud Functions npm-installs them at deploy.
 
 For deps that load WASM at runtime (e.g. `@resvg/resvg-wasm`), use `createRequire(__filename).resolve('@resvg/.../index_bg.wasm')` to locate the file inside the deployed `node_modules` tree — relative paths from `import.meta` don't work in CJS bundles. Cache the `initWasm()` result in module scope; cold start runs it once, warm starts skip.
+
+## Lazy-load heavy renderers (satori, puppeteer, sharp, …)
+
+All Cloud Functions in this repo share a single `index.ts` bundle, so any module imported at the top of `index.ts` (or re-exported from a shared barrel like `./profile/index.ts`) initialises in **every** function's cold start — even ones that never touch it. For deps over a few megabytes (satori + `@resvg/resvg-wasm` is ~15 MB combined), that's an unacceptable tax on unrelated triggers.
+
+Pattern:
+
+```ts
+export const ogProfile = onRequest(
+  {
+    /* … */
+  },
+  async (req, res) => {
+    // …Firestore reads, validation, 404 path…
+
+    const { renderProfileOg } = await import('./profile/og-render');
+    const png = await renderProfileOg(projection);
+    // …
+  }
+);
+```
+
+And keep the heavy module **out** of the shared `./profile/index.ts` barrel — direct path imports (`./profile/og-render`) inside the dynamic `import()` only.
+
+The renderer caches its own state (font bytes, `initWasm()` result) in module scope, so the dynamic import runs once per warm container and is free thereafter. First OG request after a cold start still pays the full cost — bump function memory (`512MiB` minimum for satori) and `timeoutSeconds` accordingly.

--- a/docs/gotchas/cloud-functions.md
+++ b/docs/gotchas/cloud-functions.md
@@ -54,3 +54,25 @@ Increment `USERSTATS_VERSION` in `@pu-stats/models`. Affected users automaticall
 ## Pure business logic modules
 
 Keep Cloud Function business logic in separate pure modules (e.g. `user-stats-delta.ts`) for unit testing without Firestore mocks. The trigger functions in `index.ts` are thin wrappers. See [`testing.md`](testing.md) for the testing pattern.
+
+## Public-projection pattern (private docs → anonymous-readable surface)
+
+When you need to expose a sanitized subset of an owner-only Firestore doc to anonymous callers (e.g. `/u/:uid` public profiles), do NOT widen Firestore rules. Use a callable that reads via Admin SDK and returns a **whitelisted** projection, with a regression spec asserting the output keys are a subset of an explicit allowlist (`Set` of allowed keys). See `data-store/functions/src/profile/public-profile.ts` + spec for the canonical implementation.
+
+**Privacy gates:**
+
+- Opt-in flag must be `=== true`, never truthy. Defaults to private.
+- Map both "user does not exist" and "user is private" to the same `not-found` response so account existence cannot be probed by walking UIDs.
+- Map invalid/malformed UIDs to the same `not-found` (not `invalid-argument`) so the public route stays on one consistent UX/privacy path.
+
+## `onCall` vs `onRequest` for anonymous endpoints
+
+- `onCall` requires a CORS preflight + Firebase SDK envelope and is awkward for raw `<img>` / crawler use cases. Use it for callable RPCs from authenticated clients.
+- `onRequest` is plain HTTP — needed when crawlers, social-card scrapers, or `<img src>` consume the response directly (e.g. dynamic OG images). Set `invoker: 'public'` to skip auth.
+- Firebase UID range: `1` to `128` characters, charset is implementation-defined but URL-safe in practice. Custom UIDs (test fixtures, custom-token flows) can be much shorter than the 28-char anonymous default — don't impose a minimum length floor in validators or you'll lock out valid users.
+
+## Shipping deps with WASM/native bytes
+
+`@nx/esbuild` with `thirdParty: false` keeps `node_modules` external; with `generatePackageJson: true` new deps just get registered in the emitted `package.json` and Cloud Functions npm-installs them at deploy.
+
+For deps that load WASM at runtime (e.g. `@resvg/resvg-wasm`), use `createRequire(__filename).resolve('@resvg/.../index_bg.wasm')` to locate the file inside the deployed `node_modules` tree — relative paths from `import.meta` don't work in CJS bundles. Cache the `initWasm()` result in module scope; cold start runs it once, warm starts skip.

--- a/docs/gotchas/i18n.md
+++ b/docs/gotchas/i18n.md
@@ -13,6 +13,22 @@
 
 - Use locale-aware date pipe formats (`'longDate'`, `'short'`). Never hardcode a locale parameter like `'de'`.
 
+## Number formatting
+
+Raw `{{ value }}` of numerics in templates ignores `LOCALE_ID` — `5000` stays as `5000` regardless of locale. Pipe through `| number:'1.0-0'` so digits group per the active locale (`5,000` vs `5.000`):
+
+```html
+<b>{{ p.total | number: '1.0-0' }}</b>
+```
+
+The pipe consumes the active `LOCALE_ID` automatically; **do not** pass a hard-coded locale arg (third pipe arg) — that defeats the build-time locale split.
+
+For strings built outside templates (share text, OG image content), use `value.toLocaleString('de-DE')` with the locale you want — those run on whatever runtime locale is active and don't go through Angular's pipe machinery.
+
+## Mark brand strings with `i18n` even when the source already reads English
+
+The source locale is `de`. Templates without an `i18n` attribute bypass XLIFF extraction entirely, so a hard-coded `Pushup Tracker` subtitle never gets a translation slot — even if the German and English text happen to be identical, marking it preserves the option for translators and keeps the XLIFF file consistent. Cost is one i18n id; benefit is no future "why is this string untranslatable" surprise.
+
 ## Dynamic / non-template content
 
 Dynamic data (blog posts, feature descriptions, etc.) must be locale-aware too — XLIFF only covers templates and `$localize`. Use `inject(LOCALE_ID)` to pick the right data at runtime.

--- a/docs/gotchas/signals.md
+++ b/docs/gotchas/signals.md
@@ -75,6 +75,29 @@ try {
 
 The `readFlag`/`writeFlag` helpers in `goal-reached-notification.service.ts` follow this pattern. Apply it anywhere a `providedIn: 'root'` service touches `localStorage`/`sessionStorage` during construction — a single uncaught `SecurityError` there breaks the whole app, not just the feature.
 
+## Stale async loads on route-param changes
+
+Subscribing to `ActivatedRoute.paramMap` and dispatching an `async load(uid)` per emission lets a slower earlier request finish last and overwrite state/SEO for the newer route. Symptom: navigating quickly between two `/u/:uid` pages flashes the wrong profile.
+
+Two fixes (pick one):
+
+- **Monotonic request token** — increment `loadVersion` on entry, snapshot it locally, compare after each `await` and bail if stale. Used in `PublicProfilePageComponent` because the load happens once per emission and the guard reads cleanly.
+- **`switchMap`** — derive the load from a piped observable so RxJS cancels the previous inner subscription when a new uid arrives. Cleaner when the load itself returns an Observable.
+
+```ts
+private loadVersion = 0;
+
+private async load(uid: string): Promise<void> {
+  const version = ++this.loadVersion;
+  this.state.set({ kind: 'loading' });
+  const profile = await this.api.getProfile(uid);
+  if (version !== this.loadVersion) return; // stale
+  this.state.set({ kind: 'ready', profile });
+}
+```
+
+Apply anywhere a route-param-driven async fetch can race itself: `/u/:uid`, `/blog/:slug`, `/training-plans/:slug`, etc. Bumping the token on the "no-uid → not-found" branch matters too — without it, an in-flight load can still resolve and revive a stale profile.
+
 ## Display-defaulted signals vs "is this configured?"
 
 Several signals in the app return defaulted values for display convenience:

--- a/libs/data-access/src/lib/api/public-profile-api.service.spec.ts
+++ b/libs/data-access/src/lib/api/public-profile-api.service.spec.ts
@@ -92,5 +92,36 @@ describe('PublicProfileApiService', () => {
 
       expect(result).toBeNull();
     });
+
+    it('Invokes the callable with the function name getPublicProfile', () => {
+      const { service: svc } = setup(async () => ({ data: sampleProfile }));
+      // Regression: the service must wire to the correct Cloud Function name
+      // so requests aren't silently swallowed by an undefined endpoint.
+      void svc.getProfile('abcdef1234567890');
+
+      expect(httpsCallable).toHaveBeenCalledWith(
+        expect.anything(),
+        'getPublicProfile'
+      );
+    });
+
+    it('Given the callable rejects with a code-less Error, Then re-throws', async () => {
+      const err = new Error('unexpected');
+      const { service } = setup(async () => {
+        throw err;
+      });
+
+      await expect(service.getProfile('abcdef1234567890')).rejects.toBe(err);
+    });
+
+    it('Given the callable rejects with a non-Error primitive, Then re-throws it', async () => {
+      // Defensive edge: some SDK transports surface async rejections as
+      // primitives. The service must NOT swallow these as `null` profiles.
+      const { service } = setup(() => Promise.reject('boom-string'));
+
+      await expect(service.getProfile('abcdef1234567890')).rejects.toBe(
+        'boom-string'
+      );
+    });
   });
 });

--- a/libs/data-access/src/lib/api/public-profile-api.service.spec.ts
+++ b/libs/data-access/src/lib/api/public-profile-api.service.spec.ts
@@ -27,7 +27,11 @@ describe('PublicProfileApiService', () => {
     spy: jest.Mock;
   } {
     const spy = jest.fn(callableImpl);
-    (httpsCallable as unknown as jest.Mock).mockReturnValue(spy);
+    // Reset the shared `httpsCallable` mock between tests so per-test call
+    // assertions don't see leftover invocations from earlier specs.
+    const callableFactory = httpsCallable as unknown as jest.Mock;
+    callableFactory.mockReset();
+    callableFactory.mockReturnValue(spy);
 
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,12 +378,18 @@ importers:
       '@google/generative-ai':
         specifier: ^0.21.0
         version: 0.21.0
+      '@resvg/resvg-wasm':
+        specifier: ^2.6.2
+        version: 2.6.2
       firebase-admin:
         specifier: ^13.5.0
         version: 13.8.0(encoding@0.1.13)
       firebase-functions:
         specifier: ^7.2.3
         version: 7.2.5(firebase-admin@13.8.0(encoding@0.1.13))
+      satori:
+        specifier: ^0.26.0
+        version: 0.26.0
       web-push:
         specifier: ^3.6.7
         version: 3.6.7
@@ -3815,6 +3821,10 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@resvg/resvg-wasm@2.6.2':
+    resolution: {integrity: sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw==}
+    engines: {node: '>= 10'}
+
   '@rolldown/binding-android-arm64@1.0.0-rc.4':
     resolution: {integrity: sha512-vRq9f4NzvbdZavhQbjkJBx7rRebDKYR9zHfO/Wg486+I7bSecdUapzCm5cyXoK+LHokTxgSq7A5baAXUZkIz0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4251,6 +4261,11 @@ packages:
       '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
       '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
 
   '@sigstore/bundle@4.0.0':
     resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
@@ -5363,6 +5378,10 @@ packages:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
     engines: {node: '>= 0.6.0'}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -5519,6 +5538,9 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
@@ -5885,11 +5907,25 @@ packages:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
 
+  css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+
+  css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+
+  css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+
   css-declaration-sorter@7.4.0:
     resolution: {integrity: sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
+
+  css-gradient-parser@0.0.17:
+    resolution: {integrity: sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==}
+    engines: {node: '>=16'}
 
   css-line-break@2.1.0:
     resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
@@ -5948,6 +5984,9 @@ packages:
 
   css-select@6.0.0:
     resolution: {integrity: sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==}
+
+  css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
@@ -6206,6 +6245,10 @@ packages:
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
+
+  emoji-regex-xs@2.0.1:
+    resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
+    engines: {node: '>=10.0.0'}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -6587,6 +6630,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
@@ -6998,6 +7044,10 @@ packages:
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
+  hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -7851,6 +7901,9 @@ packages:
   limiter@1.1.5:
     resolution: {integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==}
 
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -8616,9 +8669,15 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -9616,6 +9675,10 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  satori@0.26.0:
+    resolution: {integrity: sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==}
+    engines: {node: '>=16'}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -9958,6 +10021,9 @@ packages:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
+  string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
@@ -10162,6 +10228,9 @@ packages:
 
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -10437,6 +10506,9 @@ packages:
   unicode-property-aliases-ecmascript@2.2.0:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   union@0.5.0:
     resolution: {integrity: sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==}
@@ -11001,6 +11073,9 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -15778,6 +15853,8 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@resvg/resvg-wasm@2.6.2': {}
+
   '@rolldown/binding-android-arm64@1.0.0-rc.4':
     optional: true
 
@@ -16149,6 +16226,11 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@sentry/core': 10.49.0
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    dependencies:
+      fflate: 0.7.4
+      string.prototype.codepointat: 0.2.1
 
   '@sigstore/bundle@4.0.0':
     dependencies:
@@ -17432,6 +17514,8 @@ snapshots:
 
   base64-arraybuffer@1.0.2: {}
 
+  base64-js@0.0.8: {}
+
   base64-js@1.5.1: {}
 
   base64id@2.0.0: {}
@@ -17627,6 +17711,8 @@ snapshots:
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
+
+  camelize@1.0.1: {}
 
   caniuse-api@3.0.0:
     dependencies:
@@ -18000,9 +18086,17 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
+  css-background-parser@0.1.0: {}
+
+  css-box-shadow@1.0.0-3: {}
+
+  css-color-keywords@1.0.0: {}
+
   css-declaration-sorter@7.4.0(postcss@8.5.12):
     dependencies:
       postcss: 8.5.12
+
+  css-gradient-parser@0.0.17: {}
 
   css-line-break@2.1.0:
     dependencies:
@@ -18063,6 +18157,12 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       nth-check: 2.1.1
+
+  css-to-react-native@3.2.0:
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
 
   css-tree@2.2.1:
     dependencies:
@@ -18297,6 +18397,8 @@ snapshots:
   electron-to-chromium@1.5.345: {}
 
   emittery@0.13.1: {}
+
+  emoji-regex-xs@2.0.1: {}
 
   emoji-regex@10.6.0: {}
 
@@ -18771,6 +18873,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.7.4: {}
 
   fflate@0.8.2: {}
 
@@ -19427,6 +19531,8 @@ snapshots:
   heap-js@2.7.1: {}
 
   help-me@5.0.0: {}
+
+  hex-rgb@4.3.0: {}
 
   highlight.js@10.7.3: {}
 
@@ -20482,6 +20588,11 @@ snapshots:
 
   limiter@1.1.5: {}
 
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
+
   lines-and-columns@1.2.4: {}
 
   lines-and-columns@2.0.3: {}
@@ -21477,9 +21588,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  pako@0.2.9: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-css-color@0.2.1:
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
 
   parse-json@5.2.0:
     dependencies:
@@ -22504,6 +22622,20 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.6
 
+  satori@0.26.0:
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.17
+      css-to-react-native: 3.2.0
+      emoji-regex-xs: 2.0.1
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-layout: 3.2.1
+
   sax@1.6.0: {}
 
   saxes@6.0.0:
@@ -22947,6 +23079,8 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
+  string.prototype.codepointat@0.2.1: {}
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -23212,6 +23346,8 @@ snapshots:
 
   thunky@1.1.0: {}
 
+  tiny-inflate@1.0.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
@@ -23451,6 +23587,11 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.1: {}
 
   unicode-property-aliases-ecmascript@2.2.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   union@0.5.0:
     dependencies:
@@ -24121,6 +24262,8 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  yoga-layout@3.2.1: {}
 
   zip-stream@6.0.1:
     dependencies:

--- a/web/src/app/app.routes.server.spec.ts
+++ b/web/src/app/app.routes.server.spec.ts
@@ -1,0 +1,80 @@
+import { RenderMode } from '@angular/ssr';
+import { serverRoutes } from './app.routes.server';
+
+describe('serverRoutes', () => {
+  it('includes the u/:uid route', () => {
+    const paths = serverRoutes.map((r) => r.path);
+    expect(paths).toContain('u/:uid');
+  });
+
+  it('renders u/:uid in Server mode so crawlers receive populated meta tags', () => {
+    const route = serverRoutes.find((r) => r.path === 'u/:uid');
+    expect(route?.renderMode).toBe(RenderMode.Server);
+  });
+
+  it('prerenders login, register, blog, impressum, datenschutz and root', () => {
+    const prerendered = [
+      'login',
+      'register',
+      'blog',
+      'impressum',
+      'datenschutz',
+      '',
+    ];
+    for (const path of prerendered) {
+      const route = serverRoutes.find((r) => r.path === path);
+      expect(route?.renderMode).toBe(RenderMode.Prerender);
+    }
+  });
+
+  it('renders leaderboard and the app shell features in Server mode', () => {
+    const serverPaths = [
+      'leaderboard',
+      'app',
+      'history',
+      'analysis',
+      'settings',
+      'reminders',
+    ];
+    for (const path of serverPaths) {
+      const route = serverRoutes.find((r) => r.path === path);
+      expect(route?.renderMode).toBe(RenderMode.Server);
+    }
+  });
+
+  it('renders admin and wildcard in Client mode', () => {
+    for (const path of ['admin', '**']) {
+      const route = serverRoutes.find((r) => r.path === path);
+      expect(route?.renderMode).toBe(RenderMode.Client);
+    }
+  });
+
+  it('blog/:slug has getPrerenderParams that emits at least one slug', async () => {
+    const route = serverRoutes.find((r) => r.path === 'blog/:slug');
+    expect(route).toBeDefined();
+    expect(route?.renderMode).toBe(RenderMode.Prerender);
+    // ServerRoute is a discriminated union; only the Prerender variant
+    // carries `getPrerenderParams`, so narrow with a runtime cast and
+    // guard the call. Don't index-access the property without the cast —
+    // strict type narrowing rejects it for non-Prerender variants.
+    const fn = (route as { getPrerenderParams?: () => Promise<unknown[]> })
+      .getPrerenderParams;
+    expect(typeof fn).toBe('function');
+    const params = (await fn?.()) ?? [];
+    expect(Array.isArray(params)).toBe(true);
+    expect(params.length).toBeGreaterThan(0);
+    for (const p of params) {
+      expect(Object.prototype.hasOwnProperty.call(p, 'slug')).toBe(true);
+      expect(typeof (p as { slug: string }).slug).toBe('string');
+    }
+  });
+
+  it('u/:uid is NOT prerendered and NOT client-only', () => {
+    // Public profiles depend on per-request Firestore reads, so they must
+    // not be statically built (Prerender) and must run server-side so
+    // crawlers see meta tags without executing client JS.
+    const route = serverRoutes.find((r) => r.path === 'u/:uid');
+    expect(route?.renderMode).not.toBe(RenderMode.Prerender);
+    expect(route?.renderMode).not.toBe(RenderMode.Client);
+  });
+});

--- a/web/src/app/app.routes.spec.ts
+++ b/web/src/app/app.routes.spec.ts
@@ -139,4 +139,30 @@ describe('appRoutes', () => {
     const wildcard = appRoutes.find((r) => r.path === '**');
     expect(wildcard?.redirectTo).toBe('');
   });
+
+  it('lazy-loads the PublicProfilePageComponent on /u/:uid', async () => {
+    const route = appRoutes.find((r) => r.path === 'u/:uid');
+    expect(route?.loadComponent).toBeDefined();
+    const component = await route?.loadComponent?.();
+    const { PublicProfilePageComponent } =
+      await import('./public-profile/public-profile-page.component');
+    expect(component).toBe(PublicProfilePageComponent);
+  });
+
+  it('provides seoTitle and seoDescription for the u/:uid route', () => {
+    const route = appRoutes.find((r) => r.path === 'u/:uid');
+    expect(route?.data?.['seoTitle']).toBeTruthy();
+    expect(route?.data?.['seoDescription']).toBeTruthy();
+    // Sanity: the generic SEO fallback includes the brand name so crawlers
+    // hitting a cold-load /u/<uid> see a recognisable title before the
+    // component hydrates the dynamic per-profile SEO.
+    expect(route?.data?.['seoTitle']).toContain('Pushup Tracker');
+  });
+
+  it('does not require auth on /u/:uid (public access)', () => {
+    // Public profiles must be reachable without an account so anonymous
+    // visitors and social-card crawlers can open /u/<uid> directly.
+    const route = appRoutes.find((r) => r.path === 'u/:uid');
+    expect(route?.canActivate).toBeUndefined();
+  });
 });

--- a/web/src/app/public-profile/public-profile-page.component.spec.ts
+++ b/web/src/app/public-profile/public-profile-page.component.spec.ts
@@ -1,12 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { ActivatedRoute, convertToParamMap, ParamMap } from '@angular/router';
+import { FirebaseApp } from '@angular/fire/app';
 import { BehaviorSubject } from 'rxjs';
 import { PublicProfileApiService } from '@pu-stats/data-access';
 import { type PublicProfile } from '@pu-stats/models';
 import { PublicProfilePageComponent } from './public-profile-page.component';
 import { ShareService } from '../core/share.service';
 import { SeoService } from '../core/seo.service';
+
+const firebaseAppMock = {
+  options: { projectId: 'pushup-stats' },
+} as unknown as FirebaseApp;
 
 const sampleProfile: PublicProfile = {
   uid: 'abcdef1234567890',
@@ -65,6 +70,7 @@ describe('PublicProfilePageComponent', () => {
         { provide: PublicProfileApiService, useValue: apiMock },
         { provide: ShareService, useValue: shareMock },
         { provide: SeoService, useValue: seoMock },
+        { provide: FirebaseApp, useValue: firebaseAppMock },
       ],
     }).compileComponents();
 
@@ -164,17 +170,21 @@ describe('PublicProfilePageComponent', () => {
   });
 
   describe('SEO and OG image wiring', () => {
-    it('Sets a dynamic OG image URL pointing at the ogProfile function with URL-encoded UID', async () => {
+    it('Sets a dynamic OG image URL pointing at the ogProfile function with URL-encoded UID + locale', async () => {
       await setup({ resolve: sampleProfile });
 
       const args: unknown[] = seoMock.update.mock.calls.at(-1)!;
       const ogExtras = args[3] as
         | { imageUrl?: string; imageAlt?: string }
         | undefined;
+      // URL must be derived from the active FirebaseApp.options.projectId
+      // so PR previews / staging / prod each hit their own function host.
+      expect(ogExtras?.imageUrl).toContain('-pushup-stats.cloudfunctions.net');
       expect(ogExtras?.imageUrl).toContain('ogProfile');
       expect(ogExtras?.imageUrl).toContain(
         encodeURIComponent(sampleProfile.uid)
       );
+      expect(ogExtras?.imageUrl).toMatch(/[?&]lang=(de|en)/);
     });
 
     it('Sets an imageAlt that mentions the displayName', async () => {

--- a/web/src/app/public-profile/public-profile-page.component.spec.ts
+++ b/web/src/app/public-profile/public-profile-page.component.spec.ts
@@ -162,4 +162,66 @@ describe('PublicProfilePageComponent', () => {
       ).toBeTruthy();
     });
   });
+
+  describe('SEO and OG image wiring', () => {
+    it('Sets a dynamic OG image URL pointing at the ogProfile function with URL-encoded UID', async () => {
+      await setup({ resolve: sampleProfile });
+
+      const args: unknown[] = seoMock.update.mock.calls.at(-1)!;
+      const ogExtras = args[3] as
+        | { imageUrl?: string; imageAlt?: string }
+        | undefined;
+      expect(ogExtras?.imageUrl).toContain('ogProfile');
+      expect(ogExtras?.imageUrl).toContain(
+        encodeURIComponent(sampleProfile.uid)
+      );
+    });
+
+    it('Sets an imageAlt that mentions the displayName', async () => {
+      await setup({ resolve: sampleProfile });
+
+      const args: unknown[] = seoMock.update.mock.calls.at(-1)!;
+      const ogExtras = args[3] as
+        | { imageUrl?: string; imageAlt?: string }
+        | undefined;
+      expect(ogExtras?.imageAlt).toContain('Wolfi');
+    });
+
+    it('Does not pass an imageUrl in the not-found state (no per-profile card to render)', async () => {
+      await setup({ resolve: null });
+
+      const args: unknown[] = seoMock.update.mock.calls.at(-1)!;
+      const ogExtras = args[3] as { imageUrl?: string } | undefined;
+      expect(ogExtras?.imageUrl).toBeUndefined();
+    });
+
+    it('Includes the canonical path /u/:uid in the SEO call for a ready profile', async () => {
+      await setup({ resolve: sampleProfile });
+
+      const args: unknown[] = seoMock.update.mock.calls.at(-1)!;
+      expect(args[2]).toBe('/u/abcdef1234567890');
+    });
+  });
+
+  describe('Share button visibility', () => {
+    it('Renders the share button when a profile is loaded', async () => {
+      await setup({ resolve: sampleProfile });
+
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="public-profile-share"]'
+        )
+      ).not.toBeNull();
+    });
+
+    it('Hides the share button on the not-found state', async () => {
+      await setup({ resolve: null });
+
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="public-profile-share"]'
+        )
+      ).toBeNull();
+    });
+  });
 });

--- a/web/src/app/public-profile/public-profile-page.component.ts
+++ b/web/src/app/public-profile/public-profile-page.component.ts
@@ -26,6 +26,18 @@ type LoadState =
 
 const SHARE_URL_BASE = 'https://pushup-stats.de';
 
+/**
+ * Public URL of the dynamic OG image function. We do NOT branch by env
+ * here on purpose — staging/dev have a small audience and social cards are
+ * a production-shipping concern; falling back to the default static
+ * og:image (set by `index.html`) on staging is acceptable.
+ *
+ * The function lives behind the legacy `cloudfunctions.net` alias rather
+ * than the `*.run.app` URL so the URL stays stable across redeploys.
+ */
+const OG_IMAGE_BASE =
+  'https://europe-west3-pushup-stats.cloudfunctions.net/ogProfile';
+
 @Component({
   selector: 'app-public-profile-page',
   standalone: true,
@@ -149,7 +161,14 @@ export class PublicProfilePageComponent {
     this.seo.update(
       $localize`:@@publicProfile.seo.title:${profile.displayName}:name: – Pushup Tracker Profil`,
       $localize`:@@publicProfile.seo.description:${profile.displayName}:name: hat ${profile.total}:total: Liegestütze und eine ${profile.currentStreak}:streak:-Tage-Streak auf Pushup Tracker.`,
-      `/u/${profile.uid}`
+      `/u/${profile.uid}`,
+      {
+        // Per-user dynamic OG card (1200×630 PNG rendered by satori + resvg
+        // in the `ogProfile` Cloud Function). Crawlers fetch this directly,
+        // so the full absolute URL is required.
+        imageUrl: `${OG_IMAGE_BASE}?uid=${encodeURIComponent(profile.uid)}`,
+        imageAlt: $localize`:@@publicProfile.seo.imageAlt:${profile.displayName}:name: auf Pushup Tracker`,
+      }
     );
   }
 }

--- a/web/src/app/public-profile/public-profile-page.component.ts
+++ b/web/src/app/public-profile/public-profile-page.component.ts
@@ -5,8 +5,10 @@ import {
   computed,
   DestroyRef,
   inject,
+  LOCALE_ID,
   signal,
 } from '@angular/core';
+import { FirebaseApp } from '@angular/fire/app';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
@@ -26,17 +28,26 @@ type LoadState =
 
 const SHARE_URL_BASE = 'https://pushup-stats.de';
 
+const OG_FUNCTION_REGION = 'europe-west3';
+
 /**
- * Public URL of the dynamic OG image function. We do NOT branch by env
- * here on purpose — staging/dev have a small audience and social cards are
- * a production-shipping concern; falling back to the default static
- * og:image (set by `index.html`) on staging is acceptable.
+ * Builds the absolute OG-image URL for the active Firebase project.
  *
- * The function lives behind the legacy `cloudfunctions.net` alias rather
- * than the `*.run.app` URL so the URL stays stable across redeploys.
+ * Derived from the active `FirebaseApp.options.projectId` so prod / staging
+ * / preview deployments all point crawlers at their own `ogProfile` function
+ * instead of leaking through to prod (which doesn't have staging users'
+ * Firestore docs and would 404 every staging-shared link).
+ *
+ * Uses the legacy `cloudfunctions.net` alias rather than the `*.run.app`
+ * URL so the value stays stable across redeploys.
  */
-const OG_IMAGE_BASE =
-  'https://europe-west3-pushup-stats.cloudfunctions.net/ogProfile';
+function buildOgImageUrl(
+  projectId: string,
+  encodedUid: string,
+  lang: string
+): string {
+  return `https://${OG_FUNCTION_REGION}-${projectId}.cloudfunctions.net/ogProfile?uid=${encodedUid}&lang=${lang}`;
+}
 
 @Component({
   selector: 'app-public-profile-page',
@@ -59,6 +70,8 @@ export class PublicProfilePageComponent {
   private readonly seo = inject(SeoService);
   private readonly shareService = inject(ShareService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly firebaseApp = inject(FirebaseApp);
+  private readonly localeId = inject(LOCALE_ID) as string;
 
   protected readonly state = signal<LoadState>({ kind: 'loading' });
   protected readonly profile = computed(() => {
@@ -118,7 +131,7 @@ export class PublicProfilePageComponent {
     void this.shareService.share({
       title: $localize`:@@publicProfile.share.title:Pushup Tracker Profil`,
       text,
-      url: `${SHARE_URL_BASE}/u/${profile.uid}`,
+      url: `${SHARE_URL_BASE}/u/${encodeURIComponent(profile.uid)}`,
     });
   }
 
@@ -144,7 +157,13 @@ export class PublicProfilePageComponent {
 
   private currentPath(): string {
     const uid = this.route.snapshot.paramMap.get('uid')?.trim();
-    return uid ? `/u/${uid}` : '/u/';
+    return uid ? `/u/${encodeURIComponent(uid)}` : '/u/';
+  }
+
+  private localeShortCode(): string {
+    // 'de-DE' / 'en-US' → 'de' / 'en'. Fallback to 'de' (source locale).
+    const lang = this.localeId?.split('-')[0]?.toLowerCase();
+    return lang === 'en' ? 'en' : 'de';
   }
 
   private applySeo(profile: PublicProfile | null): void {
@@ -158,15 +177,25 @@ export class PublicProfilePageComponent {
       );
       return;
     }
+    const encodedUid = encodeURIComponent(profile.uid);
+    const projectId =
+      (this.firebaseApp.options as { projectId?: string }).projectId ??
+      'pushup-stats';
     this.seo.update(
       $localize`:@@publicProfile.seo.title:${profile.displayName}:name: – Pushup Tracker Profil`,
       $localize`:@@publicProfile.seo.description:${profile.displayName}:name: hat ${profile.total}:total: Liegestütze und eine ${profile.currentStreak}:streak:-Tage-Streak auf Pushup Tracker.`,
-      `/u/${profile.uid}`,
+      `/u/${encodedUid}`,
       {
         // Per-user dynamic OG card (1200×630 PNG rendered by satori + resvg
         // in the `ogProfile` Cloud Function). Crawlers fetch this directly,
-        // so the full absolute URL is required.
-        imageUrl: `${OG_IMAGE_BASE}?uid=${encodeURIComponent(profile.uid)}`,
+        // so the full absolute URL is required. URL is environment-correct:
+        // `projectId` is read from `FirebaseApp.options` so prod / staging /
+        // preview deployments each point at their own function instance.
+        imageUrl: buildOgImageUrl(
+          projectId,
+          encodedUid,
+          this.localeShortCode()
+        ),
         imageAlt: $localize`:@@publicProfile.seo.imageAlt:${profile.displayName}:name: auf Pushup Tracker`,
       }
     );

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -6072,6 +6072,12 @@ Deine Position: # ·  Reps        </source>
         <target>Pushup Tracker</target>
       </segment>
     </unit>
+    <unit id="publicProfile.seo.imageAlt">
+      <segment state="translated">
+        <source><ph id="0" equiv="name" disp="name"/> auf Pushup Tracker</source>
+        <target><ph id="0" equiv="name" disp="name"/> on Pushup Tracker</target>
+      </segment>
+    </unit>
     <unit id="publicProfile.notFound.title">
       <segment state="translated">
         <source>Profil nicht gefunden</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2570,7 +2570,7 @@
     </unit>
     <unit id="publicProfile.notFound.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:57</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:69</note>
       </notes>
       <segment>
         <source>Profil nicht gefunden</source>
@@ -2578,7 +2578,7 @@
     </unit>
     <unit id="publicProfile.notFound.body">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:58</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:70</note>
       </notes>
       <segment>
         <source>Dieses Profil existiert nicht oder wurde nicht öffentlich freigegeben.</source>
@@ -2586,7 +2586,7 @@
     </unit>
     <unit id="publicProfile.error.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:59</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:71</note>
       </notes>
       <segment>
         <source>Profil konnte nicht geladen werden</source>
@@ -2594,7 +2594,7 @@
     </unit>
     <unit id="publicProfile.error.body">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:60</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:72</note>
       </notes>
       <segment>
         <source>Bitte versuche es später erneut.</source>
@@ -2602,7 +2602,7 @@
     </unit>
     <unit id="publicProfile.retry">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:61</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:73</note>
       </notes>
       <segment>
         <source>Erneut versuchen</source>
@@ -2610,7 +2610,7 @@
     </unit>
     <unit id="publicProfile.toHome">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:62</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:74</note>
       </notes>
       <segment>
         <source>Zur Startseite</source>
@@ -2618,7 +2618,7 @@
     </unit>
     <unit id="publicProfile.stats">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:63</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:75</note>
       </notes>
       <segment>
         <source>Statistik</source>
@@ -2626,7 +2626,7 @@
     </unit>
     <unit id="publicProfile.total">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:64</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:76</note>
       </notes>
       <segment>
         <source>Gesamte Reps</source>
@@ -2634,7 +2634,7 @@
     </unit>
     <unit id="publicProfile.streak">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:65</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:77</note>
       </notes>
       <segment>
         <source>Aktuelle Streak</source>
@@ -2642,7 +2642,7 @@
     </unit>
     <unit id="publicProfile.days">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:66</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:78</note>
       </notes>
       <segment>
         <source>Aktive Tage</source>
@@ -2650,7 +2650,7 @@
     </unit>
     <unit id="publicProfile.entries">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:67</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:79</note>
       </notes>
       <segment>
         <source>Einträge</source>
@@ -2658,7 +2658,7 @@
     </unit>
     <unit id="publicProfile.bestSet">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:68</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:80</note>
       </notes>
       <segment>
         <source>Bester Einzel-Eintrag</source>
@@ -2666,7 +2666,7 @@
     </unit>
     <unit id="publicProfile.bestDay">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:69</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:81</note>
       </notes>
       <segment>
         <source>Bester Tag</source>
@@ -2674,7 +2674,7 @@
     </unit>
     <unit id="publicProfile.share.aria">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:70</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:82</note>
       </notes>
       <segment>
         <source>Profil teilen</source>
@@ -2682,7 +2682,7 @@
     </unit>
     <unit id="publicProfile.share">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:71</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:83</note>
       </notes>
       <segment>
         <source>Teilen</source>
@@ -2690,7 +2690,7 @@
     </unit>
     <unit id="publicProfile.cta">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:72</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:84</note>
       </notes>
       <segment>
         <source>Selbst tracken – pushup-stats.de</source>
@@ -2698,7 +2698,7 @@
     </unit>
     <unit id="publicProfile.share.text">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:105</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:117</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze auf Pushup Tracker geschafft 💪 Schau&apos;s dir an:</source>
@@ -2706,7 +2706,7 @@
     </unit>
     <unit id="publicProfile.share.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:107</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:119</note>
       </notes>
       <segment>
         <source>Pushup Tracker Profil</source>
@@ -2714,7 +2714,7 @@
     </unit>
     <unit id="publicProfile.seo.notFound.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:143</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:155</note>
       </notes>
       <segment>
         <source>Profil nicht verfügbar – Pushup Tracker</source>
@@ -2722,7 +2722,7 @@
     </unit>
     <unit id="publicProfile.seo.notFound.description">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:144</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:156</note>
       </notes>
       <segment>
         <source>Dieses Profil existiert nicht oder ist nicht öffentlich.</source>
@@ -2730,7 +2730,7 @@
     </unit>
     <unit id="publicProfile.seo.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:150</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:162</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> – Pushup Tracker Profil</source>
@@ -2738,10 +2738,18 @@
     </unit>
     <unit id="publicProfile.seo.description">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:151</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:163</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze und eine <ph id="2" equiv="streak" disp="profile.currentStreak"/>-Tage-Streak auf Pushup Tracker.</source>
+      </segment>
+    </unit>
+    <unit id="publicProfile.seo.imageAlt">
+      <notes>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:170</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="name" disp="profile.displayName"/> auf Pushup Tracker</source>
       </segment>
     </unit>
     <unit id="reminders.page.title">


### PR DESCRIPTION
## Summary
Stacked on top of #255 (public profiles). Adds an HTTP Cloud Function `ogProfile` that renders a per-user 1200×630 OpenGraph card via [`satori`](https://github.com/vercel/satori) (HTML → SVG) + [`@resvg/resvg-wasm`](https://github.com/yisibl/resvg-js) (SVG → PNG), then wires it into the `<meta og:image>` of `/u/:uid`.

Social-card crawlers (FB, X, LinkedIn, Discord, Slack, …) now see a card with the user's display name, total reps and current streak rather than the generic site image.

## Architecture
- **Pure tree-builder** (`buildOgTree`) decoupled from satori/resvg so layout assertions stay testable without WASM init in Jest.
- **HTTP function** (`onRequest`, not `onCall`) — crawlers and `<img>` tags fetch directly, no SDK preflight.
- **Cache**: `max-age=300, s-maxage=3600, stale-while-revalidate=86400` so the Firebase Hosting CDN amortises the satori cost; 404s cached briefly so a hot-linked dead URL doesn't hammer Firestore.
- **Privacy**: same `not-found` mapping as `getPublicProfile` for opted-out / unknown UIDs — invalid UIDs collapsed into the same response so account existence cannot be probed via the OG endpoint.
- **WASM not native**: `@resvg/resvg-wasm` chosen over `@resvg/resvg-js` to avoid Cloud Functions Gen2 native-binary arch issues. The WASM file is loaded once at first call and cached in module scope.
- **Font handling**: Inter Bold fetched from GitHub raw on first invocation, cached in module scope (~150ms cold start, free warm starts). Avoids bundling a binary asset.

## Why a separate PR
Stacked on #255 because it depends on the `getPublicProfile` projection logic and the `publicProfile` opt-in flag introduced there. Once #255 merges, this PR's diff against `main` becomes self-contained.

## Test plan
- [x] `pnpm nx affected -t=lint,test,build -c=production --parallel=3` — 11 projects passed locally.
- [ ] Verify cold-start render time on staging (target: < 3 s end-to-end).
- [ ] Validate the rendered card on https://www.opengraph.xyz/ for an opted-in profile.
- [ ] Confirm 404 path returns the cached short-TTL response for an opted-out user.
- [ ] Spot-check Cloud Function memory/timeout (`512MiB`, 30 s) is enough for satori warm starts; bump if cold-start P99 exceeds budget.

## Follow-up (not in this PR)
- Custom-domain rewrite so `og:image` is served from `https://pushup-stats.de/og/u/<uid>.png` instead of the `cloudfunctions.net` URL.
- Subset the bundled font (numbers + Latin Basic only) to drop the cold-start fetch.
- Per-locale card variant (German vs English copy in the card).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGKDZpVUBj489VTNAshbXo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public profile pages with shareable profile cards featuring dynamic OpenGraph preview images
  * Made profiles publicly accessible via `/u/:uid` route with SEO optimizations

* **Documentation**
  * Expanded Cloud Functions documentation with best practices for asset bundling and performance optimization
  * Enhanced internationalization guidance for number formatting
  * Added documentation on handling async race conditions in route-driven data loading

* **Tests**
  * Extended test coverage for routing configuration, public profiles, and SEO behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->