### PR TITLE
feat(training-plans): make plans public with signup CTA and onboarding pre-selection

### DIFF
--- a/libs/auth/src/lib/ui/register/register-ui.store.spec.ts
+++ b/libs/auth/src/lib/ui/register/register-ui.store.spec.ts
@@ -129,4 +129,35 @@ describe('RegisterUiStore', () => {
     expect(persisted).toBe(false);
     expect(store.registerSuccess()).toBe(false);
   });
+
+  describe('training plan preselection', () => {
+    it('Given a known plan id When setSelectedPlanId Then exposes the plan and a return URL with autoStart', async () => {
+      const store = await setup();
+
+      store.setSelectedPlanId('recruit-6w-v1');
+
+      expect(store.selectedPlanId()).toBe('recruit-6w-v1');
+      expect(store.selectedPlan()?.slug).toBe('recruit-6w');
+      expect(store.selectedPlanReturnUrl()).toBe(
+        '/training-plans/recruit-6w?autoStart=1'
+      );
+    });
+
+    it('Given an unknown plan id When setSelectedPlanId Then ignores it (no dead-end redirect)', async () => {
+      const store = await setup();
+
+      store.setSelectedPlanId('does-not-exist');
+
+      expect(store.selectedPlanId()).toBeNull();
+      expect(store.selectedPlan()).toBeNull();
+      expect(store.selectedPlanReturnUrl()).toBeNull();
+    });
+
+    it('Given no plan id Then selectedPlanReturnUrl is null', async () => {
+      const store = await setup();
+
+      expect(store.selectedPlanId()).toBeNull();
+      expect(store.selectedPlanReturnUrl()).toBeNull();
+    });
+  });
 });

--- a/libs/auth/src/lib/ui/register/register-ui.store.ts
+++ b/libs/auth/src/lib/ui/register/register-ui.store.ts
@@ -8,6 +8,7 @@ import {
   withProps,
   withState,
 } from '@ngrx/signals';
+import { findPlanById, TrainingPlan } from '@pu-stats/models';
 import { AuthStore } from '../../core/state/auth.store';
 import { RegisterOnboardingStore } from '../../core/state/register-onboarding.store';
 import { hasStrongPasswordPolicy } from '../password-policy';
@@ -20,6 +21,13 @@ type RegisterUiState = {
   isGoogleRegistration: boolean;
   registeringCredentials: boolean;
   registerSuccess: boolean;
+  /**
+   * Plan id pre-selected via `?planId=...` on the register URL — set when the
+   * user lands here from a training plan detail page. Drives the post-signup
+   * redirect to `/training-plans/:slug?autoStart=1` so the plan is started
+   * automatically once the account is ready.
+   */
+  selectedPlanId: string | null;
 };
 
 const initialState: RegisterUiState = {
@@ -30,6 +38,7 @@ const initialState: RegisterUiState = {
   isGoogleRegistration: false,
   registeringCredentials: false,
   registerSuccess: false,
+  selectedPlanId: null,
 };
 
 export const RegisterUiStore = signalStore(
@@ -47,6 +56,10 @@ export const RegisterUiStore = signalStore(
         store.registeringCredentials()
     ),
     onboardingError: computed(() => onboardingStore.error()),
+    selectedPlan: computed<TrainingPlan | null>(() => {
+      const id = store.selectedPlanId();
+      return id ? findPlanById(id) : null;
+    }),
   })),
   withMethods(({ authStore, onboardingStore, auth, ...store }) => ({
     toggleHidePassword: () =>
@@ -56,6 +69,19 @@ export const RegisterUiStore = signalStore(
     setDailyGoal: (value: number) => patchState(store, { dailyGoal: value }),
     setConsentAccepted: (value: boolean) =>
       patchState(store, { consentAccepted: value }),
+    setSelectedPlanId: (planId: string | null) => {
+      // Only accept ids that resolve to a real plan; ignore stale or
+      // malformed query-param values silently — better than redirecting
+      // the user into a dead-end after registration.
+      const resolved = planId && findPlanById(planId) ? planId : null;
+      patchState(store, { selectedPlanId: resolved });
+    },
+    selectedPlanReturnUrl: (): string | null => {
+      const id = store.selectedPlanId();
+      if (!id) return null;
+      const plan = findPlanById(id);
+      return plan ? `/training-plans/${plan.slug}?autoStart=1` : null;
+    },
     prepareGoogleRegistration: () => {
       // Prefer auth.currentUser (synchronous, immediately available after the
       // Google popup closes) over the signal-based authStore.user() which is

--- a/libs/auth/src/lib/ui/register/register.component.html
+++ b/libs/auth/src/lib/ui/register/register.component.html
@@ -10,6 +10,22 @@
     </mat-card-header>
 
     <mat-card-content>
+      @if (selectedPlanTitle(); as planTitle) {
+        <div class="plan-banner" data-testid="register-plan-banner">
+          <mat-icon>fitness_center</mat-icon>
+          <div>
+            <strong i18n="@@auth.register.plan.preselected"
+              >Trainingsplan vorausgewählt:</strong
+            >
+            <span class="plan-banner-title">{{ planTitle }}</span>
+            <p class="plan-banner-hint" i18n="@@auth.register.plan.hint">
+              Nach der Registrierung starten wir den Plan automatisch und setzen
+              dein Tagesziel passend.
+            </p>
+          </div>
+        </div>
+      }
+
       @if (authState.error()) {
         <div class="error-message">
           <mat-icon color="warn">error</mat-icon

--- a/libs/auth/src/lib/ui/register/register.component.scss
+++ b/libs/auth/src/lib/ui/register/register.component.scss
@@ -68,6 +68,33 @@ mat-checkbox {
   margin-bottom: 16px;
 }
 
+.plan-banner {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  border-left: 4px solid var(--mat-sys-primary, #7c4dff);
+  background: rgba(124, 77, 255, 0.08);
+  border-radius: 8px;
+}
+
+.plan-banner mat-icon {
+  flex-shrink: 0;
+  color: var(--mat-sys-primary, #7c4dff);
+}
+
+.plan-banner-title {
+  margin-left: 6px;
+  font-weight: 500;
+}
+
+.plan-banner-hint {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: var(--text-muted, #666);
+}
+
 .divider {
   display: flex;
   align-items: center;

--- a/libs/auth/src/lib/ui/register/register.component.spec.ts
+++ b/libs/auth/src/lib/ui/register/register.component.spec.ts
@@ -30,12 +30,18 @@ const breakpointObserverMock = {
   observe: jest.fn().mockReturnValue(of({ matches: true } as BreakpointState)),
 };
 
-async function renderRegister() {
+async function renderRegister(queryParams: Record<string, string> = {}) {
   return render(RegisterComponent, {
     providers: [
       {
         provide: ActivatedRoute,
-        useValue: { snapshot: { queryParamMap: { get: () => null } } },
+        useValue: {
+          snapshot: {
+            queryParamMap: {
+              get: (key: string): string | null => queryParams[key] ?? null,
+            },
+          },
+        },
       },
       { provide: AuthStore, useValue: authStoreMock },
       { provide: RegisterOnboardingStore, useValue: onboardingStoreMock },
@@ -83,6 +89,40 @@ describe('RegisterComponent', () => {
     const matErrors = document.querySelectorAll('mat-error');
     matErrors.forEach((el) => {
       expect(el.textContent).not.toBe('[object Object]');
+    });
+  });
+
+  describe('with preselected training plan', () => {
+    it('Given ?planId=recruit-6w-v1 When rendered Then shows the plan banner with the localized title', async () => {
+      const view = await renderRegister({ planId: 'recruit-6w-v1' });
+
+      const banner = view.fixture.nativeElement.querySelector(
+        '[data-testid="register-plan-banner"]'
+      ) as HTMLElement | null;
+      expect(banner).not.toBeNull();
+      expect(banner?.textContent).toContain('Trainingsplan vorausgewählt');
+      // The detail-page title is locale-aware (de: "Von 0 auf 100 …", en:
+      // "From 0 to 100 …"). Both share the "0" and "100" tokens, so
+      // assert both to keep this stable across LOCALE_ID defaults.
+      expect(banner?.textContent).toMatch(/0.*100/);
+    });
+
+    it('Given an unknown planId Then no plan banner is shown', async () => {
+      const view = await renderRegister({ planId: 'unknown-plan' });
+
+      const banner = view.fixture.nativeElement.querySelector(
+        '[data-testid="register-plan-banner"]'
+      );
+      expect(banner).toBeNull();
+    });
+
+    it('Given no planId Then no plan banner is shown', async () => {
+      const view = await renderRegister();
+
+      const banner = view.fixture.nativeElement.querySelector(
+        '[data-testid="register-plan-banner"]'
+      );
+      expect(banner).toBeNull();
     });
   });
 });

--- a/libs/auth/src/lib/ui/register/register.component.ts
+++ b/libs/auth/src/lib/ui/register/register.component.ts
@@ -3,7 +3,10 @@ import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   inject,
+  LOCALE_ID,
+  OnInit,
   signal,
 } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -28,6 +31,7 @@ import {
   StepperOrientation,
 } from '@angular/material/stepper';
 import { ActivatedRoute, Router } from '@angular/router';
+import { localizePlan } from '@pu-stats/models';
 import { map, Observable } from 'rxjs';
 import { AuthStore } from '../../core/state/auth.store';
 import { RegisterSuccessComponent } from './components/register-success';
@@ -53,12 +57,25 @@ import { RegisterUiStore } from './register-ui.store';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [RegisterUiStore],
 })
-export class RegisterComponent {
+export class RegisterComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly breakpointObserver = inject(BreakpointObserver);
+  private readonly locale = inject(LOCALE_ID) as string;
   readonly authState = inject(AuthStore);
   readonly registerUiStore = inject(RegisterUiStore);
+
+  readonly selectedPlanTitle = computed(() => {
+    const plan = this.registerUiStore.selectedPlan();
+    return plan ? localizePlan(plan, this.locale).title : null;
+  });
+
+  ngOnInit(): void {
+    const planId = this.route.snapshot.queryParamMap.get('planId');
+    if (planId) {
+      this.registerUiStore.setSelectedPlanId(planId);
+    }
+  }
 
   private readonly registerData = signal({
     email: '',
@@ -157,8 +174,8 @@ export class RegisterComponent {
   }
 
   async goToDashboard(): Promise<void> {
-    await this.router.navigateByUrl(
-      this.route.snapshot.queryParamMap.get('returnUrl') ?? '/app'
-    );
+    const planReturnUrl = this.registerUiStore.selectedPlanReturnUrl();
+    const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl');
+    await this.router.navigateByUrl(planReturnUrl ?? returnUrl ?? '/app');
   }
 }

--- a/web/src/app/app.routes.spec.ts
+++ b/web/src/app/app.routes.spec.ts
@@ -108,14 +108,7 @@ describe('appRoutes', () => {
   });
 
   it('protects app routes and keeps landing/login/register public-only', () => {
-    const protectedPaths = [
-      'app',
-      'history',
-      'analysis',
-      'settings',
-      'training-plans',
-      'training-plans/:slug',
-    ];
+    const protectedPaths = ['app', 'history', 'analysis', 'settings'];
     for (const path of protectedPaths) {
       const route = appRoutes.find((r) => r.path === path);
       expect(route?.canActivate).toEqual([authGuard]);
@@ -129,6 +122,13 @@ describe('appRoutes', () => {
 
     const registerRoute = appRoutes.find((r) => r.path === 'register');
     expect(registerRoute?.canActivate).toEqual([publicOnlyGuard]);
+  });
+
+  it('keeps training-plans routes publicly accessible (no auth guard)', () => {
+    const list = appRoutes.find((r) => r.path === 'training-plans');
+    const detail = appRoutes.find((r) => r.path === 'training-plans/:slug');
+    expect(list?.canActivate).toBeUndefined();
+    expect(detail?.canActivate).toBeUndefined();
   });
 
   it('redirects legacy /landing and wildcard to /', () => {

--- a/web/src/app/app.routes.ts
+++ b/web/src/app/app.routes.ts
@@ -93,7 +93,6 @@ export const appRoutes: Routes = [
   },
   {
     path: 'training-plans',
-    canActivate: [authGuard],
     data: {
       seoTitle: $localize`:@@seo.trainingPlans.title:Trainingspläne – Pushup Tracker`,
       seoDescription: $localize`:@@seo.trainingPlans.description:Strukturierte Liegestütz-Trainingspläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung.`,
@@ -105,7 +104,6 @@ export const appRoutes: Routes = [
   },
   {
     path: 'training-plans/:slug',
-    canActivate: [authGuard],
     loadComponent: () =>
       import('./training-plans/training-plan-detail.component').then(
         (m) => m.TrainingPlanDetailComponent

--- a/web/src/app/blog/blog-article.component.ts
+++ b/web/src/app/blog/blog-article.component.ts
@@ -217,6 +217,29 @@ const LOGO_URL = `${BASE_URL}/assets/pushup-logo.png`;
           a:hover {
             text-decoration-thickness: 2px;
           }
+
+          aside.plan-cta {
+            margin: 24px 0;
+            padding: 16px 20px;
+            border-left: 4px solid var(--mat-sys-primary, #7c4dff);
+            border-radius: 8px;
+            background: rgba(124, 77, 255, 0.06);
+          }
+
+          aside.plan-cta h3 {
+            margin: 0 0 8px;
+            font-size: 1.05rem;
+            color: var(--text-heading-secondary);
+          }
+
+          aside.plan-cta p {
+            margin: 0 0 8px;
+          }
+
+          aside.plan-cta p:last-child {
+            margin-bottom: 0;
+            font-weight: 500;
+          }
         }
       }
 

--- a/web/src/app/blog/blog-posts.data.ts
+++ b/web/src/app/blog/blog-posts.data.ts
@@ -114,6 +114,18 @@ export const BLOG_POSTS: BlogPost[] = [
   Mit einem digitalen Tracker wie Pushup Tracker hast du alle Daten auf einen Blick – inklusive
   Streak, Wochenvolumen und Bestleistungen.
 </p>
+
+<aside class="plan-cta">
+  <h3>Direkt loslegen: 6-Wochen-Plan im Tracker</h3>
+  <p>
+    Diesen 6-Wochen-Aufbau gibt es als geführten Trainingsplan in Pushup Tracker.
+    Du bekommst dein Tagesziel, die genauen Sätze pro Tag und automatische
+    Fortschrittsverfolgung. Vorbei mit Excel-Listen.
+  </p>
+  <p>
+    <a href="/training-plans/recruit-6w">Plan ansehen &rarr;</a>
+  </p>
+</aside>
     `.trim(),
   },
   {
@@ -457,6 +469,18 @@ export const BLOG_POSTS: BlogPost[] = [
   um jeden Trainingstag einzutragen – inklusive Variante, Sätze und Gesamtwiederholungen. Die
   Challenge-Grafik zeigt dir täglich, ob du auf Kurs bist.
 </p>
+
+<aside class="plan-cta">
+  <h3>Challenge im Tracker starten</h3>
+  <p>
+    Die 30-Tage-Challenge gibt es als geführten Trainingsplan: Tag 1 ist der
+    Maximaltest, jeder Tag hat ein Tagesziel und passende Sätze. Pushup Tracker
+    markiert deinen Fortschritt automatisch – du musst nur trainieren.
+  </p>
+  <p>
+    <a href="/training-plans/challenge-30d">30-Tage-Plan starten &rarr;</a>
+  </p>
+</aside>
     `.trim(),
   },
   {
@@ -550,6 +574,18 @@ export const BLOG_POSTS: BlogPost[] = [
   oft trügt. Mit Pushup Tracker siehst du auf einen Blick, ob du diese Woche mehr geschafft hast
   als letzte Woche. Das ist der Anker, der dich auch an schwierigen Tagen motiviert.
 </p>
+
+<aside class="plan-cta">
+  <h3>4-Wochen-Plan ab 40 — schonend & strukturiert</h3>
+  <p>
+    Speziell für den Einstieg ab 40: vier Wochen mit Fokus auf saubere Technik,
+    ausreichend Pause und langsames Tempo. Dein Tagesziel passt sich automatisch
+    an den Plan an, sobald du startest.
+  </p>
+  <p>
+    <a href="/training-plans/over-40-4w">Plan ab 40 ansehen &rarr;</a>
+  </p>
+</aside>
     `.trim(),
   },
 
@@ -887,6 +923,18 @@ export const BLOG_POSTS: BlogPost[] = [
   like Pushup Tracker, you have all your data at a glance – including streaks, weekly volume,
   and personal bests.
 </p>
+
+<aside class="plan-cta">
+  <h3>Start the 6-week plan in the tracker</h3>
+  <p>
+    This 6-week build-up is available as a guided training plan in Pushup Tracker.
+    You get a daily target, the exact sets per day, and automatic progress tracking.
+    No more spreadsheets.
+  </p>
+  <p>
+    <a href="/training-plans/recruit-6w">View the plan &rarr;</a>
+  </p>
+</aside>
     `.trim(),
   },
   {
@@ -1152,6 +1200,18 @@ export const BLOG_POSTS: BlogPost[] = [
   – including variation, sets, and total reps. The challenge graph shows you daily whether you're
   on track.
 </p>
+
+<aside class="plan-cta">
+  <h3>Start the challenge in the tracker</h3>
+  <p>
+    The 30-day challenge is available as a guided training plan: Day 1 is the
+    baseline test, every day has a daily target and matching sets. Pushup Tracker
+    marks your progress automatically — you just have to train.
+  </p>
+  <p>
+    <a href="/training-plans/challenge-30d">Start the 30-day plan &rarr;</a>
+  </p>
+</aside>
     `.trim(),
   },
   {
@@ -1242,6 +1302,18 @@ export const BLOG_POSTS: BlogPost[] = [
   feeling often misleads. With Pushup Tracker you can see at a glance whether you've done more
   this week than last week. That's the anchor that keeps you motivated even on tough days.
 </p>
+
+<aside class="plan-cta">
+  <h3>4-week plan after 40 — gentle &amp; structured</h3>
+  <p>
+    Designed for getting back into push-ups after 40: four weeks focused on
+    clean technique, full recovery, and controlled tempo. Your daily target
+    automatically adapts to the plan once you start it.
+  </p>
+  <p>
+    <a href="/training-plans/over-40-4w">View the over-40 plan &rarr;</a>
+  </p>
+</aside>
     `.trim(),
   },
   {

--- a/web/src/app/marketing/shell/landing-page.component.html
+++ b/web/src/app/marketing/shell/landing-page.component.html
@@ -7,73 +7,181 @@
       i18n-alt="@@brandLogoAlt"
     />
     <div class="hero-text">
-    <p class="eyebrow" i18n="@@landing.eyebrow">Pushup Tracker</p>
-    <span class="early-access-badge" i18n="@@landing.earlyAccess.badge"
-      >Early Access</span
-    >
-    <span class="free-badge" i18n="@@landing.free.badge"
-      >Kostenlos & ohne Kreditkarte</span
-    >
-    <h1 i18n="@@landing.title">Dein Training. Klar visualisiert.</h1>
-    <p class="subtitle" i18n="@@landing.subtitle">
-      Kostenlos tracken: Reps, Trends und Streaks in Sekunden – mobil, schnell
-      und mit Live-Updates.
-    </p>
+      <p class="eyebrow" i18n="@@landing.eyebrow">Pushup Tracker</p>
+      <span class="early-access-badge" i18n="@@landing.earlyAccess.badge"
+        >Early Access</span
+      >
+      <span class="free-badge" i18n="@@landing.free.badge"
+        >Kostenlos & ohne Kreditkarte</span
+      >
+      <h1 i18n="@@landing.title">Dein Training. Klar visualisiert.</h1>
+      <p class="subtitle" i18n="@@landing.subtitle">
+        Kostenlos tracken: Reps, Trends und Streaks in Sekunden – mobil, schnell
+        und mit Live-Updates.
+      </p>
 
-    <div class="cta-row">
-      @if (isAuthenticated()) {
-        <!-- Already logged in: go to dashboard -->
-        <a
-          mat-flat-button
-          color="primary"
-          routerLink="/app"
-          (click)="onCtaClick('dashboard')"
-          i18n="@@landing.cta.dashboard"
-          >Zum Dashboard</a
-        >
-        @if (isGuest()) {
-          <!-- Guest: offer to create a real account -->
+      <div class="cta-row">
+        @if (isAuthenticated()) {
+          <!-- Already logged in: go to dashboard -->
           <a
-            mat-stroked-button
+            mat-flat-button
+            color="primary"
+            routerLink="/app"
+            (click)="onCtaClick('dashboard')"
+            i18n="@@landing.cta.dashboard"
+            >Zum Dashboard</a
+          >
+          @if (isGuest()) {
+            <!-- Guest: offer to create a real account -->
+            <a
+              mat-stroked-button
+              routerLink="/register"
+              [queryParams]="{ returnUrl: '/app' }"
+              (click)="onCtaClick('signup')"
+              i18n="@@landing.cta.signup"
+              >Konto erstellen</a
+            >
+          }
+        } @else if (authResolved()) {
+          <!-- Not logged in (auth state confirmed): show all options -->
+          <a
+            mat-flat-button
+            color="primary"
             routerLink="/register"
             [queryParams]="{ returnUrl: '/app' }"
             (click)="onCtaClick('signup')"
             i18n="@@landing.cta.signup"
-            >Konto erstellen</a
+            >Jetzt registrieren</a
           >
+          <a
+            mat-stroked-button
+            routerLink="/login"
+            [queryParams]="{ returnUrl: '/app' }"
+            (click)="onCtaClick('login')"
+            i18n="@@landing.cta.login"
+            >Einloggen</a
+          >
+          <button
+            mat-button
+            type="button"
+            (click)="onTryAsGuest()"
+            i18n="@@landing.cta.guest"
+          >
+            Als Gast ausprobieren
+          </button>
         }
-      } @else if (authResolved()) {
-        <!-- Not logged in (auth state confirmed): show all options -->
-        <a
-          mat-flat-button
-          color="primary"
-          routerLink="/register"
-          [queryParams]="{ returnUrl: '/app' }"
-          (click)="onCtaClick('signup')"
-          i18n="@@landing.cta.signup"
-          >Jetzt registrieren</a
-        >
+      </div>
+      <p class="cta-hint" i18n="@@landing.cta.hint">
+        Kostenlos · Kein Abo · Jederzeit kündbar
+      </p>
+    </div>
+  </section>
+
+  <section
+    class="training-plans-feature"
+    aria-labelledby="training-plans-title"
+  >
+    <div class="training-plans-intro">
+      <span class="section-eyebrow" i18n="@@landing.plans.eyebrow"
+        >Strukturiert trainieren</span
+      >
+      <h2 id="training-plans-title" i18n="@@landing.plans.title">
+        Liegestütz-Trainingspläne, die wirklich funktionieren
+      </h2>
+      <p i18n="@@landing.plans.subtitle">
+        Vom Einsteiger zum 100er-Set: Geführte Pläne mit Tagesziel, Sätzen und
+        automatischer Fortschrittsverfolgung. Stöbere kostenlos — starten und
+        tracken kannst du mit einem kostenlosen Konto.
+      </p>
+    </div>
+
+    <div class="plans-cards">
+      <mat-card class="plan-card-mini">
+        <mat-card-header class="key-features-header">
+          <mat-icon aria-hidden="true">trending_up</mat-icon>
+          <mat-card-title i18n="@@landing.plans.recruit.title"
+            >Von 0 auf 100 — 6 Wochen</mat-card-title
+          >
+        </mat-card-header>
+        <mat-card-content i18n="@@landing.plans.recruit.body">
+          Einsteigerfreundlich: 3 Trainingstage pro Woche, progressiver Aufbau
+          und ein Maximaltest in Woche 6.
+        </mat-card-content>
+        <mat-card-actions>
+          <a
+            mat-stroked-button
+            routerLink="/training-plans/recruit-6w"
+            (click)="onPlanCardClick('recruit-6w')"
+            i18n="@@landing.plans.viewPlan"
+            >Plan ansehen</a
+          >
+        </mat-card-actions>
+      </mat-card>
+
+      <mat-card class="plan-card-mini">
+        <mat-card-header class="key-features-header">
+          <mat-icon aria-hidden="true">local_fire_department</mat-icon>
+          <mat-card-title i18n="@@landing.plans.challenge.title"
+            >30-Tage-Challenge</mat-card-title
+          >
+        </mat-card-header>
+        <mat-card-content i18n="@@landing.plans.challenge.body">
+          30 Tage Pushups mit gezielten Ruhetagen. Tag 1 ist der Maximaltest,
+          Tag 30 der Endtest.
+        </mat-card-content>
+        <mat-card-actions>
+          <a
+            mat-stroked-button
+            routerLink="/training-plans/challenge-30d"
+            (click)="onPlanCardClick('challenge-30d')"
+            i18n="@@landing.plans.viewPlan"
+            >Plan ansehen</a
+          >
+        </mat-card-actions>
+      </mat-card>
+
+      <mat-card class="plan-card-mini">
+        <mat-card-header class="key-features-header">
+          <mat-icon aria-hidden="true">favorite</mat-icon>
+          <mat-card-title i18n="@@landing.plans.over40.title"
+            >Liegestütze ab 40 — 4 Wochen</mat-card-title
+          >
+        </mat-card-header>
+        <mat-card-content i18n="@@landing.plans.over40.body">
+          Schonender Plan mit Fokus auf saubere Technik, ausreichend Pause und
+          langsames Tempo.
+        </mat-card-content>
+        <mat-card-actions>
+          <a
+            mat-stroked-button
+            routerLink="/training-plans/over-40-4w"
+            (click)="onPlanCardClick('over-40-4w')"
+            i18n="@@landing.plans.viewPlan"
+            >Plan ansehen</a
+          >
+        </mat-card-actions>
+      </mat-card>
+    </div>
+
+    <div class="plans-cta">
+      <a
+        mat-flat-button
+        color="primary"
+        routerLink="/training-plans"
+        (click)="onPlansCtaClick('overview')"
+        i18n="@@landing.plans.cta.overview"
+        >Alle Pläne ansehen</a
+      >
+      @if (!isAuthenticated() && authResolved()) {
         <a
           mat-stroked-button
-          routerLink="/login"
-          [queryParams]="{ returnUrl: '/app' }"
-          (click)="onCtaClick('login')"
-          i18n="@@landing.cta.login"
-          >Einloggen</a
+          routerLink="/register"
+          [queryParams]="{ returnUrl: '/training-plans' }"
+          (click)="onPlansCtaClick('signup')"
+          i18n="@@landing.plans.cta.signup"
+          >Konto erstellen & Plan starten</a
         >
-        <button
-          mat-button
-          type="button"
-          (click)="onTryAsGuest()"
-          i18n="@@landing.cta.guest"
-        >
-          Als Gast ausprobieren
-        </button>
       }
-    </div>
-    <p class="cta-hint" i18n="@@landing.cta.hint">
-      Kostenlos · Kein Abo · Jederzeit kündbar
-    </p>
     </div>
   </section>
 
@@ -211,8 +319,9 @@
           >
         </mat-card-header>
         <mat-card-content i18n="@@landing.discover.blog.body">
-          Tipps, Trainingspläne und Motivation rund um Liegestütze – von
-          Einsteiger bis Fortgeschritten.
+          Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von
+          Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den
+          passenden Trainingsplan.
         </mat-card-content>
         <mat-card-actions>
           <a

--- a/web/src/app/marketing/shell/landing-page.component.scss
+++ b/web/src/app/marketing/shell/landing-page.component.scss
@@ -192,6 +192,83 @@ h1 {
   }
 }
 
+.training-plans-feature {
+  display: grid;
+  gap: 16px;
+  border: 1px solid rgba(123, 159, 255, 0.25);
+  border-radius: 20px;
+  padding: clamp(18px, 3vw, 28px);
+  background: linear-gradient(
+    155deg,
+    rgba(30, 43, 74, 0.55),
+    rgba(14, 19, 33, 0.7)
+  );
+
+  .training-plans-intro {
+    display: grid;
+    gap: 6px;
+  }
+
+  .section-eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #93adea;
+    font-size: 0.74rem;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: clamp(1.4rem, 2.8vw, 1.9rem);
+    line-height: 1.15;
+  }
+
+  p {
+    margin: 0;
+    max-width: 70ch;
+    color: #c4d2f2;
+  }
+
+  .plans-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 12px;
+  }
+
+  .plan-card-mini .key-features-header {
+    align-items: end;
+    gap: 0.5rem;
+  }
+
+  .plans-cta {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+}
+
+:host-context(html.light-theme) {
+  .training-plans-feature {
+    border-color: rgba(59, 130, 246, 0.25);
+    background: linear-gradient(
+      155deg,
+      rgba(239, 246, 255, 0.85),
+      rgba(255, 255, 255, 0.95)
+    );
+
+    .section-eyebrow {
+      color: #3b82f6;
+    }
+
+    h2 {
+      color: #1e293b;
+    }
+
+    p {
+      color: #475569;
+    }
+  }
+}
+
 mat-card-header mat-icon {
   margin-right: 1rem;
   color: #94b1ff;

--- a/web/src/app/marketing/shell/landing-page.component.spec.ts
+++ b/web/src/app/marketing/shell/landing-page.component.spec.ts
@@ -210,6 +210,83 @@ describe('LandingPageComponent', () => {
     expect(blogLink.getAttribute('href')).toBe('/blog');
   });
 
+  describe('training plans section', () => {
+    it('renders three plan cards linking to the public detail pages', async () => {
+      await render(LandingPageComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: AdsStore, useValue: adsConfigMock },
+          { provide: AuthService, useValue: makeAuthServiceMock() },
+          { provide: AuthStore, useValue: makeAuthStoreMock() },
+        ],
+      });
+
+      const planLinks = screen.getAllByRole('link', { name: 'Plan ansehen' });
+      const hrefs = planLinks.map((a) => a.getAttribute('href'));
+
+      expect(hrefs).toEqual(
+        expect.arrayContaining([
+          '/training-plans/recruit-6w',
+          '/training-plans/challenge-30d',
+          '/training-plans/over-40-4w',
+        ])
+      );
+    });
+
+    it('always shows "Alle Pläne ansehen" linking to /training-plans', async () => {
+      await render(LandingPageComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: AdsStore, useValue: adsConfigMock },
+          { provide: AuthService, useValue: makeAuthServiceMock() },
+          { provide: AuthStore, useValue: makeAuthStoreMock() },
+        ],
+      });
+
+      const overviewLink = screen.getByRole('link', {
+        name: 'Alle Pläne ansehen',
+      });
+      expect(overviewLink.getAttribute('href')).toBe('/training-plans');
+    });
+
+    it('shows signup CTA pointing to /register?returnUrl=/training-plans for unauthenticated visitors', async () => {
+      await render(LandingPageComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: AdsStore, useValue: adsConfigMock },
+          { provide: AuthService, useValue: makeAuthServiceMock() },
+          { provide: AuthStore, useValue: makeAuthStoreMock() },
+        ],
+      });
+
+      const signupLink = screen.getByRole('link', {
+        name: 'Konto erstellen & Plan starten',
+      });
+      const href = signupLink.getAttribute('href') ?? '';
+
+      expect(href).toContain('/register');
+      expect(decodeURIComponent(href)).toContain('returnUrl=/training-plans');
+    });
+
+    it('hides plan signup CTA for authenticated users', async () => {
+      await render(LandingPageComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: AdsStore, useValue: adsConfigMock },
+          { provide: AuthService, useValue: makeAuthServiceMock() },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({ isAuthenticated: true }),
+          },
+        ],
+      });
+
+      expect(
+        screen.queryByRole('link', { name: 'Konto erstellen & Plan starten' })
+      ).toBeNull();
+    });
+  });
+
   it('clicking "Als Gast ausprobieren" calls signInGuestIfNeeded and navigates to /app', async () => {
     const signInGuestIfNeeded = vitest.fn().mockResolvedValue(undefined);
     const view = await render(LandingPageComponent, {

--- a/web/src/app/marketing/shell/landing-page.component.ts
+++ b/web/src/app/marketing/shell/landing-page.component.ts
@@ -49,6 +49,14 @@ export class LandingPageComponent {
     this.track('landing_discover_click', { target });
   }
 
+  onPlanCardClick(planSlug: string): void {
+    this.track('landing_plan_card_click', { plan: planSlug });
+  }
+
+  onPlansCtaClick(target: 'overview' | 'signup'): void {
+    this.track('landing_plans_cta_click', { target });
+  }
+
   private track(
     eventName: string,
     params: Record<string, string | number | boolean>

--- a/web/src/app/training-plans/training-plan-detail.component.spec.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.spec.ts
@@ -20,6 +20,7 @@ function baseStore() {
     activeCatalog: signal(null),
     activePlan: signal(null),
     hasActivePlan: signal(false),
+    activePlanLoaded: signal(true),
     currentDayIndex: signal(null),
     completionPercent: signal(0),
     todayDay: signal(null),
@@ -44,6 +45,60 @@ function makeRouteMock(slug: string, queryParams: Record<string, string> = {}) {
 }
 
 describe('TrainingPlanDetailComponent', () => {
+  describe('while auth is unresolved', () => {
+    it('does NOT flash the signup CTA before auth is resolved', async () => {
+      await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: ActivatedRoute, useValue: makeRouteMock('recruit-6w') },
+          { provide: TrainingPlanStore, useValue: makeStoreMock() },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: false,
+              authResolved: false,
+            }),
+          },
+        ],
+      });
+
+      // Neither manual-start nor signup CTA renders during the
+      // pre-resolution window — avoids a misleading flash for users
+      // whose persisted Firebase session is still being restored.
+      expect(screen.queryByRole('button', { name: 'Plan starten' })).toBeNull();
+      expect(
+        screen.queryByRole('link', { name: 'Konto erstellen & Plan starten' })
+      ).toBeNull();
+      expect(
+        screen.queryByRole('link', { name: 'Schon Konto? Einloggen' })
+      ).toBeNull();
+    });
+
+    it('does NOT auto-start while auth is unresolved (even with ?autoStart=1)', async () => {
+      const store = makeStoreMock();
+      await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          {
+            provide: ActivatedRoute,
+            useValue: makeRouteMock('recruit-6w', { autoStart: '1' }),
+          },
+          { provide: TrainingPlanStore, useValue: store },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: false,
+              authResolved: false,
+            }),
+          },
+        ],
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(store.start).not.toHaveBeenCalled();
+    });
+  });
+
   describe('when unauthenticated', () => {
     it('shows the signup CTA pointing to /register with planId and autoStart returnUrl', async () => {
       await render(TrainingPlanDetailComponent, {
@@ -186,6 +241,59 @@ describe('TrainingPlanDetailComponent', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(store.start).not.toHaveBeenCalled();
+    });
+
+    it('does NOT auto-start while active-plan resource has not loaded yet (avoids race-overwrite of an existing plan)', async () => {
+      const store = makeStoreMock({ activePlanLoaded: signal(false) });
+      await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          {
+            provide: ActivatedRoute,
+            useValue: makeRouteMock('recruit-6w', { autoStart: '1' }),
+          },
+          { provide: TrainingPlanStore, useValue: store },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: true,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(store.start).not.toHaveBeenCalled();
+    });
+
+    it('shows a snackbar and does not get stuck when auto-start fails', async () => {
+      const store = makeStoreMock();
+      store.start.mockRejectedValueOnce(new Error('network'));
+      await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          {
+            provide: ActivatedRoute,
+            useValue: makeRouteMock('recruit-6w', { autoStart: '1' }),
+          },
+          { provide: TrainingPlanStore, useValue: store },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: true,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+
+      // Allow the rejected promise to surface.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(store.start).toHaveBeenCalled();
+      // No throw → unhandled rejection isn't propagated. The user-facing
+      // error path (snackbar) is wired up; we'd need a snackbar mock to
+      // assert it directly without provoking jsdom matSnackBar quirks.
     });
 
     it('does NOT auto-start (even with ?autoStart=1) when a different plan is already active', async () => {

--- a/web/src/app/training-plans/training-plan-detail.component.spec.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.spec.ts
@@ -73,6 +73,32 @@ describe('TrainingPlanDetailComponent', () => {
       );
     });
 
+    it('login CTA returnUrl does NOT carry autoStart (would silently replace an existing plan after login)', async () => {
+      await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: ActivatedRoute, useValue: makeRouteMock('recruit-6w') },
+          { provide: TrainingPlanStore, useValue: makeStoreMock() },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: false,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+
+      const loginLink = screen.getByRole('link', {
+        name: 'Schon Konto? Einloggen',
+      });
+      const href = decodeURIComponent(loginLink.getAttribute('href') ?? '');
+
+      expect(href).toContain('/login');
+      expect(href).toContain('returnUrl=/training-plans/recruit-6w');
+      expect(href).not.toContain('autoStart');
+    });
+
     it('does not render the "Plan starten" button when unauthenticated', async () => {
       await render(TrainingPlanDetailComponent, {
         providers: [
@@ -147,6 +173,37 @@ describe('TrainingPlanDetailComponent', () => {
         providers: [
           provideRouter([]),
           { provide: ActivatedRoute, useValue: makeRouteMock('recruit-6w') },
+          { provide: TrainingPlanStore, useValue: store },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: true,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(store.start).not.toHaveBeenCalled();
+    });
+
+    it('does NOT auto-start (even with ?autoStart=1) when a different plan is already active', async () => {
+      const store = makeStoreMock({
+        hasActivePlan: signal(true),
+        // Different plan than the one whose detail page is being viewed.
+        activePlan: signal({
+          planId: 'challenge-30d-v1',
+          status: 'active',
+        } as never),
+      });
+      await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          {
+            provide: ActivatedRoute,
+            useValue: makeRouteMock('recruit-6w', { autoStart: '1' }),
+          },
           { provide: TrainingPlanStore, useValue: store },
           {
             provide: AuthStore,

--- a/web/src/app/training-plans/training-plan-detail.component.spec.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.spec.ts
@@ -1,0 +1,165 @@
+import { signal } from '@angular/core';
+import {
+  ActivatedRoute,
+  convertToParamMap,
+  provideRouter,
+} from '@angular/router';
+import { render, screen } from '@testing-library/angular';
+import { of } from 'rxjs';
+import { AuthStore } from '@pu-auth/auth';
+import { makeAuthStoreMock } from '@pu-stats/testing';
+import { TrainingPlanDetailComponent } from './training-plan-detail.component';
+import { TrainingPlanStore } from './training-plan.store';
+
+function makeStoreMock(overrides: Partial<ReturnType<typeof baseStore>> = {}) {
+  return { ...baseStore(), ...overrides };
+}
+
+function baseStore() {
+  return {
+    activeCatalog: signal(null),
+    activePlan: signal(null),
+    hasActivePlan: signal(false),
+    currentDayIndex: signal(null),
+    completionPercent: signal(0),
+    todayDay: signal(null),
+    todayDone: signal(false),
+    start: vitest.fn().mockResolvedValue(undefined),
+    abandon: vitest.fn().mockResolvedValue(undefined),
+    markDayDone: vitest.fn().mockResolvedValue(undefined),
+    unmarkDayDone: vitest.fn().mockResolvedValue(undefined),
+    logPlanDay: vitest.fn().mockResolvedValue('noop' as const),
+  };
+}
+
+function makeRouteMock(slug: string, queryParams: Record<string, string> = {}) {
+  return {
+    paramMap: of(convertToParamMap({ slug })),
+    queryParamMap: of(convertToParamMap(queryParams)),
+    snapshot: {
+      paramMap: convertToParamMap({ slug }),
+      queryParamMap: convertToParamMap(queryParams),
+    },
+  };
+}
+
+describe('TrainingPlanDetailComponent', () => {
+  describe('when unauthenticated', () => {
+    it('shows the signup CTA pointing to /register with planId and autoStart returnUrl', async () => {
+      await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: ActivatedRoute, useValue: makeRouteMock('recruit-6w') },
+          { provide: TrainingPlanStore, useValue: makeStoreMock() },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: false,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+
+      const signupLink = screen.getByRole('link', {
+        name: 'Konto erstellen & Plan starten',
+      });
+      const href = decodeURIComponent(signupLink.getAttribute('href') ?? '');
+
+      expect(href).toContain('/register');
+      expect(href).toContain('planId=recruit-6w-v1');
+      expect(href).toContain(
+        'returnUrl=/training-plans/recruit-6w?autoStart=1'
+      );
+    });
+
+    it('does not render the "Plan starten" button when unauthenticated', async () => {
+      await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: ActivatedRoute, useValue: makeRouteMock('recruit-6w') },
+          { provide: TrainingPlanStore, useValue: makeStoreMock() },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: false,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+
+      expect(screen.queryByRole('button', { name: 'Plan starten' })).toBeNull();
+    });
+  });
+
+  describe('when authenticated', () => {
+    it('shows the "Plan starten" button and hides the signup CTA', async () => {
+      await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: ActivatedRoute, useValue: makeRouteMock('recruit-6w') },
+          { provide: TrainingPlanStore, useValue: makeStoreMock() },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: true,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+
+      expect(screen.getByRole('button', { name: 'Plan starten' })).toBeTruthy();
+      expect(
+        screen.queryByRole('link', { name: 'Konto erstellen & Plan starten' })
+      ).toBeNull();
+    });
+
+    it('auto-starts the plan when ?autoStart=1 is set in the URL', async () => {
+      const store = makeStoreMock();
+      await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          {
+            provide: ActivatedRoute,
+            useValue: makeRouteMock('recruit-6w', { autoStart: '1' }),
+          },
+          { provide: TrainingPlanStore, useValue: store },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: true,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+
+      // Yield once so the constructor's effect runs.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(store.start).toHaveBeenCalledWith('recruit-6w-v1');
+    });
+
+    it('does not auto-start when ?autoStart is missing', async () => {
+      const store = makeStoreMock();
+      await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: ActivatedRoute, useValue: makeRouteMock('recruit-6w') },
+          { provide: TrainingPlanStore, useValue: store },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: true,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(store.start).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -410,8 +410,13 @@ export class TrainingPlanDetailComponent {
 
   readonly loginQueryParams = computed(() => {
     const p = this.plan();
+    // Intentionally NO `autoStart=1` here: a returning user logging back
+    // in might already have a different active plan, and silently
+    // replacing it would bypass the in-UI replacement warning shown for
+    // manual starts. Send them back to the detail page so they can
+    // explicitly confirm via "Plan starten".
     return p
-      ? { returnUrl: `/training-plans/${p.slug}?autoStart=1` }
+      ? { returnUrl: `/training-plans/${p.slug}` }
       : { returnUrl: '/training-plans' };
   });
 
@@ -421,11 +426,18 @@ export class TrainingPlanDetailComponent {
     effect(() => {
       const p = this.plan();
       const wantsAutoStart = this.queryParamsSignal().get('autoStart') === '1';
+      // Defense-in-depth: even with `autoStart=1` (only set by the
+      // signup flow), refuse to silently replace a *different* active
+      // plan. Force the user through the manual flow that surfaces the
+      // replacement warning.
+      const wouldReplaceDifferentPlan =
+        this.store.hasActivePlan() && !this.isThisPlanActive();
       if (
         p &&
         wantsAutoStart &&
         this.isAuthenticated() &&
         !this.isThisPlanActive() &&
+        !wouldReplaceDifferentPlan &&
         !this.autoStartTriggered
       ) {
         this.autoStartTriggered = true;

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -106,7 +106,7 @@ interface DayRow {
               </button>
             </mat-card-actions>
           </mat-card>
-        } @else {
+        } @else if (authResolved()) {
           <mat-card class="status-card">
             <mat-card-content>
               @if (isAuthenticated()) {
@@ -388,6 +388,7 @@ export class TrainingPlanDetailComponent {
   private readonly authStore = inject(AuthStore);
 
   protected readonly isAuthenticated = this.authStore.isAuthenticated;
+  protected readonly authResolved = this.authStore.authResolved;
 
   private readonly slugSignal = toSignal(this.route.paramMap, {
     initialValue: this.route.snapshot.paramMap,
@@ -429,19 +430,36 @@ export class TrainingPlanDetailComponent {
       // Defense-in-depth: even with `autoStart=1` (only set by the
       // signup flow), refuse to silently replace a *different* active
       // plan. Force the user through the manual flow that surfaces the
-      // replacement warning.
+      // replacement warning. Also wait until the active-plan resource
+      // has emitted at least once — otherwise during the initial-fetch
+      // window `!isThisPlanActive()` is true even for a plan that's
+      // already active, and we'd race the listener and overwrite it.
       const wouldReplaceDifferentPlan =
         this.store.hasActivePlan() && !this.isThisPlanActive();
       if (
         p &&
         wantsAutoStart &&
+        this.authResolved() &&
         this.isAuthenticated() &&
+        this.store.activePlanLoaded() &&
         !this.isThisPlanActive() &&
         !wouldReplaceDifferentPlan &&
         !this.autoStartTriggered
       ) {
         this.autoStartTriggered = true;
-        void this.start();
+        // Surface failures with a snackbar so the user knows to retry
+        // manually. The flag stays set to prevent a tight retry loop
+        // inside this component instance — a manual reload will
+        // re-attempt because `?autoStart=1` is still in the URL until
+        // a successful start clears it.
+        this.start().catch((error) => {
+          console.error('Auto-start failed', error);
+          this.snackbar.open(
+            $localize`:@@trainingPlans.autoStartFailed:Plan-Start fehlgeschlagen — bitte erneut versuchen.`,
+            undefined,
+            { duration: 4000 }
+          );
+        });
       }
     });
   }

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   inject,
   LOCALE_ID,
 } from '@angular/core';
@@ -13,6 +14,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { AuthStore } from '@pu-auth/auth';
 import {
   findPlanBySlug,
   localizePlan,
@@ -107,24 +109,64 @@ interface DayRow {
         } @else {
           <mat-card class="status-card">
             <mat-card-content>
-              <p i18n="@@trainingPlans.startCta">
-                Starte den Plan und das Tagesziel im Dashboard wird automatisch
-                nach diesem Plan gesetzt.
-              </p>
+              @if (isAuthenticated()) {
+                <p i18n="@@trainingPlans.startCta">
+                  Starte den Plan und das Tagesziel im Dashboard wird
+                  automatisch nach diesem Plan gesetzt.
+                </p>
+              } @else {
+                <p i18n="@@trainingPlans.signupCta">
+                  Erstelle ein kostenloses Konto, um diesen Plan zu starten. Wir
+                  tracken deinen Fortschritt automatisch und setzen dein
+                  Tagesziel passend zum Plan.
+                </p>
+                <ul class="signup-benefits">
+                  <li i18n="@@trainingPlans.signupBenefit.tracking">
+                    Automatische Fortschrittsverfolgung
+                  </li>
+                  <li i18n="@@trainingPlans.signupBenefit.goal">
+                    Tagesziel passt sich täglich an deinen Plan an
+                  </li>
+                  <li i18n="@@trainingPlans.signupBenefit.streak">
+                    Streaks, Statistiken und Bestenliste
+                  </li>
+                </ul>
+              }
             </mat-card-content>
             <mat-card-actions align="end">
-              @if (store.hasActivePlan()) {
-                <p
-                  class="muted warn-replace"
-                  i18n="@@trainingPlans.replaceWarn"
+              @if (isAuthenticated()) {
+                @if (store.hasActivePlan()) {
+                  <p
+                    class="muted warn-replace"
+                    i18n="@@trainingPlans.replaceWarn"
+                  >
+                    Achtung: Dies ersetzt den aktuell aktiven Plan.
+                  </p>
+                }
+                <button mat-flat-button color="primary" (click)="start()">
+                  <mat-icon>play_arrow</mat-icon>
+                  <span i18n="@@trainingPlans.start">Plan starten</span>
+                </button>
+              } @else {
+                <a
+                  mat-flat-button
+                  color="primary"
+                  [routerLink]="['/register']"
+                  [queryParams]="signupQueryParams()"
                 >
-                  Achtung: Dies ersetzt den aktuell aktiven Plan.
-                </p>
+                  <mat-icon>person_add</mat-icon>
+                  <span i18n="@@trainingPlans.signupAndStart"
+                    >Konto erstellen & Plan starten</span
+                  >
+                </a>
+                <a
+                  mat-stroked-button
+                  [routerLink]="['/login']"
+                  [queryParams]="loginQueryParams()"
+                  i18n="@@trainingPlans.loginAndStart"
+                  >Schon Konto? Einloggen</a
+                >
               }
-              <button mat-flat-button color="primary" (click)="start()">
-                <mat-icon>play_arrow</mat-icon>
-                <span i18n="@@trainingPlans.start">Plan starten</span>
-              </button>
             </mat-card-actions>
           </mat-card>
         }
@@ -327,6 +369,13 @@ interface DayRow {
       .day-desc {
         font-size: 0.9rem;
       }
+      .signup-benefits {
+        margin: 12px 0 0;
+        padding-left: 20px;
+      }
+      .signup-benefits li {
+        margin-bottom: 4px;
+      }
     `,
   ],
 })
@@ -336,15 +385,54 @@ export class TrainingPlanDetailComponent {
   private readonly router = inject(Router);
   private readonly snackbar = inject(MatSnackBar);
   private readonly locale = inject(LOCALE_ID) as string;
+  private readonly authStore = inject(AuthStore);
+
+  protected readonly isAuthenticated = this.authStore.isAuthenticated;
 
   private readonly slugSignal = toSignal(this.route.paramMap, {
     initialValue: this.route.snapshot.paramMap,
+  });
+  private readonly queryParamsSignal = toSignal(this.route.queryParamMap, {
+    initialValue: this.route.snapshot.queryParamMap,
   });
 
   readonly plan = computed(() => {
     const slug = this.slugSignal().get('slug');
     return slug ? findPlanBySlug(slug) : null;
   });
+
+  readonly signupQueryParams = computed(() => {
+    const p = this.plan();
+    return p
+      ? { planId: p.id, returnUrl: `/training-plans/${p.slug}?autoStart=1` }
+      : { returnUrl: '/training-plans' };
+  });
+
+  readonly loginQueryParams = computed(() => {
+    const p = this.plan();
+    return p
+      ? { returnUrl: `/training-plans/${p.slug}?autoStart=1` }
+      : { returnUrl: '/training-plans' };
+  });
+
+  private autoStartTriggered = false;
+
+  constructor() {
+    effect(() => {
+      const p = this.plan();
+      const wantsAutoStart = this.queryParamsSignal().get('autoStart') === '1';
+      if (
+        p &&
+        wantsAutoStart &&
+        this.isAuthenticated() &&
+        !this.isThisPlanActive() &&
+        !this.autoStartTriggered
+      ) {
+        this.autoStartTriggered = true;
+        void this.start();
+      }
+    });
+  }
 
   /** Plan with title/summary/day descriptions in the active locale. */
   readonly localized = computed(() => {
@@ -396,12 +484,26 @@ export class TrainingPlanDetailComponent {
   async start(): Promise<void> {
     const p = this.plan();
     if (!p) return;
+    if (!this.isAuthenticated()) {
+      void this.router.navigate(['/register'], {
+        queryParams: this.signupQueryParams(),
+      });
+      return;
+    }
     await this.store.start(p.id);
     this.snackbar.open(
       $localize`:@@trainingPlans.started:Plan gestartet — viel Erfolg!`,
       undefined,
       { duration: 3000 }
     );
+    if (this.queryParamsSignal().get('autoStart') === '1') {
+      void this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: { autoStart: null },
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
+    }
   }
 
   async abandon(): Promise<void> {

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -176,6 +176,20 @@ export const TrainingPlanStore = signalStore(
         activeCatalog() !== null
     );
 
+    /**
+     * True once the Firestore listener for the active plan has emitted
+     * at least one value (or resolved synchronously to `null` for
+     * unauthenticated users). Distinguishes "we haven't heard yet" from
+     * "we know there's no active plan" — critical for one-shot
+     * decisions like the auto-start effect on the detail page, which
+     * would otherwise race the resource and overwrite an existing
+     * active plan during the initial-emission window.
+     */
+    const activePlanLoaded = computed(() => {
+      const status = store.activeResource.status();
+      return status === 'resolved' || status === 'local';
+    });
+
     return {
       activePlan,
       activeCatalog,
@@ -186,6 +200,7 @@ export const TrainingPlanStore = signalStore(
       completionPercent,
       isCompleted,
       hasActivePlan,
+      activePlanLoaded,
     };
   }),
   withMethods((store) => ({
@@ -223,8 +238,8 @@ export const TrainingPlanStore = signalStore(
 
     /** Sum of reps already logged on a given local date. */
     _repsLoggedOn(dateIso: string): number {
-      return store
-        ._live.entries()
+      return store._live
+        .entries()
         .filter((e) => e.timestamp.slice(0, 10) === dateIso)
         .reduce((sum, e) => sum + e.reps, 0);
     },
@@ -370,7 +385,7 @@ export const TrainingPlanStore = signalStore(
           // logged some reps already, just top up the remainder as
           // a single set — we don't try to second-guess their split.
           const sets =
-            alreadyLogged === 0 ? day.sets ?? [day.targetReps] : [remaining];
+            alreadyLogged === 0 ? (day.sets ?? [day.targetReps]) : [remaining];
           const reps = alreadyLogged === 0 ? day.targetReps : remaining;
           await firstValueFrom(
             store._statsApi.createPushup({

--- a/web/src/app/training-plans/training-plans-page.component.spec.ts
+++ b/web/src/app/training-plans/training-plans-page.component.spec.ts
@@ -1,0 +1,112 @@
+import { signal } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { render, screen } from '@testing-library/angular';
+import { AuthStore } from '@pu-auth/auth';
+import { makeAuthStoreMock } from '@pu-stats/testing';
+import { TRAINING_PLANS } from '@pu-stats/models';
+import { TrainingPlansPageComponent } from './training-plans-page.component';
+import { TrainingPlanStore } from './training-plan.store';
+
+function makeStoreMock() {
+  return {
+    allPlans: () => TRAINING_PLANS,
+    activeCatalog: signal(null),
+    activePlan: signal(null),
+    hasActivePlan: signal(false),
+    currentDayIndex: signal(null),
+    completionPercent: signal(0),
+    todayDay: signal(null),
+    todayDone: signal(false),
+    abandon: vitest.fn(),
+    logTodayPlanDay: vitest.fn().mockResolvedValue('noop'),
+  };
+}
+
+describe('TrainingPlansPageComponent', () => {
+  it('shows the public signup banner for unauthenticated visitors once auth is resolved', async () => {
+    await render(TrainingPlansPageComponent, {
+      providers: [
+        provideRouter([]),
+        { provide: TrainingPlanStore, useValue: makeStoreMock() },
+        {
+          provide: AuthStore,
+          useValue: makeAuthStoreMock({
+            isAuthenticated: false,
+            authResolved: true,
+          }),
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText('Plan auswählen, Konto erstellen, durchstarten')
+    ).toBeTruthy();
+
+    const signupLink = screen.getByRole('link', {
+      name: 'Kostenlos registrieren',
+    });
+    expect(signupLink.getAttribute('href')).toContain('/register');
+    expect(decodeURIComponent(signupLink.getAttribute('href') ?? '')).toContain(
+      'returnUrl=/training-plans'
+    );
+  });
+
+  it('hides the signup banner before auth state is resolved', async () => {
+    await render(TrainingPlansPageComponent, {
+      providers: [
+        provideRouter([]),
+        { provide: TrainingPlanStore, useValue: makeStoreMock() },
+        {
+          provide: AuthStore,
+          useValue: makeAuthStoreMock({
+            isAuthenticated: false,
+            authResolved: false,
+          }),
+        },
+      ],
+    });
+
+    expect(
+      screen.queryByText('Plan auswählen, Konto erstellen, durchstarten')
+    ).toBeNull();
+  });
+
+  it('hides the signup banner for authenticated users', async () => {
+    await render(TrainingPlansPageComponent, {
+      providers: [
+        provideRouter([]),
+        { provide: TrainingPlanStore, useValue: makeStoreMock() },
+        {
+          provide: AuthStore,
+          useValue: makeAuthStoreMock({
+            isAuthenticated: true,
+            authResolved: true,
+          }),
+        },
+      ],
+    });
+
+    expect(
+      screen.queryByText('Plan auswählen, Konto erstellen, durchstarten')
+    ).toBeNull();
+  });
+
+  it('renders all curated plans regardless of auth state', async () => {
+    await render(TrainingPlansPageComponent, {
+      providers: [
+        provideRouter([]),
+        { provide: TrainingPlanStore, useValue: makeStoreMock() },
+        {
+          provide: AuthStore,
+          useValue: makeAuthStoreMock({
+            isAuthenticated: false,
+            authResolved: true,
+          }),
+        },
+      ],
+    });
+
+    const planLinks = screen.getAllByRole('link', { name: 'Plan ansehen' });
+    expect(planLinks.length).toBe(TRAINING_PLANS.length);
+  });
+});

--- a/web/src/app/training-plans/training-plans-page.component.spec.ts
+++ b/web/src/app/training-plans/training-plans-page.component.spec.ts
@@ -13,6 +13,7 @@ function makeStoreMock() {
     activeCatalog: signal(null),
     activePlan: signal(null),
     hasActivePlan: signal(false),
+    activePlanLoaded: signal(true),
     currentDayIndex: signal(null),
     completionPercent: signal(0),
     todayDay: signal(null),

--- a/web/src/app/training-plans/training-plans-page.component.ts
+++ b/web/src/app/training-plans/training-plans-page.component.ts
@@ -13,6 +13,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterLink } from '@angular/router';
+import { AuthStore } from '@pu-auth/auth';
 import { LogPlanDayResult, TrainingPlanStore } from './training-plan.store';
 
 @Component({
@@ -37,6 +38,43 @@ import { LogPlanDayResult, TrainingPlanStore } from './training-plan.store';
           Dashboard wird automatisch gesetzt.
         </p>
       </header>
+
+      @if (!isAuthenticated() && authResolved()) {
+        <mat-card class="signup-banner">
+          <mat-card-content>
+            <div class="signup-banner-content">
+              <mat-icon class="signup-icon">person_add</mat-icon>
+              <div>
+                <h2 i18n="@@trainingPlans.banner.title">
+                  Plan auswählen, Konto erstellen, durchstarten
+                </h2>
+                <p i18n="@@trainingPlans.banner.body">
+                  Suche dir unten einen Plan aus. Mit einem kostenlosen Konto
+                  tracken wir deinen Fortschritt automatisch und passen dein
+                  Tagesziel an den gewählten Plan an.
+                </p>
+              </div>
+            </div>
+          </mat-card-content>
+          <mat-card-actions align="end">
+            <a
+              mat-stroked-button
+              routerLink="/login"
+              [queryParams]="{ returnUrl: '/training-plans' }"
+              i18n="@@trainingPlans.banner.login"
+              >Einloggen</a
+            >
+            <a
+              mat-flat-button
+              color="primary"
+              routerLink="/register"
+              [queryParams]="{ returnUrl: '/training-plans' }"
+              i18n="@@trainingPlans.banner.signup"
+              >Kostenlos registrieren</a
+            >
+          </mat-card-actions>
+        </mat-card>
+      }
 
       @if (activeView(); as active) {
         <mat-card class="active-plan">
@@ -101,10 +139,7 @@ import { LogPlanDayResult, TrainingPlanStore } from './training-plan.store';
               <mat-icon>cancel</mat-icon>
               Plan beenden
             </button>
-            @if (
-              todayLocalized();
-              as today
-            ) {
+            @if (todayLocalized(); as today) {
               @if (
                 today.kind !== 'rest' &&
                 today.targetReps > 0 &&
@@ -117,9 +152,7 @@ import { LogPlanDayResult, TrainingPlanStore } from './training-plan.store';
                   (click)="logToday()"
                 >
                   <mat-icon>play_circle</mat-icon>
-                  <span i18n="@@trainingPlans.logToday"
-                    >Heute eintragen</span
-                  >
+                  <span i18n="@@trainingPlans.logToday">Heute eintragen</span>
                 </button>
               }
             }
@@ -239,6 +272,25 @@ import { LogPlanDayResult, TrainingPlanStore } from './training-plan.store';
       .plan-card mat-card-content {
         min-height: 64px;
       }
+      .signup-banner {
+        margin-bottom: 24px;
+        border-left: 4px solid var(--mat-sys-primary, #3f51b5);
+      }
+      .signup-banner-content {
+        display: flex;
+        gap: 16px;
+        align-items: flex-start;
+      }
+      .signup-icon {
+        font-size: 32px;
+        height: 32px;
+        width: 32px;
+        flex-shrink: 0;
+      }
+      .signup-banner h2 {
+        margin: 0 0 4px;
+        font-size: 1.1rem;
+      }
     `,
   ],
 })
@@ -246,6 +298,10 @@ export class TrainingPlansPageComponent {
   readonly store = inject(TrainingPlanStore);
   private readonly snackbar = inject(MatSnackBar);
   private readonly locale = inject(LOCALE_ID) as string;
+  private readonly authStore = inject(AuthStore);
+
+  readonly isAuthenticated = this.authStore.isAuthenticated;
+  readonly authResolved = this.authStore.authResolved;
 
   /** Catalog with `title`/`summary` fields swapped to the active locale. */
   readonly localizedPlans = computed(() =>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -852,6 +852,24 @@ Active:         </target>
         <target>Create your account</target>
       </segment>
     </unit>
+    <unit id="auth.register.plan.preselected">
+      <notes>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source>Trainingsplan vorausgewählt:</source>
+        <target>Training plan pre-selected:</target>
+      </segment>
+    </unit>
+    <unit id="auth.register.plan.hint">
+      <notes>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source> Nach der Registrierung starten wir den Plan automatisch und setzen dein Tagesziel passend. </source>
+        <target> After signing up we'll start the plan automatically and set your daily goal accordingly. </target>
+      </segment>
+    </unit>
     <unit id="auth.register.success.dashboard">
       <segment state="translated">
         <source/>
@@ -1966,8 +1984,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
       </notes>
       <segment state="translated">
-        <source> Tipps, Trainingspläne und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. </source>
-        <target> Tips, training plans, and motivation around push-ups – from beginner to advanced. </target>
+        <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
+        <target> Tips, background knowledge, and motivation around push-ups – from beginner to advanced. Many articles link directly to the matching training plan. </target>
       </segment>
     </unit>
     <unit id="landing.discover.blog.cta">
@@ -2084,6 +2102,114 @@ Deine Position: # ·  Reps        </source>
       
       
         </unit>
+    <unit id="landing.plans.eyebrow">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source>Strukturiert trainieren</source>
+        <target>Structured training</target>
+      </segment>
+    </unit>
+    <unit id="landing.plans.title">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source> Liegestütz-Trainingspläne, die wirklich funktionieren </source>
+        <target> Push-up training plans that actually work </target>
+      </segment>
+    </unit>
+    <unit id="landing.plans.subtitle">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source> Vom Einsteiger zum 100er-Set: Geführte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Stöbere kostenlos — starten und tracken kannst du mit einem kostenlosen Konto. </source>
+        <target> From beginner to 100 reps: guided plans with daily targets, sets, and automatic progress tracking. Browse for free — to start and track a plan, just create a free account. </target>
+      </segment>
+    </unit>
+    <unit id="landing.plans.recruit.title">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source>Von 0 auf 100 — 6 Wochen</source>
+        <target>From 0 to 100 — 6 weeks</target>
+      </segment>
+    </unit>
+    <unit id="landing.plans.recruit.body">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source> Einsteigerfreundlich: 3 Trainingstage pro Woche, progressiver Aufbau und ein Maximaltest in Woche 6. </source>
+        <target> Beginner-friendly: 3 training days per week, progressive overload, and a max test in week 6. </target>
+      </segment>
+    </unit>
+    <unit id="landing.plans.viewPlan">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source>Plan ansehen</source>
+        <target>View plan</target>
+      </segment>
+    </unit>
+    <unit id="landing.plans.challenge.title">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source>30-Tage-Challenge</source>
+        <target>30-day challenge</target>
+      </segment>
+    </unit>
+    <unit id="landing.plans.challenge.body">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source> 30 Tage Pushups mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest. </source>
+        <target> 30 days of push-ups with strategic rest days. Day 1 is the baseline test, Day 30 the final. </target>
+      </segment>
+    </unit>
+    <unit id="landing.plans.over40.title">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source>Liegestütze ab 40 — 4 Wochen</source>
+        <target>Push-ups after 40 — 4 weeks</target>
+      </segment>
+    </unit>
+    <unit id="landing.plans.over40.body">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source> Schonender Plan mit Fokus auf saubere Technik, ausreichend Pause und langsames Tempo. </source>
+        <target> Gentle plan focused on clean technique, full recovery, and a controlled tempo. </target>
+      </segment>
+    </unit>
+    <unit id="landing.plans.cta.overview">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle Pläne ansehen</source>
+        <target>See all plans</target>
+      </segment>
+    </unit>
+    <unit id="landing.plans.cta.signup">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
+      </notes>
+      <segment state="translated">
+        <source>Konto erstellen &amp; Plan starten</source>
+        <target>Create account &amp; start plan</target>
+      </segment>
+    </unit>
     <unit id="landing.preview.title">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:170,173</note>
@@ -5578,6 +5704,66 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source>Strukturierte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Starte einen Plan, und dein Tagesziel im Dashboard wird automatisch gesetzt.</source>
         <target>Structured plans with daily goals, sets, and automatic progress tracking. Start a plan and your daily goal on the dashboard will be set automatically.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.banner.title">
+      <segment state="translated">
+        <source> Plan auswählen, Konto erstellen, durchstarten </source>
+        <target> Pick a plan, create your account, get going </target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.banner.body">
+      <segment state="translated">
+        <source> Suche dir unten einen Plan aus. Mit einem kostenlosen Konto tracken wir deinen Fortschritt automatisch und passen dein Tagesziel an den gewählten Plan an. </source>
+        <target> Pick a plan below. With a free account we'll track your progress automatically and adapt your daily goal to the chosen plan. </target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.banner.login">
+      <segment state="translated">
+        <source>Einloggen</source>
+        <target>Log in</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.banner.signup">
+      <segment state="translated">
+        <source>Kostenlos registrieren</source>
+        <target>Sign up free</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.signupCta">
+      <segment state="translated">
+        <source> Erstelle ein kostenloses Konto, um diesen Plan zu starten. Wir tracken deinen Fortschritt automatisch und setzen dein Tagesziel passend zum Plan. </source>
+        <target> Create a free account to start this plan. We'll track your progress automatically and set your daily goal to match the plan. </target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.signupBenefit.tracking">
+      <segment state="translated">
+        <source> Automatische Fortschrittsverfolgung </source>
+        <target> Automatic progress tracking </target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.signupBenefit.goal">
+      <segment state="translated">
+        <source> Tagesziel passt sich täglich an deinen Plan an </source>
+        <target> Daily goal adapts to your plan every day </target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.signupBenefit.streak">
+      <segment state="translated">
+        <source> Streaks, Statistiken und Bestenliste </source>
+        <target> Streaks, stats, and leaderboard </target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.signupAndStart">
+      <segment state="translated">
+        <source>Konto erstellen &amp; Plan starten</source>
+        <target>Create account &amp; start plan</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.loginAndStart">
+      <segment state="translated">
+        <source>Schon Konto? Einloggen</source>
+        <target>Already have an account? Log in</target>
       </segment>
     </unit>
     <unit id="trainingPlans.active.title">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -5886,6 +5886,12 @@ Deine Position: # ·  Reps        </source>
         <target>Plan started — good luck!</target>
       </segment>
     </unit>
+    <unit id="trainingPlans.autoStartFailed">
+      <segment state="translated">
+        <source>Plan-Start fehlgeschlagen — bitte erneut versuchen.</source>
+        <target>Failed to start plan — please try again.</target>
+      </segment>
+    </unit>
     <unit id="trainingPlans.abandoned">
       <segment state="translated">
         <source>Plan beendet.</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -182,8 +182,8 @@
     <unit id="auth.onboarding.google.username">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:8,11</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:195,197</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:199,201</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:211,213</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:215,217</note>
       </notes>
       <segment>
         <source>Benutzername</source>
@@ -192,8 +192,8 @@
     <unit id="auth.onboarding.google.goal">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:19,21</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:230,232</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:234,236</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:246,248</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:250,252</note>
       </notes>
       <segment>
         <source>Tagesziel</source>
@@ -202,8 +202,8 @@
     <unit id="auth.onboarding.google.consent.checkbox">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:36,39</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:269,271</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:280,282</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:285,287</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:296,298</note>
       </notes>
       <segment>
         <source>Einwilligung erteilen</source>
@@ -220,11 +220,11 @@
     <unit id="auth.next">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:62,65</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:65,66</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:114,115</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:185,186</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:223,224</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:260,261</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:81,82</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:130,131</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:201,202</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:239,240</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:276,277</note>
       </notes>
       <segment>
         <source> Weiter </source>
@@ -233,7 +233,7 @@
     <unit id="cancel">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:67,69</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:314,315</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:330,331</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:199,200</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
@@ -294,8 +294,8 @@
     <unit id="auth.email">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:27,28</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:42,43</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:44,45</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:58,59</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:60,61</note>
       </notes>
       <segment>
         <source>E-Mail</source>
@@ -304,8 +304,8 @@
     <unit id="auth.password">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:41,42</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:93,95</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:122,123</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:109,111</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:138,139</note>
       </notes>
       <segment>
         <source>Passwort</source>
@@ -322,7 +322,7 @@
     <unit id="auth.or">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:80,81</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:68,69</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:84,85</note>
       </notes>
       <segment>
         <source>oder</source>
@@ -355,7 +355,7 @@
     <unit id="validate.email.required">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:61</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:72</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:89</note>
       </notes>
       <segment>
         <source>Bitte E-Mail eingeben!</source>
@@ -364,7 +364,7 @@
     <unit id="validate.email.email">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:64</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:75</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:92</note>
       </notes>
       <segment>
         <source>Bitte gültige E-Mail eingeben!</source>
@@ -373,7 +373,7 @@
     <unit id="validate.password.required">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:67</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:78</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:95</note>
       </notes>
       <segment>
         <source>Bitte Passwort eingeben!</source>
@@ -382,7 +382,7 @@
     <unit id="validate.password.minLength">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:70</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:81</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:98</note>
       </notes>
       <segment>
         <source>Passwort muss mindestens 8 Zeichen lang sein!</source>
@@ -436,9 +436,25 @@
         <source>Erstelle dein Konto</source>
       </segment>
     </unit>
+    <unit id="auth.register.plan.preselected">
+      <notes>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:18,20</note>
+      </notes>
+      <segment>
+        <source>Trainingsplan vorausgewählt:</source>
+      </segment>
+    </unit>
+    <unit id="auth.register.plan.hint">
+      <notes>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:22,24</note>
+      </notes>
+      <segment>
+        <source> Nach der Registrierung starten wir den Plan automatisch und setzen dein Tagesziel passend. </source>
+      </segment>
+    </unit>
     <unit id="auth.google.signup">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:77,78</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:93,94</note>
       </notes>
       <segment>
         <source> Mit Google registrieren </source>
@@ -446,7 +462,7 @@
     </unit>
     <unit id="auth.register.google.skipPassword">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:97,99</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:113,115</note>
       </notes>
       <segment>
         <source> Passwort-Schritt übersprungen (Google Registrierung). </source>
@@ -454,11 +470,11 @@
     </unit>
     <unit id="auth.register.back">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:106,107</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:169,170</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:214,215</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:251,252</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:289,290</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:122,123</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:185,186</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:230,231</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:267,268</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:305,306</note>
       </notes>
       <segment>
         <source> Zurück</source>
@@ -466,7 +482,7 @@
     </unit>
     <unit id="auth.register.password.hint">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:146,148</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:162,164</note>
       </notes>
       <segment>
         <source> Mindestens 8 Zeichen, Groß- und Kleinbuchstaben, Zahl und Sonderzeichen. </source>
@@ -474,7 +490,7 @@
     </unit>
     <unit id="auth.register.password.repeat">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:154,156</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:170,172</note>
       </notes>
       <segment>
         <source>Passwort wiederholen</source>
@@ -482,7 +498,7 @@
     </unit>
     <unit id="auth.onboarding.google.consent.text">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:272,275</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:288,291</note>
       </notes>
       <segment>
         <source> Ich willige in die Datenverarbeitung zum Erheben technisch notwendiger Daten, statistischer Auswertungen und zum Ausspielen gezielter Werbung ein. </source>
@@ -490,7 +506,7 @@
     </unit>
     <unit id="auth.register.submit">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:306,307</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:322,323</note>
       </notes>
       <segment>
         <source> Registrieren </source>
@@ -498,7 +514,7 @@
     </unit>
     <unit id="validate.password.policy">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:87</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:104</note>
       </notes>
       <segment>
         <source>Passwort braucht Groß-/Kleinbuchstaben, Zahl und Sonderzeichen.</source>
@@ -1428,7 +1444,7 @@
     </unit>
     <unit id="seo.trainingPlans.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:98</note>
+        <note category="location">web/src/app/app.routes.ts:97</note>
       </notes>
       <segment>
         <source>Trainingspläne – Pushup Tracker</source>
@@ -1436,7 +1452,7 @@
     </unit>
     <unit id="seo.trainingPlans.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:99</note>
+        <note category="location">web/src/app/app.routes.ts:98</note>
       </notes>
       <segment>
         <source>Strukturierte Liegestütz-Trainingspläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung.</source>
@@ -1444,7 +1460,7 @@
     </unit>
     <unit id="seo.reminders.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:118</note>
+        <note category="location">web/src/app/app.routes.ts:116</note>
       </notes>
       <segment>
         <source>Erinnerungen – Pushup Tracker</source>
@@ -1452,7 +1468,7 @@
     </unit>
     <unit id="seo.reminders.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:119</note>
+        <note category="location">web/src/app/app.routes.ts:117</note>
       </notes>
       <segment>
         <source>Konfiguriere Liegestütz-Erinnerungen und Push-Benachrichtigungen.</source>
@@ -1460,7 +1476,7 @@
     </unit>
     <unit id="seo.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:129</note>
+        <note category="location">web/src/app/app.routes.ts:127</note>
       </notes>
       <segment>
         <source>Bestenliste – Pushup Tracker</source>
@@ -1468,7 +1484,7 @@
     </unit>
     <unit id="seo.leaderboard.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:130</note>
+        <note category="location">web/src/app/app.routes.ts:128</note>
       </notes>
       <segment>
         <source>Öffentliche Bestenliste für tägliche, wöchentliche und monatliche Pushup-Reps.</source>
@@ -1476,7 +1492,7 @@
     </unit>
     <unit id="seo.blog.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:144</note>
+        <note category="location">web/src/app/app.routes.ts:142</note>
       </notes>
       <segment>
         <source>Blog – Liegestütze Tipps &amp; Guides | Pushup Tracker</source>
@@ -1484,7 +1500,7 @@
     </unit>
     <unit id="seo.blog.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:145</note>
+        <note category="location">web/src/app/app.routes.ts:143</note>
       </notes>
       <segment>
         <source>Tipps, Trainingspläne und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten.</source>
@@ -1492,7 +1508,7 @@
     </unit>
     <unit id="seo.impressum.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:162</note>
+        <note category="location">web/src/app/app.routes.ts:160</note>
       </notes>
       <segment>
         <source>Impressum – Pushup Tracker</source>
@@ -1500,7 +1516,7 @@
     </unit>
     <unit id="seo.impressum.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:163</note>
+        <note category="location">web/src/app/app.routes.ts:161</note>
       </notes>
       <segment>
         <source>Impressum und Anbieterkennzeichnung von Pushup Tracker.</source>
@@ -1508,7 +1524,7 @@
     </unit>
     <unit id="seo.datenschutz.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:173</note>
+        <note category="location">web/src/app/app.routes.ts:171</note>
       </notes>
       <segment>
         <source>Datenschutzerklärung – Pushup Tracker</source>
@@ -1516,7 +1532,7 @@
     </unit>
     <unit id="seo.datenschutz.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:174</note>
+        <note category="location">web/src/app/app.routes.ts:172</note>
       </notes>
       <segment>
         <source>Datenschutzerklärung von Pushup Tracker – Informationen zu Datenverarbeitung, Cookies und Ihren Rechten.</source>
@@ -2246,9 +2262,107 @@
         <source> Kostenlos · Kein Abo · Jederzeit kündbar </source>
       </segment>
     </unit>
+    <unit id="landing.plans.eyebrow">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:83,85</note>
+      </notes>
+      <segment>
+        <source>Strukturiert trainieren</source>
+      </segment>
+    </unit>
+    <unit id="landing.plans.title">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:86,88</note>
+      </notes>
+      <segment>
+        <source> Liegestütz-Trainingspläne, die wirklich funktionieren </source>
+      </segment>
+    </unit>
+    <unit id="landing.plans.subtitle">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:89,93</note>
+      </notes>
+      <segment>
+        <source> Vom Einsteiger zum 100er-Set: Geführte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Stöbere kostenlos — starten und tracken kannst du mit einem kostenlosen Konto. </source>
+      </segment>
+    </unit>
+    <unit id="landing.plans.recruit.title">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:100,102</note>
+      </notes>
+      <segment>
+        <source>Von 0 auf 100 — 6 Wochen</source>
+      </segment>
+    </unit>
+    <unit id="landing.plans.recruit.body">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:104,106</note>
+      </notes>
+      <segment>
+        <source> Einsteigerfreundlich: 3 Trainingstage pro Woche, progressiver Aufbau und ein Maximaltest in Woche 6. </source>
+      </segment>
+    </unit>
+    <unit id="landing.plans.viewPlan">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:113,115</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:135,137</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:157,159</note>
+      </notes>
+      <segment>
+        <source>Plan ansehen</source>
+      </segment>
+    </unit>
+    <unit id="landing.plans.challenge.title">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:122,124</note>
+      </notes>
+      <segment>
+        <source>30-Tage-Challenge</source>
+      </segment>
+    </unit>
+    <unit id="landing.plans.challenge.body">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:126,128</note>
+      </notes>
+      <segment>
+        <source> 30 Tage Pushups mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest. </source>
+      </segment>
+    </unit>
+    <unit id="landing.plans.over40.title">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:144,146</note>
+      </notes>
+      <segment>
+        <source>Liegestütze ab 40 — 4 Wochen</source>
+      </segment>
+    </unit>
+    <unit id="landing.plans.over40.body">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:148,150</note>
+      </notes>
+      <segment>
+        <source> Schonender Plan mit Fokus auf saubere Technik, ausreichend Pause und langsames Tempo. </source>
+      </segment>
+    </unit>
+    <unit id="landing.plans.cta.overview">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:170,172</note>
+      </notes>
+      <segment>
+        <source>Alle Pläne ansehen</source>
+      </segment>
+    </unit>
+    <unit id="landing.plans.cta.signup">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:179,183</note>
+      </notes>
+      <segment>
+        <source>Konto erstellen &amp; Plan starten</source>
+      </segment>
+    </unit>
     <unit id="landing.trust.bar">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:83,86</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:188,191</note>
       </notes>
       <segment>
         <source> ✓ Kostenlos · ✓ Kein Abo · ✓ Keine Kreditkarte · ✓ Datenschutz first </source>
@@ -2256,7 +2370,7 @@
     </unit>
     <unit id="landing.feature.analytics.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:91,93</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:196,198</note>
       </notes>
       <segment>
         <source>Smarter Überblick</source>
@@ -2264,7 +2378,7 @@
     </unit>
     <unit id="landing.feature.analytics.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:95,98</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:200,203</note>
       </notes>
       <segment>
         <source>KPIs, Charts und Custom-Zeiträume. Sieh auf einen Blick wie sich dein Training entwickelt.</source>
@@ -2272,7 +2386,7 @@
     </unit>
     <unit id="landing.feature.quick.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:104,106</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:209,211</note>
       </notes>
       <segment>
         <source>Quick Logging</source>
@@ -2280,7 +2394,7 @@
     </unit>
     <unit id="landing.feature.quick.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:108,111</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:213,216</note>
       </notes>
       <segment>
         <source>Eintrag in 2 Sekunden. Schnellaktionen für 10, 20, 30 Reps oder freie Eingabe.</source>
@@ -2288,7 +2402,7 @@
     </unit>
     <unit id="landing.feature.live.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:117,119</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:222,224</note>
       </notes>
       <segment>
         <source>Live &amp; überall</source>
@@ -2296,7 +2410,7 @@
     </unit>
     <unit id="landing.feature.live.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:121,124</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:226,229</note>
       </notes>
       <segment>
         <source>Alle Geräte. Echtzeit-Sync hält deine Daten überall aktuell – kein Refresh nötig.</source>
@@ -2304,7 +2418,7 @@
     </unit>
     <unit id="landing.feature.streak.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:130,132</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:235,237</note>
       </notes>
       <segment>
         <source>Streaks &amp; Bestenliste</source>
@@ -2312,7 +2426,7 @@
     </unit>
     <unit id="landing.feature.streak.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:134,137</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:239,242</note>
       </notes>
       <segment>
         <source>Täglich dabei bleiben. Verfolge deine Streak und miss dich mit der Community.</source>
@@ -2320,7 +2434,7 @@
     </unit>
     <unit id="landing.feature.free.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:143,145</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:248,250</note>
       </notes>
       <segment>
         <source>100% Kostenlos</source>
@@ -2328,7 +2442,7 @@
     </unit>
     <unit id="landing.feature.free.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:147,150</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:252,255</note>
       </notes>
       <segment>
         <source>Keine Kreditkarte. Kein Abo. Einfach registrieren und loslegen – für immer kostenlos.</source>
@@ -2336,7 +2450,7 @@
     </unit>
     <unit id="landing.feature.adaptive.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:156,158</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:261,263</note>
       </notes>
       <segment>
         <source>Smarte Schnellaktionen</source>
@@ -2344,7 +2458,7 @@
     </unit>
     <unit id="landing.feature.adaptive.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:160,163</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:265,268</note>
       </notes>
       <segment>
         <source>Basierend auf deiner Trainingshistorie schlägt die App automatisch passende Wiederholungszahlen vor. Ein Tap genügt.</source>
@@ -2352,7 +2466,7 @@
     </unit>
     <unit id="ads.landing.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:165</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:270</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -2360,7 +2474,7 @@
     </unit>
     <unit id="landing.preview.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:170,173</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:275,278</note>
       </notes>
       <segment>
         <source> Deine Statistik auf einen Blick </source>
@@ -2368,7 +2482,7 @@
     </unit>
     <unit id="landing.preview.alt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:174,175</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:279,280</note>
       </notes>
       <segment>
         <source>Vorschau der Statistikansicht</source>
@@ -2376,7 +2490,7 @@
     </unit>
     <unit id="landing.discover.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:181,182</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:286,287</note>
       </notes>
       <segment>
         <source>Mehr entdecken</source>
@@ -2384,7 +2498,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:187,189</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:292,294</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -2392,7 +2506,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:191,194</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:296,299</note>
       </notes>
       <segment>
         <source> Vergleiche dich mit der Community: tägliche, wöchentliche und monatliche Top-Reps. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
@@ -2400,7 +2514,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:201,204</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:306,309</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -2408,7 +2522,7 @@
     </unit>
     <unit id="landing.discover.blog.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:210,212</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:315,317</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -2416,15 +2530,15 @@
     </unit>
     <unit id="landing.discover.blog.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:214,216</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:319,322</note>
       </notes>
       <segment>
-        <source> Tipps, Trainingspläne und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. </source>
+        <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
       </segment>
     </unit>
     <unit id="landing.discover.blog.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:223,225</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:329,331</note>
       </notes>
       <segment>
         <source>Zum Blog</source>
@@ -4269,7 +4383,7 @@
     <unit id="trainingPlans.day">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:70,71</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:52,53</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:92,93</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -4278,8 +4392,8 @@
     <unit id="trainingPlans.kind.rest">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:73,74</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:165,166</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:66,67</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:207,208</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:106,107</note>
       </notes>
       <segment>
         <source>Ruhetag</source>
@@ -4288,8 +4402,8 @@
     <unit id="trainingPlans.kind.light">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:76,77</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:172,174</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:69,70</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:214,216</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:109,110</note>
       </notes>
       <segment>
         <source>Leichter Tag</source>
@@ -4298,8 +4412,8 @@
     <unit id="trainingPlans.kind.test">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:78,80</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:168,170</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:72,74</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:210,212</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:112,114</note>
       </notes>
       <segment>
         <source>Maximaltest</source>
@@ -4308,9 +4422,9 @@
     <unit id="trainingPlans.reps">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:81,83</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:177,178</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:181,183</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:84,86</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:219,220</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:223,225</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:124,126</note>
       </notes>
       <segment>
         <source>Wdh.</source>
@@ -4319,7 +4433,7 @@
     <unit id="trainingPlans.openDetail">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:90,92</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:125,127</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:169,171</note>
       </notes>
       <segment>
         <source> Details öffnen </source>
@@ -4519,8 +4633,8 @@
     </unit>
     <unit id="trainingPlans.back">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:51</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:234,236</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:53</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:278,280</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -4528,8 +4642,8 @@
     </unit>
     <unit id="trainingPlans.daysSuffix">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:64,66</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:140,142</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:66,68</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:184,186</note>
       </notes>
       <segment>
         <source>Tage</source>
@@ -4537,8 +4651,8 @@
     </unit>
     <unit id="trainingPlans.level.beginner">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:68,69</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:145,147</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:70,71</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:189,191</note>
       </notes>
       <segment>
         <source>Einsteiger</source>
@@ -4546,8 +4660,8 @@
     </unit>
     <unit id="trainingPlans.level.intermediate">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:70,72</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:149,151</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:72,74</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:193,195</note>
       </notes>
       <segment>
         <source>Mittelstufe</source>
@@ -4555,8 +4669,8 @@
     </unit>
     <unit id="trainingPlans.level.advanced">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:72,74</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:153,155</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:74,76</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:197,199</note>
       </notes>
       <segment>
         <source>Fortgeschritten</source>
@@ -4564,7 +4678,7 @@
     </unit>
     <unit id="trainingPlans.progress">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:81,82</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:83,84</note>
       </notes>
       <segment>
         <source>Fortschritt</source>
@@ -4572,7 +4686,7 @@
     </unit>
     <unit id="trainingPlans.currentDay">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:90,91</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:92,93</note>
       </notes>
       <segment>
         <source>Aktueller Tag:</source>
@@ -4580,8 +4694,8 @@
     </unit>
     <unit id="trainingPlans.abandon">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:102,104</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:99,101</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:104,106</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:139,141</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">cancel</pc> Plan beenden </source>
@@ -4589,15 +4703,47 @@
     </unit>
     <unit id="trainingPlans.startCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:111,113</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:114,116</note>
       </notes>
       <segment>
         <source> Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt. </source>
       </segment>
     </unit>
+    <unit id="trainingPlans.signupCta">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:119,121</note>
+      </notes>
+      <segment>
+        <source> Erstelle ein kostenloses Konto, um diesen Plan zu starten. Wir tracken deinen Fortschritt automatisch und setzen dein Tagesziel passend zum Plan. </source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.signupBenefit.tracking">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:125,127</note>
+      </notes>
+      <segment>
+        <source> Automatische Fortschrittsverfolgung </source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.signupBenefit.goal">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:128,130</note>
+      </notes>
+      <segment>
+        <source> Tagesziel passt sich täglich an deinen Plan an </source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.signupBenefit.streak">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:131,133</note>
+      </notes>
+      <segment>
+        <source> Streaks, Statistiken und Bestenliste </source>
+      </segment>
+    </unit>
     <unit id="trainingPlans.replaceWarn">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:121,123</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:143,144</note>
       </notes>
       <segment>
         <source> Achtung: Dies ersetzt den aktuell aktiven Plan. </source>
@@ -4605,15 +4751,31 @@
     </unit>
     <unit id="trainingPlans.start">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:126,128</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:148,150</note>
       </notes>
       <segment>
         <source>Plan starten</source>
       </segment>
     </unit>
+    <unit id="trainingPlans.signupAndStart">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:159,161</note>
+      </notes>
+      <segment>
+        <source>Konto erstellen &amp; Plan starten</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.loginAndStart">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:167,170</note>
+      </notes>
+      <segment>
+        <source>Schon Konto? Einloggen</source>
+      </segment>
+    </unit>
     <unit id="trainingPlans.week">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:135,136</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:177,178</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -4621,7 +4783,7 @@
     </unit>
     <unit id="trainingPlans.unmarkAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:197,198</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:239,240</note>
       </notes>
       <segment>
         <source>Als nicht erledigt markieren</source>
@@ -4629,7 +4791,7 @@
     </unit>
     <unit id="trainingPlans.logAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:207,208</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:250,251</note>
       </notes>
       <segment>
         <source>Plan-Sätze eintragen und als erledigt markieren</source>
@@ -4637,7 +4799,7 @@
     </unit>
     <unit id="trainingPlans.markAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:215,216</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:259,260</note>
       </notes>
       <segment>
         <source>Nur als erledigt markieren (ohne Eintrag)</source>
@@ -4645,7 +4807,7 @@
     </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:231,232</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:275,276</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -4653,7 +4815,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:399</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:496</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -4661,7 +4823,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:408</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:513</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
@@ -4669,7 +4831,8 @@
     </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:426</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:539</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:364</note>
       </notes>
       <segment>
         <source>Plan-Sätze wurden eingetragen.</source>
@@ -4677,8 +4840,8 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:541</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:366</note>
       </notes>
       <segment>
         <source>Tag war schon eingetragen — als erledigt markiert.</source>
@@ -4686,8 +4849,8 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:543</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:368</note>
       </notes>
       <segment>
         <source>Daten werden noch geladen, bitte gleich noch einmal versuchen.</source>
@@ -4695,7 +4858,7 @@
     </unit>
     <unit id="trainingPlans.title">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:31,32</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:34,35</note>
       </notes>
       <segment>
         <source>Trainingspläne</source>
@@ -4703,15 +4866,47 @@
     </unit>
     <unit id="trainingPlans.intro">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:33,36</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:36,39</note>
       </notes>
       <segment>
         <source> Strukturierte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Starte einen Plan, und dein Tagesziel im Dashboard wird automatisch gesetzt. </source>
       </segment>
     </unit>
+    <unit id="trainingPlans.banner.title">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:49,51</note>
+      </notes>
+      <segment>
+        <source> Plan auswählen, Konto erstellen, durchstarten </source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.banner.body">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:52,54</note>
+      </notes>
+      <segment>
+        <source> Suche dir unten einen Plan aus. Mit einem kostenlosen Konto tracken wir deinen Fortschritt automatisch und passen dein Tagesziel an den gewählten Plan an. </source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.banner.login">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:65,68</note>
+      </notes>
+      <segment>
+        <source>Einloggen</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.banner.signup">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:73,75</note>
+      </notes>
+      <segment>
+        <source>Kostenlos registrieren</source>
+      </segment>
+    </unit>
     <unit id="trainingPlans.active.title">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:43,44</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:83,84</note>
       </notes>
       <segment>
         <source> Aktiver Plan </source>
@@ -4719,7 +4914,7 @@
     </unit>
     <unit id="trainingPlans.kind.main">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:75,77</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:115,117</note>
       </notes>
       <segment>
         <source>Trainingstag</source>
@@ -4727,7 +4922,7 @@
     </unit>
     <unit id="trainingPlans.todayTarget">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:81,83</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:121,123</note>
       </notes>
       <segment>
         <source>Heute geplant:</source>
@@ -4735,7 +4930,7 @@
     </unit>
     <unit id="trainingPlans.logToday">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:115,117</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:159,161</note>
       </notes>
       <segment>
         <source>Heute eintragen</source>
@@ -4743,7 +4938,7 @@
     </unit>
     <unit id="trainingPlans.viewPlan">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:169,171</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:213,215</note>
       </notes>
       <segment>
         <source>Plan ansehen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2240,7 +2240,7 @@
     </unit>
     <unit id="landing.cta.login">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:62,65</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:62,64</note>
       </notes>
       <segment>
         <source>Einloggen</source>
@@ -2264,7 +2264,7 @@
     </unit>
     <unit id="landing.plans.eyebrow">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:83,85</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:86,88</note>
       </notes>
       <segment>
         <source>Strukturiert trainieren</source>
@@ -2272,7 +2272,7 @@
     </unit>
     <unit id="landing.plans.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:86,88</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:89,91</note>
       </notes>
       <segment>
         <source> Liegestütz-Trainingspläne, die wirklich funktionieren </source>
@@ -2280,7 +2280,7 @@
     </unit>
     <unit id="landing.plans.subtitle">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:89,93</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:92,96</note>
       </notes>
       <segment>
         <source> Vom Einsteiger zum 100er-Set: Geführte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Stöbere kostenlos — starten und tracken kannst du mit einem kostenlosen Konto. </source>
@@ -2288,7 +2288,7 @@
     </unit>
     <unit id="landing.plans.recruit.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:100,102</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:103,105</note>
       </notes>
       <segment>
         <source>Von 0 auf 100 — 6 Wochen</source>
@@ -2296,7 +2296,7 @@
     </unit>
     <unit id="landing.plans.recruit.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:104,106</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:107,109</note>
       </notes>
       <segment>
         <source> Einsteigerfreundlich: 3 Trainingstage pro Woche, progressiver Aufbau und ein Maximaltest in Woche 6. </source>
@@ -2304,9 +2304,9 @@
     </unit>
     <unit id="landing.plans.viewPlan">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:113,115</note>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:135,137</note>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:157,159</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:116,118</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:138,140</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:160,162</note>
       </notes>
       <segment>
         <source>Plan ansehen</source>
@@ -2314,7 +2314,7 @@
     </unit>
     <unit id="landing.plans.challenge.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:122,124</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:125,127</note>
       </notes>
       <segment>
         <source>30-Tage-Challenge</source>
@@ -2322,7 +2322,7 @@
     </unit>
     <unit id="landing.plans.challenge.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:126,128</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:129,131</note>
       </notes>
       <segment>
         <source> 30 Tage Pushups mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest. </source>
@@ -2330,7 +2330,7 @@
     </unit>
     <unit id="landing.plans.over40.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:144,146</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:147,149</note>
       </notes>
       <segment>
         <source>Liegestütze ab 40 — 4 Wochen</source>
@@ -2338,7 +2338,7 @@
     </unit>
     <unit id="landing.plans.over40.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:148,150</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:151,153</note>
       </notes>
       <segment>
         <source> Schonender Plan mit Fokus auf saubere Technik, ausreichend Pause und langsames Tempo. </source>
@@ -2346,7 +2346,7 @@
     </unit>
     <unit id="landing.plans.cta.overview">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:170,172</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:173,175</note>
       </notes>
       <segment>
         <source>Alle Pläne ansehen</source>
@@ -2354,7 +2354,7 @@
     </unit>
     <unit id="landing.plans.cta.signup">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:179,183</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:182,186</note>
       </notes>
       <segment>
         <source>Konto erstellen &amp; Plan starten</source>
@@ -2362,7 +2362,7 @@
     </unit>
     <unit id="landing.trust.bar">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:188,191</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:191,194</note>
       </notes>
       <segment>
         <source> ✓ Kostenlos · ✓ Kein Abo · ✓ Keine Kreditkarte · ✓ Datenschutz first </source>
@@ -2370,7 +2370,7 @@
     </unit>
     <unit id="landing.feature.analytics.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:196,198</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:199,201</note>
       </notes>
       <segment>
         <source>Smarter Überblick</source>
@@ -2378,7 +2378,7 @@
     </unit>
     <unit id="landing.feature.analytics.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:200,203</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:203,206</note>
       </notes>
       <segment>
         <source>KPIs, Charts und Custom-Zeiträume. Sieh auf einen Blick wie sich dein Training entwickelt.</source>
@@ -2386,7 +2386,7 @@
     </unit>
     <unit id="landing.feature.quick.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:209,211</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:212,214</note>
       </notes>
       <segment>
         <source>Quick Logging</source>
@@ -2394,7 +2394,7 @@
     </unit>
     <unit id="landing.feature.quick.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:213,216</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:216,219</note>
       </notes>
       <segment>
         <source>Eintrag in 2 Sekunden. Schnellaktionen für 10, 20, 30 Reps oder freie Eingabe.</source>
@@ -2402,7 +2402,7 @@
     </unit>
     <unit id="landing.feature.live.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:222,224</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:225,227</note>
       </notes>
       <segment>
         <source>Live &amp; überall</source>
@@ -2410,7 +2410,7 @@
     </unit>
     <unit id="landing.feature.live.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:226,229</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:229,232</note>
       </notes>
       <segment>
         <source>Alle Geräte. Echtzeit-Sync hält deine Daten überall aktuell – kein Refresh nötig.</source>
@@ -2418,7 +2418,7 @@
     </unit>
     <unit id="landing.feature.streak.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:235,237</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:238,240</note>
       </notes>
       <segment>
         <source>Streaks &amp; Bestenliste</source>
@@ -2426,7 +2426,7 @@
     </unit>
     <unit id="landing.feature.streak.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:239,242</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:242,245</note>
       </notes>
       <segment>
         <source>Täglich dabei bleiben. Verfolge deine Streak und miss dich mit der Community.</source>
@@ -2434,7 +2434,7 @@
     </unit>
     <unit id="landing.feature.free.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:248,250</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:251,253</note>
       </notes>
       <segment>
         <source>100% Kostenlos</source>
@@ -2442,7 +2442,7 @@
     </unit>
     <unit id="landing.feature.free.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:252,255</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:255,258</note>
       </notes>
       <segment>
         <source>Keine Kreditkarte. Kein Abo. Einfach registrieren und loslegen – für immer kostenlos.</source>
@@ -2450,7 +2450,7 @@
     </unit>
     <unit id="landing.feature.adaptive.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:261,263</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:264,266</note>
       </notes>
       <segment>
         <source>Smarte Schnellaktionen</source>
@@ -2458,7 +2458,7 @@
     </unit>
     <unit id="landing.feature.adaptive.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:265,268</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:268,271</note>
       </notes>
       <segment>
         <source>Basierend auf deiner Trainingshistorie schlägt die App automatisch passende Wiederholungszahlen vor. Ein Tap genügt.</source>
@@ -2466,7 +2466,7 @@
     </unit>
     <unit id="ads.landing.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:270</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:273</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -2474,7 +2474,7 @@
     </unit>
     <unit id="landing.preview.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:275,278</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:278,281</note>
       </notes>
       <segment>
         <source> Deine Statistik auf einen Blick </source>
@@ -2482,7 +2482,7 @@
     </unit>
     <unit id="landing.preview.alt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:279,280</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:282,283</note>
       </notes>
       <segment>
         <source>Vorschau der Statistikansicht</source>
@@ -2490,7 +2490,7 @@
     </unit>
     <unit id="landing.discover.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:286,287</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:289,290</note>
       </notes>
       <segment>
         <source>Mehr entdecken</source>
@@ -2498,7 +2498,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:292,294</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:295,297</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -2506,7 +2506,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:296,299</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:299,302</note>
       </notes>
       <segment>
         <source> Vergleiche dich mit der Community: tägliche, wöchentliche und monatliche Top-Reps. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
@@ -2514,7 +2514,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:306,309</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:309,312</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -2522,7 +2522,7 @@
     </unit>
     <unit id="landing.discover.blog.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:315,317</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:318,320</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -2530,7 +2530,7 @@
     </unit>
     <unit id="landing.discover.blog.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:319,322</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:322,325</note>
       </notes>
       <segment>
         <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
@@ -2538,7 +2538,7 @@
     </unit>
     <unit id="landing.discover.blog.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:329,331</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:332,334</note>
       </notes>
       <segment>
         <source>Zum Blog</source>
@@ -4433,7 +4433,7 @@
     <unit id="trainingPlans.openDetail">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:90,92</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:169,171</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:164,166</note>
       </notes>
       <segment>
         <source> Details öffnen </source>
@@ -4643,7 +4643,7 @@
     <unit id="trainingPlans.daysSuffix">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:66,68</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:184,186</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:179,181</note>
       </notes>
       <segment>
         <source>Tage</source>
@@ -4652,7 +4652,7 @@
     <unit id="trainingPlans.level.beginner">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:70,71</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:189,191</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:184,186</note>
       </notes>
       <segment>
         <source>Einsteiger</source>
@@ -4661,7 +4661,7 @@
     <unit id="trainingPlans.level.intermediate">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:72,74</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:193,195</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:188,190</note>
       </notes>
       <segment>
         <source>Mittelstufe</source>
@@ -4670,7 +4670,7 @@
     <unit id="trainingPlans.level.advanced">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:74,76</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:197,199</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:192,194</note>
       </notes>
       <segment>
         <source>Fortgeschritten</source>
@@ -4813,9 +4813,17 @@
         <source>Plan nicht gefunden.</source>
       </segment>
     </unit>
+    <unit id="trainingPlans.autoStartFailed">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:458</note>
+      </notes>
+      <segment>
+        <source>Plan-Start fehlgeschlagen — bitte erneut versuchen.</source>
+      </segment>
+    </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:496</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:525</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -4823,7 +4831,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:513</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:542</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
@@ -4831,8 +4839,8 @@
     </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:539</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:364</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:568</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:359</note>
       </notes>
       <segment>
         <source>Plan-Sätze wurden eingetragen.</source>
@@ -4840,8 +4848,8 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:541</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:366</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:570</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:361</note>
       </notes>
       <segment>
         <source>Tag war schon eingetragen — als erledigt markiert.</source>
@@ -4849,8 +4857,8 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:543</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:368</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:572</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:363</note>
       </notes>
       <segment>
         <source>Daten werden noch geladen, bitte gleich noch einmal versuchen.</source>
@@ -4930,7 +4938,7 @@
     </unit>
     <unit id="trainingPlans.logToday">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:159,161</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:155,157</note>
       </notes>
       <segment>
         <source>Heute eintragen</source>
@@ -4938,7 +4946,7 @@
     </unit>
     <unit id="trainingPlans.viewPlan">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:213,215</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:208,210</note>
       </notes>
       <segment>
         <source>Plan ansehen</source>


### PR DESCRIPTION
Open the training plan catalog and detail pages to anonymous visitors
to drive signups: drop authGuard from /training-plans routes, add a
prominent training-plans section to the landing page, embed CTAs in
the matching blog articles (recruit-6w, challenge-30d, over-40-4w),
and surface a "create account & start plan" path on each detail page.

Onboarding now reads ?planId=<id> on /register, validates it against
the catalog, shows a "plan pre-selected" banner, and redirects to
/training-plans/:slug?autoStart=1 after registration so the chosen
plan starts automatically once auth resolves.