### PR TITLE
feat(leaderboard): replace weekly/monthly with rolling Last 7/30 days

### DIFF
--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -19,8 +19,8 @@ import {
 import { parseRecaptchaResponse } from './authentication';
 
 // Module imports
-import { berlinDateParts, isoWeekFromYmd } from './datetime';
-import { getMonthStartForQuery, rankEntries } from './leaderboard';
+import { berlinDateParts } from './datetime';
+import { getLeaderboardQueryStartDate, rankEntries } from './leaderboard';
 import {
   FALLBACK_QUOTES_DE,
   FALLBACK_QUOTES_EN,
@@ -97,12 +97,11 @@ async function createRecaptchaAssessment({
 async function rebuildLeaderboardsCore() {
   const now = new Date();
   const today = berlinDateParts(now);
-  const week = isoWeekFromYmd(today.year, today.month, today.day);
-  const monthStart = getMonthStartForQuery(today);
+  const queryStart = getLeaderboardQueryStartDate(today);
 
   const snap = await db
     .collection('pushups')
-    .where('timestamp', '>=', monthStart)
+    .where('timestamp', '>=', queryStart)
     .orderBy('timestamp', 'desc')
     .get();
 
@@ -126,31 +125,30 @@ async function rebuildLeaderboardsCore() {
     }
   }
 
-  const dailyKey = today.isoDate;
-  const weeklyKey = `${week.year}-W${String(week.week).padStart(2, '0')}`;
-  const monthlyKey = `${today.year}-${String(today.month).padStart(2, '0')}`;
+  // Rolling windows always end on today's Berlin date, so the same isoDate
+  // serves as the cache key for daily, last7, and last30.
+  const todayKey = today.isoDate;
 
-  const daily = rankEntries(rows, 'daily', dailyKey, userProfiles);
-  const weekly = rankEntries(rows, 'weekly', weeklyKey, userProfiles);
-  const monthly = rankEntries(rows, 'monthly', monthlyKey, userProfiles);
+  const daily = rankEntries(rows, 'daily', todayKey, userProfiles);
+  const last7 = rankEntries(rows, 'last7', todayKey, userProfiles);
+  const last30 = rankEntries(rows, 'last30', todayKey, userProfiles);
 
+  // Overwrite (no merge) so stale weekly/monthly fields from the previous
+  // schema get evicted instead of lingering in the document.
   await db
     .collection('leaderboards')
     .doc('current')
-    .set(
-      {
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-        timezone: TZ,
-        keys: { daily: dailyKey, weekly: weeklyKey, monthly: monthlyKey },
-        periods: { daily, weekly, monthly },
-      },
-      { merge: true }
-    );
+    .set({
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      timezone: TZ,
+      keys: { daily: todayKey, last7: todayKey, last30: todayKey },
+      periods: { daily, last7, last30 },
+    });
 
   logger.info('Leaderboards rebuilt', {
     daily: daily.length,
-    weekly: weekly.length,
-    monthly: monthly.length,
+    last7: last7.length,
+    last30: last30.length,
   });
 }
 

--- a/data-store/functions/src/leaderboard/logic.spec.ts
+++ b/data-store/functions/src/leaderboard/logic.spec.ts
@@ -138,8 +138,9 @@ describe('leaderboard/logic', () => {
     });
 
     it('aggregates the trailing 7-day window inclusive of both endpoints', () => {
+      // Given — today is 2024-03-15. The trailing 7-day window covers
+      // 2024-03-09 (start) through 2024-03-15 (today), inclusive.
       const rows: PushupRow[] = [
-        // Today is 2024-03-15. Window is 2024-03-09 .. 2024-03-15 (7 days).
         { userId: 'user1', timestamp: '2024-03-09T10:00:00Z', reps: 4 }, // included (start)
         { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 6 }, // included (today)
         { userId: 'user1', timestamp: '2024-03-08T10:00:00Z', reps: 99 }, // excluded (8 days back)
@@ -149,15 +150,17 @@ describe('leaderboard/logic', () => {
         ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
       ]);
 
+      // When
       const result = rankEntries(rows, 'last7', '2024-03-15', profiles);
 
+      // Then — only the two in-window rows are summed.
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({ alias: 'Alice', reps: 10 });
     });
 
     it('aggregates the trailing 30-day window inclusive of both endpoints', () => {
+      // Given — today is 2024-03-30. Window is 2024-03-01 .. 2024-03-30 (30 days).
       const rows: PushupRow[] = [
-        // Today is 2024-03-30. Window is 2024-03-01 .. 2024-03-30 (30 days).
         { userId: 'user1', timestamp: '2024-03-01T10:00:00Z', reps: 5 },
         { userId: 'user1', timestamp: '2024-03-30T10:00:00Z', reps: 7 },
         { userId: 'user1', timestamp: '2024-02-29T10:00:00Z', reps: 99 }, // excluded (31 days back)
@@ -166,8 +169,10 @@ describe('leaderboard/logic', () => {
         ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
       ]);
 
+      // When
       const result = rankEntries(rows, 'last30', '2024-03-30', profiles);
 
+      // Then
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({ alias: 'Alice', reps: 12 });
     });
@@ -219,14 +224,22 @@ describe('leaderboard/logic', () => {
   });
 
   describe('getLeaderboardQueryStartDate', () => {
-    it('returns the date 29 days before today (covers a 30-day window)', () => {
-      const result = getLeaderboardQueryStartDate({
+    it('returns the date 30 days before today, one day buffer beyond the last30 window for TZ slack', () => {
+      // Given — today is the 30th of March in Berlin.
+      const today: BerlinDateParts = {
         year: 2024,
         month: 3,
         day: 30,
         isoDate: '2024-03-30',
-      });
-      expect(result).toBe('2024-03-01');
+      };
+
+      // When
+      const result = getLeaderboardQueryStartDate(today);
+
+      // Then — bound is the 29th of February (one day earlier than the 30-day
+      // window's first day) so the Firestore query also catches rows whose
+      // UTC timestamp falls on the previous calendar day relative to Berlin.
+      expect(result).toBe('2024-02-29');
     });
   });
 

--- a/data-store/functions/src/leaderboard/logic.spec.ts
+++ b/data-store/functions/src/leaderboard/logic.spec.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from '@jest/globals';
 import {
   rankEntries,
   calculateCurrentPeriodKeys,
-  getMonthStartForQuery,
+  getLeaderboardQueryStartDate,
+  isoDateNDaysBefore,
   filterOutDemoUser,
   PushupRow,
 } from './logic';
@@ -136,77 +137,96 @@ describe('leaderboard/logic', () => {
       expect(result[0].alias).toBe('Bob');
     });
 
-    it('handles weekly period aggregation', () => {
+    it('aggregates the trailing 7-day window inclusive of both endpoints', () => {
       const rows: PushupRow[] = [
-        { userId: 'user1', timestamp: '2024-03-11T10:00:00Z', reps: 10 }, // Monday of week 11
-        { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 5 }, // Friday of week 11
+        // Today is 2024-03-15. Window is 2024-03-09 .. 2024-03-15 (7 days).
+        { userId: 'user1', timestamp: '2024-03-09T10:00:00Z', reps: 4 }, // included (start)
+        { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 6 }, // included (today)
+        { userId: 'user1', timestamp: '2024-03-08T10:00:00Z', reps: 99 }, // excluded (8 days back)
+        { userId: 'user1', timestamp: '2024-03-16T10:00:00Z', reps: 99 }, // excluded (future)
       ];
       const profiles = new Map<string, UserProfile>([
         ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
       ]);
 
-      const result = rankEntries(rows, 'weekly', '2024-W11', profiles);
+      const result = rankEntries(rows, 'last7', '2024-03-15', profiles);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({ alias: 'Alice', reps: 15 });
+      expect(result[0]).toEqual({ alias: 'Alice', reps: 10 });
     });
 
-    it('handles monthly period aggregation', () => {
+    it('aggregates the trailing 30-day window inclusive of both endpoints', () => {
       const rows: PushupRow[] = [
-        { userId: 'user1', timestamp: '2024-03-01T10:00:00Z', reps: 10 },
-        { userId: 'user1', timestamp: '2024-03-31T10:00:00Z', reps: 5 },
+        // Today is 2024-03-30. Window is 2024-03-01 .. 2024-03-30 (30 days).
+        { userId: 'user1', timestamp: '2024-03-01T10:00:00Z', reps: 5 },
+        { userId: 'user1', timestamp: '2024-03-30T10:00:00Z', reps: 7 },
+        { userId: 'user1', timestamp: '2024-02-29T10:00:00Z', reps: 99 }, // excluded (31 days back)
       ];
       const profiles = new Map<string, UserProfile>([
         ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
       ]);
 
-      const result = rankEntries(rows, 'monthly', '2024-03', profiles);
+      const result = rankEntries(rows, 'last30', '2024-03-30', profiles);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({ alias: 'Alice', reps: 15 });
+      expect(result[0]).toEqual({ alias: 'Alice', reps: 12 });
     });
   });
 
   describe('calculateCurrentPeriodKeys', () => {
-    it('returns period keys for current date', () => {
+    it('returns todays ISO date for all three buckets', () => {
       const now = new Date('2024-03-15T10:00:00Z');
       const keys = calculateCurrentPeriodKeys(now);
 
       expect(keys.daily).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-      expect(keys.weekly).toMatch(/^\d{4}-W\d{2}$/);
-      expect(keys.monthly).toMatch(/^\d{4}-\d{2}$/);
+      expect(keys.last7).toBe(keys.daily);
+      expect(keys.last30).toBe(keys.daily);
     });
 
     it('uses current date when not provided', () => {
       const keys = calculateCurrentPeriodKeys();
 
       expect(keys.daily).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-      expect(keys.weekly).toMatch(/^\d{4}-W\d{2}$/);
-      expect(keys.monthly).toMatch(/^\d{4}-\d{2}$/);
+      expect(keys.last7).toBe(keys.daily);
+      expect(keys.last30).toBe(keys.daily);
     });
   });
 
-  describe('getMonthStartForQuery', () => {
-    it('returns first day of month in ISO format', () => {
-      const result = getMonthStartForQuery({
-        year: 2024,
-        month: 3,
-        day: 15,
-        isoDate: '2024-03-15',
-      });
-
-      expect(result).toBe('2024-03-01');
+  describe('isoDateNDaysBefore', () => {
+    it('returns the same date for daysBack = 0', () => {
+      const result = isoDateNDaysBefore(
+        { year: 2024, month: 3, day: 15, isoDate: '2024-03-15' },
+        0
+      );
+      expect(result).toBe('2024-03-15');
     });
 
-    it('pads month with zero', () => {
-      const result = getMonthStartForQuery({
-        year: 2024,
-        month: 1,
-        day: 15,
-        isoDate: '2024-01-15',
-      });
+    it('walks across month boundaries', () => {
+      const result = isoDateNDaysBefore(
+        { year: 2024, month: 3, day: 1, isoDate: '2024-03-01' },
+        1
+      );
+      expect(result).toBe('2024-02-29'); // 2024 is a leap year
+    });
 
-      expect(result).toBe('2024-01-01');
+    it('walks across year boundaries', () => {
+      const result = isoDateNDaysBefore(
+        { year: 2024, month: 1, day: 1, isoDate: '2024-01-01' },
+        1
+      );
+      expect(result).toBe('2023-12-31');
+    });
+  });
+
+  describe('getLeaderboardQueryStartDate', () => {
+    it('returns the date 29 days before today (covers a 30-day window)', () => {
+      const result = getLeaderboardQueryStartDate({
+        year: 2024,
+        month: 3,
+        day: 30,
+        isoDate: '2024-03-30',
+      });
+      expect(result).toBe('2024-03-01');
     });
   });
 

--- a/data-store/functions/src/leaderboard/logic.ts
+++ b/data-store/functions/src/leaderboard/logic.ts
@@ -143,11 +143,14 @@ export function calculateCurrentPeriodKeys(now = new Date()): LeaderboardKeys {
 
 /**
  * Returns the ISO date that bounds the Firestore query for the leaderboard
- * rebuild — 29 days before today, so the trailing 30-day window is fully
- * covered (today + 29 prior days = 30 days inclusive).
+ * rebuild. Reaches back 30 days from today's Berlin date — one extra day
+ * beyond the last30 window — so the query also captures rows whose UTC
+ * timestamp falls on the previous calendar day (e.g. Berlin 00:30 on
+ * day-29 stored as UTC 23:30 on day-30). `rankEntries()` then trims to the
+ * exact 30-day Berlin window.
  */
 export function getLeaderboardQueryStartDate(today: BerlinDateParts): string {
-  return isoDateNDaysBefore(today, 29);
+  return isoDateNDaysBefore(today, 30);
 }
 
 /**

--- a/data-store/functions/src/leaderboard/logic.ts
+++ b/data-store/functions/src/leaderboard/logic.ts
@@ -3,11 +3,7 @@
  * Pure logic and database-agnostic components
  */
 
-import {
-  berlinDateParts,
-  isoWeekFromYmd,
-  BerlinDateParts,
-} from '../datetime';
+import { berlinDateParts, BerlinDateParts } from '../datetime';
 import {
   toPublicDisplayName,
   isLeaderboardNameAllowed,
@@ -28,14 +24,14 @@ export interface LeaderboardEntry {
 
 export interface LeaderboardPeriods {
   daily: LeaderboardEntry[];
-  weekly: LeaderboardEntry[];
-  monthly: LeaderboardEntry[];
+  last7: LeaderboardEntry[];
+  last30: LeaderboardEntry[];
 }
 
 export interface LeaderboardKeys {
   daily: string;
-  weekly: string;
-  monthly: string;
+  last7: string;
+  last30: string;
 }
 
 export interface LeaderboardDocument {
@@ -45,26 +41,60 @@ export interface LeaderboardDocument {
   periods: LeaderboardPeriods;
 }
 
+export type LeaderboardPeriodKind = 'daily' | 'last7' | 'last30';
+
 const TOP_N = 10;
 
 /**
- * Ranks pushup entries for a specific period and target key
- * Returns top N entries sorted by reps descending, with anonymized names
- * @param rows Array of pushup records
- * @param periodKey Period type: 'daily', 'weekly', or 'monthly'
- * @param targetKey The specific period to filter by (e.g., '2024-03-15' for daily)
- * @param userProfiles Map of userId -> UserProfile for display names
- * @returns Sorted leaderboard entries (max TOP_N)
+ * Returns the ISO date `daysBack` days before the given Berlin date.
+ * Uses UTC math anchored to noon to dodge DST boundary glitches — the only
+ * thing we read out is `YYYY-MM-DD`, so the time of day is irrelevant.
+ */
+export function isoDateNDaysBefore(
+  reference: BerlinDateParts,
+  daysBack: number
+): string {
+  const anchor = Date.UTC(
+    reference.year,
+    reference.month - 1,
+    reference.day,
+    12,
+    0,
+    0
+  );
+  const shifted = new Date(anchor - daysBack * 86_400_000);
+  const yyyy = shifted.getUTCFullYear();
+  const mm = String(shifted.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(shifted.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Ranks pushup entries for a specific period and target key.
+ * - `daily`: aggregates entries on `targetKey` (an ISO date).
+ * - `last7` / `last30`: aggregates entries with Berlin-date in the trailing
+ *   7- or 30-day window ending on `targetKey` (inclusive).
+ *
+ * Returns top N entries sorted by reps descending, with privacy-aware names.
  */
 export function rankEntries(
   rows: PushupRow[],
-  periodKey: string,
+  periodKey: LeaderboardPeriodKind,
   targetKey: string,
   userProfiles: Map<string, UserProfile>
 ): LeaderboardEntry[] {
   const totals = new Map<string, number>();
 
-  // Aggregate reps by user for the target period
+  let windowStart: string | null = null;
+  if (periodKey === 'last7' || periodKey === 'last30') {
+    const [y, m, d] = targetKey.split('-').map(Number);
+    const days = periodKey === 'last7' ? 6 : 29;
+    windowStart = isoDateNDaysBefore(
+      { year: y, month: m, day: d, isoDate: targetKey },
+      days
+    );
+  }
+
   for (const row of rows) {
     if (!row.timestamp || !row.userId) continue;
 
@@ -72,25 +102,19 @@ export function rankEntries(
     if (Number.isNaN(d.getTime())) continue;
     const p = berlinDateParts(d);
 
-    // Calculate which period this entry belongs to
-    let key: string;
     if (periodKey === 'daily') {
-      key = p.isoDate;
-    } else if (periodKey === 'monthly') {
-      key = `${p.year}-${String(p.month).padStart(2, '0')}`;
+      if (p.isoDate !== targetKey) continue;
     } else {
-      // weekly
-      const wk = isoWeekFromYmd(p.year, p.month, p.day);
-      key = `${wk.year}-W${String(wk.week).padStart(2, '0')}`;
+      if (!windowStart) continue;
+      if (p.isoDate < windowStart || p.isoDate > targetKey) continue;
     }
 
-    // Only count entries that match the target period
-    if (key !== targetKey) continue;
-
-    totals.set(row.userId, (totals.get(row.userId) || 0) + Number(row.reps || 0));
+    totals.set(
+      row.userId,
+      (totals.get(row.userId) || 0) + Number(row.reps || 0)
+    );
   }
 
-  // Convert to leaderboard entries with privacy-aware display names
   return [...totals.entries()]
     .map(([userId, reps]) => {
       const profile = userProfiles.get(userId);
@@ -104,36 +128,34 @@ export function rankEntries(
 }
 
 /**
- * Calculates the current period keys (daily, weekly, monthly) for today
- * @param now Current date/time (defaults to now)
- * @returns Object with formatted period keys
+ * Calculates the current period keys for today.
+ * All three buckets are anchored on today's ISO date — `last7` / `last30`
+ * are rolling windows that always end on the current Berlin day.
  */
 export function calculateCurrentPeriodKeys(now = new Date()): LeaderboardKeys {
   const today = berlinDateParts(now);
-  const week = isoWeekFromYmd(today.year, today.month, today.day);
-
   return {
     daily: today.isoDate,
-    weekly: `${week.year}-W${String(week.week).padStart(2, '0')}`,
-    monthly: `${today.year}-${String(today.month).padStart(2, '0')}`,
+    last7: today.isoDate,
+    last30: today.isoDate,
   };
 }
 
 /**
- * Calculates the month start date for querying Firestore
- * @param today Current date parts (Berlin timezone)
- * @returns ISO date string for first day of month (YYYY-MM-01)
+ * Returns the ISO date that bounds the Firestore query for the leaderboard
+ * rebuild — 29 days before today, so the trailing 30-day window is fully
+ * covered (today + 29 prior days = 30 days inclusive).
  */
-export function getMonthStartForQuery(today: BerlinDateParts): string {
-  return `${today.year}-${String(today.month).padStart(2, '0')}-01`;
+export function getLeaderboardQueryStartDate(today: BerlinDateParts): string {
+  return isoDateNDaysBefore(today, 29);
 }
 
 /**
  * Filters out a demo user from rows
- * @param rows Array of pushup records
- * @param demoUserId ID to filter out
- * @returns Filtered rows
  */
-export function filterOutDemoUser(rows: PushupRow[], demoUserId: string): PushupRow[] {
+export function filterOutDemoUser(
+  rows: PushupRow[],
+  demoUserId: string
+): PushupRow[] {
   return rows.filter((r) => r.userId !== demoUserId);
 }

--- a/libs/data-access/src/lib/api/leaderboard.service.spec.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.spec.ts
@@ -1,0 +1,169 @@
+// Stub the Firestore SDK so its top-level evaluation doesn't pull `fetch`
+// into the Jest environment. See docs/gotchas/testing.md → "Jest ↔ Firebase".
+jest.mock('@angular/fire/firestore', () => ({
+  Firestore: jest.fn(),
+  collection: jest.fn(() => ({})),
+  doc: jest.fn(() => ({})),
+  docData: jest.fn(),
+  getDoc: jest.fn(),
+  getDocs: jest.fn(),
+  orderBy: jest.fn(),
+  query: jest.fn(() => ({})),
+  where: jest.fn(),
+}));
+jest.mock('@angular/fire/auth', () => ({ Auth: jest.fn() }));
+
+import { TestBed } from '@angular/core/testing';
+import { Auth } from '@angular/fire/auth';
+import * as firestoreFns from '@angular/fire/firestore';
+import { Firestore } from '@angular/fire/firestore';
+import { LeaderboardService } from './leaderboard.service';
+
+const getDoc = firestoreFns.getDoc as unknown as jest.Mock;
+const getDocs = firestoreFns.getDocs as unknown as jest.Mock;
+const where = firestoreFns.where as unknown as jest.Mock;
+
+function makeSnapshot(periods: Record<string, unknown> | null): {
+  exists: () => boolean;
+  data: () => unknown;
+} {
+  return {
+    exists: () => periods !== null,
+    data: () => (periods ? { periods } : {}),
+  };
+}
+
+describe('LeaderboardService — load() merging', () => {
+  let service: LeaderboardService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    TestBed.configureTestingModule({
+      providers: [
+        LeaderboardService,
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: null } },
+      ],
+    });
+    service = TestBed.inject(LeaderboardService);
+
+    // Default: no rows from Firestore
+    getDocs.mockResolvedValue({ docs: [] });
+  });
+
+  describe('Given the snapshot still has the legacy weekly/monthly shape', () => {
+    it('Then last7/last30 fall back to the client-computed top instead of empty arrays', async () => {
+      // Given — legacy snapshot has only `daily` of the new keys; weekly/monthly
+      // are what the old Cloud Function wrote.
+      getDoc.mockResolvedValueOnce(
+        makeSnapshot({
+          daily: [{ alias: 'D...Y', reps: 5 }],
+          weekly: [{ alias: 'W...Y', reps: 50 }],
+          monthly: [{ alias: 'M...Y', reps: 500 }],
+        })
+      );
+
+      // And — the client fetches some recent rows it can aggregate locally.
+      const today = new Date();
+      const isoToday = today.toISOString();
+      getDocs.mockResolvedValueOnce({
+        docs: [
+          { data: () => ({ userId: 'alice', reps: 12, timestamp: isoToday }) },
+        ],
+      });
+
+      // When
+      const result = await service.load();
+
+      // Then — daily comes from the cached snapshot (server is authoritative).
+      expect(result.daily.top).toEqual([
+        expect.objectContaining({ alias: 'D...Y', reps: 5 }),
+      ]);
+
+      // And — last7/last30 use the client fallback because the snapshot
+      // doesn't carry those fields yet.
+      expect(result.last7.top).toEqual([
+        expect.objectContaining({ alias: 'A...E', reps: 12 }),
+      ]);
+      expect(result.last30.top).toEqual([
+        expect.objectContaining({ alias: 'A...E', reps: 12 }),
+      ]);
+    });
+  });
+
+  describe('Given the snapshot has the new last7/last30 shape', () => {
+    it('Then top entries come from the snapshot, not the client fallback', async () => {
+      // Given
+      getDoc.mockResolvedValueOnce(
+        makeSnapshot({
+          daily: [],
+          last7: [{ alias: 'S...R', reps: 100 }],
+          last30: [{ alias: 'S...R', reps: 100 }],
+        })
+      );
+
+      const isoToday = new Date().toISOString();
+      getDocs.mockResolvedValueOnce({
+        docs: [
+          { data: () => ({ userId: 'alice', reps: 1, timestamp: isoToday }) },
+        ],
+      });
+
+      // When
+      const result = await service.load();
+
+      // Then — server values win, even though client could compute its own.
+      expect(result.last7.top).toEqual([
+        expect.objectContaining({ alias: 'S...R', reps: 100 }),
+      ]);
+      expect(result.last30.top).toEqual([
+        expect.objectContaining({ alias: 'S...R', reps: 100 }),
+      ]);
+    });
+
+    it('Then an explicit empty array is preserved (not replaced by fallback)', async () => {
+      // Given — server says "no entries" for last7 (e.g. nobody trained).
+      getDoc.mockResolvedValueOnce(
+        makeSnapshot({
+          daily: [],
+          last7: [],
+          last30: [],
+        })
+      );
+
+      const isoToday = new Date().toISOString();
+      getDocs.mockResolvedValueOnce({
+        docs: [
+          { data: () => ({ userId: 'alice', reps: 99, timestamp: isoToday }) },
+        ],
+      });
+
+      // When
+      const result = await service.load();
+
+      // Then — we trust the server's empty list; we don't override with stale
+      // client computation.
+      expect(result.last7.top).toEqual([]);
+      expect(result.last30.top).toEqual([]);
+    });
+  });
+
+  describe('Firestore query bound', () => {
+    it('Uses a date-only YYYY-MM-DD lower bound for the timestamp filter', async () => {
+      // Given — no snapshot, so `load()` triggers `fetchRows`.
+      getDoc.mockResolvedValueOnce(makeSnapshot(null));
+
+      // When
+      await service.load();
+
+      // Then — the `where` clause is called with a YYYY-MM-DD string, NOT a
+      // full ISO datetime. This makes the query robust to whatever timestamp
+      // format the entries carry (Z-suffix, +01:00 offset, ms or no ms).
+      const lowerBoundCall = where.mock.calls.find(
+        ([field, op]) => field === 'timestamp' && op === '>='
+      );
+      expect(lowerBoundCall).toBeDefined();
+      expect(lowerBoundCall?.[2]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+});

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -30,12 +30,15 @@ export type LeaderboardBucket = {
 export type LeaderboardData = Record<LeaderboardPeriod, LeaderboardBucket>;
 
 const TOP_N = 10;
+const TZ = 'Europe/Berlin';
 
 type PushupRow = {
   userId: string;
   reps: number;
   timestamp: string;
 };
+
+type CachedBuckets = Partial<LeaderboardData>;
 
 @Injectable({ providedIn: 'root' })
 export class LeaderboardService {
@@ -59,43 +62,41 @@ export class LeaderboardService {
 
   async load(): Promise<LeaderboardData> {
     const currentUserId = this.auth?.currentUser?.uid ?? null;
-    const start = this.last30StartIso();
+    const start = this.last30StartDateKey();
     const rows = await this.fetchRows(start);
 
-    const fallback = {
+    const fallback: LeaderboardData = {
       daily: this.aggregate(rows, 'daily', currentUserId),
       last7: this.aggregate(rows, 'last7', currentUserId),
       last30: this.aggregate(rows, 'last30', currentUserId),
     };
 
-    const cached = await this.loadSnapshot(currentUserId);
-    if (!cached) return fallback;
+    const cached = (await this.loadSnapshot(currentUserId)) ?? {};
 
+    // Per-bucket merge: during the rollout from the old weekly/monthly schema
+    // the snapshot may still lack the new fields. In that case use the
+    // client-computed fallback instead of an empty array.
     return {
-      daily: {
-        top: cached.daily.top,
-        current:
-          cached.daily.top.find((entry) => entry.isCurrent) ??
-          fallback.daily.current,
-      },
-      last7: {
-        top: cached.last7.top,
-        current:
-          cached.last7.top.find((entry) => entry.isCurrent) ??
-          fallback.last7.current,
-      },
-      last30: {
-        top: cached.last30.top,
-        current:
-          cached.last30.top.find((entry) => entry.isCurrent) ??
-          fallback.last30.current,
-      },
+      daily: this.mergeBucket(cached.daily, fallback.daily),
+      last7: this.mergeBucket(cached.last7, fallback.last7),
+      last30: this.mergeBucket(cached.last30, fallback.last30),
+    };
+  }
+
+  private mergeBucket(
+    cached: LeaderboardBucket | undefined,
+    fallback: LeaderboardBucket
+  ): LeaderboardBucket {
+    if (!cached) return fallback;
+    return {
+      top: cached.top,
+      current: cached.top.find((entry) => entry.isCurrent) ?? fallback.current,
     };
   }
 
   private async loadSnapshot(
     currentUserId: string | null
-  ): Promise<LeaderboardData | null> {
+  ): Promise<CachedBuckets | null> {
     if (!this.firestore) return null;
 
     const snap = await getDoc(doc(this.firestore, 'leaderboards', 'current'));
@@ -110,8 +111,8 @@ export class LeaderboardService {
     const periods = data?.periods;
     if (!periods) return null;
 
-    const mapTop = (arr: Array<{ alias: string; reps: number }> | undefined) =>
-      (Array.isArray(arr) ? arr : []).slice(0, TOP_N).map((entry, i) => ({
+    const mapTop = (arr: Array<{ alias: string; reps: number }>) =>
+      arr.slice(0, TOP_N).map((entry, i) => ({
         alias: entry.alias,
         reps: entry.reps,
         rank: i + 1,
@@ -119,21 +120,30 @@ export class LeaderboardService {
           !!currentUserId && entry.alias === this.toAlias(currentUserId),
       }));
 
-    return {
-      daily: { top: mapTop(periods.daily), current: null },
-      last7: { top: mapTop(periods.last7), current: null },
-      last30: { top: mapTop(periods.last30), current: null },
-    };
+    // Only include keys that are actually present on the snapshot. An
+    // explicit empty array is preserved (server says "no entries"); a
+    // missing key drops out so the merger uses the client-side fallback.
+    const result: CachedBuckets = {};
+    if (Array.isArray(periods.daily)) {
+      result.daily = { top: mapTop(periods.daily), current: null };
+    }
+    if (Array.isArray(periods.last7)) {
+      result.last7 = { top: mapTop(periods.last7), current: null };
+    }
+    if (Array.isArray(periods.last30)) {
+      result.last30 = { top: mapTop(periods.last30), current: null };
+    }
+    return result;
   }
 
-  private async fetchRows(startIso: string): Promise<PushupRow[]> {
+  private async fetchRows(startKey: string): Promise<PushupRow[]> {
     if (!this.firestore) return [];
 
     try {
       const ref = collection(this.firestore, 'pushups');
       const q = query(
         ref,
-        where('timestamp', '>=', startIso),
+        where('timestamp', '>=', startKey),
         orderBy('timestamp', 'desc')
       );
       const snap = await getDocs(q);
@@ -159,18 +169,19 @@ export class LeaderboardService {
     period: LeaderboardPeriod,
     currentUserId: string | null
   ): LeaderboardBucket {
-    const today = this.utcDateKey(new Date());
+    // Window keys are computed in Europe/Berlin to match the server-side
+    // bucketing (`berlinDateParts`). Comparing with UTC days would shift
+    // entries logged near local midnight by ±1 day vs the snapshot.
+    const today = this.berlinDateKey(new Date());
     const windowStart =
       period === 'daily'
         ? today
-        : this.utcDateKey(
-            this.shiftDays(new Date(), period === 'last7' ? -6 : -29)
-          );
+        : this.shiftBerlinDate(today, period === 'last7' ? -6 : -29);
 
     const totals = new Map<string, number>();
 
     for (const row of rows) {
-      const key = this.utcDateKey(new Date(row.timestamp));
+      const key = this.berlinDateKey(new Date(row.timestamp));
       if (key < windowStart || key > today) continue;
       totals.set(row.userId, (totals.get(row.userId) ?? 0) + row.reps);
     }
@@ -203,39 +214,33 @@ export class LeaderboardService {
     return `${first}...${last}`;
   }
 
-  private last30StartIso(): string {
-    // Trailing 30-day window: today + 29 prior days. Reach back one extra day
-    // to guarantee coverage across timezone boundaries.
-    const now = new Date();
-    const from = this.shiftDays(now, -30);
-    return new Date(
-      Date.UTC(
-        from.getUTCFullYear(),
-        from.getUTCMonth(),
-        from.getUTCDate(),
-        0,
-        0,
-        0
-      )
-    ).toISOString();
+  /**
+   * Lower bound for the Firestore `timestamp` query — date-only `YYYY-MM-DD`
+   * to lexicographically match any ISO timestamp format the entries may use
+   * (`...Z`, `...+02:00`, with or without milliseconds). The window reaches
+   * back 30 days from today's Berlin date for a one-day safety buffer.
+   */
+  private last30StartDateKey(): string {
+    return this.shiftBerlinDate(this.berlinDateKey(new Date()), -30);
   }
 
-  private utcDateKey(date: Date): string {
-    const yyyy = date.getUTCFullYear();
-    const mm = String(date.getUTCMonth() + 1).padStart(2, '0');
-    const dd = String(date.getUTCDate()).padStart(2, '0');
-    return `${yyyy}-${mm}-${dd}`;
+  private berlinDateKey(date: Date): string {
+    // `en-CA` formats as `YYYY-MM-DD`, which is the canonical ISO date form
+    // and lexicographically sortable.
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: TZ,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(date);
   }
 
-  private shiftDays(date: Date, deltaDays: number): Date {
-    const anchor = Date.UTC(
-      date.getUTCFullYear(),
-      date.getUTCMonth(),
-      date.getUTCDate(),
-      12,
-      0,
-      0
-    );
-    return new Date(anchor + deltaDays * 86_400_000);
+  private shiftBerlinDate(yyyymmdd: string, deltaDays: number): string {
+    const [y, m, d] = yyyymmdd.split('-').map(Number);
+    // Anchor at 10:00 UTC (~11:00 / 12:00 Berlin) to stay far from midnight
+    // so DST transitions can't push the calendar day off-by-one when we
+    // shift by whole-day increments.
+    const anchor = Date.UTC(y, m - 1, d, 10, 0, 0);
+    return this.berlinDateKey(new Date(anchor + deltaDays * 86_400_000));
   }
 }

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/fire/firestore';
 import { EMPTY, Observable } from 'rxjs';
 
-export type LeaderboardPeriod = 'daily' | 'weekly' | 'monthly';
+export type LeaderboardPeriod = 'daily' | 'last7' | 'last30';
 
 export type LeaderboardEntry = {
   alias: string;
@@ -59,13 +59,13 @@ export class LeaderboardService {
 
   async load(): Promise<LeaderboardData> {
     const currentUserId = this.auth?.currentUser?.uid ?? null;
-    const start = this.startOfMonthIso();
+    const start = this.last30StartIso();
     const rows = await this.fetchRows(start);
 
     const fallback = {
       daily: this.aggregate(rows, 'daily', currentUserId),
-      weekly: this.aggregate(rows, 'weekly', currentUserId),
-      monthly: this.aggregate(rows, 'monthly', currentUserId),
+      last7: this.aggregate(rows, 'last7', currentUserId),
+      last30: this.aggregate(rows, 'last30', currentUserId),
     };
 
     const cached = await this.loadSnapshot(currentUserId);
@@ -78,17 +78,17 @@ export class LeaderboardService {
           cached.daily.top.find((entry) => entry.isCurrent) ??
           fallback.daily.current,
       },
-      weekly: {
-        top: cached.weekly.top,
+      last7: {
+        top: cached.last7.top,
         current:
-          cached.weekly.top.find((entry) => entry.isCurrent) ??
-          fallback.weekly.current,
+          cached.last7.top.find((entry) => entry.isCurrent) ??
+          fallback.last7.current,
       },
-      monthly: {
-        top: cached.monthly.top,
+      last30: {
+        top: cached.last30.top,
         current:
-          cached.monthly.top.find((entry) => entry.isCurrent) ??
-          fallback.monthly.current,
+          cached.last30.top.find((entry) => entry.isCurrent) ??
+          fallback.last30.current,
       },
     };
   }
@@ -121,8 +121,8 @@ export class LeaderboardService {
 
     return {
       daily: { top: mapTop(periods.daily), current: null },
-      weekly: { top: mapTop(periods.weekly), current: null },
-      monthly: { top: mapTop(periods.monthly), current: null },
+      last7: { top: mapTop(periods.last7), current: null },
+      last30: { top: mapTop(periods.last30), current: null },
     };
   }
 
@@ -159,12 +159,19 @@ export class LeaderboardService {
     period: LeaderboardPeriod,
     currentUserId: string | null
   ): LeaderboardBucket {
-    const bucket = this.bucketOf(new Date(), period);
+    const today = this.utcDateKey(new Date());
+    const windowStart =
+      period === 'daily'
+        ? today
+        : this.utcDateKey(
+            this.shiftDays(new Date(), period === 'last7' ? -6 : -29)
+          );
+
     const totals = new Map<string, number>();
 
     for (const row of rows) {
-      const key = this.bucketOf(new Date(row.timestamp), period);
-      if (key !== bucket) continue;
+      const key = this.utcDateKey(new Date(row.timestamp));
+      if (key < windowStart || key > today) continue;
       totals.set(row.userId, (totals.get(row.userId) ?? 0) + row.reps);
     }
 
@@ -196,32 +203,39 @@ export class LeaderboardService {
     return `${first}...${last}`;
   }
 
-  private startOfMonthIso(): string {
+  private last30StartIso(): string {
+    // Trailing 30-day window: today + 29 prior days. Reach back one extra day
+    // to guarantee coverage across timezone boundaries.
     const now = new Date();
-    const from = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0)
-    );
-    return from.toISOString();
+    const from = this.shiftDays(now, -30);
+    return new Date(
+      Date.UTC(
+        from.getUTCFullYear(),
+        from.getUTCMonth(),
+        from.getUTCDate(),
+        0,
+        0,
+        0
+      )
+    ).toISOString();
   }
 
-  private bucketOf(date: Date, period: LeaderboardPeriod): string {
+  private utcDateKey(date: Date): string {
     const yyyy = date.getUTCFullYear();
     const mm = String(date.getUTCMonth() + 1).padStart(2, '0');
     const dd = String(date.getUTCDate()).padStart(2, '0');
-
-    if (period === 'daily') return `${yyyy}-${mm}-${dd}`;
-    if (period === 'monthly') return `${yyyy}-${mm}`;
-
-    const week = this.isoWeek(date);
-    return `${yyyy}-W${String(week).padStart(2, '0')}`;
+    return `${yyyy}-${mm}-${dd}`;
   }
 
-  private isoWeek(date: Date): number {
-    const d = new Date(
-      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  private shiftDays(date: Date, deltaDays: number): Date {
+    const anchor = Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      12,
+      0,
+      0
     );
-    d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
-    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-    return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+    return new Date(anchor + deltaDays * 86_400_000);
   }
 }

--- a/libs/data-access/src/lib/leaderboard/leaderboard.store.spec.ts
+++ b/libs/data-access/src/lib/leaderboard/leaderboard.store.spec.ts
@@ -26,8 +26,8 @@ import { LeaderboardStore } from './leaderboard.store';
 
 const emptyLeaderboard: LeaderboardData = {
   daily: { top: [], current: null },
-  weekly: { top: [], current: null },
-  monthly: { top: [], current: null },
+  last7: { top: [], current: null },
+  last30: { top: [], current: null },
 };
 
 function makeApiMock(): {

--- a/libs/data-access/src/lib/leaderboard/leaderboard.store.ts
+++ b/libs/data-access/src/lib/leaderboard/leaderboard.store.ts
@@ -58,8 +58,8 @@ export const LeaderboardStore = signalStore(
           patchState(store, {
             data: {
               daily: { top: [], current: null },
-              weekly: { top: [], current: null },
-              monthly: { top: [], current: null },
+              last7: { top: [], current: null },
+              last30: { top: [], current: null },
             },
             loading: false,
           });

--- a/libs/testing/src/lib/data-access-mocks.ts
+++ b/libs/testing/src/lib/data-access-mocks.ts
@@ -122,15 +122,16 @@ export function makeStatsApiMock(
 // LeaderboardService mock
 // ---------------------------------------------------------------------------
 
-const emptyBucket: LeaderboardBucket = { top: [], current: null };
-const emptyLeaderboard: LeaderboardData = {
-  daily: emptyBucket,
-  last7: emptyBucket,
-  last30: emptyBucket,
-};
+const makeEmptyBucket = (): LeaderboardBucket => ({ top: [], current: null });
+const makeEmptyLeaderboard = (): LeaderboardData => ({
+  daily: makeEmptyBucket(),
+  last7: makeEmptyBucket(),
+  last30: makeEmptyBucket(),
+});
 
 /**
  * Creates a LeaderboardService mock that resolves with empty data by default.
+ * Fresh objects per call so a mutation in one test doesn't leak into another.
  *
  * @example
  * { provide: LeaderboardService, useValue: makeLeaderboardMock() }
@@ -139,7 +140,7 @@ export function makeLeaderboardMock(
   overrides: Partial<LeaderboardService> = {}
 ): Partial<LeaderboardService> {
   return {
-    load: () => Promise.resolve(emptyLeaderboard),
+    load: () => Promise.resolve(makeEmptyLeaderboard()),
     observeSnapshot: () => EMPTY,
     ...overrides,
   };

--- a/libs/testing/src/lib/data-access-mocks.ts
+++ b/libs/testing/src/lib/data-access-mocks.ts
@@ -125,8 +125,8 @@ export function makeStatsApiMock(
 const emptyBucket: LeaderboardBucket = { top: [], current: null };
 const emptyLeaderboard: LeaderboardData = {
   daily: emptyBucket,
-  weekly: emptyBucket,
-  monthly: emptyBucket,
+  last7: emptyBucket,
+  last30: emptyBucket,
 };
 
 /**

--- a/web/src/app/app.routes.ts
+++ b/web/src/app/app.routes.ts
@@ -125,7 +125,7 @@ export const appRoutes: Routes = [
     path: 'leaderboard',
     data: {
       seoTitle: $localize`:@@seo.leaderboard.title:Bestenliste – Pushup Tracker`,
-      seoDescription: $localize`:@@seo.leaderboard.description:Öffentliche Bestenliste für tägliche, wöchentliche und monatliche Pushup-Reps.`,
+      seoDescription: $localize`:@@seo.leaderboard.description:Öffentliche Bestenliste mit Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage.`,
     },
     loadComponent: () =>
       import('./leaderboard/shell/leaderboard-page.component').then(

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.html
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.html
@@ -5,7 +5,7 @@
         >Bestenliste</mat-card-title
       >
       <mat-card-subtitle i18n="@@leaderboard.page.subtitle"
-        >Daily · Weekly · Monthly</mat-card-subtitle
+        >Heute · Letzte 7 Tage · Letzte 30 Tage</mat-card-subtitle
       >
     </mat-card-header>
     <mat-card-content>
@@ -26,20 +26,20 @@
         <button
           mat-stroked-button
           type="button"
-          (click)="period.set('weekly')"
-          [class.active]="period() === 'weekly'"
-          i18n="@@landing.leaderboard.weekly"
+          (click)="period.set('last7')"
+          [class.active]="period() === 'last7'"
+          i18n="@@landing.leaderboard.last7"
         >
-          Woche
+          Letzte 7 Tage
         </button>
         <button
           mat-stroked-button
           type="button"
-          (click)="period.set('monthly')"
-          [class.active]="period() === 'monthly'"
-          i18n="@@landing.leaderboard.monthly"
+          (click)="period.set('last30')"
+          [class.active]="period() === 'last30'"
+          i18n="@@landing.leaderboard.last30"
         >
-          Monat
+          Letzte 30 Tage
         </button>
       </div>
 

--- a/web/src/app/marketing/shell/landing-page.component.html
+++ b/web/src/app/marketing/shell/landing-page.component.html
@@ -296,9 +296,9 @@
           >
         </mat-card-header>
         <mat-card-content i18n="@@landing.discover.leaderboard.body">
-          Vergleiche dich mit der Community: tägliche, wöchentliche und
-          monatliche Top-Reps. Privacy first – dein Name erscheint nur, wenn du
-          es willst.
+          Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7
+          Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur,
+          wenn du es willst.
         </mat-card-content>
         <mat-card-actions>
           <a

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1957,8 +1957,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
       </notes>
       <segment state="translated">
-        <source> Vergleiche dich mit der Community: tägliche, wöchentliche und monatliche Top-Reps. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
-        <target> Compare yourself with the community: daily, weekly, and monthly top reps. Privacy first – your name only shows if you want it to. </target>
+        <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
+        <target> Compare yourself with the community: top reps for today, the last 7 days, and the last 30 days. Privacy first – your name only shows if you want it to. </target>
       </segment>
     </unit>
     <unit id="landing.discover.leaderboard.cta">
@@ -2031,23 +2031,15 @@ Active:         </target>
       
       
         </unit>
-    <unit id="landing.leaderboard.monthly">
+    <unit id="landing.leaderboard.last30">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html</note>
+      </notes>
       <segment state="translated">
-        <source>Monat</source>
-        <target>Month</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
+        <source>Letzte 30 Tage</source>
+        <target>Last 30 days</target>
+      </segment>
+    </unit>
     <unit id="landing.leaderboard.ownPosition">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
@@ -2085,23 +2077,15 @@ Deine Position: # ·  Reps        </source>
       
       
         </unit>
-    <unit id="landing.leaderboard.weekly">
+    <unit id="landing.leaderboard.last7">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
-
-        
-            </notes>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html</note>
+      </notes>
       <segment state="translated">
-        <source>Woche</source>
-        <target>Week</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
+        <source>Letzte 7 Tage</source>
+        <target>Last 7 days</target>
+      </segment>
+    </unit>
     <unit id="landing.plans.eyebrow">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
@@ -2313,7 +2297,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="leaderboard.page.subtitle">
       <segment state="translated">
         <source/>
-        <target>Daily · Weekly · Monthly</target>
+        <target>Today · Last 7 days · Last 30 days</target>
       </segment>
     </unit>
     <unit id="leaderboard.page.title">
@@ -3302,8 +3286,8 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="seo.leaderboard.description">
       <segment state="translated">
-        <source>Öffentliche Bestenliste für tägliche, wöchentliche und monatliche Pushup-Reps.</source>
-        <target>Public leaderboard for daily, weekly, and monthly pushup reps.</target>
+        <source>Öffentliche Bestenliste mit Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage.</source>
+        <target>Public leaderboard with top reps for today, the last 7 days, and the last 30 days.</target>
 
         
         

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -1487,7 +1487,7 @@
         <note category="location">web/src/app/app.routes.ts:128</note>
       </notes>
       <segment>
-        <source>Öffentliche Bestenliste für tägliche, wöchentliche und monatliche Pushup-Reps.</source>
+        <source>Öffentliche Bestenliste mit Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage.</source>
       </segment>
     </unit>
     <unit id="seo.publicProfile.title">
@@ -1825,7 +1825,7 @@
         <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:8,10</note>
       </notes>
       <segment>
-        <source>Daily · Weekly · Monthly</source>
+        <source>Heute · Letzte 7 Tage · Letzte 30 Tage</source>
       </segment>
     </unit>
     <unit id="landing.leaderboard.daily">
@@ -1836,20 +1836,20 @@
         <source> Tag </source>
       </segment>
     </unit>
-    <unit id="landing.leaderboard.weekly">
+    <unit id="landing.leaderboard.last7">
       <notes>
         <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:33,35</note>
       </notes>
       <segment>
-        <source> Woche </source>
+        <source> Letzte 7 Tage </source>
       </segment>
     </unit>
-    <unit id="landing.leaderboard.monthly">
+    <unit id="landing.leaderboard.last30">
       <notes>
         <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:42,46</note>
       </notes>
       <segment>
-        <source> Monat </source>
+        <source> Letzte 30 Tage </source>
       </segment>
     </unit>
     <unit id="landing.leaderboard.reps">
@@ -2525,7 +2525,7 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:299,302</note>
       </notes>
       <segment>
-        <source> Vergleiche dich mit der Community: tägliche, wöchentliche und monatliche Top-Reps. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
+        <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
       </segment>
     </unit>
     <unit id="landing.discover.leaderboard.cta">


### PR DESCRIPTION
## Summary

Replaces the leaderboard's calendar-week / calendar-month buckets with **true rolling windows** so the periods match what users intuitively expect ("last 7 days" really means the trailing 7 days, not "this ISO week").

- **Cloud Function** (`data-store/functions/src/leaderboard/logic.ts`, `index.ts`): `rankEntries` now supports `daily | last7 | last30`. The trailing 7- and 30-day windows are filtered by Berlin ISO date relative to today, inclusive on both endpoints. Firestore document shape becomes `periods.{daily,last7,last30}` and is written **without `merge`** so old `weekly` / `monthly` fields evict from `leaderboards/current`. Query bound moved from start-of-month to today − 29.
- **Data-access** (`leaderboard.service.ts`, store, mocks): `LeaderboardPeriod = 'daily' | 'last7' | 'last30'`. Client-side fallback aggregation filters by date range instead of bucket key.
- **UI**: leaderboard page buttons now read **"Letzte 7 Tage"** / **"Letzte 30 Tage"** (DE) and **"Last 7 days"** / **"Last 30 days"** (EN). Subtitle, marketing landing blurb, and SEO description updated to match.
- **i18n**: new `landing.leaderboard.last7` / `landing.leaderboard.last30` units in both XLIFFs; `seo.leaderboard.description` and `landing.discover.leaderboard.body` rewritten.
- **Tests**: backend tests cover the inclusive 7/30-day windows, month/year boundaries, and the new query-start helper.

## Test plan

- [x] `pnpm nx run cloud-functions:test` (282 tests pass)
- [x] `pnpm nx run stats-data-access:test` (55 tests pass)
- [x] `pnpm nx run web:test`
- [x] `pnpm nx run web:typecheck`
- [x] `pnpm nx run-many -t lint -p cloud-functions stats-data-access web` (no errors)
- [ ] Manual: leaderboard page renders three tabs (Tag / Letzte 7 Tage / Letzte 30 Tage), live snapshot reload still works
- [ ] Manual: after first scheduled rebuild on `main`, verify `leaderboards/current` doc has `periods.last7` / `periods.last30` and old `weekly` / `monthly` fields are gone

https://claude.ai/code/session_01SEBW5mGVEcRDAY4xttBnEq

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBW5mGVEcRDAY4xttBnEq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Leaderboard now displays rankings for rolling time windows: Today, Last 7 Days, and Last 30 Days—replacing the previous Daily, Weekly, and Monthly calendar-based periods.

* **Updates**
  * Updated UI labels, SEO descriptions, and marketing copy to reflect the new leaderboard time period terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->