### PR TITLE
fix(ssr): allow Cloud Run revision hosts in NG_ALLOWED_HOSTS

### DIFF
--- a/apphosting.staging.yaml
+++ b/apphosting.staging.yaml
@@ -8,7 +8,11 @@ runConfig:
 
 env:
   - variable: NG_ALLOWED_HOSTS
-    value: '.hosted.app'
+    # `.hosted.app` covers Firebase App Hosting URLs; `.run.app` covers the
+    # Cloud Run revision/traffic-tag URLs that App Hosting routes through
+    # internally during rolling deploys (Angular SSR's SSRF guard otherwise
+    # rejects them with a 400). Same rationale as `apphosting.yaml`.
+    value: '.hosted.app,.run.app'
     availability:
       - RUNTIME
 

--- a/apphosting.staging.yaml
+++ b/apphosting.staging.yaml
@@ -8,11 +8,13 @@ runConfig:
 
 env:
   - variable: NG_ALLOWED_HOSTS
-    # `.hosted.app` covers Firebase App Hosting URLs; `.run.app` covers the
+    # `*.hosted.app` covers Firebase App Hosting URLs; `*.run.app` covers the
     # Cloud Run revision/traffic-tag URLs that App Hosting routes through
     # internally during rolling deploys (Angular SSR's SSRF guard otherwise
-    # rejects them with a 400). Same rationale as `apphosting.yaml`.
-    value: '.hosted.app,.run.app'
+    # rejects them with a 400). Angular's `isHostAllowed` only treats `*.`
+    # prefixes as wildcards — a bare leading dot is matched literally and
+    # would NOT cover the revision URLs.
+    value: '*.hosted.app,*.run.app'
     availability:
       - RUNTIME
 

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -12,7 +12,13 @@ env:
   # Configure environment variables.
   # See https://firebase.google.com/docs/app-hosting/configure#user-defined-environment
   - variable: NG_ALLOWED_HOSTS
-    value: 'pushup-stats-service--pushup-stats.europe-west4.hosted.app,pushup-stats.de'
+    # Angular SSR (`@angular/ssr`) rejects requests whose `Host` header isn't
+    # in this list as an SSRF guard. Firebase App Hosting routes through Cloud
+    # Run, so during rolling deploys traffic-tag URLs like
+    # `t-<id>---pushup-stats-service-<hash>-<region>.a.run.app` need to pass
+    # too — the leading dot in `.run.app` matches any subdomain of `run.app`,
+    # which covers every Cloud Run revision URL App Hosting may use.
+    value: 'pushup-stats-service--pushup-stats.europe-west4.hosted.app,pushup-stats.de,.run.app'
     availability:
       - RUNTIME
 

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -15,10 +15,13 @@ env:
     # Angular SSR (`@angular/ssr`) rejects requests whose `Host` header isn't
     # in this list as an SSRF guard. Firebase App Hosting routes through Cloud
     # Run, so during rolling deploys traffic-tag URLs like
-    # `t-<id>---pushup-stats-service-<hash>-<region>.a.run.app` need to pass
-    # too — the leading dot in `.run.app` matches any subdomain of `run.app`,
-    # which covers every Cloud Run revision URL App Hosting may use.
-    value: 'pushup-stats-service--pushup-stats.europe-west4.hosted.app,pushup-stats.de,.run.app'
+    # `t-<id>---pushup-stats-service-<hash>-<region>.a.run.app` reach the SSR
+    # with that internal hostname.
+    #
+    # Angular only treats entries starting with `*.` as wildcards
+    # (see `isHostAllowed` in `@angular/ssr`); `*.run.app` matches any
+    # hostname ending in `.run.app`, including the random per-revision tags.
+    value: 'pushup-stats-service--pushup-stats.europe-west4.hosted.app,pushup-stats.de,*.run.app'
     availability:
       - RUNTIME
 

--- a/docs/gotchas/build-and-tooling.md
+++ b/docs/gotchas/build-and-tooling.md
@@ -28,3 +28,11 @@ pnpm nx-cloud start-ci-run --distribute-on=".nx/workflows/distribution-config.ya
 ```
 
 To scale further (bigger agents for e2e specifically, or higher ceilings), edit the YAML — the CI workflow doesn't need to change.
+
+## Angular SSR `NG_ALLOWED_HOSTS` must include `.run.app`
+
+Angular SSR (`@angular/ssr` v19+) rejects requests whose `Host` header isn't in `NG_ALLOWED_HOSTS` as an SSRF guard. Firebase App Hosting forwards traffic through Cloud Run, so during rolling deploys traffic-tag URLs like `t-<id>---<service>-<hash>-<region>.a.run.app` reach the SSR with that internal hostname — Angular returns `400: Header "host" with value "..." is not allowed`, and the affected page (most visibly `/u/:uid`, which is `RenderMode.Server`) refuses to render.
+
+Fix: include `.run.app` (leading-dot subdomain wildcard) in the comma-separated `NG_ALLOWED_HOSTS` value in **both** `apphosting.yaml` and `apphosting.staging.yaml`. The leading dot matches any subdomain of `run.app`, covering every Cloud Run revision URL App Hosting may forward through.
+
+`.run.app` is broad but acceptable: the SSR doesn't make outgoing requests based on the `Host` header — canonical / `og:url` come from a hardcoded `BASE_URL` in `SeoService` — so the SSRF risk reduces to "an attacker-controlled `*.run.app` host renders our public HTML on their domain", which doesn't expose any private state.

--- a/docs/gotchas/build-and-tooling.md
+++ b/docs/gotchas/build-and-tooling.md
@@ -29,10 +29,12 @@ pnpm nx-cloud start-ci-run --distribute-on=".nx/workflows/distribution-config.ya
 
 To scale further (bigger agents for e2e specifically, or higher ceilings), edit the YAML — the CI workflow doesn't need to change.
 
-## Angular SSR `NG_ALLOWED_HOSTS` must include `.run.app`
+## Angular SSR `NG_ALLOWED_HOSTS` must include `*.run.app`
 
 Angular SSR (`@angular/ssr` v19+) rejects requests whose `Host` header isn't in `NG_ALLOWED_HOSTS` as an SSRF guard. Firebase App Hosting forwards traffic through Cloud Run, so during rolling deploys traffic-tag URLs like `t-<id>---<service>-<hash>-<region>.a.run.app` reach the SSR with that internal hostname — Angular returns `400: Header "host" with value "..." is not allowed`, and the affected page (most visibly `/u/:uid`, which is `RenderMode.Server`) refuses to render.
 
-Fix: include `.run.app` (leading-dot subdomain wildcard) in the comma-separated `NG_ALLOWED_HOSTS` value in **both** `apphosting.yaml` and `apphosting.staging.yaml`. The leading dot matches any subdomain of `run.app`, covering every Cloud Run revision URL App Hosting may forward through.
+Fix: include `*.run.app` in the comma-separated `NG_ALLOWED_HOSTS` value in **both** `apphosting.yaml` and `apphosting.staging.yaml`.
 
-`.run.app` is broad but acceptable: the SSR doesn't make outgoing requests based on the `Host` header — canonical / `og:url` come from a hardcoded `BASE_URL` in `SeoService` — so the SSRF risk reduces to "an attacker-controlled `*.run.app` host renders our public HTML on their domain", which doesn't expose any private state.
+**Angular's wildcard syntax requires the `*.` prefix specifically** — `isHostAllowed` in `@angular/ssr` only treats entries that start with `*.` as wildcards (it does `allowedHost.startsWith('*.')` then `hostname.endsWith(allowedHost.slice(1))`). A bare leading dot like `.run.app` is matched literally and silently fails to cover the revision URLs.
+
+`*.run.app` is broad but acceptable: the SSR doesn't make outgoing requests based on the `Host` header — canonical / `og:url` come from a hardcoded `BASE_URL` in `SeoService` — so the SSRF risk reduces to "an attacker-controlled `*.run.app` host renders our public HTML on their domain", which doesn't expose any private state.


### PR DESCRIPTION
## Hotfix
`/u/:uid` (and any other `RenderMode.Server` route) returns

```
Header "host" with value "t-3733244052---pushup-stats-service-2deny3ggea-ez.a.run.app" is not allowed.
```

in production after the public-profile rollout (PR #255).

## Root cause
Angular SSR (`@angular/ssr` v19+) rejects unknown `Host` headers as an SSRF guard. Firebase App Hosting routes traffic through Cloud Run, and during rolling deploys the request reaches the SSR with the internal Cloud Run revision / traffic-tag URL as the `Host` header — that hostname pattern wasn't in `NG_ALLOWED_HOSTS`.

## Fix
Add `*.run.app` (Angular's documented wildcard syntax — entries must start with `*.`) in both:
- `apphosting.yaml` (prod)
- `apphosting.staging.yaml` (PR previews)

> **Note** — the first commit on this branch tried `.run.app` (bare leading dot). Codex caught that `@angular/ssr`'s `isHostAllowed` only treats `*.`-prefixed entries as wildcards (it does `allowedHost.startsWith('*.')` then `hostname.endsWith(allowedHost.slice(1))`), so the bare-dot form was matched literally and would have silently failed. Second commit switches to `*.run.app`.

## Why `*.run.app` is the right level of broad
The SSR doesn't make outgoing requests based on the `Host` header — canonical / `og:url` come from a hardcoded `BASE_URL = 'https://pushup-stats.de'` in `SeoService`. So the SSRF risk via Host header is purely about which HTML the renderer produces, and an attacker-controlled `*.run.app` host would still get the same public-profile HTML it could already fetch by hitting prod directly. No private state exposure.

## Docs
Added a section in `docs/gotchas/build-and-tooling.md` so the next time someone Googles this error, they find our local fix instead of the StackOverflow answer that suggests disabling the SSRF guard. The note also calls out Angular's `*.`-only wildcard semantics so future patches don't repeat the same bare-dot mistake.

## Test plan
- [ ] After deploy, hit `https://pushup-stats.de/u/<opted-in-uid>` and confirm SSR HTML renders (instead of the 400).
- [ ] Verify `*.run.app` actually matches the revision URLs by tailing logs during a rolling deploy and confirming no `Header "host" ... is not allowed` errors.