### PR TITLE
fix(public-profile): bare-URL redirect + OG metadata polish

### DIFF
--- a/data-store/functions/src/profile/og-render.ts
+++ b/data-store/functions/src/profile/og-render.ts
@@ -97,11 +97,25 @@ interface OgCopy {
   numberLocale: string;
   /** Suffix label between the streak count and active-day count (e.g. "Tage" / "days"). */
   daysLabel: string;
+  /** Headline above the displayName (call-to-action context, e.g. "💪 X reps tracked"). */
+  headline: string;
+  /** Footer call-to-action (e.g. "Track yours – pushup-stats.de"). */
+  cta: string;
 }
 
 const OG_COPY: Readonly<Record<OgLocale, OgCopy>> = {
-  de: { numberLocale: 'de-DE', daysLabel: 'Tage' },
-  en: { numberLocale: 'en-US', daysLabel: 'days' },
+  de: {
+    numberLocale: 'de-DE',
+    daysLabel: 'Tage',
+    headline: 'Pushup-Profil',
+    cta: 'Selbst tracken — kostenlos auf pushup-stats.de',
+  },
+  en: {
+    numberLocale: 'en-US',
+    daysLabel: 'days',
+    headline: 'Push-up profile',
+    cta: 'Track yours — free at pushup-stats.de',
+  },
 };
 
 function copyFor(locale: OgLocale | string | undefined): OgCopy {
@@ -137,10 +151,10 @@ export function buildOgTree(
           textTransform: 'uppercase',
           color: '#9fb3de',
         },
-        children: 'Pushup Tracker',
+        children: `Pushup Tracker · ${copy.headline}`,
       }),
       el('div', {
-        style: { display: 'flex', flexDirection: 'column', gap: '12px' },
+        style: { display: 'flex', flexDirection: 'column', gap: '14px' },
         children: [
           el('div', {
             style: {
@@ -165,10 +179,11 @@ export function buildOgTree(
         style: {
           display: 'flex',
           alignItems: 'center',
-          fontSize: '28px',
-          color: '#8ca8e8',
+          fontSize: '32px',
+          fontWeight: 600,
+          color: '#f4f8ff',
         },
-        children: 'pushup-stats.de',
+        children: copy.cta,
       }),
     ],
   });

--- a/web/src/app/core/profile-share-url.spec.ts
+++ b/web/src/app/core/profile-share-url.spec.ts
@@ -1,0 +1,44 @@
+import { buildProfileShareUrl } from './profile-share-url';
+
+describe('buildProfileShareUrl', () => {
+  it.each([
+    ['de-DE', 'de'],
+    ['de', 'de'],
+    ['en-US', 'en'],
+    ['en', 'en'],
+    ['EN', 'en'],
+    // Unknown / unsupported locales fall back to the source locale.
+    ['fr-FR', 'de'],
+    ['', 'de'],
+  ])(
+    'Given LOCALE_ID=%j, Then it builds /%s/u/<uid>',
+    (localeId, expectedLang) => {
+      expect(buildProfileShareUrl('abcdef1234567890', localeId)).toBe(
+        `https://pushup-stats.de/${expectedLang}/u/abcdef1234567890`
+      );
+    }
+  );
+
+  it('Returns an empty string when uid is missing', () => {
+    expect(buildProfileShareUrl(undefined, 'de')).toBe('');
+    expect(buildProfileShareUrl(null, 'de')).toBe('');
+    expect(buildProfileShareUrl('', 'de')).toBe('');
+  });
+
+  it('Treats a missing localeId as the source locale (de)', () => {
+    expect(buildProfileShareUrl('abc12345', undefined)).toBe(
+      'https://pushup-stats.de/de/u/abc12345'
+    );
+    expect(buildProfileShareUrl('abc12345', null)).toBe(
+      'https://pushup-stats.de/de/u/abc12345'
+    );
+  });
+
+  it('URL-encodes the uid so reserved characters cannot break the path', () => {
+    // Real Firebase UIDs are URL-safe, but custom UIDs may contain
+    // characters that need encoding — keep the contract explicit.
+    expect(buildProfileShareUrl('a/b c?d', 'de')).toBe(
+      'https://pushup-stats.de/de/u/a%2Fb%20c%3Fd'
+    );
+  });
+});

--- a/web/src/app/core/profile-share-url.ts
+++ b/web/src/app/core/profile-share-url.ts
@@ -1,0 +1,20 @@
+/**
+ * Builds the canonical public-profile share URL for the current locale.
+ *
+ * Centralised so the public-profile page (`shareProfile()`) and the Settings
+ * page (`profileUrl` computed) produce the same shape — including the
+ * locale prefix the SSR redirect would otherwise have to inject. Without
+ * the prefix, a recipient pasting the link into a tool that strips 30x
+ * hops would land on the static `Cannot GET /u/<uid>` instead of the
+ * Angular bundle for their locale.
+ */
+const SHARE_URL_BASE = 'https://pushup-stats.de';
+
+export function buildProfileShareUrl(
+  uid: string | null | undefined,
+  localeId: string | null | undefined
+): string {
+  if (!uid) return '';
+  const lang = localeId?.toLowerCase().startsWith('en') ? 'en' : 'de';
+  return `${SHARE_URL_BASE}/${lang}/u/${encodeURIComponent(uid)}`;
+}

--- a/web/src/app/public-profile/public-profile-page.component.spec.ts
+++ b/web/src/app/public-profile/public-profile-page.component.spec.ts
@@ -121,7 +121,13 @@ describe('PublicProfilePageComponent', () => {
 
       expect(shareMock.share).toHaveBeenCalledTimes(1);
       const payload = shareMock.share.mock.calls[0][0];
-      expect(payload.url).toBe('https://pushup-stats.de/u/abcdef1234567890');
+      // Share URL must include the locale prefix so the recipient lands on
+      // the right Angular bundle directly — bare `/u/<uid>` requires the
+      // SSR redirect and wouldn't survive a client cache or copy-paste
+      // through tools that strip 30x hops.
+      expect(payload.url).toMatch(
+        /^https:\/\/pushup-stats\.de\/(de|en)\/u\/abcdef1234567890$/
+      );
       expect(payload.text).toContain('Wolfi');
       expect(payload.text).toContain('5000');
     });

--- a/web/src/app/public-profile/public-profile-page.component.spec.ts
+++ b/web/src/app/public-profile/public-profile-page.component.spec.ts
@@ -1,3 +1,4 @@
+import { LOCALE_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { ActivatedRoute, convertToParamMap, ParamMap } from '@angular/router';
@@ -71,6 +72,10 @@ describe('PublicProfilePageComponent', () => {
         { provide: ShareService, useValue: shareMock },
         { provide: SeoService, useValue: seoMock },
         { provide: FirebaseApp, useValue: firebaseAppMock },
+        // Pin the locale so the share-URL assertion below is deterministic
+        // (the unit-test default differs per Angular setup; pinning here
+        // documents which prefix the share builder should pick).
+        { provide: LOCALE_ID, useValue: 'en-US' },
       ],
     }).compileComponents();
 
@@ -124,10 +129,11 @@ describe('PublicProfilePageComponent', () => {
       // Share URL must include the locale prefix so the recipient lands on
       // the right Angular bundle directly — bare `/u/<uid>` requires the
       // SSR redirect and wouldn't survive a client cache or copy-paste
-      // through tools that strip 30x hops.
-      expect(payload.url).toMatch(
-        /^https:\/\/pushup-stats\.de\/(de|en)\/u\/abcdef1234567890$/
-      );
+      // through tools that strip 30x hops. Tests run with the default
+      // LOCALE_ID `en-US`, so we assert the exact `/en/...` URL — going
+      // permissive (matching `(de|en)`) would let a regression silently
+      // map every locale to the source fallback.
+      expect(payload.url).toBe('https://pushup-stats.de/en/u/abcdef1234567890');
       expect(payload.text).toContain('Wolfi');
       expect(payload.text).toContain('5000');
     });

--- a/web/src/app/public-profile/public-profile-page.component.ts
+++ b/web/src/app/public-profile/public-profile-page.component.ts
@@ -19,14 +19,13 @@ import { PublicProfileApiService } from '@pu-stats/data-access';
 import { type PublicProfile } from '@pu-stats/models';
 import { ShareService } from '../core/share.service';
 import { SeoService } from '../core/seo.service';
+import { buildProfileShareUrl } from '../core/profile-share-url';
 
 type LoadState =
   | { kind: 'loading' }
   | { kind: 'ready'; profile: PublicProfile }
   | { kind: 'not-found' }
   | { kind: 'error' };
-
-const SHARE_URL_BASE = 'https://pushup-stats.de';
 
 const OG_FUNCTION_REGION = 'europe-west3';
 
@@ -128,17 +127,13 @@ export class PublicProfilePageComponent {
     const profile = this.profile();
     if (!profile) return;
     const text = $localize`:@@publicProfile.share.text:${profile.displayName}:name: hat ${profile.total}:total: Liegestütze auf Pushup Tracker geschafft 💪 Schau's dir an:`;
-    // Include the locale prefix so the shared link lands on the right
-    // Angular bundle directly. Without it, the bare `/u/<uid>` path used to
-    // 404 (it only exists inside `/de/...` and `/en/...` builds); the SSR
-    // server now also redirects bare → locale-prefixed, but the shared URL
-    // should be the canonical one.
-    const lang = this.localeShortCode();
-    const encodedUid = encodeURIComponent(profile.uid);
     void this.shareService.share({
       title: $localize`:@@publicProfile.share.title:Pushup Tracker Profil`,
       text,
-      url: `${SHARE_URL_BASE}/${lang}/u/${encodedUid}`,
+      // Locale-prefixed canonical share URL — see `buildProfileShareUrl`
+      // for the rationale (locale-prefixed link survives 30x-stripping
+      // tools and lands on the right Angular bundle directly).
+      url: buildProfileShareUrl(profile.uid, this.localeId),
     });
   }
 

--- a/web/src/app/public-profile/public-profile-page.component.ts
+++ b/web/src/app/public-profile/public-profile-page.component.ts
@@ -128,10 +128,17 @@ export class PublicProfilePageComponent {
     const profile = this.profile();
     if (!profile) return;
     const text = $localize`:@@publicProfile.share.text:${profile.displayName}:name: hat ${profile.total}:total: Liegestütze auf Pushup Tracker geschafft 💪 Schau's dir an:`;
+    // Include the locale prefix so the shared link lands on the right
+    // Angular bundle directly. Without it, the bare `/u/<uid>` path used to
+    // 404 (it only exists inside `/de/...` and `/en/...` builds); the SSR
+    // server now also redirects bare → locale-prefixed, but the shared URL
+    // should be the canonical one.
+    const lang = this.localeShortCode();
+    const encodedUid = encodeURIComponent(profile.uid);
     void this.shareService.share({
       title: $localize`:@@publicProfile.share.title:Pushup Tracker Profil`,
       text,
-      url: `${SHARE_URL_BASE}/u/${encodeURIComponent(profile.uid)}`,
+      url: `${SHARE_URL_BASE}/${lang}/u/${encodedUid}`,
     });
   }
 
@@ -181,9 +188,14 @@ export class PublicProfilePageComponent {
     const projectId =
       (this.firebaseApp.options as { projectId?: string }).projectId ??
       'pushup-stats';
+    // Title and description are tuned for the OpenGraph "optimal" ranges
+    // (title ~50-60 chars, description ~110-160 chars) so social cards
+    // don't get truncated and search snippets show meaningful copy. Both
+    // include the user's actual stats so the preview is informative even
+    // before the visitor clicks through.
     this.seo.update(
-      $localize`:@@publicProfile.seo.title:${profile.displayName}:name: – Pushup Tracker Profil`,
-      $localize`:@@publicProfile.seo.description:${profile.displayName}:name: hat ${profile.total}:total: Liegestütze und eine ${profile.currentStreak}:streak:-Tage-Streak auf Pushup Tracker.`,
+      $localize`:@@publicProfile.seo.title:${profile.displayName}:name: – ${profile.total}:total: Liegestütze · Streak ${profile.currentStreak}:streak: · Pushup Tracker`,
+      $localize`:@@publicProfile.seo.description:${profile.displayName}:name: hat ${profile.total}:total: Liegestütze in ${profile.totalDays}:days: aktiven Tagen geschafft – aktuelle Streak: ${profile.currentStreak}:streak: Tage. Tracke selbst kostenlos auf pushup-stats.de.`,
       `/u/${encodedUid}`,
       {
         // Per-user dynamic OG card (1200×630 PNG rendered by satori + resvg

--- a/web/src/app/stats/shell/settings-page.component.ts
+++ b/web/src/app/stats/shell/settings-page.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  LOCALE_ID,
   TemplateRef,
   computed,
   effect,
@@ -454,6 +455,7 @@ export class SettingsPageComponent {
   private readonly pushService = inject(PushSubscriptionService);
   private readonly userConfigStore = inject(UserConfigStore);
   private readonly shareService = inject(ShareService);
+  private readonly localeId = inject(LOCALE_ID) as string;
 
   readonly isGuest = this.user.isGuest;
   readonly userId = this.user.userIdSafe;
@@ -469,7 +471,12 @@ export class SettingsPageComponent {
 
   readonly profileUrl = computed(() => {
     const uid = this.userId();
-    return uid ? `https://pushup-stats.de/u/${uid}` : '';
+    if (!uid) return '';
+    // Include the locale prefix so the link lands on the right Angular
+    // bundle directly — bare `/u/<uid>` only works via the SSR redirect
+    // and we want the canonical share URL to be the prefixed one.
+    const lang = this.localeId?.startsWith('en') ? 'en' : 'de';
+    return `https://pushup-stats.de/${lang}/u/${encodeURIComponent(uid)}`;
   });
 
   readonly saving = signal(false);

--- a/web/src/app/stats/shell/settings-page.component.ts
+++ b/web/src/app/stats/shell/settings-page.component.ts
@@ -24,6 +24,7 @@ import { PushSubscriptionService } from '@pu-reminders/reminders';
 import { DEFAULT_SNAP_QUALITY, SnapQuality } from '@pu-stats/models';
 import { UserConfigStore } from '../../core/user-config.store';
 import { ShareService } from '../../core/share.service';
+import { buildProfileShareUrl } from '../../core/profile-share-url';
 
 @Component({
   selector: 'app-settings-page',
@@ -469,15 +470,9 @@ export class SettingsPageComponent {
   readonly adsConsentDraft = signal(false);
   readonly snapQualityDraft = signal<SnapQuality>(DEFAULT_SNAP_QUALITY);
 
-  readonly profileUrl = computed(() => {
-    const uid = this.userId();
-    if (!uid) return '';
-    // Include the locale prefix so the link lands on the right Angular
-    // bundle directly — bare `/u/<uid>` only works via the SSR redirect
-    // and we want the canonical share URL to be the prefixed one.
-    const lang = this.localeId?.startsWith('en') ? 'en' : 'de';
-    return `https://pushup-stats.de/${lang}/u/${encodeURIComponent(uid)}`;
-  });
+  readonly profileUrl = computed(() =>
+    buildProfileShareUrl(this.userId(), this.localeId)
+  );
 
   readonly saving = signal(false);
   readonly saved = signal(false);

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -6184,14 +6184,14 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="publicProfile.seo.title">
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="name"/> – Pushup Tracker Profil</source>
-        <target><ph id="0" equiv="name" disp="name"/> – Pushup Tracker profile</target>
+        <source><ph id="0" equiv="name" disp="name"/> – <ph id="1" equiv="total" disp="total"/> Liegestütze · Streak <ph id="2" equiv="streak" disp="streak"/> · Pushup Tracker</source>
+        <target><ph id="0" equiv="name" disp="name"/> – <ph id="1" equiv="total" disp="total"/> push-ups · streak <ph id="2" equiv="streak" disp="streak"/> · Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="publicProfile.seo.description">
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="name"/> hat <ph id="1" equiv="total" disp="total"/> Liegestütze und eine <ph id="2" equiv="streak" disp="streak"/>-Tage-Streak auf Pushup Tracker.</source>
-        <target><ph id="0" equiv="name" disp="name"/> has <ph id="1" equiv="total" disp="total"/> push-ups and a <ph id="2" equiv="streak" disp="streak"/>-day streak on Pushup Tracker.</target>
+        <source><ph id="0" equiv="name" disp="name"/> hat <ph id="1" equiv="total" disp="total"/> Liegestütze in <ph id="2" equiv="days" disp="days"/> aktiven Tagen geschafft – aktuelle Streak: <ph id="3" equiv="streak" disp="streak"/> Tage. Tracke selbst kostenlos auf pushup-stats.de.</source>
+        <target><ph id="0" equiv="name" disp="name"/> hit <ph id="1" equiv="total" disp="total"/> push-ups across <ph id="2" equiv="days" disp="days"/> active days – current streak: <ph id="3" equiv="streak" disp="streak"/> days. Start tracking free at pushup-stats.de.</target>
       </segment>
     </unit>
     <unit id="settings.publicProfile.toggle">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -237,7 +237,7 @@
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:199,200</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:328,329</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:329,330</note>
       </notes>
       <segment>
         <source> Abbrechen </source>
@@ -1846,7 +1846,7 @@
     </unit>
     <unit id="landing.leaderboard.last30">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:42,46</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:42,45</note>
       </notes>
       <segment>
         <source> Letzte 30 Tage </source>
@@ -2570,7 +2570,7 @@
     </unit>
     <unit id="publicProfile.notFound.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:69</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:82</note>
       </notes>
       <segment>
         <source>Profil nicht gefunden</source>
@@ -2578,7 +2578,7 @@
     </unit>
     <unit id="publicProfile.notFound.body">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:70</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:83</note>
       </notes>
       <segment>
         <source>Dieses Profil existiert nicht oder wurde nicht öffentlich freigegeben.</source>
@@ -2586,7 +2586,7 @@
     </unit>
     <unit id="publicProfile.error.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:71</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:84</note>
       </notes>
       <segment>
         <source>Profil konnte nicht geladen werden</source>
@@ -2594,7 +2594,7 @@
     </unit>
     <unit id="publicProfile.error.body">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:72</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:85</note>
       </notes>
       <segment>
         <source>Bitte versuche es später erneut.</source>
@@ -2602,7 +2602,7 @@
     </unit>
     <unit id="publicProfile.retry">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:73</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:86</note>
       </notes>
       <segment>
         <source>Erneut versuchen</source>
@@ -2610,7 +2610,7 @@
     </unit>
     <unit id="publicProfile.toHome">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:74</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:87</note>
       </notes>
       <segment>
         <source>Zur Startseite</source>
@@ -2618,7 +2618,7 @@
     </unit>
     <unit id="publicProfile.stats">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:75</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:88</note>
       </notes>
       <segment>
         <source>Statistik</source>
@@ -2626,7 +2626,7 @@
     </unit>
     <unit id="publicProfile.total">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:76</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:89</note>
       </notes>
       <segment>
         <source>Gesamte Reps</source>
@@ -2634,7 +2634,7 @@
     </unit>
     <unit id="publicProfile.streak">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:77</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:90</note>
       </notes>
       <segment>
         <source>Aktuelle Streak</source>
@@ -2642,7 +2642,7 @@
     </unit>
     <unit id="publicProfile.days">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:78</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:91</note>
       </notes>
       <segment>
         <source>Aktive Tage</source>
@@ -2650,7 +2650,7 @@
     </unit>
     <unit id="publicProfile.entries">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:79</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:92</note>
       </notes>
       <segment>
         <source>Einträge</source>
@@ -2658,7 +2658,7 @@
     </unit>
     <unit id="publicProfile.bestSet">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:80</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:93</note>
       </notes>
       <segment>
         <source>Bester Einzel-Eintrag</source>
@@ -2666,7 +2666,7 @@
     </unit>
     <unit id="publicProfile.bestDay">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:81</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:94</note>
       </notes>
       <segment>
         <source>Bester Tag</source>
@@ -2674,7 +2674,7 @@
     </unit>
     <unit id="publicProfile.share.aria">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:82</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:95</note>
       </notes>
       <segment>
         <source>Profil teilen</source>
@@ -2682,7 +2682,7 @@
     </unit>
     <unit id="publicProfile.share">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:83</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:96</note>
       </notes>
       <segment>
         <source>Teilen</source>
@@ -2690,7 +2690,7 @@
     </unit>
     <unit id="publicProfile.cta">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:84</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:97</note>
       </notes>
       <segment>
         <source>Selbst tracken – pushup-stats.de</source>
@@ -2698,7 +2698,7 @@
     </unit>
     <unit id="publicProfile.share.text">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:117</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:130</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze auf Pushup Tracker geschafft 💪 Schau&apos;s dir an:</source>
@@ -2706,7 +2706,7 @@
     </unit>
     <unit id="publicProfile.share.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:119</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:139</note>
       </notes>
       <segment>
         <source>Pushup Tracker Profil</source>
@@ -2714,7 +2714,7 @@
     </unit>
     <unit id="publicProfile.seo.notFound.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:155</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:181</note>
       </notes>
       <segment>
         <source>Profil nicht verfügbar – Pushup Tracker</source>
@@ -2722,7 +2722,7 @@
     </unit>
     <unit id="publicProfile.seo.notFound.description">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:156</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:182</note>
       </notes>
       <segment>
         <source>Dieses Profil existiert nicht oder ist nicht öffentlich.</source>
@@ -2730,23 +2730,23 @@
     </unit>
     <unit id="publicProfile.seo.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:162</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:197</note>
       </notes>
       <segment>
-        <source><ph id="0" equiv="name" disp="profile.displayName"/> – Pushup Tracker Profil</source>
+        <source><ph id="0" equiv="name" disp="profile.displayName"/> – <ph id="1" equiv="total" disp="profile.total"/> Liegestütze · Streak <ph id="2" equiv="streak" disp="profile.currentStreak"/> · Pushup Tracker</source>
       </segment>
     </unit>
     <unit id="publicProfile.seo.description">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:163</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:198</note>
       </notes>
       <segment>
-        <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze und eine <ph id="2" equiv="streak" disp="profile.currentStreak"/>-Tage-Streak auf Pushup Tracker.</source>
+        <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze in <ph id="2" equiv="days" disp="profile.totalDays"/> aktiven Tagen geschafft – aktuelle Streak: <ph id="3" equiv="streak" disp="profile.currentStreak"/> Tage. Tracke selbst kostenlos auf pushup-stats.de.</source>
       </segment>
     </unit>
     <unit id="publicProfile.seo.imageAlt">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:170</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:211</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> auf Pushup Tracker</source>
@@ -4190,7 +4190,7 @@
     </unit>
     <unit id="settingsTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:45,46</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:46,47</note>
       </notes>
       <segment>
         <source>Einstellungen</source>
@@ -4198,7 +4198,7 @@
     </unit>
     <unit id="settingsSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:47,48</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:48,49</note>
       </notes>
       <segment>
         <source>User-Profil &amp; Tagesziel</source>
@@ -4206,7 +4206,7 @@
     </unit>
     <unit id="guest.banner.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:56,58</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:57,59</note>
       </notes>
       <segment>
         <source>Du nutzt die App als Gast. Erstelle ein Konto um alle Funktionen zu nutzen.</source>
@@ -4214,7 +4214,7 @@
     </unit>
     <unit id="guest.banner.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:63,65</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:64,66</note>
       </notes>
       <segment>
         <source>Konto erstellen</source>
@@ -4222,7 +4222,7 @@
     </unit>
     <unit id="displayNameLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:69,70</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:70,71</note>
       </notes>
       <segment>
         <source>Anzeigename</source>
@@ -4230,7 +4230,7 @@
     </unit>
     <unit id="displayNamePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:75</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:76</note>
       </notes>
       <segment>
         <source>Wolf</source>
@@ -4238,7 +4238,7 @@
     </unit>
     <unit id="settings.displayNameHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:78,80</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:79,81</note>
       </notes>
       <segment>
         <source>Kann in der Bestenliste angezeigt werden.</source>
@@ -4246,7 +4246,7 @@
     </unit>
     <unit id="settings.leaderboardOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:87,88</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:88,89</note>
       </notes>
       <segment>
         <source> In Bestenliste anzeigen </source>
@@ -4254,7 +4254,7 @@
     </unit>
     <unit id="settings.leaderboardOptOutHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:91,94</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:92,95</note>
       </notes>
       <segment>
         <source> Wenn deaktiviert, wird dein Profil in der Bestenliste nicht angezeigt. </source>
@@ -4262,7 +4262,7 @@
     </unit>
     <unit id="settings.publicProfile.toggle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:101,102</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:102,103</note>
       </notes>
       <segment>
         <source> Öffentliches Profil aktivieren </source>
@@ -4270,7 +4270,7 @@
     </unit>
     <unit id="settings.publicProfile.hint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:105,108</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:106,109</note>
       </notes>
       <segment>
         <source> Erlaubt jedem mit dem Link den Zugriff auf deine Reps, Streak und Bestleistungen. Dein Anzeigename ist sichtbar; E-Mail, Ziele und Erinnerungen bleiben privat. </source>
@@ -4278,7 +4278,7 @@
     </unit>
     <unit id="settings.publicProfile.shareCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:127,129</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:128,130</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">share</pc> Profil teilen </source>
@@ -4286,7 +4286,7 @@
     </unit>
     <unit id="settings.adsConsentOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:138,139</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:139,140</note>
       </notes>
       <segment>
         <source> Personalisierte Werbung aktivieren </source>
@@ -4294,7 +4294,7 @@
     </unit>
     <unit id="settings.adsConsentHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:142,145</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:143,146</note>
       </notes>
       <segment>
         <source> Steuert, ob Werbe-Slots im Dashboard geladen werden dürfen. </source>
@@ -4302,7 +4302,7 @@
     </unit>
     <unit id="dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:146,147</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:147,148</note>
       </notes>
       <segment>
         <source>Tagesziel (Reps)</source>
@@ -4310,7 +4310,7 @@
     </unit>
     <unit id="dailyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:156</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:157</note>
       </notes>
       <segment>
         <source>10</source>
@@ -4318,7 +4318,7 @@
     </unit>
     <unit id="settings.goalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:159,161</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:160,162</note>
       </notes>
       <segment>
         <source>Wird prominent in der Toolbar angezeigt.</source>
@@ -4326,7 +4326,7 @@
     </unit>
     <unit id="weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:164,165</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:165,166</note>
       </notes>
       <segment>
         <source>Wochenziel (Reps)</source>
@@ -4334,7 +4334,7 @@
     </unit>
     <unit id="weeklyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:174</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:175</note>
       </notes>
       <segment>
         <source>50</source>
@@ -4342,7 +4342,7 @@
     </unit>
     <unit id="settings.weeklyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:177,179</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:178,180</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Woche (Mo–So).</source>
@@ -4350,7 +4350,7 @@
     </unit>
     <unit id="monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:182,183</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:183,184</note>
       </notes>
       <segment>
         <source>Monatsziel (Reps)</source>
@@ -4358,7 +4358,7 @@
     </unit>
     <unit id="monthlyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:192</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:193</note>
       </notes>
       <segment>
         <source>200</source>
@@ -4366,7 +4366,7 @@
     </unit>
     <unit id="settings.monthlyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:195,197</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:196,198</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Monat.</source>
@@ -4374,7 +4374,7 @@
     </unit>
     <unit id="settings.snapQualityLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:204,206</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:205,207</note>
       </notes>
       <segment>
         <source>Snap-Animation Qualität</source>
@@ -4382,7 +4382,7 @@
     </unit>
     <unit id="settings.snapQuality.low">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:214,216</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:215,217</note>
       </notes>
       <segment>
         <source>Niedrig</source>
@@ -4390,7 +4390,7 @@
     </unit>
     <unit id="settings.snapQuality.middle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:219,221</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:220,222</note>
       </notes>
       <segment>
         <source>Mittel</source>
@@ -4398,7 +4398,7 @@
     </unit>
     <unit id="settings.snapQuality.high">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:224,226</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:225,227</note>
       </notes>
       <segment>
         <source>Hoch</source>
@@ -4406,7 +4406,7 @@
     </unit>
     <unit id="settings.snapQualityHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:228,230</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:229,231</note>
       </notes>
       <segment>
         <source> Steuert die Partikelanzahl der „Ziel erreicht“-Animation (40k / 120k / 200k). </source>
@@ -4414,7 +4414,7 @@
     </unit>
     <unit id="saveSettings">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:246,248</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:247,249</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc> Speichern </source>
@@ -4422,7 +4422,7 @@
     </unit>
     <unit id="saving">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:250,251</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:251,252</note>
       </notes>
       <segment>
         <source>Speichert…</source>
@@ -4430,7 +4430,7 @@
     </unit>
     <unit id="saved">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:253,254</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:254,255</note>
       </notes>
       <segment>
         <source>Gespeichert.</source>
@@ -4438,7 +4438,7 @@
     </unit>
     <unit id="settings.remindersLinkTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:258,259</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:259,260</note>
       </notes>
       <segment>
         <source>🔔 Erinnerungen</source>
@@ -4446,7 +4446,7 @@
     </unit>
     <unit id="settings.remindersLinkDesc">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:260,262</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:261,263</note>
       </notes>
       <segment>
         <source> Liegestütz-Erinnerungen und Push-Benachrichtigungen konfigurieren. </source>
@@ -4454,7 +4454,7 @@
     </unit>
     <unit id="settings.remindersLinkCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:267,269</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:268,270</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications</pc> Erinnerungen verwalten </source>
@@ -4462,7 +4462,7 @@
     </unit>
     <unit id="settings.dangerZoneTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:273,274</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:274,275</note>
       </notes>
       <segment>
         <source>Danger Zone</source>
@@ -4470,7 +4470,7 @@
     </unit>
     <unit id="settings.dangerZoneBody">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:275,277</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:276,278</note>
       </notes>
       <segment>
         <source> Konto löschen entfernt dein Konto. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -4478,7 +4478,7 @@
     </unit>
     <unit id="settings.deleteAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:286,288</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:287,289</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Konto löschen </source>
@@ -4486,7 +4486,7 @@
     </unit>
     <unit id="settings.deletingAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:291,294</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:292,295</note>
       </notes>
       <segment>
         <source>Konto wird gelöscht…</source>
@@ -4494,7 +4494,7 @@
     </unit>
     <unit id="settings.deleteDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:298,300</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:299,301</note>
       </notes>
       <segment>
         <source> Account wirklich löschen? </source>
@@ -4502,7 +4502,7 @@
     </unit>
     <unit id="settings.deleteDialogWarning">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:302,304</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:303,305</note>
       </notes>
       <segment>
         <source> Achtung: Diese Aktion ist nicht rückgängig. </source>
@@ -4510,7 +4510,7 @@
     </unit>
     <unit id="settings.deleteDialogInfo">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:305,307</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:306,308</note>
       </notes>
       <segment>
         <source> Dein Konto wird gelöscht. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -4518,7 +4518,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:310,312</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:311,313</note>
       </notes>
       <segment>
         <source>Bestätigungswort eingeben</source>
@@ -4526,7 +4526,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:319,321</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:320,322</note>
       </notes>
       <segment>
         <source>Bitte exakt „löscchen“ eingeben.</source>
@@ -4534,7 +4534,7 @@
     </unit>
     <unit id="settings.deleteConfirmFinal">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:336,338</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:337,339</note>
       </notes>
       <segment>
         <source> Final löschen </source>
@@ -4542,7 +4542,7 @@
     </unit>
     <unit id="settings.publicProfile.share.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:543</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:550</note>
       </notes>
       <segment>
         <source>Mein Pushup Tracker Profil</source>
@@ -4550,7 +4550,7 @@
     </unit>
     <unit id="settings.publicProfile.share.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:544</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:551</note>
       </notes>
       <segment>
         <source>Schau dir mein Pushup-Profil an:</source>
@@ -5063,7 +5063,7 @@
     </unit>
     <unit id="trainingPlans.autoStartFailed">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:473</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:492</note>
       </notes>
       <segment>
         <source>Plan-Start fehlgeschlagen — bitte erneut versuchen.</source>
@@ -5071,7 +5071,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:540</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:559</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -5079,7 +5079,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:557</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:576</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
@@ -5087,7 +5087,7 @@
     </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:583</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:602</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:359</note>
       </notes>
       <segment>
@@ -5096,7 +5096,7 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:585</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:604</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:361</note>
       </notes>
       <segment>
@@ -5105,7 +5105,7 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:587</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:606</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:363</note>
       </notes>
       <segment>

--- a/web/src/server-locale-redirect.spec.ts
+++ b/web/src/server-locale-redirect.spec.ts
@@ -1,0 +1,158 @@
+import {
+  computeLocaleRedirect,
+  pickLocale,
+  type LocaleRedirectInput,
+} from './server-locale-redirect';
+
+function input(
+  overrides: Partial<LocaleRedirectInput> = {}
+): LocaleRedirectInput {
+  return {
+    method: 'GET',
+    path: '/u/abc123',
+    url: '/u/abc123',
+    acceptLanguage: undefined,
+    ...overrides,
+  };
+}
+
+describe('pickLocale', () => {
+  it.each([
+    [undefined, 'de'],
+    ['', 'de'],
+    ['de', 'de'],
+    ['de-DE', 'de'],
+    ['en', 'en'],
+    ['en-US', 'en'],
+    ['EN', 'en'],
+    // ANY presence of English in the header switches us to the en bundle.
+    // We deliberately don't parse q-values: so `de;q=0.9,en;q=0.1` still
+    // picks `en`. That's fine for our use case (most tools send a single
+    // primary language), and parsing q-values would be a maintenance trap
+    // for what's essentially a marketing-redirect heuristic.
+    ['de;q=0.5,en;q=0.3', 'en'],
+    ['en-GB,de;q=0.5', 'en'],
+    ['fr-FR', 'de'], // unsupported → source locale fallback
+    ['xen-fake', 'de'], // word boundary prevents matching `en` inside `xen`
+  ])('Given Accept-Language=%j, Then picks %s', (header, expected) => {
+    expect(pickLocale(header)).toBe(expected);
+  });
+});
+
+describe('computeLocaleRedirect', () => {
+  describe('Pass-through cases (no redirect)', () => {
+    it('Skips non-GET/HEAD methods', () => {
+      expect(computeLocaleRedirect(input({ method: 'POST' }))).toEqual({
+        kind: 'pass',
+      });
+      expect(computeLocaleRedirect(input({ method: 'PUT' }))).toEqual({
+        kind: 'pass',
+      });
+    });
+
+    it('Skips the root path (Angular SSR handles its own locale redirect)', () => {
+      expect(computeLocaleRedirect(input({ path: '/', url: '/' }))).toEqual({
+        kind: 'pass',
+      });
+    });
+
+    it('Skips already-prefixed paths', () => {
+      for (const path of ['/de', '/de/u/abc', '/en', '/en/login']) {
+        expect(computeLocaleRedirect(input({ path, url: path }))).toEqual({
+          kind: 'pass',
+        });
+      }
+    });
+
+    it('Skips well-known root files', () => {
+      for (const path of ['/robots.txt', '/sitemap.xml', '/ads.txt']) {
+        expect(computeLocaleRedirect(input({ path, url: path }))).toEqual({
+          kind: 'pass',
+        });
+      }
+    });
+
+    it('Skips paths whose last segment carries a file extension', () => {
+      expect(
+        computeLocaleRedirect(
+          input({ path: '/favicon.ico', url: '/favicon.ico' })
+        )
+      ).toEqual({ kind: 'pass' });
+      expect(
+        computeLocaleRedirect(
+          input({ path: '/assets/logo.png', url: '/assets/logo.png' })
+        )
+      ).toEqual({ kind: 'pass' });
+    });
+
+    it('Skips paths with characters outside the URL-safe app-route set', () => {
+      // Backslash, CR/LF, control characters, exotic Unicode — anything
+      // that could trick downstream Location parsing falls through.
+      for (const path of ['/\\evil', '/foo\r\nbar', '/<script>', '/u/ä']) {
+        expect(computeLocaleRedirect(input({ path, url: path }))).toEqual({
+          kind: 'pass',
+        });
+      }
+    });
+  });
+
+  describe('Redirect cases', () => {
+    it('Defaults to /de/<path> when Accept-Language is missing', () => {
+      expect(
+        computeLocaleRedirect(input({ path: '/u/abc', url: '/u/abc' }))
+      ).toEqual({ kind: 'redirect', location: '/de/u/abc' });
+    });
+
+    it('Picks /en when Accept-Language indicates English', () => {
+      expect(
+        computeLocaleRedirect(
+          input({
+            path: '/u/abc',
+            url: '/u/abc',
+            acceptLanguage: 'en-US,en;q=0.9',
+          })
+        )
+      ).toEqual({ kind: 'redirect', location: '/en/u/abc' });
+    });
+
+    it('Preserves the query string for routes like /login?returnUrl=…', () => {
+      // Regression: dropping the suffix used to break post-login navigation
+      // because `/login` reads `returnUrl`. Search is preserved verbatim
+      // (already URL-safe by construction in the app) but normalised
+      // through the URL parser to neutralise header-injection attempts.
+      expect(
+        computeLocaleRedirect(
+          input({
+            path: '/login',
+            url: '/login?returnUrl=/training-plans',
+          })
+        )
+      ).toEqual({
+        kind: 'redirect',
+        location: '/de/login?returnUrl=/training-plans',
+      });
+    });
+
+    it('URL-parses the search component so a fragment cannot leak into Location', () => {
+      const result = computeLocaleRedirect(
+        input({ path: '/u/abc', url: '/u/abc?x=1#frag' })
+      );
+      expect(result).toEqual({
+        kind: 'redirect',
+        location: '/de/u/abc?x=1',
+      });
+    });
+
+    it('Drops the suffix when URL parsing fails', () => {
+      // Defensive: an unparseable url string should still redirect, just
+      // without echoing the bogus suffix into the Location header.
+      const result = computeLocaleRedirect(
+        input({ path: '/u/abc', url: '\x00not-a-url' })
+      );
+      expect(result.kind).toBe('redirect');
+      expect((result as { location: string }).location).toMatch(
+        /^\/de\/u\/abc$/
+      );
+    });
+  });
+});

--- a/web/src/server-locale-redirect.ts
+++ b/web/src/server-locale-redirect.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure decision logic for the SSR locale-redirect middleware.
+ *
+ * Kept Express-free so the routing semantics are unit-testable without
+ * spinning up Supertest. The Express wrapper in `server.ts` only has to
+ * adapt request fields in and apply the result out.
+ *
+ * The middleware exists because Angular's i18n build registers app
+ * routes (`/u/:uid`, `/login`, `/leaderboard`, …) only inside the
+ * `/de/...` and `/en/...` bundles. Angular SSR's own locale middleware
+ * only redirects the bare root `/`; every other unprefixed path
+ * otherwise reaches the Angular app with no matching route and surfaces
+ * as Express's default `Cannot GET /<path>`.
+ */
+
+export interface LocaleRedirectInput {
+  /** HTTP method (e.g. `'GET'`). Only GET / HEAD are eligible for redirect. */
+  readonly method: string;
+  /** Pathname only, no query/hash (matches Express `req.path`). */
+  readonly path: string;
+  /** Full request URL, path + query + hash (matches Express `req.url`). */
+  readonly url: string;
+  /** Raw `Accept-Language` header value, may be undefined. */
+  readonly acceptLanguage: string | undefined;
+}
+
+export type LocaleRedirectResult =
+  | { readonly kind: 'pass' }
+  | { readonly kind: 'redirect'; readonly location: string };
+
+/** Locale prefixes registered by the Angular i18n build. */
+export const LOCALE_PREFIXES: ReadonlySet<string> = new Set(['de', 'en']);
+
+/**
+ * Files served from the domain root (rewritten to `/de/<file>` by an
+ * earlier middleware) — must NOT be redirected here, otherwise crawlers
+ * would land on `/de/robots.txt` instead of `/robots.txt`.
+ */
+export const ROOT_FILES: ReadonlySet<string> = new Set([
+  'ads.txt',
+  'robots.txt',
+  'sitemap.xml',
+]);
+
+/**
+ * Restricted to URL-safe app-route characters. Anything outside
+ * (backslashes, control characters, exotic Unicode) falls through to
+ * Angular instead of being redirected — defense-in-depth against
+ * open-redirect / header-injection through the `Location` header
+ * (CodeQL js/server-side-unvalidated-url-redirection).
+ */
+export const SAFE_REDIRECT_PATH_RE = /^\/[A-Za-z0-9/_\-.~%]*$/;
+
+/**
+ * Pick the source locale (`de`) by default, switch to `en` only when
+ * `Accept-Language` actually starts with English (after optional `,` /
+ * `;` separators between weighted entries). Avoids matching `de` in
+ * `de;q=0.5,en;q=0.3` — a `\ben` boundary is enough.
+ */
+export function pickLocale(acceptLanguage: string | undefined): 'de' | 'en' {
+  const accept = String(acceptLanguage ?? '').toLowerCase();
+  return /\ben(-|;|,|$)/.test(accept) ? 'en' : 'de';
+}
+
+/**
+ * Decide whether a request should be redirected to its locale-prefixed
+ * variant, and where to.
+ *
+ * Skipped (returns `pass`):
+ * - non-GET/HEAD methods
+ * - root path `/` (Angular SSR's own locale middleware handles it)
+ * - already-prefixed paths (`/de`, `/en`, and any subpath thereof)
+ * - well-known root files (rewritten by an earlier middleware)
+ * - paths with a file extension (static assets)
+ * - paths with characters outside `SAFE_REDIRECT_PATH_RE`
+ *
+ * The `Location` is built from `lang` (whitelisted) plus `path`
+ * (regex-validated). Query/hash is preserved by way of `url.search`
+ * after parsing — see test for header-injection edge cases — but we
+ * carry forward only the search component since none of the handled
+ * routes care about hash on the server side.
+ */
+export function computeLocaleRedirect(
+  input: LocaleRedirectInput
+): LocaleRedirectResult {
+  if (input.method !== 'GET' && input.method !== 'HEAD')
+    return { kind: 'pass' };
+  const path = input.path;
+  if (path === '/') return { kind: 'pass' };
+
+  const firstSegment = path.split('/')[1] ?? '';
+  if (LOCALE_PREFIXES.has(firstSegment)) return { kind: 'pass' };
+  if (ROOT_FILES.has(firstSegment)) return { kind: 'pass' };
+
+  const lastSegment = path.split('/').pop() ?? '';
+  if (lastSegment.includes('.')) return { kind: 'pass' };
+
+  if (!SAFE_REDIRECT_PATH_RE.test(path)) return { kind: 'pass' };
+
+  const lang = pickLocale(input.acceptLanguage);
+
+  // Preserve `?returnUrl=…` and similar load-bearing query params (e.g.
+  // for `/login`). We re-parse via `URL` against a synthetic base so the
+  // search component is normalised (encoded, no fragment, no host
+  // injection) before being concatenated into the Location header.
+  // Malformed URLs drop the suffix entirely rather than echo it back.
+  let search: string;
+  try {
+    search = new URL(input.url, 'http://internal.invalid').search;
+  } catch {
+    search = '';
+  }
+
+  return { kind: 'redirect', location: `/${lang}${path}${search}` };
+}

--- a/web/src/server.ts
+++ b/web/src/server.ts
@@ -97,7 +97,11 @@ app.use((req, res, next) => {
   // omitting it eliminates the second user-controlled string from the
   // Location header. The locale-prefixed app keeps its own routing, so a
   // crawler hitting `/u/<uid>` will still land on the right page.
-  res.setHeader('Vary', 'Accept-Language');
+  //
+  // `res.vary` (instead of `setHeader('Vary', ...)`) APPENDS to whatever
+  // upstream middleware (compression, CORS, …) may have already set —
+  // overwriting can quietly break caching semantics elsewhere.
+  res.vary('Accept-Language');
   res.redirect(302, `/${lang}${path}`);
 });
 

--- a/web/src/server.ts
+++ b/web/src/server.ts
@@ -12,6 +12,8 @@ import { join } from 'node:path';
 import { pino } from 'pino';
 import { pinoHttp } from 'pino-http';
 
+import { computeLocaleRedirect } from './server-locale-redirect';
+
 const isProduction = process.env['NODE_ENV'] === 'production';
 
 if (isProduction) {
@@ -56,54 +58,36 @@ app.use((req, res, next) => {
 // `/u/<uid>` (which only exist inside the locale-specific Angular bundles)
 // don't 404 with `Cannot GET /u/<uid>` when shared as a bare URL.
 //
-// Angular's own SSR locale middleware only handles the root `/` redirect;
-// every other unprefixed path is forwarded to Angular which has no matching
-// route. We bridge that gap here, picking the locale from `Accept-Language`
-// and falling back to the source locale `de`.
+// Pure decision logic + path/query validation lives in
+// `./server-locale-redirect` so the routing semantics are unit-tested
+// without spinning up Supertest. This wrapper only adapts request fields
+// in and applies the result out.
 //
-// Skipped:
-//  - already-prefixed paths (`/de`, `/en` and any subpath thereof)
-//  - well-known files rewritten to `/de/...` by the middleware above
-//  - paths with a file extension (static assets like `/favicon.ico`)
-//  - non-GET/HEAD methods (POSTs to API routes shouldn't be redirected)
-const LOCALE_PREFIXES = new Set(['de', 'en']);
-// Restrict path characters to the URL-safe app-route alphabet. Anything
-// outside this falls through to Angular instead of being redirected — this
-// is defense in depth against open-redirect / header-injection attacks
-// flowing from the user-controlled `req.url` into the `Location` header
-// (CodeQL js/server-side-unvalidated-url-redirection). Even though the
-// `/<lang>` prefix already constrains the redirect target to the same
-// origin, validating the dataflow source closes the finding cleanly.
-const SAFE_REDIRECT_PATH_RE = /^\/[A-Za-z0-9/_\-.~%]*$/;
-app.use((req, res, next) => {
-  if (req.method !== 'GET' && req.method !== 'HEAD') return next();
-  const path = req.path;
-  if (path === '/') return next();
-  const firstSegment = path.split('/')[1] ?? '';
-  if (LOCALE_PREFIXES.has(firstSegment)) return next();
-  if (rootFiles.has(firstSegment)) return next();
-  // Skip static assets (any path whose last segment carries a file extension).
-  const lastSegment = path.split('/').pop() ?? '';
-  if (lastSegment.includes('.')) return next();
-  // Reject anything outside the safe character class — keeps weird inputs
-  // (backslashes, CR/LF, control characters, exotic Unicode) out of the
-  // Location header instead of trying to sanitise them.
-  if (!SAFE_REDIRECT_PATH_RE.test(path)) return next();
-
-  const accept = String(req.headers['accept-language'] ?? '').toLowerCase();
-  const lang = /\ben(-|;|,|$)/.test(accept) ? 'en' : 'de';
-  // Drop the original query/hash entirely: it isn't load-bearing for any
-  // of the routes this redirect serves (`/u/<uid>`, `/login`, etc.) and
-  // omitting it eliminates the second user-controlled string from the
-  // Location header. The locale-prefixed app keeps its own routing, so a
-  // crawler hitting `/u/<uid>` will still land on the right page.
-  //
-  // `res.vary` (instead of `setHeader('Vary', ...)`) APPENDS to whatever
-  // upstream middleware (compression, CORS, …) may have already set —
-  // overwriting can quietly break caching semantics elsewhere.
-  res.vary('Accept-Language');
-  res.redirect(302, `/${lang}${path}`);
-});
+// Production-only: the Angular dev server (`nx serve`) shares this same
+// `reqHandler` but disables localization, so `/de/login` etc. don't
+// exist in dev builds. Redirecting unprefixed paths there breaks
+// `nx serve` and any e2e suite that hits `/login` directly. The locale
+// prefixes only really exist in the localized SSR build.
+//
+// `res.vary` (instead of `setHeader('Vary', ...)`) APPENDS to whatever
+// upstream middleware (compression, CORS, …) may have already set —
+// overwriting can quietly break caching semantics elsewhere.
+if (isProduction) {
+  app.use((req, res, next) => {
+    const result = computeLocaleRedirect({
+      method: req.method,
+      path: req.path,
+      url: req.originalUrl ?? req.url,
+      acceptLanguage:
+        typeof req.headers['accept-language'] === 'string'
+          ? req.headers['accept-language']
+          : undefined,
+    });
+    if (result.kind === 'pass') return next();
+    res.vary('Accept-Language');
+    res.redirect(302, result.location);
+  });
+}
 
 /**
  * Serve static files from /browser

--- a/web/src/server.ts
+++ b/web/src/server.ts
@@ -67,6 +67,14 @@ app.use((req, res, next) => {
 //  - paths with a file extension (static assets like `/favicon.ico`)
 //  - non-GET/HEAD methods (POSTs to API routes shouldn't be redirected)
 const LOCALE_PREFIXES = new Set(['de', 'en']);
+// Restrict path characters to the URL-safe app-route alphabet. Anything
+// outside this falls through to Angular instead of being redirected — this
+// is defense in depth against open-redirect / header-injection attacks
+// flowing from the user-controlled `req.url` into the `Location` header
+// (CodeQL js/server-side-unvalidated-url-redirection). Even though the
+// `/<lang>` prefix already constrains the redirect target to the same
+// origin, validating the dataflow source closes the finding cleanly.
+const SAFE_REDIRECT_PATH_RE = /^\/[A-Za-z0-9/_\-.~%]*$/;
 app.use((req, res, next) => {
   if (req.method !== 'GET' && req.method !== 'HEAD') return next();
   const path = req.path;
@@ -77,12 +85,20 @@ app.use((req, res, next) => {
   // Skip static assets (any path whose last segment carries a file extension).
   const lastSegment = path.split('/').pop() ?? '';
   if (lastSegment.includes('.')) return next();
+  // Reject anything outside the safe character class — keeps weird inputs
+  // (backslashes, CR/LF, control characters, exotic Unicode) out of the
+  // Location header instead of trying to sanitise them.
+  if (!SAFE_REDIRECT_PATH_RE.test(path)) return next();
 
   const accept = String(req.headers['accept-language'] ?? '').toLowerCase();
   const lang = /\ben(-|;|,|$)/.test(accept) ? 'en' : 'de';
-  const originalSuffix = req.url.slice(path.length);
+  // Drop the original query/hash entirely: it isn't load-bearing for any
+  // of the routes this redirect serves (`/u/<uid>`, `/login`, etc.) and
+  // omitting it eliminates the second user-controlled string from the
+  // Location header. The locale-prefixed app keeps its own routing, so a
+  // crawler hitting `/u/<uid>` will still land on the right page.
   res.setHeader('Vary', 'Accept-Language');
-  res.redirect(302, `/${lang}${path}${originalSuffix}`);
+  res.redirect(302, `/${lang}${path}`);
 });
 
 /**

--- a/web/src/server.ts
+++ b/web/src/server.ts
@@ -52,6 +52,39 @@ app.use((req, res, next) => {
   next();
 });
 
+// Redirect non-locale-prefixed app routes to /<lang>/... so paths like
+// `/u/<uid>` (which only exist inside the locale-specific Angular bundles)
+// don't 404 with `Cannot GET /u/<uid>` when shared as a bare URL.
+//
+// Angular's own SSR locale middleware only handles the root `/` redirect;
+// every other unprefixed path is forwarded to Angular which has no matching
+// route. We bridge that gap here, picking the locale from `Accept-Language`
+// and falling back to the source locale `de`.
+//
+// Skipped:
+//  - already-prefixed paths (`/de`, `/en` and any subpath thereof)
+//  - well-known files rewritten to `/de/...` by the middleware above
+//  - paths with a file extension (static assets like `/favicon.ico`)
+//  - non-GET/HEAD methods (POSTs to API routes shouldn't be redirected)
+const LOCALE_PREFIXES = new Set(['de', 'en']);
+app.use((req, res, next) => {
+  if (req.method !== 'GET' && req.method !== 'HEAD') return next();
+  const path = req.path;
+  if (path === '/') return next();
+  const firstSegment = path.split('/')[1] ?? '';
+  if (LOCALE_PREFIXES.has(firstSegment)) return next();
+  if (rootFiles.has(firstSegment)) return next();
+  // Skip static assets (any path whose last segment carries a file extension).
+  const lastSegment = path.split('/').pop() ?? '';
+  if (lastSegment.includes('.')) return next();
+
+  const accept = String(req.headers['accept-language'] ?? '').toLowerCase();
+  const lang = /\ben(-|;|,|$)/.test(accept) ? 'en' : 'de';
+  const originalSuffix = req.url.slice(path.length);
+  res.setHeader('Vary', 'Accept-Language');
+  res.redirect(302, `/${lang}${path}${originalSuffix}`);
+});
+
 /**
  * Serve static files from /browser
  */


### PR DESCRIPTION
## What's broken
Two issues found after the public-profile rollout went to production:

### 1. `Cannot GET /u/<uid>` for bare URLs
Sharing `https://pushup-stats.de/u/<uid>` (without locale prefix) returns Express's `Cannot GET /u/<uid>`. Angular's i18n build registers `/u/:uid` only inside the `/de/...` and `/en/...` bundles, and Angular's own SSR locale middleware only redirects the bare root `/`. Every other non-prefixed app route falls through to a 404.

### 2. OpenGraph metadata too short
[opengraph.xyz](https://www.opengraph.xyz/) flagged:
- Title 14 chars (optimal 50–60)
- Description 62 chars (optimal 110–160)
- Missing CTA in image
- Missing headline in image

The 14-char title was the static `index.html` `og:title` leaking through (the SSR `400` from PR #261 sent crawlers to the static fallback). But even the dynamic SSR title was below the optimal range and didn't include the user's stats.

## Fix

### Locale redirect in `server.ts`
New Express middleware between the well-known-files middleware and Angular's SSR handler. For any GET/HEAD request whose path:
- isn't `/`,
- isn't already locale-prefixed (`/de`, `/en`),
- isn't a well-known root file (`robots.txt`, `sitemap.xml`, `ads.txt`),
- and doesn't have a file extension on the last segment

it redirects `302` to `/<lang>{path}` where `<lang>` is `en` if `Accept-Language` matches `en` and `de` otherwise, with `Vary: Accept-Language` so caches don't poison each other. Existing shared `/u/<uid>` links work without the user noticing.

### OG metadata
- **Title** (~60 chars): `<name> – <total> Liegestütze · Streak <n> · Pushup Tracker`
- **Description** (~135 chars): `<name> hat <total> Liegestütze in <days> aktiven Tagen geschafft – aktuelle Streak: <n> Tage. Tracke selbst kostenlos auf pushup-stats.de.`
- **OG image card**: real headline `Pushup Tracker · Pushup-Profil` (instead of just the brand) + a prominent CTA footer `Selbst tracken — kostenlos auf pushup-stats.de` (instead of the bare `pushup-stats.de` domain). English variant: `Push-up profile` headline + `Track yours — free at pushup-stats.de` CTA.

### Share URLs include the locale prefix
`shareProfile()` (public profile component) and `profileUrl` (settings page) now build `https://pushup-stats.de/<lang>/u/<uid>` instead of the bare path. Defense in depth — if the recipient's tool strips 30x hops, they still land on the right Angular bundle.

## Test plan
- [x] `pnpm nx affected -t=lint,test,build -c=production --parallel=3` — green locally.
- [ ] After deploy, hit `https://pushup-stats.de/u/<opted-in-uid>` and confirm the 302 → `/de/u/<uid>` (or `/en/u/<uid>` with `Accept-Language: en`).
- [ ] Re-run https://www.opengraph.xyz/ on the prefixed URL: title and description should be in the optimal ranges and the OG image should show the new CTA footer.
- [ ] Click "Profil teilen" on Settings — clipboard / share-sheet text should now contain the locale-prefixed URL.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGKDZpVUBj489VTNAshbXo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced social sharing cards with localized messaging and improved typography
  * Automatic language detection and routing for shared profile links based on browser preferences
  * Dynamic profile statistics now display in social media previews

* **Bug Fixes**
  * Fixed profile share links to include locale prefix and prevent routing errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->