### PR TITLE
fix(observability): ensure Sentry source maps reach App Hosting bundles

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,6 +13,9 @@ env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN_WRITE }}
   # More heap for Angular SSR build + Playwright webServer in CI.
   NODE_OPTIONS: --max-old-space-size=6144
+  # Token for Sentry source map upload. The script (scripts/upload-sentry-sourcemaps.sh)
+  # is a no-op when this is empty, so deploys don't fail when the secret is unset.
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
@@ -52,9 +55,6 @@ jobs:
       - name: Build Cloud Functions
         run: pnpm nx run cloud-functions:build
       - name: Upload source maps to Sentry
-        if: env.SENTRY_AUTH_TOKEN != ''
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: pnpm sentry:sourcemaps
       - name: Prepare Hosting artifact
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,9 +308,12 @@ Stores consuming server-side precomputed data (e.g. `UserStats`) must validate p
   - **Browser:** Injected into HTML as `globalThis.SENTRY_RELEASE` by the upload script. Read by `Sentry.init()` in `main.ts`.
   - **Server:** Read from `process.env['GIT_SHA']` in `server.ts`.
   - **Cloud Functions:** Read from `process.env['SENTRY_RELEASE']` — written to `data-store/functions-dist/.env` by the upload script during CI deploy.
-- **Release lifecycle:** The deploy script (`scripts/upload-sentry-sourcemaps.sh`) creates a release, links commits (`set-commits --auto` for suspect commits), uploads source maps (web + Cloud Functions), and finalizes the release. Map files are deleted from build outputs after upload so they are not shipped to production.
+- **Release lifecycle:** The deploy script (`scripts/upload-sentry-sourcemaps.sh`) creates a release, links commits (`set-commits --auto --ignore-missing` for suspect commits), injects debug IDs, uploads source maps (web + Cloud Functions) with `--strict`, and finalizes the release. Map files are deleted from build outputs after upload so they are not shipped to production. The script is idempotent and a no-op if `SENTRY_AUTH_TOKEN` is unset, so local builds and uninitialized environments don't break.
 - **Config:** Org and project are set in `.sentryclirc`. DSN is hardcoded in `main.ts`, `server.ts`, and CF `index.ts`.
-- **GitHub Secret required:** `SENTRY_AUTH_TOKEN` — Sentry auth token with scopes `org:ci`, `project:releases`, `project:write`. The deploy step is skipped gracefully when the secret is absent.
+- **`SENTRY_AUTH_TOKEN` is needed in TWO places** (because two separate build pipelines deploy production code):
+  - **GitHub Actions** (Hosting + Functions deploy): repo Secret consumed by `firebase-hosting-merge.yml` job env.
+  - **Firebase App Hosting** (Cloud Run SSR build that serves `pushup-stats.de`): Cloud Secret Manager secret named `SENTRY_AUTH_TOKEN`, referenced as a `BUILD`-availability secret in `apphosting.yaml`. Without this, the bundles deployed to Cloud Run have debug IDs that don't match anything in Sentry → minified stack traces in production. One-time setup: `gcloud secrets create SENTRY_AUTH_TOKEN` + `firebase apphosting:secrets:grantaccess SENTRY_AUTH_TOKEN --backend pushup-stats-service`.
+- Token scopes: `org:ci`, `project:releases`, `project:write`. The deploy step is skipped gracefully when the secret is absent.
 
 ## Gotchas & Pitfalls
 

--- a/apphosting.staging.yaml
+++ b/apphosting.staging.yaml
@@ -12,5 +12,14 @@ env:
     availability:
       - RUNTIME
 
+  # Optional: tag staging events with the same commit-based release as prod so
+  # both share source maps. Falls through harmlessly if the staging project
+  # doesn't have the secret bound (script no-ops without the token).
+  - variable: SENTRY_AUTH_TOKEN
+    secret: SENTRY_AUTH_TOKEN
+    availability:
+      - BUILD
+
 scripts:
+  buildCommand: pnpm nx run web:build -c staging && pnpm sentry:sourcemaps
   runCommand: node dist/web/server/server.mjs

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -16,9 +16,26 @@ env:
     availability:
       - RUNTIME
 
+  # Sentry auth token for source map upload during App Hosting's build.
+  # App Hosting builds independently from GitHub Actions, so the bundles served
+  # at pushup-stats.de need their own debug-ID upload — otherwise Sentry can't
+  # match runtime stack traces to source maps.
+  #
+  # Setup (one-time, requires gcloud + Firebase project owner role):
+  #   gcloud secrets create SENTRY_AUTH_TOKEN --replication-policy=automatic
+  #   echo -n "<token>" | gcloud secrets versions add SENTRY_AUTH_TOKEN --data-file=-
+  #   firebase apphosting:secrets:grantaccess SENTRY_AUTH_TOKEN \
+  #     --backend pushup-stats-service --project pushup-stats
+  - variable: SENTRY_AUTH_TOKEN
+    secret: SENTRY_AUTH_TOKEN
+    availability:
+      - BUILD
+
 # Grant access to secrets in Cloud Secret Manager.
 # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters
-# - variable: MY_SECRET
-#   secret: mySecretRef
 scripts:
+  # Custom build: produce the Angular SSR artifact, then upload debug IDs +
+  # source maps to Sentry. The Sentry script is a no-op if SENTRY_AUTH_TOKEN
+  # is not bound, so the build still succeeds during initial bring-up.
+  buildCommand: pnpm nx run web:build -c production && pnpm sentry:sourcemaps
   runCommand: node dist/web/server/server.mjs

--- a/scripts/upload-sentry-sourcemaps.sh
+++ b/scripts/upload-sentry-sourcemaps.sh
@@ -1,55 +1,95 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Upload source maps to Sentry and create a release with commit tracking.
-# Requires SENTRY_AUTH_TOKEN env var. Org/project read from .sentryclirc.
-# Usage: pnpm sentry:sourcemaps
-set -e
+#
+# Per the Sentry Wizard guidance for Angular (sentry-cli ≥ 2.30):
+#   1. inject debug IDs into JS bundles + source maps
+#   2. upload them with the release tag
+#   3. delete .map files so they don't ship to production
+#
+# Idempotent and safe to run anywhere:
+#   - skips silently if SENTRY_AUTH_TOKEN is unset (so local builds + App Hosting
+#     builds without secrets configured don't break)
+#   - skips silently if dist/web doesn't exist (run before web build)
+#
+# Used by:
+#   - GitHub Actions deploy (Firebase Hosting + Functions): pnpm sentry:sourcemaps
+#   - Firebase App Hosting build (apphosting.yaml scripts.buildCommand)
+#
+# Org/project read from .sentryclirc.
 
-RELEASE=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+set -euo pipefail
 
-echo "Sentry release -- version: $RELEASE"
+# --- Preconditions ---
+if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+  echo "[sentry] SENTRY_AUTH_TOKEN not set — skipping source map upload."
+  exit 0
+fi
+
+if [ ! -d "dist/web" ]; then
+  echo "[sentry] dist/web not found — run web build first. Skipping."
+  exit 0
+fi
+
+# --- Resolve sentry-cli binary ---
+# Prefer the pinned @sentry/cli devDep over `npx` (deterministic, no re-download).
+if command -v pnpm >/dev/null 2>&1 && pnpm exec sentry-cli --version >/dev/null 2>&1; then
+  SENTRY_CLI=(pnpm exec sentry-cli)
+else
+  SENTRY_CLI=(npx --yes @sentry/cli)
+fi
+
+RELEASE="${SENTRY_RELEASE:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")}"
+export SENTRY_LOG_LEVEL="${SENTRY_LOG_LEVEL:-info}"
+
+echo "[sentry] release: $RELEASE"
+echo "[sentry] cli:     ${SENTRY_CLI[*]}"
 
 # --- Release lifecycle ---
-# Create a new release (idempotent — safe to re-run).
-npx sentry-cli releases new "$RELEASE"
+"${SENTRY_CLI[@]}" releases new "$RELEASE"
 
-# Link commits so Sentry can identify suspect commits for errors.
-npx sentry-cli releases set-commits "$RELEASE" --auto
+# Link commits for the "Suspect Commits" feature. --ignore-missing prevents the
+# step from failing when the GitHub integration isn't configured in Sentry org
+# settings (otherwise the deploy would fail on a non-critical link step).
+"${SENTRY_CLI[@]}" releases set-commits "$RELEASE" --auto --ignore-missing
 
-# --- Source maps ---
-# Inject SENTRY_RELEASE into browser HTML so the SDK picks it up at runtime.
-# Production build outputs localized dirs (de/, en/) each with index.html
-# and possibly index.csr.html (prerendered client-side fallback pages).
+# --- Web (browser + SSR server) ---
+# Inject runtime release ID into every HTML so main.ts can set Sentry.init({ release }).
+# Both index.html and index.csr.html are touched: prerendered routes use index.html;
+# SSR-only routes use index.csr.html as the SPA-shell template.
 find dist/web/browser \( -name "index.html" -o -name "index.csr.html" \) \
   -exec sed -i "s|</head>|<script>globalThis.SENTRY_RELEASE=\"${RELEASE}\";</script></head>|" {} \;
 
-# Inject debug IDs into JS bundles and their .map files.
-# This lets Sentry match errors to source maps without relying on release alone.
-npx sentry-cli sourcemaps inject dist/web
+# Inject debug IDs into JS bundles + .map files (matches errors to maps regardless of URL).
+"${SENTRY_CLI[@]}" sourcemaps inject dist/web
 
-# Upload source maps (browser + server) with release association.
-npx sentry-cli sourcemaps upload \
+# --strict: fail loudly if zero files are matched (silent skips were the historical bug).
+"${SENTRY_CLI[@]}" sourcemaps upload \
   --release="$RELEASE" \
+  --strict \
   dist/web
 
-# Upload Cloud Functions source maps (if built).
+# --- Cloud Functions (optional, only if previously built) ---
 if [ -d "data-store/functions-dist" ]; then
-  npx sentry-cli sourcemaps inject data-store/functions-dist
-  npx sentry-cli sourcemaps upload \
+  "${SENTRY_CLI[@]}" sourcemaps inject data-store/functions-dist
+  "${SENTRY_CLI[@]}" sourcemaps upload \
     --release="$RELEASE" \
+    --strict \
     data-store/functions-dist
-  find data-store/functions-dist -name "*.map" -delete 2>/dev/null || true
-  echo "Cloud Functions source maps uploaded."
 
-  # Write SENTRY_RELEASE to .env so Firebase Functions picks it up at runtime.
+  # Strip .map files from the deploy bundle (functions don't need them at runtime).
+  find data-store/functions-dist -name "*.map" -delete 2>/dev/null || true
+
+  # Surface the release to runtime so Sentry.init() in functions can tag events.
   echo "SENTRY_RELEASE=$RELEASE" >> data-store/functions-dist/.env
+  echo "[sentry] cloud functions: source maps uploaded, .map files stripped"
 fi
 
-# Delete .map files so they are not shipped to production.
+# --- Cleanup ---
+# Keep .map files out of the deployed web artifact (debug IDs are already injected
+# into the JS, so Sentry no longer needs the maps to be reachable via URL).
 find dist/web -name "*.map" -delete 2>/dev/null || true
 
-# --- Finalize release ---
-# Marks the release as complete. Enables release health tracking
-# (crash-free sessions/users) in Sentry.
-npx sentry-cli releases finalize "$RELEASE"
+# --- Finalize ---
+"${SENTRY_CLI[@]}" releases finalize "$RELEASE"
 
-echo "Release $RELEASE created, source maps uploaded, and cleaned up."
+echo "[sentry] release $RELEASE finalized"


### PR DESCRIPTION
## Problem

Production stack traces in Sentry are fully minified (e.g. PUSHUP-STATS-F at `https://pushup-stats.de/de/app`), even though releases are being created. Confirmed via Sentry MCP: snippets show literal HTML content from the SPA shell — the classic symptom of "Sentry has the release but no usable source maps".

## Root cause

`pushup-stats.de` is served by **Firebase App Hosting** (Cloud Run SSR — confirmed by the `x-deny-reason: host_not_allowed` SSR-side header that comes from `apphosting.yaml`'s `NG_ALLOWED_HOSTS` check). App Hosting builds independently in Google Cloud Build, **not** via the GitHub Actions workflow. The debug IDs uploaded by `firebase-hosting-merge.yml` belong to a different artifact than the bundles users actually load, so Sentry can never match them.

## Fix

- **`apphosting.yaml` + `apphosting.staging.yaml`**: bind `SENTRY_AUTH_TOKEN` as a `BUILD`-availability secret (Cloud Secret Manager) and override `scripts.buildCommand` so `pnpm sentry:sourcemaps` runs after the Angular build. One-time gcloud/firebase setup commands are inline in the YAML.
- **`scripts/upload-sentry-sourcemaps.sh`**: rewrite per the latest Sentry Wizard guidance.
  - `set -euo pipefail` + `--strict` on uploads (silent failures were the historical bug).
  - No-ops cleanly when `SENTRY_AUTH_TOKEN` or `dist/web` are absent, so local builds and uninitialized App Hosting backends don't break.
  - Prefer the pinned `@sentry/cli` devDep over `npx` (deterministic, no re-download).
  - `set-commits --auto --ignore-missing` so the deploy doesn't fail when the GitHub integration in Sentry isn't configured.
- **`firebase-hosting-merge.yml`**: move `SENTRY_AUTH_TOKEN` to job-level env, drop the redundant `if`-guard (script handles missing tokens itself).
- **`AGENTS.md`**: document that `SENTRY_AUTH_TOKEN` must be bound in **two** places (GitHub repo Secret + Cloud Secret Manager for App Hosting).

## Required one-time setup before this can work in prod

```bash
gcloud secrets create SENTRY_AUTH_TOKEN --replication-policy=automatic --project pushup-stats
echo -n "<token>" | gcloud secrets versions add SENTRY_AUTH_TOKEN --data-file=- --project pushup-stats
firebase apphosting:secrets:grantaccess SENTRY_AUTH_TOKEN \
  --backend pushup-stats-service --project pushup-stats
```

If the secret isn't bound yet, the App Hosting rollout will fail with "secret not found" — production keeps serving the previous version, no outage.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge + `deploy` promotion, App Hosting rollout completes successfully.
- [ ] `curl -s https://pushup-stats.de/de/main-*.js | grep _sentryDebugIds` returns a hit.
- [ ] A test exception thrown in DevTools on prod arrives in Sentry with an **un**minified stack trace within ~1 minute.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyWBbF3UWGFYKcnc1wTsu5)_