### PR TITLE
fix(observability): make Sentry upload script idempotent + scope token

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,9 +13,6 @@ env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN_WRITE }}
   # More heap for Angular SSR build + Playwright webServer in CI.
   NODE_OPTIONS: --max-old-space-size=6144
-  # Token for Sentry source map upload. The script (scripts/upload-sentry-sourcemaps.sh)
-  # is a no-op when this is empty, so deploys don't fail when the secret is unset.
-  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
@@ -55,6 +52,10 @@ jobs:
       - name: Build Cloud Functions
         run: pnpm nx run cloud-functions:build
       - name: Upload source maps to Sentry
+        # Scope the secret to this step only — script no-ops if the env is empty,
+        # so we don't need an explicit `if:` guard.
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: pnpm sentry:sourcemaps
       - name: Prepare Hosting artifact
         run: |

--- a/scripts/upload-sentry-sourcemaps.sh
+++ b/scripts/upload-sentry-sourcemaps.sh
@@ -56,32 +56,58 @@ echo "[sentry] cli:     ${SENTRY_CLI[*]}"
 # Inject runtime release ID into every HTML so main.ts can set Sentry.init({ release }).
 # Both index.html and index.csr.html are touched: prerendered routes use index.html;
 # SSR-only routes use index.csr.html as the SPA-shell template.
+# Idempotent: strip any prior SENTRY_RELEASE script tag before inserting the new one,
+# so re-running the script doesn't accumulate duplicate tags in the same HTML.
 find dist/web/browser \( -name "index.html" -o -name "index.csr.html" \) \
-  -exec sed -i "s|</head>|<script>globalThis.SENTRY_RELEASE=\"${RELEASE}\";</script></head>|" {} \;
+  -exec sed -i \
+    -e 's|<script>globalThis\.SENTRY_RELEASE="[^"]*";</script>||g' \
+    -e "s|</head>|<script>globalThis.SENTRY_RELEASE=\"${RELEASE}\";</script></head>|" \
+    {} \;
 
-# Inject debug IDs into JS bundles + .map files (matches errors to maps regardless of URL).
-"${SENTRY_CLI[@]}" sourcemaps inject dist/web
+# Skip inject/upload if no .map files remain in dist/web (e.g. a second run in the
+# same workspace where cleanup already deleted them). With --strict the upload
+# would otherwise abort the build for a no-op situation.
+WEB_MAP_COUNT=$(find dist/web -name "*.map" -type f 2>/dev/null | wc -l)
+if [ "$WEB_MAP_COUNT" -eq 0 ]; then
+  echo "[sentry] dist/web has no .map files — already uploaded? skipping web upload."
+else
+  # Inject debug IDs into JS bundles + .map files (matches errors to maps regardless of URL).
+  "${SENTRY_CLI[@]}" sourcemaps inject dist/web
 
-# --strict: fail loudly if zero files are matched (silent skips were the historical bug).
-"${SENTRY_CLI[@]}" sourcemaps upload \
-  --release="$RELEASE" \
-  --strict \
-  dist/web
-
-# --- Cloud Functions (optional, only if previously built) ---
-if [ -d "data-store/functions-dist" ]; then
-  "${SENTRY_CLI[@]}" sourcemaps inject data-store/functions-dist
+  # --strict: fail loudly if zero files are matched (silent skips were the historical bug).
   "${SENTRY_CLI[@]}" sourcemaps upload \
     --release="$RELEASE" \
     --strict \
-    data-store/functions-dist
+    dist/web
+fi
 
-  # Strip .map files from the deploy bundle (functions don't need them at runtime).
-  find data-store/functions-dist -name "*.map" -delete 2>/dev/null || true
+# --- Cloud Functions (optional, only if previously built) ---
+if [ -d "data-store/functions-dist" ]; then
+  CF_MAP_COUNT=$(find data-store/functions-dist -name "*.map" -type f 2>/dev/null | wc -l)
+  if [ "$CF_MAP_COUNT" -eq 0 ]; then
+    echo "[sentry] data-store/functions-dist has no .map files — skipping CF upload."
+  else
+    "${SENTRY_CLI[@]}" sourcemaps inject data-store/functions-dist
+    "${SENTRY_CLI[@]}" sourcemaps upload \
+      --release="$RELEASE" \
+      --strict \
+      data-store/functions-dist
+
+    # Strip .map files from the deploy bundle (functions don't need them at runtime).
+    find data-store/functions-dist -name "*.map" -delete 2>/dev/null || true
+    echo "[sentry] cloud functions: source maps uploaded, .map files stripped"
+  fi
 
   # Surface the release to runtime so Sentry.init() in functions can tag events.
-  echo "SENTRY_RELEASE=$RELEASE" >> data-store/functions-dist/.env
-  echo "[sentry] cloud functions: source maps uploaded, .map files stripped"
+  # Replace any existing SENTRY_RELEASE line instead of appending — avoids
+  # duplicate keys in .env if the script runs more than once on the same dist.
+  ENV_FILE="data-store/functions-dist/.env"
+  touch "$ENV_FILE"
+  if grep -q '^SENTRY_RELEASE=' "$ENV_FILE"; then
+    sed -i "s|^SENTRY_RELEASE=.*|SENTRY_RELEASE=$RELEASE|" "$ENV_FILE"
+  else
+    echo "SENTRY_RELEASE=$RELEASE" >> "$ENV_FILE"
+  fi
 fi
 
 # --- Cleanup ---


### PR DESCRIPTION
## Follow-up to #263

Addresses review feedback from the Sentry source maps PR. None of these are urgent for the current deploy (a fresh build always has clean `dist/`), but they harden the script against re-runs and tighten secret scope.

## Changes

- **HTML injection idempotency** *(Copilot)*: `sed` first strips any existing `globalThis.SENTRY_RELEASE` script tag before inserting the new one. Re-running on the same `dist/` no longer accumulates duplicate tags. Verified locally — exactly one tag remains after multiple runs.

- **`--strict` re-run safety** *(Copilot)*: the script deletes `.map` files at the end of a successful run; a second run would have hit `--strict` with zero matches and aborted the build. Now both `dist/web` and `data-store/functions-dist` skip inject/upload when no `.map` files exist.

- **`.env` replace, not append** *(Copilot)*: `SENTRY_RELEASE=` is now substituted in `data-store/functions-dist/.env` (or appended only if absent). No more stale duplicate keys after re-runs. Other env keys are preserved.

- **Step-scoped token** *(Copilot)*: `SENTRY_AUTH_TOKEN` moved from job-level back to the `Upload source maps to Sentry` step only. The script no-ops when the env is empty, so no `if:` guard is needed.

## Intentionally not changed

- **Codex P1 on `apphosting.staging.yaml`**: the user explicitly edited the file after the merge to keep the `SENTRY_AUTH_TOKEN` secret reference. They've indicated awareness, so this stays as-is. If the staging GCP project doesn't have the secret created/granted, App Hosting rollouts there will fail with "secret not found" — the production deploy is unaffected.

## Test plan

Local idempotency smoke-test (in this PR's branch):
```bash
# Two runs against the same dist/ produce exactly one SENTRY_RELEASE tag
# and don't crash the second run with --strict.
# Verified: single tag in HTML, no duplicate SENTRY_RELEASE= in .env.
```

- [ ] CI green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyWBbF3UWGFYKcnc1wTsu5)_