### PR TITLE
feat(public-profile): dashboard-share + leaderboard linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,15 @@ jobs:
         # Dynamic agent allocation: small PRs use 4 agents, large changesets
         # scale up to 10 so the 5-shard e2e-ci target finishes in one round
         # instead of two. Config: .nx/workflows/distribution-config.yaml
-        run: pnpm nx-cloud start-ci-run --distribute-on=".nx/workflows/distribution-config.yaml" --stop-agents-after="e2e-ci"
+        #
+        # `--with-env-vars="NODE_OPTIONS"` forwards the orchestrator's
+        # `NODE_OPTIONS=--max-old-space-size=4096` env to every agent's task
+        # process. Without this flag, agents would run with V8's default
+        # ~2 GB old-space heap regardless of what we set on the GH job, and
+        # heavy targets (Angular SSR build, Vitest with Firebase/Material)
+        # would GC-thrash or OOM only on the agent side.
+        # Docs: https://nx.dev/docs/reference/nx-cloud/launch-templates
+        run: pnpm nx-cloud start-ci-run --distribute-on=".nx/workflows/distribution-config.yaml" --stop-agents-after="e2e-ci" --with-env-vars="NODE_OPTIONS"
 
       - name: Nx affected (lint + test + build)
         run: pnpm nx affected -t=lint,test,build,e2e-ci -c=production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,13 @@ jobs:
             && secrets.NX_CLOUD_ACCESS_TOKEN_WRITE
           || secrets.NX_CLOUD_ACCESS_TOKEN_READ
         }}
-      # More heap for Angular SSR build + Playwright webServer in CI.
-      NODE_OPTIONS: --max-old-space-size=6144
+      # 4 GB Node heap for the orchestrator job (`lint-test-build`). High
+      # enough for the Angular SSR build + Playwright webServer in CI, and
+      # matches the per-agent heap configured in
+      # `.nx/workflows/distribution-config.yaml` so a task can run on
+      # either side without a different OOM threshold. Bump in lockstep
+      # with the agent setting if the heavy targets ever need more.
+      NODE_OPTIONS: --max-old-space-size=4096
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.nx/workflows/distribution-config.yaml
+++ b/.nx/workflows/distribution-config.yaml
@@ -6,22 +6,15 @@
 #
 # Referenced from .github/workflows/ci.yml via
 #   pnpm nx-cloud start-ci-run --distribute-on=.nx/workflows/distribution-config.yaml
-
-# Custom launch template wrapping `linux-medium-js` with a 4 GB Node heap.
-# Default `linux-medium-js` agents have 8 GB total RAM but only the V8
-# default ~2 GB old-space heap, which is too tight for the Angular SSR build
-# + heavy Vitest suites with Firebase/Material — symptoms range from slow
-# GC thrashing to outright OOM. Match the orchestrator's `NODE_OPTIONS` in
-# `.github/workflows/ci.yml` so a task hits the same heap ceiling whether it
-# runs on the GH runner or an Nx Cloud agent.
-launch-templates:
-  linux-medium-js-4gb:
-    resource-class: linux-medium-js
-    env:
-      NODE_OPTIONS: '--max-old-space-size=4096'
-
+#
+# Per-agent Node heap is bumped to 4 GB via `NODE_OPTIONS` forwarded from
+# the orchestrator (`.github/workflows/ci.yml`) — `nx-cloud start-ci-run`
+# propagates `NODE_OPTIONS` to agent task execution by default. If we ever
+# need to override env on a per-agent basis (different heap per
+# resource-class), switch to `launch-templates` per the Nx Cloud workflow
+# schema docs.
 distribute-on:
-  small-changeset: 4 linux-medium-js-4gb
-  medium-changeset: 6 linux-medium-js-4gb
-  large-changeset: 8 linux-medium-js-4gb
-  extra-large-changeset: 10 linux-medium-js-4gb
+  small-changeset: 4 linux-medium-js
+  medium-changeset: 6 linux-medium-js
+  large-changeset: 8 linux-medium-js
+  extra-large-changeset: 10 linux-medium-js

--- a/.nx/workflows/distribution-config.yaml
+++ b/.nx/workflows/distribution-config.yaml
@@ -7,12 +7,13 @@
 # Referenced from .github/workflows/ci.yml via
 #   pnpm nx-cloud start-ci-run --distribute-on=.nx/workflows/distribution-config.yaml
 #
-# Per-agent Node heap is bumped to 4 GB via `NODE_OPTIONS` forwarded from
-# the orchestrator (`.github/workflows/ci.yml`) — `nx-cloud start-ci-run`
-# propagates `NODE_OPTIONS` to agent task execution by default. If we ever
-# need to override env on a per-agent basis (different heap per
-# resource-class), switch to `launch-templates` per the Nx Cloud workflow
-# schema docs.
+# Per-agent Node heap is set to 4 GB via `NODE_OPTIONS` forwarded from the
+# orchestrator. The orchestrator (`.github/workflows/ci.yml`) sets the env
+# var on the GH job AND passes `--with-env-vars="NODE_OPTIONS"` to
+# `nx-cloud start-ci-run` — without that flag agents inherit the V8
+# default (~2 GB old-space heap) regardless of what the orchestrator job
+# env says. See the start-ci-run step in the workflow file for the full
+# rationale; this file only declares the agent pool sizes.
 distribute-on:
   small-changeset: 4 linux-medium-js
   medium-changeset: 6 linux-medium-js

--- a/.nx/workflows/distribution-config.yaml
+++ b/.nx/workflows/distribution-config.yaml
@@ -6,8 +6,22 @@
 #
 # Referenced from .github/workflows/ci.yml via
 #   pnpm nx-cloud start-ci-run --distribute-on=.nx/workflows/distribution-config.yaml
+
+# Custom launch template wrapping `linux-medium-js` with a 4 GB Node heap.
+# Default `linux-medium-js` agents have 8 GB total RAM but only the V8
+# default ~2 GB old-space heap, which is too tight for the Angular SSR build
+# + heavy Vitest suites with Firebase/Material — symptoms range from slow
+# GC thrashing to outright OOM. Match the orchestrator's `NODE_OPTIONS` in
+# `.github/workflows/ci.yml` so a task hits the same heap ceiling whether it
+# runs on the GH runner or an Nx Cloud agent.
+launch-templates:
+  linux-medium-js-4gb:
+    resource-class: linux-medium-js
+    env:
+      NODE_OPTIONS: '--max-old-space-size=4096'
+
 distribute-on:
-  small-changeset: 4 linux-medium-js
-  medium-changeset: 6 linux-medium-js
-  large-changeset: 8 linux-medium-js
-  extra-large-changeset: 10 linux-medium-js
+  small-changeset: 4 linux-medium-js-4gb
+  medium-changeset: 6 linux-medium-js-4gb
+  large-changeset: 8 linux-medium-js-4gb
+  extra-large-changeset: 10 linux-medium-js-4gb

--- a/data-store/functions/src/leaderboard/logic.spec.ts
+++ b/data-store/functions/src/leaderboard/logic.spec.ts
@@ -79,6 +79,74 @@ describe('leaderboard/logic', () => {
       expect(result[1]).toEqual({ alias: 'Alice', reps: 10 });
     });
 
+    describe('uid attachment for public-profile linking', () => {
+      it('attaches uid only when both leaderboard + publicProfile opt-ins are on', () => {
+        const rows: PushupRow[] = [
+          { userId: 'optedIn', timestamp: '2024-03-15T10:00:00Z', reps: 30 },
+          { userId: 'leaderOnly', timestamp: '2024-03-15T10:00:00Z', reps: 20 },
+          {
+            userId: 'profileOnly',
+            timestamp: '2024-03-15T10:00:00Z',
+            reps: 10,
+          },
+        ];
+        const profiles = new Map<string, UserProfile>([
+          [
+            'optedIn',
+            {
+              displayName: 'Alice',
+              ui: { hideFromLeaderboard: false, publicProfile: true },
+            },
+          ],
+          [
+            'leaderOnly',
+            {
+              displayName: 'Bob',
+              ui: { hideFromLeaderboard: false, publicProfile: false },
+            },
+          ],
+          [
+            'profileOnly',
+            {
+              displayName: 'Carol',
+              ui: { hideFromLeaderboard: true, publicProfile: true },
+            },
+          ],
+        ]);
+
+        const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
+
+        expect(result[0]).toEqual({
+          alias: 'Alice',
+          reps: 30,
+          uid: 'optedIn',
+        });
+        // Leaderboard-only user: name shown but no link.
+        expect(result[1]).toEqual({ alias: 'Bob', reps: 20 });
+        expect(result[1].uid).toBeUndefined();
+        // Public-profile user who hid from the leaderboard stays anonymous
+        // and never gets a link — leaderboard alias is `anonym`, so a UID
+        // would let attackers correlate that anonymous row to a real
+        // profile.
+        expect(result[2]).toEqual({ alias: 'anonym', reps: 10 });
+        expect(result[2].uid).toBeUndefined();
+      });
+
+      it('omits uid for profiles missing the ui block entirely', () => {
+        const rows: PushupRow[] = [
+          { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 10 },
+        ];
+        const profiles = new Map<string, UserProfile>([
+          ['user1', { displayName: 'Alice' }],
+        ]);
+
+        const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
+
+        // Defaults to private — no opt-in, no uid.
+        expect(result[0].uid).toBeUndefined();
+      });
+    });
+
     it('uses anonymous label for users without profiles', () => {
       const rows: PushupRow[] = [
         { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 10 },

--- a/data-store/functions/src/leaderboard/logic.spec.ts
+++ b/data-store/functions/src/leaderboard/logic.spec.ts
@@ -145,6 +145,42 @@ describe('leaderboard/logic', () => {
         // Defaults to private — no opt-in, no uid.
         expect(result[0].uid).toBeUndefined();
       });
+
+      it('omits uid when displayName is empty/whitespace even with both opt-ins', () => {
+        // Privacy regression: a user with an empty `displayName` would
+        // render as `anonym` via `toPublicDisplayName`'s fallback. If the
+        // row also carried a `uid`, the visible "anonym" label would
+        // become correlatable to a stable `/u/<uid>` permalink — leaking
+        // identity through what looks like an anonymous row. Block the
+        // UID until the user actually has a display name.
+        const rows: PushupRow[] = [
+          { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 10 },
+          { userId: 'user2', timestamp: '2024-03-15T10:00:00Z', reps: 20 },
+        ];
+        const profiles = new Map<string, UserProfile>([
+          [
+            'user1',
+            {
+              displayName: '',
+              ui: { hideFromLeaderboard: false, publicProfile: true },
+            },
+          ],
+          [
+            'user2',
+            {
+              displayName: '   ',
+              ui: { hideFromLeaderboard: false, publicProfile: true },
+            },
+          ],
+        ]);
+
+        const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
+
+        for (const entry of result) {
+          expect(entry.alias).toBe('anonym');
+          expect(entry.uid).toBeUndefined();
+        }
+      });
     });
 
     it('uses anonymous label for users without profiles', () => {

--- a/data-store/functions/src/leaderboard/logic.ts
+++ b/data-store/functions/src/leaderboard/logic.ts
@@ -7,6 +7,7 @@ import { berlinDateParts, BerlinDateParts } from '../datetime';
 import {
   toPublicDisplayName,
   isLeaderboardNameAllowed,
+  isPublicProfileLinkAllowed,
   toAnonymousLabel,
   UserProfile,
 } from '../profile';
@@ -20,6 +21,14 @@ export interface PushupRow {
 export interface LeaderboardEntry {
   alias: string;
   reps: number;
+  /**
+   * UID is only populated when the user opted into BOTH the leaderboard
+   * (`ui.hideFromLeaderboard === false`) AND a public profile
+   * (`ui.publicProfile === true`). Frontend renders entries with `uid`
+   * as links to `/u/<uid>`; entries without `uid` stay plain text.
+   * Anonymous-aliased rows (leaderboard opt-out) never carry a UID.
+   */
+  uid?: string;
 }
 
 export interface LeaderboardPeriods {
@@ -121,7 +130,14 @@ export function rankEntries(
       const alias = isLeaderboardNameAllowed(profile)
         ? toPublicDisplayName(profile)
         : toAnonymousLabel();
-      return { alias, reps };
+      // Only attach a UID when both leaderboard-visibility and
+      // public-profile opt-ins are on — otherwise the row stays plain
+      // text on the frontend and the user's stats can't be deeplinked.
+      const entry: LeaderboardEntry = { alias, reps };
+      if (isPublicProfileLinkAllowed(profile)) {
+        entry.uid = userId;
+      }
+      return entry;
     })
     .sort((a, b) => b.reps - a.reps)
     .slice(0, TOP_N);

--- a/data-store/functions/src/profile/logic.ts
+++ b/data-store/functions/src/profile/logic.ts
@@ -45,13 +45,18 @@ export function isLeaderboardNameAllowed(profile?: UserProfile): boolean {
  * Whether a leaderboard entry should carry the user's UID so the frontend
  * can link to `/u/<uid>`.
  *
- * Two independent opt-ins: the leaderboard name has to be allowed (so the
- * displayed `alias` is the real name, not `anonym`) AND the user must
- * have explicitly enabled the public profile. Either flag missing → no
- * UID, no link, the row stays a plain text entry.
+ * Three independent gates:
+ * 1. Leaderboard name is allowed (`hideFromLeaderboard === false`) so the
+ *    displayed alias is the real name.
+ * 2. Public profile is enabled (`publicProfile === true`).
+ * 3. `displayName` is non-empty after trimming. Without this, a user with
+ *    both opt-ins but a blank name would render as `anonym` (via
+ *    `toPublicDisplayName`'s fallback) AND get a clickable `/u/<uid>` —
+ *    a stable, profile-correlatable handle hiding behind an apparently
+ *    anonymous alias. The third gate forecloses that leak.
  */
 export function isPublicProfileLinkAllowed(profile?: UserProfile): boolean {
-  return (
-    isLeaderboardNameAllowed(profile) && profile?.ui?.publicProfile === true
-  );
+  if (!isLeaderboardNameAllowed(profile)) return false;
+  if (profile?.ui?.publicProfile !== true) return false;
+  return String(profile?.displayName || '').trim().length > 0;
 }

--- a/data-store/functions/src/profile/logic.ts
+++ b/data-store/functions/src/profile/logic.ts
@@ -5,7 +5,7 @@
 
 export interface UserProfile {
   displayName?: string;
-  ui?: { hideFromLeaderboard?: boolean };
+  ui?: { hideFromLeaderboard?: boolean; publicProfile?: boolean };
   role?: string;
 }
 
@@ -39,4 +39,19 @@ export function toPublicDisplayName(profile?: UserProfile): string {
  */
 export function isLeaderboardNameAllowed(profile?: UserProfile): boolean {
   return profile?.ui?.hideFromLeaderboard === false;
+}
+
+/**
+ * Whether a leaderboard entry should carry the user's UID so the frontend
+ * can link to `/u/<uid>`.
+ *
+ * Two independent opt-ins: the leaderboard name has to be allowed (so the
+ * displayed `alias` is the real name, not `anonym`) AND the user must
+ * have explicitly enabled the public profile. Either flag missing → no
+ * UID, no link, the row stays a plain text entry.
+ */
+export function isPublicProfileLinkAllowed(profile?: UserProfile): boolean {
+  return (
+    isLeaderboardNameAllowed(profile) && profile?.ui?.publicProfile === true
+  );
 }

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -20,6 +20,14 @@ export type LeaderboardEntry = {
   reps: number;
   rank: number;
   isCurrent?: boolean;
+  /**
+   * UID is present iff the user opted into BOTH the leaderboard
+   * (`ui.hideFromLeaderboard === false`) AND a public profile
+   * (`ui.publicProfile === true`). When set, the frontend renders the
+   * row as a link to `/u/<uid>`; when missing, the row stays plain text.
+   * Anonymous-aliased rows never carry a UID.
+   */
+  uid?: string;
 };
 
 export type LeaderboardBucket = {
@@ -104,20 +112,26 @@ export class LeaderboardService {
 
     const data = snap.data() as {
       periods?: Partial<
-        Record<LeaderboardPeriod, Array<{ alias: string; reps: number }>>
+        Record<
+          LeaderboardPeriod,
+          Array<{ alias: string; reps: number; uid?: string }>
+        >
       >;
     };
 
     const periods = data?.periods;
     if (!periods) return null;
 
-    const mapTop = (arr: Array<{ alias: string; reps: number }>) =>
+    const mapTop = (
+      arr: Array<{ alias: string; reps: number; uid?: string }>
+    ) =>
       arr.slice(0, TOP_N).map((entry, i) => ({
         alias: entry.alias,
         reps: entry.reps,
         rank: i + 1,
         isCurrent:
           !!currentUserId && entry.alias === this.toAlias(currentUserId),
+        ...(entry.uid ? { uid: entry.uid } : {}),
       }));
 
     // Only include keys that are actually present on the snapshot. An

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -129,8 +129,18 @@ export class LeaderboardService {
         alias: entry.alias,
         reps: entry.reps,
         rank: i + 1,
-        isCurrent:
-          !!currentUserId && entry.alias === this.toAlias(currentUserId),
+        // Prefer matching the snapshot row by `uid` (exact identity) when
+        // it's present — snapshot aliases are real display names, so the
+        // obfuscated `toAlias(currentUserId)` form would never match a
+        // public-profile-opted-in user and `mergeBucket()` would fall
+        // back to the client-side `current` unnecessarily. Older
+        // snapshots without `uid` keep the alias-based fallback so the
+        // rollout doesn't lose the highlight in flight.
+        isCurrent: currentUserId
+          ? entry.uid
+            ? entry.uid === currentUserId
+            : entry.alias === this.toAlias(currentUserId)
+          : false,
         ...(entry.uid ? { uid: entry.uid } : {}),
       }));
 

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.html
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.html
@@ -56,8 +56,9 @@
                 class="alias alias-link"
                 [routerLink]="['/u', entry.uid]"
                 [attr.data-testid]="'leaderboard-link-' + entry.rank"
-                >{{ entry.alias }}</a
               >
+                {{ entry.alias }}
+              </a>
             } @else {
               <span class="alias">{{ entry.alias }}</span>
             }

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.html
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.html
@@ -47,7 +47,20 @@
         @for (entry of leaderboardSlots(); track entry.rank) {
           <li>
             <span class="rank">#{{ entry.rank }}</span>
-            <span class="alias">{{ entry.alias }}</span>
+            <!-- Link the alias to /u/<uid> only when the user opted into a
+                 public profile AND the leaderboard. Without uid, the row is
+                 either anonymous or the user opted out of profile linking,
+                 so we keep it as plain text. -->
+            @if (entry.uid) {
+              <a
+                class="alias alias-link"
+                [routerLink]="['/u', entry.uid]"
+                [attr.data-testid]="'leaderboard-link-' + entry.rank"
+                >{{ entry.alias }}</a
+              >
+            } @else {
+              <span class="alias">{{ entry.alias }}</span>
+            }
             <strong
               >{{ entry.reps }}
               <span i18n="@@landing.leaderboard.reps">Reps</span></strong

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.scss
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.scss
@@ -39,6 +39,28 @@ li {
   min-width: 2.5rem;
 }
 
+.alias-link {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: rgba(143, 180, 255, 0.55);
+  text-underline-offset: 3px;
+  transition:
+    color 120ms ease,
+    text-decoration-color 120ms ease;
+
+  &:hover,
+  &:focus-visible {
+    color: #cfe0ff;
+    text-decoration-color: #cfe0ff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #8fb4ff;
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+}
+
 .own-rank {
   margin-top: 10px;
   color: #9bd8c3;

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.scss
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.scss
@@ -80,4 +80,21 @@ li {
     border-color: #2563eb;
     background: rgba(59, 130, 246, 0.15);
   }
+
+  // Dark-theme link colours (`#cfe0ff` etc.) are unreadable against the
+  // white mat-card surface in light theme. Override with a darker blue
+  // that hits WCAG AA on the same background.
+  .alias-link {
+    text-decoration-color: rgba(37, 99, 235, 0.55);
+
+    &:hover,
+    &:focus-visible {
+      color: #1d4ed8;
+      text-decoration-color: #1d4ed8;
+    }
+
+    &:focus-visible {
+      outline-color: #2563eb;
+    }
+  }
 }

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.spec.ts
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.spec.ts
@@ -1,0 +1,115 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { signal } from '@angular/core';
+import {
+  type LeaderboardEntry,
+  type LeaderboardPeriod,
+  LeaderboardStore,
+} from '@pu-stats/data-access';
+import { LeaderboardPageComponent } from './leaderboard-page.component';
+
+/**
+ * Frontend privacy guard: leaderboard rows only become a `<a>` linking to
+ * `/u/<uid>` when the cloud function attached a `uid` (which itself
+ * requires both leaderboard + publicProfile opt-ins). Anonymous-aliased
+ * rows or opted-out users must stay plain text — these tests fail loudly
+ * if the template ever degrades that contract.
+ */
+describe('LeaderboardPageComponent', () => {
+  let fixture: ComponentFixture<LeaderboardPageComponent>;
+  const entriesByPeriod: Record<LeaderboardPeriod, LeaderboardEntry[]> = {
+    daily: [],
+    last7: [],
+    last30: [],
+  };
+
+  const storeMock = {
+    entriesForPeriod: (
+      period: () => LeaderboardPeriod
+    ): (() => LeaderboardEntry[]) =>
+      signal<LeaderboardEntry[]>(entriesByPeriod[period()]).asReadonly(),
+    currentUserForPeriod: (): (() => LeaderboardEntry | null) =>
+      signal<LeaderboardEntry | null>(null).asReadonly(),
+    load: vitest.fn(),
+  };
+
+  async function setup(entries: LeaderboardEntry[]): Promise<void> {
+    entriesByPeriod.daily = entries;
+    entriesByPeriod.last7 = entries;
+    entriesByPeriod.last30 = entries;
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [LeaderboardPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: LeaderboardStore, useValue: storeMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LeaderboardPageComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  describe('Given an entry with uid (both opt-ins on)', () => {
+    it('Then the alias is rendered as a router link to /u/<uid>', async () => {
+      await setup([{ rank: 1, alias: 'Alice', reps: 100, uid: 'abc123' }]);
+
+      const root = fixture.nativeElement as HTMLElement;
+      const link = root.querySelector(
+        '[data-testid="leaderboard-link-1"]'
+      ) as HTMLAnchorElement | null;
+      expect(link).not.toBeNull();
+      expect(link!.tagName).toBe('A');
+      expect(link!.classList.contains('alias-link')).toBe(true);
+      // routerLink="['/u', 'abc123']" → href in test = `/u/abc123`.
+      expect(link!.getAttribute('href')).toBe('/u/abc123');
+      expect(link!.textContent?.trim()).toBe('Alice');
+    });
+  });
+
+  describe('Given an entry without uid (opted-out / anonymous)', () => {
+    it('Then the alias is rendered as a plain span — never clickable', async () => {
+      await setup([{ rank: 2, alias: 'anonym', reps: 50 }]);
+
+      const root = fixture.nativeElement as HTMLElement;
+      // Privacy regression: an anonymous-aliased row must NEVER carry an
+      // anchor, otherwise the visible "anonym" label would be linkable
+      // to a stable profile permalink.
+      expect(
+        root.querySelector('[data-testid="leaderboard-link-2"]')
+      ).toBeNull();
+      // Find the span that holds the alias text — it must not be inside an <a>.
+      const spans = Array.from(
+        root.querySelectorAll('li span.alias')
+      ) as HTMLElement[];
+      const aliasSpan = spans.find((s) => s.textContent?.trim() === 'anonym');
+      expect(aliasSpan).toBeDefined();
+      expect(aliasSpan!.closest('a')).toBeNull();
+    });
+  });
+
+  describe('Given a mix of entries', () => {
+    it('Then only opted-in rows are linked, opted-out rows stay plain text', async () => {
+      await setup([
+        { rank: 1, alias: 'Alice', reps: 100, uid: 'aaa' },
+        { rank: 2, alias: 'anonym', reps: 80 },
+        { rank: 3, alias: 'Bob', reps: 60 },
+      ]);
+
+      const root = fixture.nativeElement as HTMLElement;
+      expect(
+        root.querySelector('[data-testid="leaderboard-link-1"]')
+      ).not.toBeNull();
+      expect(
+        root.querySelector('[data-testid="leaderboard-link-2"]')
+      ).toBeNull();
+      // Bob has no uid → plain span, no link.
+      expect(
+        root.querySelector('[data-testid="leaderboard-link-3"]')
+      ).toBeNull();
+    });
+  });
+});

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.ts
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.ts
@@ -1,16 +1,12 @@
-import {
-  Component,
-  computed,
-  inject,
-  linkedSignal,
-} from '@angular/core';
+import { Component, computed, inject, linkedSignal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { RouterLink } from '@angular/router';
 import { LeaderboardPeriod, LeaderboardStore } from '@pu-stats/data-access';
 
 @Component({
   selector: 'app-leaderboard-page',
-  imports: [MatCardModule, MatButtonModule],
+  imports: [MatCardModule, MatButtonModule, RouterLink],
   templateUrl: './leaderboard-page.component.html',
   styleUrl: './leaderboard-page.component.scss',
 })

--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -1,5 +1,11 @@
 import { isPlatformBrowser } from '@angular/common';
-import { computed, inject, PLATFORM_ID, resource } from '@angular/core';
+import {
+  computed,
+  inject,
+  LOCALE_ID,
+  PLATFORM_ID,
+  resource,
+} from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import {
   signalStore,
@@ -25,6 +31,7 @@ import { MotivationStore } from '@pu-stats/motivation';
 import { firstValueFrom, of } from 'rxjs';
 import { UserConfigStore } from '../core/user-config.store';
 import { ShareResult, ShareService } from '../core/share.service';
+import { buildProfileShareUrl } from '../core/profile-share-url';
 import { TrainingPlanStore } from '../training-plans/training-plan.store';
 
 const EMPTY_STATS: StatsResponse = {
@@ -91,6 +98,7 @@ export const DashboardStore = signalStore(
     _motivation: inject(MotivationStore),
     _trainingPlan: inject(TrainingPlanStore),
     _share: inject(ShareService),
+    _localeId: inject(LOCALE_ID) as string,
     _isBrowser: isPlatformBrowser(inject(PLATFORM_ID)),
   })),
   withProps((store) => ({
@@ -408,14 +416,34 @@ export const DashboardStore = signalStore(
     shareDay(): Promise<ShareResult> {
       const total = store.todayTotal();
       const streak = store.currentStreak();
-      const text =
-        streak > 1
-          ? $localize`:@@dashboard.share.text.streak:Heute schon ${total}:total: Liegestütze geschafft – Streak: ${streak}:streak: Tage 🔥 Tracke deine Stats kostenlos:`
-          : $localize`:@@dashboard.share.text.simple:Heute schon ${total}:total: Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:`;
+      // Prefer the user's public-profile URL when they opted in — it carries
+      // the dynamic OG card (per-user stats + CTA) so the shared link
+      // produces a much richer social-card preview than the generic
+      // homepage. When the user hasn't opted in, fall back to the homepage
+      // and a plain CTA text — same as before.
+      const uid = store._user.userIdSafe();
+      const publicProfile =
+        store._userConfig.config()?.ui?.publicProfile === true;
+      const profileUrl =
+        publicProfile && uid ? buildProfileShareUrl(uid, store._localeId) : '';
+
+      let text: string;
+      if (profileUrl) {
+        text =
+          streak > 1
+            ? $localize`:@@dashboard.share.text.profile.streak:Heute schon ${total}:total: Liegestütze geschafft – Streak: ${streak}:streak: Tage 🔥 Schau dir mein Profil an:`
+            : $localize`:@@dashboard.share.text.profile.simple:Heute schon ${total}:total: Liegestütze geschafft! 💪 Schau dir mein Profil an:`;
+      } else {
+        text =
+          streak > 1
+            ? $localize`:@@dashboard.share.text.streak:Heute schon ${total}:total: Liegestütze geschafft – Streak: ${streak}:streak: Tage 🔥 Tracke deine Stats kostenlos:`
+            : $localize`:@@dashboard.share.text.simple:Heute schon ${total}:total: Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:`;
+      }
+
       return store._share.share({
         title: $localize`:@@dashboard.share.title:Pushup Tracker`,
         text,
-        url: 'https://pushup-stats.de',
+        url: profileUrl || 'https://pushup-stats.de',
       });
     },
   }))

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -128,6 +128,15 @@ describe('StatsDashboardComponent', () => {
       imports: [StatsDashboardComponent],
       providers: [
         provideRouter([]),
+        // NOTE: this spec stays on the default browser PLATFORM_ID even
+        // though stores constructed by the component start `setInterval`
+        // timers in `withHooks`. Pinning to `server` was suggested but
+        // breaks two regression tests that explicitly verify the
+        // browser-only `effect()` reacting to `LiveDataStore.updateTick`.
+        // The new tests added in this PR each call `createComponent()`
+        // exactly once — same shape as the cases that were already in
+        // the spec — so they don't materially worsen any pre-existing
+        // timer-leak budget.
         { provide: StatsApiService, useValue: serviceMock },
         {
           provide: UserStatsApiService,

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -782,6 +782,61 @@ describe('StatsDashboardComponent', () => {
       expect(payload.text).toContain('Streak');
       expect(payload.text).toContain('3');
     });
+
+    it('Given the user has opted into a public profile, Then the share URL is the profile permalink', async () => {
+      // Given — user config with `ui.publicProfile = true`. The store
+      // reads UserConfigStore.config(), so the API mock must return that
+      // shape; UserContextService.userIdSafe() returns 'u1' (see top of
+      // describe block), so the resulting URL is /<lang>/u/u1.
+      const configApi = TestBed.inject(UserConfigApiService);
+      (configApi.getConfig as ReturnType<typeof vitest.fn>).mockReturnValue(
+        of({
+          userId: 'u1',
+          dailyGoal: 100,
+          weeklyGoal: 500,
+          monthlyGoal: 2000,
+          ui: { publicProfile: true },
+        })
+      );
+      TestBed.inject(UserConfigStore).reload();
+      const freshFixture = TestBed.createComponent(StatsDashboardComponent);
+      await freshFixture.whenStable();
+      shareSpy.mockClear();
+      const button = freshFixture.nativeElement.querySelector(
+        '[data-testid="dashboard-share"]'
+      ) as HTMLButtonElement;
+
+      // When
+      button.click();
+      await freshFixture.whenStable();
+
+      // Then — URL is the locale-prefixed profile permalink, and the
+      // share text reads as a personal share ("schau dir mein Profil
+      // an") rather than the generic "tracke deine stats" CTA.
+      const payload = shareSpy.mock.calls[0][0];
+      expect(payload.url).toMatch(
+        /^https:\/\/pushup-stats\.de\/(de|en)\/u\/u1$/
+      );
+      expect(payload.text).toContain('Profil');
+    });
+
+    it('Given the user has NOT opted into a public profile, Then the share URL stays the homepage', async () => {
+      // The default mock config in this spec doesn't set publicProfile,
+      // so this is the existing baseline — assert it explicitly so a
+      // regression flipping the default to "always link to profile"
+      // (which would 404 on opted-out users) is caught.
+      await fixture.whenStable();
+      shareSpy.mockClear();
+      const button = fixture.nativeElement.querySelector(
+        '[data-testid="dashboard-share"]'
+      ) as HTMLButtonElement;
+
+      button.click();
+      await fixture.whenStable();
+
+      const payload = shareSpy.mock.calls[0][0];
+      expect(payload.url).toBe('https://pushup-stats.de');
+    });
   });
 
   describe('Given entries with consecutive dates', () => {

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -5996,6 +5996,18 @@ Deine Position: # ·  Reps        </source>
         <target>Already <ph id="0" equiv="total" disp="total"/> push-ups today – streak: <ph id="1" equiv="streak" disp="streak"/> days 🔥 Track your stats for free:</target>
       </segment>
     </unit>
+    <unit id="dashboard.share.text.profile.simple">
+      <segment state="translated">
+        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
+        <target>Already <ph id="0" equiv="total" disp="total"/> push-ups today! 💪 Check out my profile:</target>
+      </segment>
+    </unit>
+    <unit id="dashboard.share.text.profile.streak">
+      <segment state="translated">
+        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Schau dir mein Profil an:</source>
+        <target>Already <ph id="0" equiv="total" disp="total"/> push-ups today – streak: <ph id="1" equiv="streak" disp="streak"/> days 🔥 Check out my profile:</target>
+      </segment>
+    </unit>
     <unit id="share.success.clipboard">
       <segment state="translated">
         <source>In die Zwischenablage kopiert. Jetzt einfügen und teilen!</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -237,7 +237,7 @@
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:199,200</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:329,330</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:330,331</note>
       </notes>
       <segment>
         <source> Abbrechen </source>
@@ -1158,7 +1158,7 @@
       <notes>
         <note category="location">web/src/app/app.html:23,26</note>
         <note category="location">web/src/app/app.html:174,176</note>
-        <note category="location">web/src/app/app.html:223,225</note>
+        <note category="location">web/src/app/app.html:227,229</note>
       </notes>
       <segment>
         <source>Dashboard</source>
@@ -1168,7 +1168,7 @@
       <notes>
         <note category="location">web/src/app/app.html:33,36</note>
         <note category="location">web/src/app/app.html:178,180</note>
-        <note category="location">web/src/app/app.html:227,229</note>
+        <note category="location">web/src/app/app.html:231,233</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -1178,7 +1178,7 @@
       <notes>
         <note category="location">web/src/app/app.html:43,47</note>
         <note category="location">web/src/app/app.html:182,184</note>
-        <note category="location">web/src/app/app.html:231,233</note>
+        <note category="location">web/src/app/app.html:235,237</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -1187,27 +1187,29 @@
     <unit id="nav.blog">
       <notes>
         <note category="location">web/src/app/app.html:53,56</note>
-        <note category="location">web/src/app/app.html:186,188</note>
-        <note category="location">web/src/app/app.html:235,237</note>
+        <note category="location">web/src/app/app.html:190,192</note>
+        <note category="location">web/src/app/app.html:243,245</note>
       </notes>
       <segment>
         <source>Blog</source>
       </segment>
     </unit>
-    <unit id="nav.history">
-      <notes>
-        <note category="location">web/src/app/app.html:63,66</note>
-      </notes>
-      <segment>
-        <source>Historie</source>
-      </segment>
-    </unit>
     <unit id="nav.trainingPlans">
       <notes>
-        <note category="location">web/src/app/app.html:74,78</note>
+        <note category="location">web/src/app/app.html:63,67</note>
+        <note category="location">web/src/app/app.html:186,188</note>
+        <note category="location">web/src/app/app.html:239,241</note>
       </notes>
       <segment>
         <source>Trainingspläne</source>
+      </segment>
+    </unit>
+    <unit id="nav.history">
+      <notes>
+        <note category="location">web/src/app/app.html:73,76</note>
+      </notes>
+      <segment>
+        <source>Historie</source>
       </segment>
     </unit>
     <unit id="nav.reminders">
@@ -1292,7 +1294,7 @@
     </unit>
     <unit id="footer.aria">
       <notes>
-        <note category="location">web/src/app/app.html:195</note>
+        <note category="location">web/src/app/app.html:199</note>
       </notes>
       <segment>
         <source>Rechtliches</source>
@@ -1300,7 +1302,7 @@
     </unit>
     <unit id="footer.impressum">
       <notes>
-        <note category="location">web/src/app/app.html:197,199</note>
+        <note category="location">web/src/app/app.html:201,203</note>
       </notes>
       <segment>
         <source>Impressum</source>
@@ -1308,7 +1310,7 @@
     </unit>
     <unit id="footer.datenschutz">
       <notes>
-        <note category="location">web/src/app/app.html:200,203</note>
+        <note category="location">web/src/app/app.html:204,207</note>
       </notes>
       <segment>
         <source>Datenschutz</source>
@@ -1316,7 +1318,7 @@
     </unit>
     <unit id="footer.cookies">
       <notes>
-        <note category="location">web/src/app/app.html:207,209</note>
+        <note category="location">web/src/app/app.html:211,213</note>
       </notes>
       <segment>
         <source> Cookie-Einstellungen </source>
@@ -1324,7 +1326,7 @@
     </unit>
     <unit id="nav.bottom.aria">
       <notes>
-        <note category="location">web/src/app/app.html:214,215</note>
+        <note category="location">web/src/app/app.html:218,219</note>
       </notes>
       <segment>
         <source>Mobile-Navigation</source>
@@ -1854,7 +1856,7 @@
     </unit>
     <unit id="landing.leaderboard.reps">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:53,55</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:66,68</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -1862,7 +1864,7 @@
     </unit>
     <unit id="landing.leaderboard.ownPosition">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:61,63</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:74,76</note>
       </notes>
       <segment>
         <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}"/> Reps </source>
@@ -2570,7 +2572,7 @@
     </unit>
     <unit id="publicProfile.notFound.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:82</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:81</note>
       </notes>
       <segment>
         <source>Profil nicht gefunden</source>
@@ -2578,7 +2580,7 @@
     </unit>
     <unit id="publicProfile.notFound.body">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:83</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:82</note>
       </notes>
       <segment>
         <source>Dieses Profil existiert nicht oder wurde nicht öffentlich freigegeben.</source>
@@ -2586,7 +2588,7 @@
     </unit>
     <unit id="publicProfile.error.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:84</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:83</note>
       </notes>
       <segment>
         <source>Profil konnte nicht geladen werden</source>
@@ -2594,7 +2596,7 @@
     </unit>
     <unit id="publicProfile.error.body">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:85</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:84</note>
       </notes>
       <segment>
         <source>Bitte versuche es später erneut.</source>
@@ -2602,7 +2604,7 @@
     </unit>
     <unit id="publicProfile.retry">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:86</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:85</note>
       </notes>
       <segment>
         <source>Erneut versuchen</source>
@@ -2610,7 +2612,7 @@
     </unit>
     <unit id="publicProfile.toHome">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:87</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:86</note>
       </notes>
       <segment>
         <source>Zur Startseite</source>
@@ -2618,7 +2620,7 @@
     </unit>
     <unit id="publicProfile.stats">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:88</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:87</note>
       </notes>
       <segment>
         <source>Statistik</source>
@@ -2626,7 +2628,7 @@
     </unit>
     <unit id="publicProfile.total">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:89</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:88</note>
       </notes>
       <segment>
         <source>Gesamte Reps</source>
@@ -2634,7 +2636,7 @@
     </unit>
     <unit id="publicProfile.streak">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:90</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:89</note>
       </notes>
       <segment>
         <source>Aktuelle Streak</source>
@@ -2642,7 +2644,7 @@
     </unit>
     <unit id="publicProfile.days">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:91</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:90</note>
       </notes>
       <segment>
         <source>Aktive Tage</source>
@@ -2650,7 +2652,7 @@
     </unit>
     <unit id="publicProfile.entries">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:92</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:91</note>
       </notes>
       <segment>
         <source>Einträge</source>
@@ -2658,7 +2660,7 @@
     </unit>
     <unit id="publicProfile.bestSet">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:93</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:92</note>
       </notes>
       <segment>
         <source>Bester Einzel-Eintrag</source>
@@ -2666,7 +2668,7 @@
     </unit>
     <unit id="publicProfile.bestDay">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:94</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:93</note>
       </notes>
       <segment>
         <source>Bester Tag</source>
@@ -2674,7 +2676,7 @@
     </unit>
     <unit id="publicProfile.share.aria">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:95</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:94</note>
       </notes>
       <segment>
         <source>Profil teilen</source>
@@ -2682,7 +2684,7 @@
     </unit>
     <unit id="publicProfile.share">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:96</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:95</note>
       </notes>
       <segment>
         <source>Teilen</source>
@@ -2690,7 +2692,7 @@
     </unit>
     <unit id="publicProfile.cta">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:97</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:96</note>
       </notes>
       <segment>
         <source>Selbst tracken – pushup-stats.de</source>
@@ -2698,7 +2700,7 @@
     </unit>
     <unit id="publicProfile.share.text">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:130</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:129</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze auf Pushup Tracker geschafft 💪 Schau&apos;s dir an:</source>
@@ -2706,7 +2708,7 @@
     </unit>
     <unit id="publicProfile.share.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:139</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:131</note>
       </notes>
       <segment>
         <source>Pushup Tracker Profil</source>
@@ -2714,7 +2716,7 @@
     </unit>
     <unit id="publicProfile.seo.notFound.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:181</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:176</note>
       </notes>
       <segment>
         <source>Profil nicht verfügbar – Pushup Tracker</source>
@@ -2722,7 +2724,7 @@
     </unit>
     <unit id="publicProfile.seo.notFound.description">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:182</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:177</note>
       </notes>
       <segment>
         <source>Dieses Profil existiert nicht oder ist nicht öffentlich.</source>
@@ -2730,7 +2732,7 @@
     </unit>
     <unit id="publicProfile.seo.title">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:197</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:192</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> – <ph id="1" equiv="total" disp="profile.total"/> Liegestütze · Streak <ph id="2" equiv="streak" disp="profile.currentStreak"/> · Pushup Tracker</source>
@@ -2738,7 +2740,7 @@
     </unit>
     <unit id="publicProfile.seo.description">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:198</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:193</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze in <ph id="2" equiv="days" disp="profile.totalDays"/> aktiven Tagen geschafft – aktuelle Streak: <ph id="3" equiv="streak" disp="profile.currentStreak"/> Tage. Tracke selbst kostenlos auf pushup-stats.de.</source>
@@ -2746,7 +2748,7 @@
     </unit>
     <unit id="publicProfile.seo.imageAlt">
       <notes>
-        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:211</note>
+        <note category="location">web/src/app/public-profile/public-profile-page.component.ts:206</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="name" disp="profile.displayName"/> auf Pushup Tracker</source>
@@ -3912,9 +3914,25 @@
         <source>Keine Daten</source>
       </segment>
     </unit>
+    <unit id="dashboard.share.text.profile.streak">
+      <notes>
+        <note category="location">web/src/app/stats/dashboard.store.ts:436</note>
+      </notes>
+      <segment>
+        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Schau dir mein Profil an:</source>
+      </segment>
+    </unit>
+    <unit id="dashboard.share.text.profile.simple">
+      <notes>
+        <note category="location">web/src/app/stats/dashboard.store.ts:437</note>
+      </notes>
+      <segment>
+        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
+      </segment>
+    </unit>
     <unit id="dashboard.share.text.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:413</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:441</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
@@ -3922,7 +3940,7 @@
     </unit>
     <unit id="dashboard.share.text.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:414</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:442</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
@@ -3930,7 +3948,7 @@
     </unit>
     <unit id="dashboard.share.title">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:416</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:446</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -4190,7 +4208,7 @@
     </unit>
     <unit id="settingsTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:46,47</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:47,48</note>
       </notes>
       <segment>
         <source>Einstellungen</source>
@@ -4198,7 +4216,7 @@
     </unit>
     <unit id="settingsSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:48,49</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:49,50</note>
       </notes>
       <segment>
         <source>User-Profil &amp; Tagesziel</source>
@@ -4206,7 +4224,7 @@
     </unit>
     <unit id="guest.banner.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:57,59</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:58,60</note>
       </notes>
       <segment>
         <source>Du nutzt die App als Gast. Erstelle ein Konto um alle Funktionen zu nutzen.</source>
@@ -4214,7 +4232,7 @@
     </unit>
     <unit id="guest.banner.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:64,66</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:65,67</note>
       </notes>
       <segment>
         <source>Konto erstellen</source>
@@ -4222,7 +4240,7 @@
     </unit>
     <unit id="displayNameLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:70,71</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:71,72</note>
       </notes>
       <segment>
         <source>Anzeigename</source>
@@ -4230,7 +4248,7 @@
     </unit>
     <unit id="displayNamePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:76</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:77</note>
       </notes>
       <segment>
         <source>Wolf</source>
@@ -4238,7 +4256,7 @@
     </unit>
     <unit id="settings.displayNameHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:79,81</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:80,82</note>
       </notes>
       <segment>
         <source>Kann in der Bestenliste angezeigt werden.</source>
@@ -4246,7 +4264,7 @@
     </unit>
     <unit id="settings.leaderboardOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:88,89</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:89,90</note>
       </notes>
       <segment>
         <source> In Bestenliste anzeigen </source>
@@ -4254,7 +4272,7 @@
     </unit>
     <unit id="settings.leaderboardOptOutHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:92,95</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:93,96</note>
       </notes>
       <segment>
         <source> Wenn deaktiviert, wird dein Profil in der Bestenliste nicht angezeigt. </source>
@@ -4262,7 +4280,7 @@
     </unit>
     <unit id="settings.publicProfile.toggle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:102,103</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:103,104</note>
       </notes>
       <segment>
         <source> Öffentliches Profil aktivieren </source>
@@ -4270,7 +4288,7 @@
     </unit>
     <unit id="settings.publicProfile.hint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:106,109</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:107,110</note>
       </notes>
       <segment>
         <source> Erlaubt jedem mit dem Link den Zugriff auf deine Reps, Streak und Bestleistungen. Dein Anzeigename ist sichtbar; E-Mail, Ziele und Erinnerungen bleiben privat. </source>
@@ -4278,7 +4296,7 @@
     </unit>
     <unit id="settings.publicProfile.shareCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:128,130</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:129,131</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">share</pc> Profil teilen </source>
@@ -4286,7 +4304,7 @@
     </unit>
     <unit id="settings.adsConsentOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:139,140</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:140,141</note>
       </notes>
       <segment>
         <source> Personalisierte Werbung aktivieren </source>
@@ -4294,7 +4312,7 @@
     </unit>
     <unit id="settings.adsConsentHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:143,146</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:144,147</note>
       </notes>
       <segment>
         <source> Steuert, ob Werbe-Slots im Dashboard geladen werden dürfen. </source>
@@ -4302,7 +4320,7 @@
     </unit>
     <unit id="dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:147,148</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:148,149</note>
       </notes>
       <segment>
         <source>Tagesziel (Reps)</source>
@@ -4310,7 +4328,7 @@
     </unit>
     <unit id="dailyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:157</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:158</note>
       </notes>
       <segment>
         <source>10</source>
@@ -4318,7 +4336,7 @@
     </unit>
     <unit id="settings.goalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:160,162</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:161,163</note>
       </notes>
       <segment>
         <source>Wird prominent in der Toolbar angezeigt.</source>
@@ -4326,7 +4344,7 @@
     </unit>
     <unit id="weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:165,166</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:166,167</note>
       </notes>
       <segment>
         <source>Wochenziel (Reps)</source>
@@ -4334,7 +4352,7 @@
     </unit>
     <unit id="weeklyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:175</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:176</note>
       </notes>
       <segment>
         <source>50</source>
@@ -4342,7 +4360,7 @@
     </unit>
     <unit id="settings.weeklyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:178,180</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:179,181</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Woche (Mo–So).</source>
@@ -4350,7 +4368,7 @@
     </unit>
     <unit id="monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:183,184</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:184,185</note>
       </notes>
       <segment>
         <source>Monatsziel (Reps)</source>
@@ -4358,7 +4376,7 @@
     </unit>
     <unit id="monthlyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:193</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:194</note>
       </notes>
       <segment>
         <source>200</source>
@@ -4366,7 +4384,7 @@
     </unit>
     <unit id="settings.monthlyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:196,198</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:197,199</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Monat.</source>
@@ -4374,7 +4392,7 @@
     </unit>
     <unit id="settings.snapQualityLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:205,207</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:206,208</note>
       </notes>
       <segment>
         <source>Snap-Animation Qualität</source>
@@ -4382,7 +4400,7 @@
     </unit>
     <unit id="settings.snapQuality.low">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:215,217</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:216,218</note>
       </notes>
       <segment>
         <source>Niedrig</source>
@@ -4390,7 +4408,7 @@
     </unit>
     <unit id="settings.snapQuality.middle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:220,222</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:221,223</note>
       </notes>
       <segment>
         <source>Mittel</source>
@@ -4398,7 +4416,7 @@
     </unit>
     <unit id="settings.snapQuality.high">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:225,227</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:226,228</note>
       </notes>
       <segment>
         <source>Hoch</source>
@@ -4406,7 +4424,7 @@
     </unit>
     <unit id="settings.snapQualityHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:229,231</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:230,232</note>
       </notes>
       <segment>
         <source> Steuert die Partikelanzahl der „Ziel erreicht“-Animation (40k / 120k / 200k). </source>
@@ -4414,7 +4432,7 @@
     </unit>
     <unit id="saveSettings">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:247,249</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:248,250</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc> Speichern </source>
@@ -4422,7 +4440,7 @@
     </unit>
     <unit id="saving">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:251,252</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:252,253</note>
       </notes>
       <segment>
         <source>Speichert…</source>
@@ -4430,7 +4448,7 @@
     </unit>
     <unit id="saved">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:254,255</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:255,256</note>
       </notes>
       <segment>
         <source>Gespeichert.</source>
@@ -4438,7 +4456,7 @@
     </unit>
     <unit id="settings.remindersLinkTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:259,260</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:260,261</note>
       </notes>
       <segment>
         <source>🔔 Erinnerungen</source>
@@ -4446,7 +4464,7 @@
     </unit>
     <unit id="settings.remindersLinkDesc">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:261,263</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:262,264</note>
       </notes>
       <segment>
         <source> Liegestütz-Erinnerungen und Push-Benachrichtigungen konfigurieren. </source>
@@ -4454,7 +4472,7 @@
     </unit>
     <unit id="settings.remindersLinkCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:268,270</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:269,271</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications</pc> Erinnerungen verwalten </source>
@@ -4462,7 +4480,7 @@
     </unit>
     <unit id="settings.dangerZoneTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:274,275</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:275,276</note>
       </notes>
       <segment>
         <source>Danger Zone</source>
@@ -4470,7 +4488,7 @@
     </unit>
     <unit id="settings.dangerZoneBody">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:276,278</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:277,279</note>
       </notes>
       <segment>
         <source> Konto löschen entfernt dein Konto. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -4478,7 +4496,7 @@
     </unit>
     <unit id="settings.deleteAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:287,289</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:288,290</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Konto löschen </source>
@@ -4486,7 +4504,7 @@
     </unit>
     <unit id="settings.deletingAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:292,295</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:293,296</note>
       </notes>
       <segment>
         <source>Konto wird gelöscht…</source>
@@ -4494,7 +4512,7 @@
     </unit>
     <unit id="settings.deleteDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:299,301</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:300,302</note>
       </notes>
       <segment>
         <source> Account wirklich löschen? </source>
@@ -4502,7 +4520,7 @@
     </unit>
     <unit id="settings.deleteDialogWarning">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:303,305</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:304,306</note>
       </notes>
       <segment>
         <source> Achtung: Diese Aktion ist nicht rückgängig. </source>
@@ -4510,7 +4528,7 @@
     </unit>
     <unit id="settings.deleteDialogInfo">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:306,308</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:307,309</note>
       </notes>
       <segment>
         <source> Dein Konto wird gelöscht. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -4518,7 +4536,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:311,313</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:312,314</note>
       </notes>
       <segment>
         <source>Bestätigungswort eingeben</source>
@@ -4526,7 +4544,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:320,322</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:321,323</note>
       </notes>
       <segment>
         <source>Bitte exakt „löscchen“ eingeben.</source>
@@ -4534,7 +4552,7 @@
     </unit>
     <unit id="settings.deleteConfirmFinal">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:337,339</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:338,340</note>
       </notes>
       <segment>
         <source> Final löschen </source>
@@ -4542,7 +4560,7 @@
     </unit>
     <unit id="settings.publicProfile.share.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:550</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:545</note>
       </notes>
       <segment>
         <source>Mein Pushup Tracker Profil</source>
@@ -4550,7 +4568,7 @@
     </unit>
     <unit id="settings.publicProfile.share.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:551</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:546</note>
       </notes>
       <segment>
         <source>Schau dir mein Pushup-Profil an:</source>


### PR DESCRIPTION
## Summary
Two follow-ups so the public-profile feature actually drives traffic once a user has opted in.

### 1. Dashboard share button → personal profile permalink
`DashboardStore.shareDay()` now picks the share URL based on whether the active user has `ui.publicProfile === true`:

| Opt-in | Shared URL | Copy |
|---|---|---|
| ✅ on | `https://pushup-stats.de/<lang>/u/<uid>` | „… Schau dir mein Profil an" / „Check out my profile" |
| ❌ off (default) | `https://pushup-stats.de` | „Tracke deine Stats kostenlos" / „Track your stats for free" |

The opted-in link unfurls to the dynamic per-user OG card (rendered by the `ogProfile` Cloud Function), so the preview the recipient sees is informative — not just the generic site image.

### 2. Leaderboard rows link to public profiles
- **Cloud Function**: `LeaderboardEntry` gets an optional `uid` field. It is populated only when the user opted into BOTH the leaderboard (`ui.hideFromLeaderboard === false`) AND the public profile (`ui.publicProfile === true`). New `isPublicProfileLinkAllowed()` helper in `profile/logic.ts` documents the AND.

  Why both: a user who anonymises on the leaderboard but has a public profile gets *no* UID, otherwise the anonymous row could be correlated back to their real profile.
- **Frontend**: `LeaderboardEntry` type mirrors the optional `uid` and the Firestore→domain mapper propagates it. The leaderboard page renders the alias as `<a routerLink="/u/<uid>">` when `uid` is set; otherwise the row stays a plain `<span>` (anonymous + opted-out users are not clickable).

## Privacy contract
- Leaderboard opt-in alone: name visible, no link.
- Public profile opt-in alone (with leaderboard hidden): row stays anonymous, no link.
- Both opt-ins: name visible, links to `/u/<uid>`.
- Leaderboard CF spec asserts all four cells.

## Test plan
- [x] `pnpm nx affected -t=lint,test,build -c=production --parallel=3` — 6 affected projects passed locally.
- [ ] After deploy, verify the leaderboard on prod links to opted-in users' public profiles and not to opted-out ones.
- [ ] Click the dashboard "Teilen" button as an opted-in user — clipboard / share-sheet text should contain the personal `/u/<uid>` URL.
- [ ] Same as opted-out user — should fall back to the homepage URL with the generic CTA.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGKDZpVUBj489VTNAshbXo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public-profile opt-in for users to enable profile visibility.
  * Leaderboard entries show clickable profile links for opted-in users (routes to /u/<uid>).
  * Dashboard sharing generates profile-specific URLs and localized share messages when opted-in.

* **Tests**
  * New unit and component tests verifying conditional uid/link rendering and share behavior based on opt-in and display name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->