### PR TITLE
feat(dashboard): scroll-driven fly-in animation for cards

### DIFF
--- a/web/src/app/stats/shell/stats-dashboard.component.scss
+++ b/web/src/app/stats/shell/stats-dashboard.component.scss
@@ -1,5 +1,6 @@
 :host {
   display: block;
+  overflow-x: hidden;
   overflow-x: clip;
 }
 
@@ -422,11 +423,10 @@ h1 {
   .quick-actions,
   app-analysis-teaser-card,
   .latest-entries {
-    animation: dashboard-fly-in-from-right linear both;
+    animation: dashboard-fly-in-from-right 1s linear both;
     animation-duration: auto;
     animation-timeline: view();
     animation-range: entry 0% cover 35%;
-    will-change: translate, scale, opacity;
   }
 }
 
@@ -447,7 +447,6 @@ h1 {
     app-analysis-teaser-card,
     .latest-entries {
       animation: none;
-      will-change: auto;
     }
   }
 }

--- a/web/src/app/stats/shell/stats-dashboard.component.scss
+++ b/web/src/app/stats/shell/stats-dashboard.component.scss
@@ -1,6 +1,6 @@
 :host {
   display: block;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 .plan-banner {

--- a/web/src/app/stats/shell/stats-dashboard.component.scss
+++ b/web/src/app/stats/shell/stats-dashboard.component.scss
@@ -403,6 +403,30 @@ h1 {
   }
 }
 
+@keyframes dashboard-fly-in-from-right {
+  from {
+    opacity: 0;
+    transform: translateX(60%) scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@supports (animation-timeline: view()) {
+  .plan-banner,
+  .today-focus > mat-card,
+  .quick-actions,
+  app-analysis-teaser-card,
+  .latest-entries {
+    animation: dashboard-fly-in-from-right linear both;
+    animation-timeline: view();
+    animation-range: entry 0% cover 35%;
+    will-change: transform, opacity;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .latest-entries {
     transition: box-shadow 0.2s ease;
@@ -410,6 +434,16 @@ h1 {
     &:hover,
     &:focus-visible {
       transform: none;
+    }
+  }
+
+  @supports (animation-timeline: view()) {
+    .plan-banner,
+    .today-focus > mat-card,
+    .quick-actions,
+    app-analysis-teaser-card,
+    .latest-entries {
+      animation: none;
     }
   }
 }

--- a/web/src/app/stats/shell/stats-dashboard.component.scss
+++ b/web/src/app/stats/shell/stats-dashboard.component.scss
@@ -423,6 +423,7 @@ h1 {
   app-analysis-teaser-card,
   .latest-entries {
     animation: dashboard-fly-in-from-right linear both;
+    animation-duration: auto;
     animation-timeline: view();
     animation-range: entry 0% cover 35%;
     will-change: translate, scale, opacity;
@@ -446,6 +447,7 @@ h1 {
     app-analysis-teaser-card,
     .latest-entries {
       animation: none;
+      will-change: auto;
     }
   }
 }

--- a/web/src/app/stats/shell/stats-dashboard.component.scss
+++ b/web/src/app/stats/shell/stats-dashboard.component.scss
@@ -406,11 +406,13 @@ h1 {
 @keyframes dashboard-fly-in-from-right {
   from {
     opacity: 0;
-    transform: translateX(60%) scale(0.94);
+    translate: 60% 0;
+    scale: 0.94;
   }
   to {
     opacity: 1;
-    transform: translateX(0) scale(1);
+    translate: 0 0;
+    scale: 1;
   }
 }
 
@@ -423,7 +425,7 @@ h1 {
     animation: dashboard-fly-in-from-right linear both;
     animation-timeline: view();
     animation-range: entry 0% cover 35%;
-    will-change: transform, opacity;
+    will-change: translate, scale, opacity;
   }
 }
 


### PR DESCRIPTION
## Summary

- Dashboard cards (`plan-banner`, `today-focus` cards, `quick-actions`, `analysis-teaser-card`, `latest-entries`) now slide in from the right as the user scrolls them into view.
- Implemented with the modern CSS scroll-driven animations API (`animation-timeline: view()`) — no JavaScript, no `IntersectionObserver`, runs on the compositor.
- Wrapped in `@supports (animation-timeline: view())` so browsers without support fall back to the static layout.
- Disabled under `prefers-reduced-motion: reduce`.

## Test plan

- [ ] Open `/` (dashboard) in a Chromium-based browser, scroll up/down, verify each card slides in from the right.
- [ ] Verify in Safari < 26 / older Firefox: cards render statically (no broken state).
- [ ] Toggle OS "Reduce Motion" → cards appear without animation.
- [ ] `pnpm nx lint web` passes.
- [ ] `pnpm nx test web` passes.

https://claude.ai/code/session_015ND9RZAq6amY5NETXRASnK

---
_Generated by [Claude Code](https://claude.ai/code/session_015ND9RZAq6amY5NETXRASnK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added smooth scroll-triggered entry animations to dashboard sections for a more polished user experience.
  * Animations respect accessibility preferences for users with motion sensitivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->