### PR TITLE
fix(i18n): translate training-plan catalog into fr/es/it/nl/el/la

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -6241,7 +6241,7 @@
     <unit id="plan.over-40-4w.day.2.desc">
       <segment state="translated">
         <source>3×8 Knie- oder erhöhte Liegestütze</source>
-        <target>3×8 πιέσεις στα γόνατα ή ανυψωμένες</target>
+        <target>3×8 πιέσεις στα γόνατα ή ανυψωμένες πιέσεις</target>
       </segment>
     </unit>
     <unit id="plan.over-40-4w.day.4.desc">
@@ -6307,7 +6307,7 @@
     <unit id="plan.daily-100-30d.summary">
       <segment state="translated">
         <source>30-Tage-Volumenplan: ramp-up von 50 auf 100 saubere Wiederholungen pro Einheit, danach zwei Wochen Konsolidierung. 5 Trainingstage + 1 leichter + 1 Ruhetag pro Woche.</source>
-        <target>Πρόγραμμα όγκου 30 ημερών: αύξηση από 50 σε 100 καθαρές επαναλήψεις ανά προπόνηση, μετά δύο εβδομάδες παγίωσης. 5 ημέρες προπόνησης + 1 ελαφριά + 1 ξεκούρασης την εβδομάδα.</target>
+        <target>Πρόγραμμα όγκου 30 ημερών: αύξηση από 50 σε 100 καθαρές επαναλήψεις ανά προπόνηση, μετά δύο εβδομάδες παγίωσης. 5 ημέρες προπόνησης + 1 ελαφριά ημέρα + 1 ημέρα ξεκούρασης την εβδομάδα.</target>
       </segment>
     </unit>
     <unit id="plan.daily-100-30d.day.1.desc">
@@ -6463,7 +6463,7 @@
     <unit id="plan.one-arm-12w.summary">
       <segment state="translated">
         <source>Vier-Phasen-Plan in Richtung saubere einarmige Liegestütze: Archer und Wand-Negativen, Bank-Negativen, partielle Einarmige, schließlich volle Einarmige im weiten Stand. 4 aktive Tage + 3 Ruhetage pro Woche.</source>
-        <target>Πρόγραμμα τεσσάρων φάσεων προς μια καθαρή πίεση με έναν βραχίονα: archer και αρνητικές στον τοίχο, αρνητικές σε πάγκο, μερικές με έναν βραχίονα, τέλος πλήρεις με έναν βραχίονα σε φαρδιά στάση. 4 ενεργές ημέρες + 3 ξεκούρασης την εβδομάδα.</target>
+        <target>Πρόγραμμα τεσσάρων φάσεων προς μια καθαρή πίεση με έναν βραχίονα: archer και αρνητικές στον τοίχο, αρνητικές σε πάγκο, μερικές με έναν βραχίονα, τέλος πλήρεις με έναν βραχίονα σε φαρδιά στάση. 4 ενεργές ημέρες + 3 ημέρες ξεκούρασης την εβδομάδα.</target>
       </segment>
     </unit>
     <unit id="plan.one-arm-12w.day.1.desc">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -6004,5 +6004,719 @@
         <target>Άνοιγμα οδηγού</target>
       </segment>
     </unit>
+    <unit id="plan.day.rest">
+      <segment state="translated">
+        <source>Ruhetag</source>
+        <target>Ημέρα ξεκούρασης</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.mobility">
+      <segment state="translated">
+        <source>Ruhetag — Mobility</source>
+        <target>Ημέρα ξεκούρασης — κινητικότητα</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.prepFinal">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung Endtest</source>
+        <target>Ημέρα ξεκούρασης — προετοιμασία για το τελικό τεστ</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light">
+      <segment state="translated">
+        <source>Leichter Tag</source>
+        <target>Ελαφριά ημέρα</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.activeRecovery">
+      <segment state="translated">
+        <source>Aktive Erholung</source>
+        <target>Ενεργή αποκατάσταση</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.mobility.chestStretch">
+      <segment state="translated">
+        <source>Mobility &amp; Brust-Stretching</source>
+        <target>Κινητικότητα &amp; διατάσεις στήθους</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.finalTest.maxNoPause">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze ohne Pause</source>
+        <target>Τελικό τεστ: μέγιστες πιέσεις χωρίς διάλειμμα</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x">
+      <segment state="translated">
+        <source>3×AMRAP</source>
+        <target>3×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x90s">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause</source>
+        <target>3×AMRAP, 90 δευτ. διάλειμμα</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x">
+      <segment state="translated">
+        <source>4×AMRAP</source>
+        <target>4×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x60s">
+      <segment state="translated">
+        <source>4×AMRAP, 60 s Pause</source>
+        <target>4×AMRAP, 60 δευτ. διάλειμμα</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.targetReps.5">
+      <segment state="translated">
+        <source>5 Sätze Zielwiederholungen</source>
+        <target>5 σετ στοχευμένων επαναλήψεων</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.4x90s">
+      <segment state="translated">
+        <source>4 Sätze, 90 s Pause</source>
+        <target>4 σετ, 90 δευτ. διάλειμμα</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.3x70pct">
+      <segment state="translated">
+        <source>3 Sätze à 70 %</source>
+        <target>3 σετ στο 70 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light.2x50pct">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 %</source>
+        <target>Ελαφριά ημέρα — 2×50 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.title">
+      <segment state="translated">
+        <source>Von 0 auf 100 — 6-Wochen-Aufbau</source>
+        <target>Από το 0 στο 100 — πρόγραμμα 6 εβδομάδων</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.summary">
+      <segment state="translated">
+        <source>Strukturierter Plan für Einsteiger: drei Trainingstage pro Woche, progressive Belastungssteigerung und ein Endtest in Woche 6.</source>
+        <target>Δομημένο πρόγραμμα για αρχάριους: τρεις ημέρες προπόνησης την εβδομάδα, προοδευτική επιβάρυνση και τελικό τεστ στην εβδομάδα 6.</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-steigern</source>
+        <target>pieseis-ges-anabasis</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.1.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze, 90 s Pause</source>
+        <target>3×10 καθαρές πιέσεις, 90 δευτ. διάλειμμα</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.2.desc">
+      <segment state="translated">
+        <source>Ruhetag — Stretching, Mobility</source>
+        <target>Ημέρα ξεκούρασης — διατάσεις, κινητικότητα</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.3.desc">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause (Ziel ≈12-11-10)</source>
+        <target>3×AMRAP, 90 δευτ. διάλειμμα (στόχος ≈12-11-10)</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 50 % vom Maximum</source>
+        <target>Ελαφριά ημέρα — 50 % του μέγιστου</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.36.desc">
+      <segment state="translated">
+        <source>5 Sätze, volle Bewegungsamplitude</source>
+        <target>5 σετ, πλήρες εύρος κίνησης</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.38.desc">
+      <segment state="translated">
+        <source>5 Sätze, kontrolliertes Tempo</source>
+        <target>5 σετ, ελεγχόμενος ρυθμός</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.40.desc">
+      <segment state="translated">
+        <source>5 Sätze leicht</source>
+        <target>5 σετ ελαφριά</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.title">
+      <segment state="translated">
+        <source>30-Tage-Challenge</source>
+        <target>Πρόκληση 30 ημερών</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.summary">
+      <segment state="translated">
+        <source>Dreißig Tage tägliches Training mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest.</source>
+        <target>Τριάντα ημέρες καθημερινής προπόνησης με στοχευμένες ημέρες ξεκούρασης. Η ημέρα 1 είναι το μέγιστο τεστ, η ημέρα 30 το τελικό.</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.blogSlug">
+      <segment state="translated">
+        <source>30-tage-liegestuetze-challenge</source>
+        <target>triakonta-emerai-pieseos</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest — als Ausgangswert eintragen</source>
+        <target>Μέγιστο τεστ — κατέγραψέ το ως αρχική τιμή</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.3.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 % vom Maximum</source>
+        <target>Ελαφριά ημέρα — 2×50 % του μέγιστου</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.9.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 3×60 % vom Maximum</source>
+        <target>Ελαφριά ημέρα — 3×60 % του μέγιστου</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.15.desc">
+      <segment state="translated">
+        <source>5 Sätze à ~80 % vom Maximum</source>
+        <target>5 σετ στο ~80 % του μέγιστου</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.22.desc">
+      <segment state="translated">
+        <source>3 Sätze à 70 % — Qualität vor Quantität</source>
+        <target>3 σετ στο 70 % — ποιότητα πάνω από ποσότητα</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.27.desc">
+      <segment state="translated">
+        <source>Aktive Erholung — Spaziergang, Mobility</source>
+        <target>Ενεργή αποκατάσταση — περπάτημα, κινητικότητα</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhe vor dem Endtest</source>
+        <target>Ξεκούραση πριν το τελικό τεστ</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.title">
+      <segment state="translated">
+        <source>Liegestütze ab 40 — 4-Wochen-Plan</source>
+        <target>Πιέσεις μετά τα 40 — πρόγραμμα 4 εβδομάδων</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.summary">
+      <segment state="translated">
+        <source>Schonender 4-Wochen-Plan für Einsteiger ab 40: Fokus auf saubere Technik, ausreichend Pause und langsames Tempo.</source>
+        <target>Ήπιο πρόγραμμα 4 εβδομάδων για αρχάριους άνω των 40: εστίαση σε καθαρή τεχνική, επαρκή ξεκούραση και αργό ρυθμό.</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-ab-40</source>
+        <target>pieseis-ges-meta-tessarakonta</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest mit sauberer Technik</source>
+        <target>Μέγιστο τεστ με καθαρή τεχνική</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.2.desc">
+      <segment state="translated">
+        <source>3×8 Knie- oder erhöhte Liegestütze</source>
+        <target>3×8 πιέσεις στα γόνατα ή ανυψωμένες</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.4.desc">
+      <segment state="translated">
+        <source>3×9 saubere Liegestütze</source>
+        <target>3×9 καθαρές πιέσεις</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.5.desc">
+      <segment state="translated">
+        <source>Ruhetag — Schulter-Mobility</source>
+        <target>Ημέρα ξεκούρασης — κινητικότητα ώμων</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.6.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze</source>
+        <target>3×10 καθαρές πιέσεις</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.8.desc">
+      <segment state="translated">
+        <source>3×11</source>
+        <target>3×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.10.desc">
+      <segment state="translated">
+        <source>3×12</source>
+        <target>3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.12.desc">
+      <segment state="translated">
+        <source>3×13</source>
+        <target>3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.22.desc">
+      <segment state="translated">
+        <source>4 Sätze, kontrolliertes Tempo</source>
+        <target>4 σετ, ελεγχόμενος ρυθμός</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.24.desc">
+      <segment state="translated">
+        <source>4 Sätze, langsame Exzentrik</source>
+        <target>4 σετ, αργή έκκεντρη φάση</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.28.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze</source>
+        <target>Τελικό τεστ: μέγιστες πιέσεις</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.title">
+      <segment state="translated">
+        <source>Daily 100 — 30 Tage zur 100er-Marke</source>
+        <target>Daily 100 — 30 ημέρες προς τα 100</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.summary">
+      <segment state="translated">
+        <source>30-Tage-Volumenplan: ramp-up von 50 auf 100 saubere Wiederholungen pro Einheit, danach zwei Wochen Konsolidierung. 5 Trainingstage + 1 leichter + 1 Ruhetag pro Woche.</source>
+        <target>Πρόγραμμα όγκου 30 ημερών: αύξηση από 50 σε 100 καθαρές επαναλήψεις ανά προπόνηση, μετά δύο εβδομάδες παγίωσης. 5 ημέρες προπόνησης + 1 ελαφριά + 1 ξεκούρασης την εβδομάδα.</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.1.desc">
+      <segment state="translated">
+        <source>Baseline-Test: maximale Wiederholungen in einem Satz</source>
+        <target>Τεστ αναφοράς: μέγιστες επαναλήψεις σε ένα σετ</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.2.desc">
+      <segment state="translated">
+        <source>5×10 saubere Wiederholungen, 60 s Pause</source>
+        <target>5×10 καθαρές επαναλήψεις, 60 δευτ. διάλειμμα</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.3.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 δευτ. διάλειμμα</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.4.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 δευτ. διάλειμμα</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.5.desc">
+      <segment state="translated">
+        <source>5×14, 60 s Pause</source>
+        <target>5×14, 60 δευτ. διάλειμμα</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×15 in lockerem Tempo</source>
+        <target>Ελαφριά ημέρα — 2×15 σε χαλαρό ρυθμό</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.8.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.9.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.10.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.11.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.12.desc">
+      <segment state="translated">
+        <source>Erstes Hundert: 5×20</source>
+        <target>Πρώτα εκατό: 5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.15.desc">
+      <segment state="translated">
+        <source>4×25 (weniger Sätze, mehr Wiederholungen)</source>
+        <target>4×25 (λιγότερα σετ, περισσότερες επαναλήψεις)</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.16.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.17.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.18.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.19.desc">
+      <segment state="translated">
+        <source>4×25 — Tempo bewusst verlangsamen</source>
+        <target>4×25 — επιβράδυνε συνειδητά τον ρυθμό</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.22.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.23.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.24.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.25.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.26.desc">
+      <segment state="translated">
+        <source>Letzter 100er-Tag vor dem Test</source>
+        <target>Τελευταία ημέρα των 100 πριν το τεστ</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.27.desc">
+      <segment state="translated">
+        <source>Leichter Tag — Form-Check</source>
+        <target>Ελαφριά ημέρα — έλεγχος τεχνικής</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung auf den Endtest</source>
+        <target>Ημέρα ξεκούρασης — προετοιμασία για το τελικό τεστ</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.30.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale saubere Wiederholungen in einem Satz</source>
+        <target>Τελικό τεστ: μέγιστες καθαρές επαναλήψεις σε ένα σετ</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.title">
+      <segment state="translated">
+        <source>Einarmige Liegestütze — 12-Wochen-Aufbau</source>
+        <target>Πιέσεις με έναν βραχίονα — πρόγραμμα 12 εβδομάδων</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.summary">
+      <segment state="translated">
+        <source>Vier-Phasen-Plan in Richtung saubere einarmige Liegestütze: Archer und Wand-Negativen, Bank-Negativen, partielle Einarmige, schließlich volle Einarmige im weiten Stand. 4 aktive Tage + 3 Ruhetage pro Woche.</source>
+        <target>Πρόγραμμα τεσσάρων φάσεων προς μια καθαρή πίεση με έναν βραχίονα: archer και αρνητικές στον τοίχο, αρνητικές σε πάγκο, μερικές με έναν βραχίονα, τέλος πλήρεις με έναν βραχίονα σε φαρδιά στάση. 4 ενεργές ημέρες + 3 ξεκούρασης την εβδομάδα.</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.1.desc">
+      <segment state="translated">
+        <source>Archer-Liegestütze 3×6</source>
+        <target>Πιέσεις archer 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.3.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×10 (langsame Exzentrik)</source>
+        <target>Πιέσεις τοίχου με έναν βραχίονα 3×10 (αργή έκκεντρη)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.5.desc">
+      <segment state="translated">
+        <source>Standard-Liegestütze 3×20 (Volumen)</source>
+        <target>Standard πιέσεις 3×20 (όγκος)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×10</source>
+        <target>Ελαφριά ημέρα 2×10</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.8.desc">
+      <segment state="translated">
+        <source>Archer 3×8</source>
+        <target>Archer 3×8</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.10.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×12</source>
+        <target>Πιέσεις τοίχου με έναν βραχίονα 3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.12.desc">
+      <segment state="translated">
+        <source>Standard 3×22</source>
+        <target>Standard 3×22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.13.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×12</source>
+        <target>Ελαφριά ημέρα 2×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.15.desc">
+      <segment state="translated">
+        <source>Archer 3×10 — Phase 1 abschließen</source>
+        <target>Archer 3×10 — ολοκλήρωση φάσης 1</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.17.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×15</source>
+        <target>Πιέσεις τοίχου με έναν βραχίονα 3×15</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.19.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.20.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×14</source>
+        <target>Ελαφριά ημέρα 2×14</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.22.desc">
+      <segment state="translated">
+        <source>Negative Einarmige von Bank 3×5 (3 s runter)</source>
+        <target>Αρνητικές με έναν βραχίονα από πάγκο 3×5 (3 δευτ. κάτω)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.24.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×6 (Tempo 3-1-1)</source>
+        <target>Αργές archer 3×6 (ρυθμός 3-1-1)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.26.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20 (Brust-Volumen)</source>
+        <target>Φαρδιές πιέσεις 3×20 (όγκος στήθους)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.29.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×5</source>
+        <target>Αρνητικές με έναν βραχίονα 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.31.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×7</source>
+        <target>Αργές archer 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.33.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20</source>
+        <target>Φαρδιές πιέσεις 3×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.34.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×11</source>
+        <target>Ελαφριά ημέρα 2×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.36.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×6</source>
+        <target>Αρνητικές με έναν βραχίονα 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.38.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×8 — Phase 2 abschließen</source>
+        <target>Αργές archer 3×8 — ολοκλήρωση φάσης 2</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.40.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×~22</source>
+        <target>Φαρδιές πιέσεις 3×~22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.43.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige (niedrige Bank) 3×4</source>
+        <target>Μερικές με έναν βραχίονα (χαμηλός πάγκος) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.45.desc">
+      <segment state="translated">
+        <source>Archer mit langem Tempo 3×6</source>
+        <target>Archer με μακρύ ρυθμό 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.47.desc">
+      <segment state="translated">
+        <source>Diamant-Liegestütze 3×12 (Trizeps-Volumen)</source>
+        <target>Πιέσεις διαμαντιού 3×12 (όγκος τρικέφαλου)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.50.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×4</source>
+        <target>Μερικές με έναν βραχίονα 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.52.desc">
+      <segment state="translated">
+        <source>Archer mit Tempo 3×6</source>
+        <target>Archer με ρυθμό 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.54.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Διαμάντι 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.57.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×5 — Phase 3 abschließen</source>
+        <target>Μερικές με έναν βραχίονα 3×5 — ολοκλήρωση φάσης 3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.59.desc">
+      <segment state="translated">
+        <source>Tempo-Archer 3×7</source>
+        <target>Archer με ρυθμό 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.61.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Διαμάντι 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.64.desc">
+      <segment state="translated">
+        <source>Volle Einarmige (weiter Stand) 3×3</source>
+        <target>Πλήρεις με έναν βραχίονα (φαρδιά στάση) 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.66.desc">
+      <segment state="translated">
+        <source>Einarmige (etwas engerer Stand) 3×4</source>
+        <target>Με έναν βραχίονα (λίγο στενότερη στάση) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.68.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.71.desc">
+      <segment state="translated">
+        <source>Volle Einarmige 3×3</source>
+        <target>Πλήρεις με έναν βραχίονα 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.73.desc">
+      <segment state="translated">
+        <source>Einarmige enger Stand 3×5</source>
+        <target>Με έναν βραχίονα στενή στάση 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.75.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.78.desc">
+      <segment state="translated">
+        <source>Letzte schwere Einheit 3×3</source>
+        <target>Τελευταία βαριά συνεδρία 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.80.desc">
+      <segment state="translated">
+        <source>Technik-Taper 2×4 saubere Wiederholungen</source>
+        <target>Taper τεχνικής 2×4 καθαρές επαναλήψεις</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.82.desc">
+      <segment state="translated">
+        <source>Mobility + 2×3 leichte Wiederholungen</source>
+        <target>Κινητικότητα + 2×3 ελαφριές επαναλήψεις</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.83.desc">
+      <segment state="translated">
+        <source>Ruhetag — bereit für Endtest</source>
+        <target>Ημέρα ξεκούρασης — έτοιμος για το τελικό τεστ</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.84.desc">
+      <segment state="translated">
+        <source>Endtest: maximale saubere einarmige Liegestütze pro Seite</source>
+        <target>Τελικό τεστ: μέγιστες καθαρές πιέσεις με έναν βραχίονα ανά πλευρά</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -6301,7 +6301,7 @@
     <unit id="plan.daily-100-30d.title">
       <segment state="translated">
         <source>Daily 100 — 30 Tage zur 100er-Marke</source>
-        <target>Daily 100 — 30 días hasta las 100</target>
+        <target>Daily 100 — 30 días para llegar a las 100</target>
       </segment>
     </unit>
     <unit id="plan.daily-100-30d.summary">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -6004,5 +6004,719 @@
         <target>Abrir guía</target>
       </segment>
     </unit>
+    <unit id="plan.day.rest">
+      <segment state="translated">
+        <source>Ruhetag</source>
+        <target>Día de descanso</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.mobility">
+      <segment state="translated">
+        <source>Ruhetag — Mobility</source>
+        <target>Día de descanso — movilidad</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.prepFinal">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung Endtest</source>
+        <target>Día de descanso — preparación del test final</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light">
+      <segment state="translated">
+        <source>Leichter Tag</source>
+        <target>Día ligero</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.activeRecovery">
+      <segment state="translated">
+        <source>Aktive Erholung</source>
+        <target>Recuperación activa</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.mobility.chestStretch">
+      <segment state="translated">
+        <source>Mobility &amp; Brust-Stretching</source>
+        <target>Movilidad &amp; estiramientos de pecho</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.finalTest.maxNoPause">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze ohne Pause</source>
+        <target>Test final: flexiones máximas sin pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x">
+      <segment state="translated">
+        <source>3×AMRAP</source>
+        <target>3×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x90s">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause</source>
+        <target>3×AMRAP, 90 s de pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x">
+      <segment state="translated">
+        <source>4×AMRAP</source>
+        <target>4×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x60s">
+      <segment state="translated">
+        <source>4×AMRAP, 60 s Pause</source>
+        <target>4×AMRAP, 60 s de pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.targetReps.5">
+      <segment state="translated">
+        <source>5 Sätze Zielwiederholungen</source>
+        <target>5 series de repeticiones objetivo</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.4x90s">
+      <segment state="translated">
+        <source>4 Sätze, 90 s Pause</source>
+        <target>4 series, 90 s de pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.3x70pct">
+      <segment state="translated">
+        <source>3 Sätze à 70 %</source>
+        <target>3 series al 70 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light.2x50pct">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 %</source>
+        <target>Día ligero — 2×50 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.title">
+      <segment state="translated">
+        <source>Von 0 auf 100 — 6-Wochen-Aufbau</source>
+        <target>De 0 a 100 — plan de 6 semanas</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.summary">
+      <segment state="translated">
+        <source>Strukturierter Plan für Einsteiger: drei Trainingstage pro Woche, progressive Belastungssteigerung und ein Endtest in Woche 6.</source>
+        <target>Plan estructurado para principiantes: tres días de entrenamiento por semana, sobrecarga progresiva y test final en la semana 6.</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-steigern</source>
+        <target>progresion-flexiones</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.1.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze, 90 s Pause</source>
+        <target>3×10 flexiones limpias, 90 s de pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.2.desc">
+      <segment state="translated">
+        <source>Ruhetag — Stretching, Mobility</source>
+        <target>Día de descanso — estiramientos, movilidad</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.3.desc">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause (Ziel ≈12-11-10)</source>
+        <target>3×AMRAP, 90 s de pausa (objetivo ≈12-11-10)</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 50 % vom Maximum</source>
+        <target>Día ligero — 50 % del máximo</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.36.desc">
+      <segment state="translated">
+        <source>5 Sätze, volle Bewegungsamplitude</source>
+        <target>5 series, rango completo de movimiento</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.38.desc">
+      <segment state="translated">
+        <source>5 Sätze, kontrolliertes Tempo</source>
+        <target>5 series, tempo controlado</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.40.desc">
+      <segment state="translated">
+        <source>5 Sätze leicht</source>
+        <target>5 series ligeras</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.title">
+      <segment state="translated">
+        <source>30-Tage-Challenge</source>
+        <target>Desafío de 30 días</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.summary">
+      <segment state="translated">
+        <source>Dreißig Tage tägliches Training mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest.</source>
+        <target>Treinta días de entrenamiento diario con días de descanso estratégicos. Día 1 es el test máximo, día 30 el test final.</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.blogSlug">
+      <segment state="translated">
+        <source>30-tage-liegestuetze-challenge</source>
+        <target>desafio-flexiones-30-dias</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest — als Ausgangswert eintragen</source>
+        <target>Test máximo — registra como punto de partida</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.3.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 % vom Maximum</source>
+        <target>Día ligero — 2×50 % del máximo</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.9.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 3×60 % vom Maximum</source>
+        <target>Día ligero — 3×60 % del máximo</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.15.desc">
+      <segment state="translated">
+        <source>5 Sätze à ~80 % vom Maximum</source>
+        <target>5 series al ~80 % del máximo</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.22.desc">
+      <segment state="translated">
+        <source>3 Sätze à 70 % — Qualität vor Quantität</source>
+        <target>3 series al 70 % — calidad antes que cantidad</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.27.desc">
+      <segment state="translated">
+        <source>Aktive Erholung — Spaziergang, Mobility</source>
+        <target>Recuperación activa — paseo, movilidad</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhe vor dem Endtest</source>
+        <target>Descanso antes del test final</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.title">
+      <segment state="translated">
+        <source>Liegestütze ab 40 — 4-Wochen-Plan</source>
+        <target>Flexiones a partir de 40 — plan de 4 semanas</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.summary">
+      <segment state="translated">
+        <source>Schonender 4-Wochen-Plan für Einsteiger ab 40: Fokus auf saubere Technik, ausreichend Pause und langsames Tempo.</source>
+        <target>Plan suave de 4 semanas para principiantes mayores de 40: técnica limpia, pausas suficientes y tempo lento.</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-ab-40</source>
+        <target>flexiones-mayores-40</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest mit sauberer Technik</source>
+        <target>Test máximo con técnica limpia</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.2.desc">
+      <segment state="translated">
+        <source>3×8 Knie- oder erhöhte Liegestütze</source>
+        <target>3×8 flexiones de rodillas o elevadas</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.4.desc">
+      <segment state="translated">
+        <source>3×9 saubere Liegestütze</source>
+        <target>3×9 flexiones limpias</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.5.desc">
+      <segment state="translated">
+        <source>Ruhetag — Schulter-Mobility</source>
+        <target>Día de descanso — movilidad de hombros</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.6.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze</source>
+        <target>3×10 flexiones limpias</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.8.desc">
+      <segment state="translated">
+        <source>3×11</source>
+        <target>3×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.10.desc">
+      <segment state="translated">
+        <source>3×12</source>
+        <target>3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.12.desc">
+      <segment state="translated">
+        <source>3×13</source>
+        <target>3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.22.desc">
+      <segment state="translated">
+        <source>4 Sätze, kontrolliertes Tempo</source>
+        <target>4 series, tempo controlado</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.24.desc">
+      <segment state="translated">
+        <source>4 Sätze, langsame Exzentrik</source>
+        <target>4 series, excéntrica lenta</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.28.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze</source>
+        <target>Test final: flexiones máximas</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.title">
+      <segment state="translated">
+        <source>Daily 100 — 30 Tage zur 100er-Marke</source>
+        <target>Daily 100 — 30 días hasta las 100</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.summary">
+      <segment state="translated">
+        <source>30-Tage-Volumenplan: ramp-up von 50 auf 100 saubere Wiederholungen pro Einheit, danach zwei Wochen Konsolidierung. 5 Trainingstage + 1 leichter + 1 Ruhetag pro Woche.</source>
+        <target>Plan de volumen de 30 días: subida de 50 a 100 repeticiones limpias por sesión, después dos semanas de consolidación. 5 días de entrenamiento + 1 ligero + 1 descanso por semana.</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.1.desc">
+      <segment state="translated">
+        <source>Baseline-Test: maximale Wiederholungen in einem Satz</source>
+        <target>Test de referencia: repeticiones máximas en una serie</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.2.desc">
+      <segment state="translated">
+        <source>5×10 saubere Wiederholungen, 60 s Pause</source>
+        <target>5×10 repeticiones limpias, 60 s de pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.3.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 s de pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.4.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 s de pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.5.desc">
+      <segment state="translated">
+        <source>5×14, 60 s Pause</source>
+        <target>5×14, 60 s de pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×15 in lockerem Tempo</source>
+        <target>Día ligero — 2×15 a tempo relajado</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.8.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.9.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.10.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.11.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.12.desc">
+      <segment state="translated">
+        <source>Erstes Hundert: 5×20</source>
+        <target>Primer centenar: 5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.15.desc">
+      <segment state="translated">
+        <source>4×25 (weniger Sätze, mehr Wiederholungen)</source>
+        <target>4×25 (menos series, más repeticiones)</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.16.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.17.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.18.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.19.desc">
+      <segment state="translated">
+        <source>4×25 — Tempo bewusst verlangsamen</source>
+        <target>4×25 — ralentiza el tempo conscientemente</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.22.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.23.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.24.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.25.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.26.desc">
+      <segment state="translated">
+        <source>Letzter 100er-Tag vor dem Test</source>
+        <target>Último día de 100 antes del test</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.27.desc">
+      <segment state="translated">
+        <source>Leichter Tag — Form-Check</source>
+        <target>Día ligero — chequeo de técnica</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung auf den Endtest</source>
+        <target>Día de descanso — preparación para el test final</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.30.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale saubere Wiederholungen in einem Satz</source>
+        <target>Test final: repeticiones limpias máximas en una serie</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.title">
+      <segment state="translated">
+        <source>Einarmige Liegestütze — 12-Wochen-Aufbau</source>
+        <target>Flexiones a un brazo — plan de 12 semanas</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.summary">
+      <segment state="translated">
+        <source>Vier-Phasen-Plan in Richtung saubere einarmige Liegestütze: Archer und Wand-Negativen, Bank-Negativen, partielle Einarmige, schließlich volle Einarmige im weiten Stand. 4 aktive Tage + 3 Ruhetage pro Woche.</source>
+        <target>Plan en cuatro fases hacia una flexión limpia a un brazo: archer y negativas en pared, negativas en banco, parciales a un brazo, finalmente flexiones completas a un brazo en posición amplia. 4 días activos + 3 de descanso por semana.</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.1.desc">
+      <segment state="translated">
+        <source>Archer-Liegestütze 3×6</source>
+        <target>Flexiones archer 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.3.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×10 (langsame Exzentrik)</source>
+        <target>Flexiones a un brazo en pared 3×10 (excéntrica lenta)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.5.desc">
+      <segment state="translated">
+        <source>Standard-Liegestütze 3×20 (Volumen)</source>
+        <target>Flexiones estándar 3×20 (volumen)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×10</source>
+        <target>Día ligero 2×10</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.8.desc">
+      <segment state="translated">
+        <source>Archer 3×8</source>
+        <target>Archer 3×8</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.10.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×12</source>
+        <target>Flexiones a un brazo en pared 3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.12.desc">
+      <segment state="translated">
+        <source>Standard 3×22</source>
+        <target>Estándar 3×22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.13.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×12</source>
+        <target>Día ligero 2×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.15.desc">
+      <segment state="translated">
+        <source>Archer 3×10 — Phase 1 abschließen</source>
+        <target>Archer 3×10 — cerrar la fase 1</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.17.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×15</source>
+        <target>Flexiones a un brazo en pared 3×15</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.19.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Estándar 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.20.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×14</source>
+        <target>Día ligero 2×14</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.22.desc">
+      <segment state="translated">
+        <source>Negative Einarmige von Bank 3×5 (3 s runter)</source>
+        <target>Negativas a un brazo desde banco 3×5 (3 s bajada)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.24.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×6 (Tempo 3-1-1)</source>
+        <target>Archer lentas 3×6 (tempo 3-1-1)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.26.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20 (Brust-Volumen)</source>
+        <target>Flexiones amplias 3×20 (volumen pectoral)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.29.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×5</source>
+        <target>Negativas a un brazo 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.31.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×7</source>
+        <target>Archer lentas 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.33.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20</source>
+        <target>Flexiones amplias 3×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.34.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×11</source>
+        <target>Día ligero 2×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.36.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×6</source>
+        <target>Negativas a un brazo 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.38.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×8 — Phase 2 abschließen</source>
+        <target>Archer lentas 3×8 — cerrar la fase 2</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.40.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×~22</source>
+        <target>Flexiones amplias 3×~22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.43.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige (niedrige Bank) 3×4</source>
+        <target>Parciales a un brazo (banco bajo) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.45.desc">
+      <segment state="translated">
+        <source>Archer mit langem Tempo 3×6</source>
+        <target>Archer con tempo largo 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.47.desc">
+      <segment state="translated">
+        <source>Diamant-Liegestütze 3×12 (Trizeps-Volumen)</source>
+        <target>Flexiones diamante 3×12 (volumen tríceps)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.50.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×4</source>
+        <target>Parciales a un brazo 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.52.desc">
+      <segment state="translated">
+        <source>Archer mit Tempo 3×6</source>
+        <target>Archer con tempo 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.54.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Diamante 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.57.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×5 — Phase 3 abschließen</source>
+        <target>Parciales a un brazo 3×5 — cerrar la fase 3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.59.desc">
+      <segment state="translated">
+        <source>Tempo-Archer 3×7</source>
+        <target>Archer en tempo 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.61.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Diamante 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.64.desc">
+      <segment state="translated">
+        <source>Volle Einarmige (weiter Stand) 3×3</source>
+        <target>Flexiones completas a un brazo (posición amplia) 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.66.desc">
+      <segment state="translated">
+        <source>Einarmige (etwas engerer Stand) 3×4</source>
+        <target>Flexiones a un brazo (posición algo más estrecha) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.68.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Estándar 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.71.desc">
+      <segment state="translated">
+        <source>Volle Einarmige 3×3</source>
+        <target>Flexiones completas a un brazo 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.73.desc">
+      <segment state="translated">
+        <source>Einarmige enger Stand 3×5</source>
+        <target>Flexiones a un brazo posición estrecha 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.75.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Estándar 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.78.desc">
+      <segment state="translated">
+        <source>Letzte schwere Einheit 3×3</source>
+        <target>Última sesión pesada 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.80.desc">
+      <segment state="translated">
+        <source>Technik-Taper 2×4 saubere Wiederholungen</source>
+        <target>Taper técnico 2×4 repeticiones limpias</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.82.desc">
+      <segment state="translated">
+        <source>Mobility + 2×3 leichte Wiederholungen</source>
+        <target>Movilidad + 2×3 repeticiones ligeras</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.83.desc">
+      <segment state="translated">
+        <source>Ruhetag — bereit für Endtest</source>
+        <target>Día de descanso — listo para el test final</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.84.desc">
+      <segment state="translated">
+        <source>Endtest: maximale saubere einarmige Liegestütze pro Seite</source>
+        <target>Test final: flexiones limpias a un brazo máximas por lado</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -6004,5 +6004,719 @@
         <target>Ouvrir le guide</target>
       </segment>
     </unit>
+    <unit id="plan.day.rest">
+      <segment state="translated">
+        <source>Ruhetag</source>
+        <target>Jour de repos</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.mobility">
+      <segment state="translated">
+        <source>Ruhetag — Mobility</source>
+        <target>Jour de repos — mobilité</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.prepFinal">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung Endtest</source>
+        <target>Jour de repos — préparation au test final</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light">
+      <segment state="translated">
+        <source>Leichter Tag</source>
+        <target>Journée légère</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.activeRecovery">
+      <segment state="translated">
+        <source>Aktive Erholung</source>
+        <target>Récupération active</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.mobility.chestStretch">
+      <segment state="translated">
+        <source>Mobility &amp; Brust-Stretching</source>
+        <target>Mobilité &amp; étirements pectoraux</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.finalTest.maxNoPause">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze ohne Pause</source>
+        <target>Test final : pompes maximales sans pause</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x">
+      <segment state="translated">
+        <source>3×AMRAP</source>
+        <target>3×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x90s">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause</source>
+        <target>3×AMRAP, 90 s de pause</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x">
+      <segment state="translated">
+        <source>4×AMRAP</source>
+        <target>4×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x60s">
+      <segment state="translated">
+        <source>4×AMRAP, 60 s Pause</source>
+        <target>4×AMRAP, 60 s de pause</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.targetReps.5">
+      <segment state="translated">
+        <source>5 Sätze Zielwiederholungen</source>
+        <target>5 séries de répétitions cibles</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.4x90s">
+      <segment state="translated">
+        <source>4 Sätze, 90 s Pause</source>
+        <target>4 séries, 90 s de pause</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.3x70pct">
+      <segment state="translated">
+        <source>3 Sätze à 70 %</source>
+        <target>3 séries à 70 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light.2x50pct">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 %</source>
+        <target>Journée légère — 2×50 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.title">
+      <segment state="translated">
+        <source>Von 0 auf 100 — 6-Wochen-Aufbau</source>
+        <target>De 0 à 100 — programme de 6 semaines</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.summary">
+      <segment state="translated">
+        <source>Strukturierter Plan für Einsteiger: drei Trainingstage pro Woche, progressive Belastungssteigerung und ein Endtest in Woche 6.</source>
+        <target>Plan structuré pour débutants : trois jours d'entraînement par semaine, surcharge progressive et test final en semaine 6.</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-steigern</source>
+        <target>progression-pompes</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.1.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze, 90 s Pause</source>
+        <target>3×10 pompes propres, 90 s de pause</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.2.desc">
+      <segment state="translated">
+        <source>Ruhetag — Stretching, Mobility</source>
+        <target>Jour de repos — étirements, mobilité</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.3.desc">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause (Ziel ≈12-11-10)</source>
+        <target>3×AMRAP, 90 s de pause (objectif ≈12-11-10)</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 50 % vom Maximum</source>
+        <target>Journée légère — 50 % du maximum</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.36.desc">
+      <segment state="translated">
+        <source>5 Sätze, volle Bewegungsamplitude</source>
+        <target>5 séries, amplitude complète</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.38.desc">
+      <segment state="translated">
+        <source>5 Sätze, kontrolliertes Tempo</source>
+        <target>5 séries, tempo contrôlé</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.40.desc">
+      <segment state="translated">
+        <source>5 Sätze leicht</source>
+        <target>5 séries légères</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.title">
+      <segment state="translated">
+        <source>30-Tage-Challenge</source>
+        <target>Défi 30 jours</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.summary">
+      <segment state="translated">
+        <source>Dreißig Tage tägliches Training mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest.</source>
+        <target>Trente jours d'entraînement quotidien avec des jours de repos ciblés. Jour 1 est le test max, jour 30 le test final.</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.blogSlug">
+      <segment state="translated">
+        <source>30-tage-liegestuetze-challenge</source>
+        <target>defi-pompes-30-jours</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest — als Ausgangswert eintragen</source>
+        <target>Test maximum — à enregistrer comme référence</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.3.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 % vom Maximum</source>
+        <target>Journée légère — 2×50 % du maximum</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.9.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 3×60 % vom Maximum</source>
+        <target>Journée légère — 3×60 % du maximum</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.15.desc">
+      <segment state="translated">
+        <source>5 Sätze à ~80 % vom Maximum</source>
+        <target>5 séries à ~80 % du maximum</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.22.desc">
+      <segment state="translated">
+        <source>3 Sätze à 70 % — Qualität vor Quantität</source>
+        <target>3 séries à 70 % — qualité avant quantité</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.27.desc">
+      <segment state="translated">
+        <source>Aktive Erholung — Spaziergang, Mobility</source>
+        <target>Récupération active — marche, mobilité</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhe vor dem Endtest</source>
+        <target>Repos avant le test final</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.title">
+      <segment state="translated">
+        <source>Liegestütze ab 40 — 4-Wochen-Plan</source>
+        <target>Pompes après 40 ans — plan de 4 semaines</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.summary">
+      <segment state="translated">
+        <source>Schonender 4-Wochen-Plan für Einsteiger ab 40: Fokus auf saubere Technik, ausreichend Pause und langsames Tempo.</source>
+        <target>Plan doux de 4 semaines pour débutants de plus de 40 ans : technique propre, pauses suffisantes et tempo lent.</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-ab-40</source>
+        <target>pompes-apres-40-ans</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest mit sauberer Technik</source>
+        <target>Test maximum avec technique propre</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.2.desc">
+      <segment state="translated">
+        <source>3×8 Knie- oder erhöhte Liegestütze</source>
+        <target>3×8 pompes sur genoux ou inclinées</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.4.desc">
+      <segment state="translated">
+        <source>3×9 saubere Liegestütze</source>
+        <target>3×9 pompes propres</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.5.desc">
+      <segment state="translated">
+        <source>Ruhetag — Schulter-Mobility</source>
+        <target>Jour de repos — mobilité des épaules</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.6.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze</source>
+        <target>3×10 pompes propres</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.8.desc">
+      <segment state="translated">
+        <source>3×11</source>
+        <target>3×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.10.desc">
+      <segment state="translated">
+        <source>3×12</source>
+        <target>3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.12.desc">
+      <segment state="translated">
+        <source>3×13</source>
+        <target>3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.22.desc">
+      <segment state="translated">
+        <source>4 Sätze, kontrolliertes Tempo</source>
+        <target>4 séries, tempo contrôlé</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.24.desc">
+      <segment state="translated">
+        <source>4 Sätze, langsame Exzentrik</source>
+        <target>4 séries, excentrique lent</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.28.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze</source>
+        <target>Test final : pompes maximales</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.title">
+      <segment state="translated">
+        <source>Daily 100 — 30 Tage zur 100er-Marke</source>
+        <target>Daily 100 — 30 jours pour atteindre les 100</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.summary">
+      <segment state="translated">
+        <source>30-Tage-Volumenplan: ramp-up von 50 auf 100 saubere Wiederholungen pro Einheit, danach zwei Wochen Konsolidierung. 5 Trainingstage + 1 leichter + 1 Ruhetag pro Woche.</source>
+        <target>Plan de volume sur 30 jours : montée de 50 à 100 répétitions propres par séance, puis deux semaines de consolidation. 5 jours d'entraînement + 1 léger + 1 repos par semaine.</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.1.desc">
+      <segment state="translated">
+        <source>Baseline-Test: maximale Wiederholungen in einem Satz</source>
+        <target>Test de référence : répétitions maximales en une série</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.2.desc">
+      <segment state="translated">
+        <source>5×10 saubere Wiederholungen, 60 s Pause</source>
+        <target>5×10 répétitions propres, 60 s de pause</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.3.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 s de pause</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.4.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 s de pause</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.5.desc">
+      <segment state="translated">
+        <source>5×14, 60 s Pause</source>
+        <target>5×14, 60 s de pause</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×15 in lockerem Tempo</source>
+        <target>Journée légère — 2×15 à un tempo détendu</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.8.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.9.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.10.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.11.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.12.desc">
+      <segment state="translated">
+        <source>Erstes Hundert: 5×20</source>
+        <target>Première centaine : 5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.15.desc">
+      <segment state="translated">
+        <source>4×25 (weniger Sätze, mehr Wiederholungen)</source>
+        <target>4×25 (moins de séries, plus de répétitions)</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.16.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.17.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.18.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.19.desc">
+      <segment state="translated">
+        <source>4×25 — Tempo bewusst verlangsamen</source>
+        <target>4×25 — ralentir volontairement le tempo</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.22.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.23.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.24.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.25.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.26.desc">
+      <segment state="translated">
+        <source>Letzter 100er-Tag vor dem Test</source>
+        <target>Dernier jour à 100 avant le test</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.27.desc">
+      <segment state="translated">
+        <source>Leichter Tag — Form-Check</source>
+        <target>Journée légère — vérification de la forme</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung auf den Endtest</source>
+        <target>Jour de repos — préparation au test final</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.30.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale saubere Wiederholungen in einem Satz</source>
+        <target>Test final : répétitions propres maximales en une série</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.title">
+      <segment state="translated">
+        <source>Einarmige Liegestütze — 12-Wochen-Aufbau</source>
+        <target>Pompes à un bras — programme de 12 semaines</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.summary">
+      <segment state="translated">
+        <source>Vier-Phasen-Plan in Richtung saubere einarmige Liegestütze: Archer und Wand-Negativen, Bank-Negativen, partielle Einarmige, schließlich volle Einarmige im weiten Stand. 4 aktive Tage + 3 Ruhetage pro Woche.</source>
+        <target>Plan en quatre phases vers une pompe propre à un bras : archer et négatives au mur, négatives sur banc, pompes partielles à un bras, puis pompes complètes à un bras en position large. 4 jours actifs + 3 jours de repos par semaine.</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.1.desc">
+      <segment state="translated">
+        <source>Archer-Liegestütze 3×6</source>
+        <target>Pompes archer 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.3.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×10 (langsame Exzentrik)</source>
+        <target>Pompes à un bras au mur 3×10 (excentrique lent)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.5.desc">
+      <segment state="translated">
+        <source>Standard-Liegestütze 3×20 (Volumen)</source>
+        <target>Pompes standard 3×20 (volume)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×10</source>
+        <target>Journée légère 2×10</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.8.desc">
+      <segment state="translated">
+        <source>Archer 3×8</source>
+        <target>Archer 3×8</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.10.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×12</source>
+        <target>Pompes à un bras au mur 3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.12.desc">
+      <segment state="translated">
+        <source>Standard 3×22</source>
+        <target>Standard 3×22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.13.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×12</source>
+        <target>Journée légère 2×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.15.desc">
+      <segment state="translated">
+        <source>Archer 3×10 — Phase 1 abschließen</source>
+        <target>Archer 3×10 — clôturer la phase 1</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.17.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×15</source>
+        <target>Pompes à un bras au mur 3×15</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.19.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.20.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×14</source>
+        <target>Journée légère 2×14</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.22.desc">
+      <segment state="translated">
+        <source>Negative Einarmige von Bank 3×5 (3 s runter)</source>
+        <target>Négatives à un bras depuis un banc 3×5 (3 s à la descente)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.24.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×6 (Tempo 3-1-1)</source>
+        <target>Archer lentes 3×6 (tempo 3-1-1)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.26.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20 (Brust-Volumen)</source>
+        <target>Pompes larges 3×20 (volume pectoral)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.29.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×5</source>
+        <target>Négatives à un bras 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.31.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×7</source>
+        <target>Archer lentes 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.33.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20</source>
+        <target>Pompes larges 3×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.34.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×11</source>
+        <target>Journée légère 2×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.36.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×6</source>
+        <target>Négatives à un bras 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.38.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×8 — Phase 2 abschließen</source>
+        <target>Archer lentes 3×8 — clôturer la phase 2</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.40.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×~22</source>
+        <target>Pompes larges 3×~22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.43.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige (niedrige Bank) 3×4</source>
+        <target>Pompes partielles à un bras (banc bas) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.45.desc">
+      <segment state="translated">
+        <source>Archer mit langem Tempo 3×6</source>
+        <target>Archer en tempo lent 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.47.desc">
+      <segment state="translated">
+        <source>Diamant-Liegestütze 3×12 (Trizeps-Volumen)</source>
+        <target>Pompes diamant 3×12 (volume triceps)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.50.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×4</source>
+        <target>Partielles à un bras 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.52.desc">
+      <segment state="translated">
+        <source>Archer mit Tempo 3×6</source>
+        <target>Archer en tempo 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.54.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Diamant 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.57.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×5 — Phase 3 abschließen</source>
+        <target>Partielles à un bras 3×5 — clôturer la phase 3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.59.desc">
+      <segment state="translated">
+        <source>Tempo-Archer 3×7</source>
+        <target>Archer en tempo 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.61.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Diamant 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.64.desc">
+      <segment state="translated">
+        <source>Volle Einarmige (weiter Stand) 3×3</source>
+        <target>Pompes complètes à un bras (position large) 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.66.desc">
+      <segment state="translated">
+        <source>Einarmige (etwas engerer Stand) 3×4</source>
+        <target>Pompes à un bras (position un peu plus serrée) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.68.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.71.desc">
+      <segment state="translated">
+        <source>Volle Einarmige 3×3</source>
+        <target>Pompes complètes à un bras 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.73.desc">
+      <segment state="translated">
+        <source>Einarmige enger Stand 3×5</source>
+        <target>Pompes à un bras position serrée 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.75.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.78.desc">
+      <segment state="translated">
+        <source>Letzte schwere Einheit 3×3</source>
+        <target>Dernière séance lourde 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.80.desc">
+      <segment state="translated">
+        <source>Technik-Taper 2×4 saubere Wiederholungen</source>
+        <target>Affûtage technique 2×4 répétitions propres</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.82.desc">
+      <segment state="translated">
+        <source>Mobility + 2×3 leichte Wiederholungen</source>
+        <target>Mobilité + 2×3 répétitions légères</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.83.desc">
+      <segment state="translated">
+        <source>Ruhetag — bereit für Endtest</source>
+        <target>Jour de repos — prêt pour le test final</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.84.desc">
+      <segment state="translated">
+        <source>Endtest: maximale saubere einarmige Liegestütze pro Seite</source>
+        <target>Test final : pompes propres à un bras maximales par côté</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -6004,5 +6004,719 @@
         <target>Apri la guida</target>
       </segment>
     </unit>
+    <unit id="plan.day.rest">
+      <segment state="translated">
+        <source>Ruhetag</source>
+        <target>Giorno di riposo</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.mobility">
+      <segment state="translated">
+        <source>Ruhetag — Mobility</source>
+        <target>Giorno di riposo — mobilità</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.prepFinal">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung Endtest</source>
+        <target>Giorno di riposo — preparazione al test finale</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light">
+      <segment state="translated">
+        <source>Leichter Tag</source>
+        <target>Giorno leggero</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.activeRecovery">
+      <segment state="translated">
+        <source>Aktive Erholung</source>
+        <target>Recupero attivo</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.mobility.chestStretch">
+      <segment state="translated">
+        <source>Mobility &amp; Brust-Stretching</source>
+        <target>Mobilità &amp; stretching del petto</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.finalTest.maxNoPause">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze ohne Pause</source>
+        <target>Test finale: piegamenti massimi senza pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x">
+      <segment state="translated">
+        <source>3×AMRAP</source>
+        <target>3×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x90s">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause</source>
+        <target>3×AMRAP, 90 s di pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x">
+      <segment state="translated">
+        <source>4×AMRAP</source>
+        <target>4×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x60s">
+      <segment state="translated">
+        <source>4×AMRAP, 60 s Pause</source>
+        <target>4×AMRAP, 60 s di pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.targetReps.5">
+      <segment state="translated">
+        <source>5 Sätze Zielwiederholungen</source>
+        <target>5 serie di ripetizioni target</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.4x90s">
+      <segment state="translated">
+        <source>4 Sätze, 90 s Pause</source>
+        <target>4 serie, 90 s di pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.3x70pct">
+      <segment state="translated">
+        <source>3 Sätze à 70 %</source>
+        <target>3 serie al 70 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light.2x50pct">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 %</source>
+        <target>Giorno leggero — 2×50 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.title">
+      <segment state="translated">
+        <source>Von 0 auf 100 — 6-Wochen-Aufbau</source>
+        <target>Da 0 a 100 — programma di 6 settimane</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.summary">
+      <segment state="translated">
+        <source>Strukturierter Plan für Einsteiger: drei Trainingstage pro Woche, progressive Belastungssteigerung und ein Endtest in Woche 6.</source>
+        <target>Programma strutturato per principianti: tre giorni di allenamento a settimana, sovraccarico progressivo e test finale in settimana 6.</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-steigern</source>
+        <target>progressione-piegamenti</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.1.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze, 90 s Pause</source>
+        <target>3×10 piegamenti puliti, 90 s di pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.2.desc">
+      <segment state="translated">
+        <source>Ruhetag — Stretching, Mobility</source>
+        <target>Giorno di riposo — stretching, mobilità</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.3.desc">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause (Ziel ≈12-11-10)</source>
+        <target>3×AMRAP, 90 s di pausa (obiettivo ≈12-11-10)</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 50 % vom Maximum</source>
+        <target>Giorno leggero — 50 % del massimo</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.36.desc">
+      <segment state="translated">
+        <source>5 Sätze, volle Bewegungsamplitude</source>
+        <target>5 serie, escursione completa</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.38.desc">
+      <segment state="translated">
+        <source>5 Sätze, kontrolliertes Tempo</source>
+        <target>5 serie, tempo controllato</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.40.desc">
+      <segment state="translated">
+        <source>5 Sätze leicht</source>
+        <target>5 serie leggere</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.title">
+      <segment state="translated">
+        <source>30-Tage-Challenge</source>
+        <target>Sfida di 30 giorni</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.summary">
+      <segment state="translated">
+        <source>Dreißig Tage tägliches Training mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest.</source>
+        <target>Trenta giorni di allenamento quotidiano con giorni di riposo mirati. Il giorno 1 è il test massimo, il giorno 30 il test finale.</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.blogSlug">
+      <segment state="translated">
+        <source>30-tage-liegestuetze-challenge</source>
+        <target>sfida-30-giorni-piegamenti</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest — als Ausgangswert eintragen</source>
+        <target>Test massimo — registra come valore di partenza</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.3.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 % vom Maximum</source>
+        <target>Giorno leggero — 2×50 % del massimo</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.9.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 3×60 % vom Maximum</source>
+        <target>Giorno leggero — 3×60 % del massimo</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.15.desc">
+      <segment state="translated">
+        <source>5 Sätze à ~80 % vom Maximum</source>
+        <target>5 serie al ~80 % del massimo</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.22.desc">
+      <segment state="translated">
+        <source>3 Sätze à 70 % — Qualität vor Quantität</source>
+        <target>3 serie al 70 % — qualità prima della quantità</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.27.desc">
+      <segment state="translated">
+        <source>Aktive Erholung — Spaziergang, Mobility</source>
+        <target>Recupero attivo — camminata, mobilità</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhe vor dem Endtest</source>
+        <target>Riposo prima del test finale</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.title">
+      <segment state="translated">
+        <source>Liegestütze ab 40 — 4-Wochen-Plan</source>
+        <target>Piegamenti dopo i 40 — programma di 4 settimane</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.summary">
+      <segment state="translated">
+        <source>Schonender 4-Wochen-Plan für Einsteiger ab 40: Fokus auf saubere Technik, ausreichend Pause und langsames Tempo.</source>
+        <target>Programma soft di 4 settimane per principianti over 40: tecnica pulita, pause adeguate e tempo lento.</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-ab-40</source>
+        <target>piegamenti-dopo-i-40</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest mit sauberer Technik</source>
+        <target>Test massimo con tecnica pulita</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.2.desc">
+      <segment state="translated">
+        <source>3×8 Knie- oder erhöhte Liegestütze</source>
+        <target>3×8 piegamenti sulle ginocchia o sopraelevati</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.4.desc">
+      <segment state="translated">
+        <source>3×9 saubere Liegestütze</source>
+        <target>3×9 piegamenti puliti</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.5.desc">
+      <segment state="translated">
+        <source>Ruhetag — Schulter-Mobility</source>
+        <target>Giorno di riposo — mobilità delle spalle</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.6.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze</source>
+        <target>3×10 piegamenti puliti</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.8.desc">
+      <segment state="translated">
+        <source>3×11</source>
+        <target>3×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.10.desc">
+      <segment state="translated">
+        <source>3×12</source>
+        <target>3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.12.desc">
+      <segment state="translated">
+        <source>3×13</source>
+        <target>3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.22.desc">
+      <segment state="translated">
+        <source>4 Sätze, kontrolliertes Tempo</source>
+        <target>4 serie, tempo controllato</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.24.desc">
+      <segment state="translated">
+        <source>4 Sätze, langsame Exzentrik</source>
+        <target>4 serie, eccentrica lenta</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.28.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze</source>
+        <target>Test finale: piegamenti massimi</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.title">
+      <segment state="translated">
+        <source>Daily 100 — 30 Tage zur 100er-Marke</source>
+        <target>Daily 100 — 30 giorni fino a quota 100</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.summary">
+      <segment state="translated">
+        <source>30-Tage-Volumenplan: ramp-up von 50 auf 100 saubere Wiederholungen pro Einheit, danach zwei Wochen Konsolidierung. 5 Trainingstage + 1 leichter + 1 Ruhetag pro Woche.</source>
+        <target>Programma di volume di 30 giorni: ramp-up da 50 a 100 ripetizioni pulite per sessione, poi due settimane di consolidamento. 5 giorni di allenamento + 1 leggero + 1 di riposo a settimana.</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.1.desc">
+      <segment state="translated">
+        <source>Baseline-Test: maximale Wiederholungen in einem Satz</source>
+        <target>Test baseline: ripetizioni massime in una serie</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.2.desc">
+      <segment state="translated">
+        <source>5×10 saubere Wiederholungen, 60 s Pause</source>
+        <target>5×10 ripetizioni pulite, 60 s di pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.3.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 s di pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.4.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 s di pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.5.desc">
+      <segment state="translated">
+        <source>5×14, 60 s Pause</source>
+        <target>5×14, 60 s di pausa</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×15 in lockerem Tempo</source>
+        <target>Giorno leggero — 2×15 a tempo rilassato</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.8.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.9.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.10.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.11.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.12.desc">
+      <segment state="translated">
+        <source>Erstes Hundert: 5×20</source>
+        <target>Primo centinaio: 5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.15.desc">
+      <segment state="translated">
+        <source>4×25 (weniger Sätze, mehr Wiederholungen)</source>
+        <target>4×25 (meno serie, più ripetizioni)</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.16.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.17.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.18.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.19.desc">
+      <segment state="translated">
+        <source>4×25 — Tempo bewusst verlangsamen</source>
+        <target>4×25 — rallenta il tempo consapevolmente</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.22.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.23.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.24.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.25.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.26.desc">
+      <segment state="translated">
+        <source>Letzter 100er-Tag vor dem Test</source>
+        <target>Ultimo giorno da 100 prima del test</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.27.desc">
+      <segment state="translated">
+        <source>Leichter Tag — Form-Check</source>
+        <target>Giorno leggero — controllo della forma</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung auf den Endtest</source>
+        <target>Giorno di riposo — preparazione al test finale</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.30.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale saubere Wiederholungen in einem Satz</source>
+        <target>Test finale: ripetizioni pulite massime in una serie</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.title">
+      <segment state="translated">
+        <source>Einarmige Liegestütze — 12-Wochen-Aufbau</source>
+        <target>Piegamenti a un braccio — programma di 12 settimane</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.summary">
+      <segment state="translated">
+        <source>Vier-Phasen-Plan in Richtung saubere einarmige Liegestütze: Archer und Wand-Negativen, Bank-Negativen, partielle Einarmige, schließlich volle Einarmige im weiten Stand. 4 aktive Tage + 3 Ruhetage pro Woche.</source>
+        <target>Programma a quattro fasi verso un piegamento pulito a un braccio: archer e negative al muro, negative su panca, parziali a un braccio, infine piegamenti completi a un braccio in posizione larga. 4 giorni attivi + 3 di riposo a settimana.</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.1.desc">
+      <segment state="translated">
+        <source>Archer-Liegestütze 3×6</source>
+        <target>Piegamenti archer 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.3.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×10 (langsame Exzentrik)</source>
+        <target>Piegamenti a un braccio al muro 3×10 (eccentrica lenta)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.5.desc">
+      <segment state="translated">
+        <source>Standard-Liegestütze 3×20 (Volumen)</source>
+        <target>Piegamenti standard 3×20 (volume)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×10</source>
+        <target>Giorno leggero 2×10</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.8.desc">
+      <segment state="translated">
+        <source>Archer 3×8</source>
+        <target>Archer 3×8</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.10.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×12</source>
+        <target>Piegamenti a un braccio al muro 3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.12.desc">
+      <segment state="translated">
+        <source>Standard 3×22</source>
+        <target>Standard 3×22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.13.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×12</source>
+        <target>Giorno leggero 2×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.15.desc">
+      <segment state="translated">
+        <source>Archer 3×10 — Phase 1 abschließen</source>
+        <target>Archer 3×10 — chiudere la fase 1</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.17.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×15</source>
+        <target>Piegamenti a un braccio al muro 3×15</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.19.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.20.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×14</source>
+        <target>Giorno leggero 2×14</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.22.desc">
+      <segment state="translated">
+        <source>Negative Einarmige von Bank 3×5 (3 s runter)</source>
+        <target>Negative a un braccio da panca 3×5 (3 s in discesa)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.24.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×6 (Tempo 3-1-1)</source>
+        <target>Archer lente 3×6 (tempo 3-1-1)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.26.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20 (Brust-Volumen)</source>
+        <target>Piegamenti larghi 3×20 (volume pettorale)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.29.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×5</source>
+        <target>Negative a un braccio 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.31.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×7</source>
+        <target>Archer lente 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.33.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20</source>
+        <target>Piegamenti larghi 3×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.34.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×11</source>
+        <target>Giorno leggero 2×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.36.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×6</source>
+        <target>Negative a un braccio 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.38.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×8 — Phase 2 abschließen</source>
+        <target>Archer lente 3×8 — chiudere la fase 2</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.40.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×~22</source>
+        <target>Piegamenti larghi 3×~22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.43.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige (niedrige Bank) 3×4</source>
+        <target>Parziali a un braccio (panca bassa) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.45.desc">
+      <segment state="translated">
+        <source>Archer mit langem Tempo 3×6</source>
+        <target>Archer con tempo lungo 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.47.desc">
+      <segment state="translated">
+        <source>Diamant-Liegestütze 3×12 (Trizeps-Volumen)</source>
+        <target>Piegamenti diamante 3×12 (volume tricipiti)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.50.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×4</source>
+        <target>Parziali a un braccio 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.52.desc">
+      <segment state="translated">
+        <source>Archer mit Tempo 3×6</source>
+        <target>Archer con tempo 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.54.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Diamante 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.57.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×5 — Phase 3 abschließen</source>
+        <target>Parziali a un braccio 3×5 — chiudere la fase 3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.59.desc">
+      <segment state="translated">
+        <source>Tempo-Archer 3×7</source>
+        <target>Archer in tempo 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.61.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Diamante 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.64.desc">
+      <segment state="translated">
+        <source>Volle Einarmige (weiter Stand) 3×3</source>
+        <target>Piegamenti completi a un braccio (posizione larga) 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.66.desc">
+      <segment state="translated">
+        <source>Einarmige (etwas engerer Stand) 3×4</source>
+        <target>Piegamenti a un braccio (posizione un po' più stretta) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.68.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.71.desc">
+      <segment state="translated">
+        <source>Volle Einarmige 3×3</source>
+        <target>Piegamenti completi a un braccio 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.73.desc">
+      <segment state="translated">
+        <source>Einarmige enger Stand 3×5</source>
+        <target>Piegamenti a un braccio posizione stretta 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.75.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.78.desc">
+      <segment state="translated">
+        <source>Letzte schwere Einheit 3×3</source>
+        <target>Ultima sessione pesante 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.80.desc">
+      <segment state="translated">
+        <source>Technik-Taper 2×4 saubere Wiederholungen</source>
+        <target>Taper tecnico 2×4 ripetizioni pulite</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.82.desc">
+      <segment state="translated">
+        <source>Mobility + 2×3 leichte Wiederholungen</source>
+        <target>Mobilità + 2×3 ripetizioni leggere</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.83.desc">
+      <segment state="translated">
+        <source>Ruhetag — bereit für Endtest</source>
+        <target>Giorno di riposo — pronto per il test finale</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.84.desc">
+      <segment state="translated">
+        <source>Endtest: maximale saubere einarmige Liegestütze pro Seite</source>
+        <target>Test finale: piegamenti puliti a un braccio massimi per lato</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -6301,7 +6301,7 @@
     <unit id="plan.daily-100-30d.title">
       <segment state="translated">
         <source>Daily 100 — 30 Tage zur 100er-Marke</source>
-        <target>Daily 100 — triginta dies ad centum</target>
+        <target>Cotidianus Centum — triginta dies ad centum</target>
       </segment>
     </unit>
     <unit id="plan.daily-100-30d.summary">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -6004,5 +6004,719 @@
         <target>Aperire ductum</target>
       </segment>
     </unit>
+    <unit id="plan.day.rest">
+      <segment state="translated">
+        <source>Ruhetag</source>
+        <target>Dies quietis</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.mobility">
+      <segment state="translated">
+        <source>Ruhetag — Mobility</source>
+        <target>Dies quietis — mobilitas</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.prepFinal">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung Endtest</source>
+        <target>Dies quietis — praeparatio ad probam finalem</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light">
+      <segment state="translated">
+        <source>Leichter Tag</source>
+        <target>Dies levis</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.activeRecovery">
+      <segment state="translated">
+        <source>Aktive Erholung</source>
+        <target>Recreatio activa</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.mobility.chestStretch">
+      <segment state="translated">
+        <source>Mobility &amp; Brust-Stretching</source>
+        <target>Mobilitas &amp; extensio pectoris</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.finalTest.maxNoPause">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze ohne Pause</source>
+        <target>Proba finalis: pressiones quam plurimae sine quiete</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x">
+      <segment state="translated">
+        <source>3×AMRAP</source>
+        <target>3×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x90s">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause</source>
+        <target>3×AMRAP, 90 s quietis</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x">
+      <segment state="translated">
+        <source>4×AMRAP</source>
+        <target>4×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x60s">
+      <segment state="translated">
+        <source>4×AMRAP, 60 s Pause</source>
+        <target>4×AMRAP, 60 s quietis</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.targetReps.5">
+      <segment state="translated">
+        <source>5 Sätze Zielwiederholungen</source>
+        <target>5 ordines repetitionum destinatarum</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.4x90s">
+      <segment state="translated">
+        <source>4 Sätze, 90 s Pause</source>
+        <target>4 ordines, 90 s quietis</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.3x70pct">
+      <segment state="translated">
+        <source>3 Sätze à 70 %</source>
+        <target>3 ordines ad 70 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light.2x50pct">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 %</source>
+        <target>Dies levis — 2×50 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.title">
+      <segment state="translated">
+        <source>Von 0 auf 100 — 6-Wochen-Aufbau</source>
+        <target>A 0 ad 100 — progressio sex hebdomadum</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.summary">
+      <segment state="translated">
+        <source>Strukturierter Plan für Einsteiger: drei Trainingstage pro Woche, progressive Belastungssteigerung und ein Endtest in Woche 6.</source>
+        <target>Ratio composita pro novellis: tres dies exercitationis in hebdomada, onus progrediens et proba finalis in hebdomada sexta.</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-steigern</source>
+        <target>progressio-pressionum</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.1.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze, 90 s Pause</source>
+        <target>3×10 pressiones nitidae, 90 s quietis</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.2.desc">
+      <segment state="translated">
+        <source>Ruhetag — Stretching, Mobility</source>
+        <target>Dies quietis — extensio, mobilitas</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.3.desc">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause (Ziel ≈12-11-10)</source>
+        <target>3×AMRAP, 90 s quietis (destinatum ≈12-11-10)</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 50 % vom Maximum</source>
+        <target>Dies levis — 50 % maximi</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.36.desc">
+      <segment state="translated">
+        <source>5 Sätze, volle Bewegungsamplitude</source>
+        <target>5 ordines, plena amplitudo motus</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.38.desc">
+      <segment state="translated">
+        <source>5 Sätze, kontrolliertes Tempo</source>
+        <target>5 ordines, tempore moderato</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.40.desc">
+      <segment state="translated">
+        <source>5 Sätze leicht</source>
+        <target>5 ordines leves</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.title">
+      <segment state="translated">
+        <source>30-Tage-Challenge</source>
+        <target>Provocatio triginta dierum</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.summary">
+      <segment state="translated">
+        <source>Dreißig Tage tägliches Training mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest.</source>
+        <target>Triginta dies cotidianae exercitationis cum diebus quietis destinatis. Dies primus est proba maxima, dies tricesimus proba finalis.</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.blogSlug">
+      <segment state="translated">
+        <source>30-tage-liegestuetze-challenge</source>
+        <target>provocatio-triginta-dierum</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest — als Ausgangswert eintragen</source>
+        <target>Proba maxima — scribe ut initium</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.3.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 % vom Maximum</source>
+        <target>Dies levis — 2×50 % maximi</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.9.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 3×60 % vom Maximum</source>
+        <target>Dies levis — 3×60 % maximi</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.15.desc">
+      <segment state="translated">
+        <source>5 Sätze à ~80 % vom Maximum</source>
+        <target>5 ordines ad ~80 % maximi</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.22.desc">
+      <segment state="translated">
+        <source>3 Sätze à 70 % — Qualität vor Quantität</source>
+        <target>3 ordines ad 70 % — qualitas ante quantitatem</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.27.desc">
+      <segment state="translated">
+        <source>Aktive Erholung — Spaziergang, Mobility</source>
+        <target>Recreatio activa — ambulatio, mobilitas</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhe vor dem Endtest</source>
+        <target>Quies ante probam finalem</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.title">
+      <segment state="translated">
+        <source>Liegestütze ab 40 — 4-Wochen-Plan</source>
+        <target>Pressiones post 40 annos — ratio quattuor hebdomadum</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.summary">
+      <segment state="translated">
+        <source>Schonender 4-Wochen-Plan für Einsteiger ab 40: Fokus auf saubere Technik, ausreichend Pause und langsames Tempo.</source>
+        <target>Ratio mitis quattuor hebdomadum pro novellis ultra 40 annos: cura artis nitidae, satis quietis et tempore tardo.</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-ab-40</source>
+        <target>pressiones-post-xl-annos</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest mit sauberer Technik</source>
+        <target>Proba maxima cum arte nitida</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.2.desc">
+      <segment state="translated">
+        <source>3×8 Knie- oder erhöhte Liegestütze</source>
+        <target>3×8 pressiones in genibus aut elevatae</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.4.desc">
+      <segment state="translated">
+        <source>3×9 saubere Liegestütze</source>
+        <target>3×9 pressiones nitidae</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.5.desc">
+      <segment state="translated">
+        <source>Ruhetag — Schulter-Mobility</source>
+        <target>Dies quietis — mobilitas humerorum</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.6.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze</source>
+        <target>3×10 pressiones nitidae</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.8.desc">
+      <segment state="translated">
+        <source>3×11</source>
+        <target>3×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.10.desc">
+      <segment state="translated">
+        <source>3×12</source>
+        <target>3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.12.desc">
+      <segment state="translated">
+        <source>3×13</source>
+        <target>3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.22.desc">
+      <segment state="translated">
+        <source>4 Sätze, kontrolliertes Tempo</source>
+        <target>4 ordines, tempore moderato</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.24.desc">
+      <segment state="translated">
+        <source>4 Sätze, langsame Exzentrik</source>
+        <target>4 ordines, eccentrica tarda</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.28.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze</source>
+        <target>Proba finalis: pressiones quam plurimae</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.title">
+      <segment state="translated">
+        <source>Daily 100 — 30 Tage zur 100er-Marke</source>
+        <target>Daily 100 — triginta dies ad centum</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.summary">
+      <segment state="translated">
+        <source>30-Tage-Volumenplan: ramp-up von 50 auf 100 saubere Wiederholungen pro Einheit, danach zwei Wochen Konsolidierung. 5 Trainingstage + 1 leichter + 1 Ruhetag pro Woche.</source>
+        <target>Ratio voluminis triginta dierum: ascensus a 50 ad 100 repetitiones nitidas per sessionem, deinde duae hebdomades confirmationis. 5 dies exercitationis + 1 levis + 1 quietis in hebdomada.</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.1.desc">
+      <segment state="translated">
+        <source>Baseline-Test: maximale Wiederholungen in einem Satz</source>
+        <target>Proba initialis: repetitiones quam plurimae in uno ordine</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.2.desc">
+      <segment state="translated">
+        <source>5×10 saubere Wiederholungen, 60 s Pause</source>
+        <target>5×10 repetitiones nitidae, 60 s quietis</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.3.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 s quietis</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.4.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 s quietis</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.5.desc">
+      <segment state="translated">
+        <source>5×14, 60 s Pause</source>
+        <target>5×14, 60 s quietis</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×15 in lockerem Tempo</source>
+        <target>Dies levis — 2×15 tempore remisso</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.8.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.9.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.10.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.11.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.12.desc">
+      <segment state="translated">
+        <source>Erstes Hundert: 5×20</source>
+        <target>Centum prima: 5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.15.desc">
+      <segment state="translated">
+        <source>4×25 (weniger Sätze, mehr Wiederholungen)</source>
+        <target>4×25 (pauciores ordines, plures repetitiones)</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.16.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.17.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.18.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.19.desc">
+      <segment state="translated">
+        <source>4×25 — Tempo bewusst verlangsamen</source>
+        <target>4×25 — tempus consulto retarda</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.22.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.23.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.24.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.25.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.26.desc">
+      <segment state="translated">
+        <source>Letzter 100er-Tag vor dem Test</source>
+        <target>Ultimus dies centum ante probam</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.27.desc">
+      <segment state="translated">
+        <source>Leichter Tag — Form-Check</source>
+        <target>Dies levis — examinatio formae</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung auf den Endtest</source>
+        <target>Dies quietis — praeparatio ad probam finalem</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.30.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale saubere Wiederholungen in einem Satz</source>
+        <target>Proba finalis: repetitiones nitidae quam plurimae in uno ordine</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.title">
+      <segment state="translated">
+        <source>Einarmige Liegestütze — 12-Wochen-Aufbau</source>
+        <target>Pressiones uno bracchio — progressio duodecim hebdomadum</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.summary">
+      <segment state="translated">
+        <source>Vier-Phasen-Plan in Richtung saubere einarmige Liegestütze: Archer und Wand-Negativen, Bank-Negativen, partielle Einarmige, schließlich volle Einarmige im weiten Stand. 4 aktive Tage + 3 Ruhetage pro Woche.</source>
+        <target>Ratio quattuor partium ad pressionem nitidam uno bracchio: archer et negativae ad parietem, negativae ex scamno, partiales uno bracchio, denique plenae uno bracchio in statu lato. 4 dies activi + 3 quietis in hebdomada.</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.1.desc">
+      <segment state="translated">
+        <source>Archer-Liegestütze 3×6</source>
+        <target>Pressiones archer 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.3.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×10 (langsame Exzentrik)</source>
+        <target>Pressiones uno bracchio ad parietem 3×10 (eccentrica tarda)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.5.desc">
+      <segment state="translated">
+        <source>Standard-Liegestütze 3×20 (Volumen)</source>
+        <target>Pressiones usitatae 3×20 (volumen)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×10</source>
+        <target>Dies levis 2×10</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.8.desc">
+      <segment state="translated">
+        <source>Archer 3×8</source>
+        <target>Archer 3×8</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.10.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×12</source>
+        <target>Pressiones uno bracchio ad parietem 3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.12.desc">
+      <segment state="translated">
+        <source>Standard 3×22</source>
+        <target>Usitatum 3×22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.13.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×12</source>
+        <target>Dies levis 2×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.15.desc">
+      <segment state="translated">
+        <source>Archer 3×10 — Phase 1 abschließen</source>
+        <target>Archer 3×10 — phasim primam claudere</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.17.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×15</source>
+        <target>Pressiones uno bracchio ad parietem 3×15</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.19.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Usitatum 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.20.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×14</source>
+        <target>Dies levis 2×14</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.22.desc">
+      <segment state="translated">
+        <source>Negative Einarmige von Bank 3×5 (3 s runter)</source>
+        <target>Negativae uno bracchio ex scamno 3×5 (3 s descendendo)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.24.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×6 (Tempo 3-1-1)</source>
+        <target>Archer tardae 3×6 (tempore 3-1-1)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.26.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20 (Brust-Volumen)</source>
+        <target>Pressiones latae 3×20 (volumen pectoris)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.29.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×5</source>
+        <target>Negativae uno bracchio 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.31.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×7</source>
+        <target>Archer tardae 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.33.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20</source>
+        <target>Pressiones latae 3×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.34.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×11</source>
+        <target>Dies levis 2×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.36.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×6</source>
+        <target>Negativae uno bracchio 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.38.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×8 — Phase 2 abschließen</source>
+        <target>Archer tardae 3×8 — phasim secundam claudere</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.40.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×~22</source>
+        <target>Pressiones latae 3×~22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.43.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige (niedrige Bank) 3×4</source>
+        <target>Partiales uno bracchio (scamno humili) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.45.desc">
+      <segment state="translated">
+        <source>Archer mit langem Tempo 3×6</source>
+        <target>Archer tempore longo 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.47.desc">
+      <segment state="translated">
+        <source>Diamant-Liegestütze 3×12 (Trizeps-Volumen)</source>
+        <target>Pressiones adamantis 3×12 (volumen tricipitis)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.50.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×4</source>
+        <target>Partiales uno bracchio 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.52.desc">
+      <segment state="translated">
+        <source>Archer mit Tempo 3×6</source>
+        <target>Archer cum tempore 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.54.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Adamas 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.57.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×5 — Phase 3 abschließen</source>
+        <target>Partiales uno bracchio 3×5 — phasim tertiam claudere</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.59.desc">
+      <segment state="translated">
+        <source>Tempo-Archer 3×7</source>
+        <target>Archer in tempore 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.61.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Adamas 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.64.desc">
+      <segment state="translated">
+        <source>Volle Einarmige (weiter Stand) 3×3</source>
+        <target>Plenae uno bracchio (statu lato) 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.66.desc">
+      <segment state="translated">
+        <source>Einarmige (etwas engerer Stand) 3×4</source>
+        <target>Uno bracchio (statu paulo angustiore) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.68.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Usitatum 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.71.desc">
+      <segment state="translated">
+        <source>Volle Einarmige 3×3</source>
+        <target>Plenae uno bracchio 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.73.desc">
+      <segment state="translated">
+        <source>Einarmige enger Stand 3×5</source>
+        <target>Uno bracchio statu angusto 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.75.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Usitatum 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.78.desc">
+      <segment state="translated">
+        <source>Letzte schwere Einheit 3×3</source>
+        <target>Ultima sessio gravis 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.80.desc">
+      <segment state="translated">
+        <source>Technik-Taper 2×4 saubere Wiederholungen</source>
+        <target>Taper artis 2×4 repetitiones nitidae</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.82.desc">
+      <segment state="translated">
+        <source>Mobility + 2×3 leichte Wiederholungen</source>
+        <target>Mobilitas + 2×3 repetitiones leves</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.83.desc">
+      <segment state="translated">
+        <source>Ruhetag — bereit für Endtest</source>
+        <target>Dies quietis — paratus ad probam finalem</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.84.desc">
+      <segment state="translated">
+        <source>Endtest: maximale saubere einarmige Liegestütze pro Seite</source>
+        <target>Proba finalis: pressiones nitidae uno bracchio quam plurimae per latus</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -6004,5 +6004,719 @@
         <target>Open handleiding</target>
       </segment>
     </unit>
+    <unit id="plan.day.rest">
+      <segment state="translated">
+        <source>Ruhetag</source>
+        <target>Rustdag</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.mobility">
+      <segment state="translated">
+        <source>Ruhetag — Mobility</source>
+        <target>Rustdag — mobility</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.prepFinal">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung Endtest</source>
+        <target>Rustdag — voorbereiding eindtest</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light">
+      <segment state="translated">
+        <source>Leichter Tag</source>
+        <target>Lichte dag</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.activeRecovery">
+      <segment state="translated">
+        <source>Aktive Erholung</source>
+        <target>Actief herstel</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.mobility.chestStretch">
+      <segment state="translated">
+        <source>Mobility &amp; Brust-Stretching</source>
+        <target>Mobility &amp; borststretching</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.finalTest.maxNoPause">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze ohne Pause</source>
+        <target>Eindtest: maximale opdrukken zonder pauze</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x">
+      <segment state="translated">
+        <source>3×AMRAP</source>
+        <target>3×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x90s">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause</source>
+        <target>3×AMRAP, 90 s pauze</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x">
+      <segment state="translated">
+        <source>4×AMRAP</source>
+        <target>4×AMRAP</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x60s">
+      <segment state="translated">
+        <source>4×AMRAP, 60 s Pause</source>
+        <target>4×AMRAP, 60 s pauze</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.targetReps.5">
+      <segment state="translated">
+        <source>5 Sätze Zielwiederholungen</source>
+        <target>5 sets doelherhalingen</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.4x90s">
+      <segment state="translated">
+        <source>4 Sätze, 90 s Pause</source>
+        <target>4 sets, 90 s pauze</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.3x70pct">
+      <segment state="translated">
+        <source>3 Sätze à 70 %</source>
+        <target>3 sets op 70 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.day.light.2x50pct">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 %</source>
+        <target>Lichte dag — 2×50 %</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.title">
+      <segment state="translated">
+        <source>Von 0 auf 100 — 6-Wochen-Aufbau</source>
+        <target>Van 0 naar 100 — 6 weken opbouw</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.summary">
+      <segment state="translated">
+        <source>Strukturierter Plan für Einsteiger: drei Trainingstage pro Woche, progressive Belastungssteigerung und ein Endtest in Woche 6.</source>
+        <target>Gestructureerd plan voor beginners: drie trainingsdagen per week, progressieve belasting en een eindtest in week 6.</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-steigern</source>
+        <target>opdrukken-progressie</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.1.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze, 90 s Pause</source>
+        <target>3×10 schone opdrukken, 90 s pauze</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.2.desc">
+      <segment state="translated">
+        <source>Ruhetag — Stretching, Mobility</source>
+        <target>Rustdag — stretching, mobility</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.3.desc">
+      <segment state="translated">
+        <source>3×AMRAP, 90 s Pause (Ziel ≈12-11-10)</source>
+        <target>3×AMRAP, 90 s pauze (doel ≈12-11-10)</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 50 % vom Maximum</source>
+        <target>Lichte dag — 50 % van het maximum</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.36.desc">
+      <segment state="translated">
+        <source>5 Sätze, volle Bewegungsamplitude</source>
+        <target>5 sets, volledige bewegingsuitslag</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.38.desc">
+      <segment state="translated">
+        <source>5 Sätze, kontrolliertes Tempo</source>
+        <target>5 sets, gecontroleerd tempo</target>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.40.desc">
+      <segment state="translated">
+        <source>5 Sätze leicht</source>
+        <target>5 sets licht</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.title">
+      <segment state="translated">
+        <source>30-Tage-Challenge</source>
+        <target>30-dagen-challenge</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.summary">
+      <segment state="translated">
+        <source>Dreißig Tage tägliches Training mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest.</source>
+        <target>Dertig dagen dagelijkse training met gerichte rustdagen. Dag 1 is de maxtest, dag 30 de eindtest.</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.blogSlug">
+      <segment state="translated">
+        <source>30-tage-liegestuetze-challenge</source>
+        <target>30-dagen-opdruk-challenge</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest — als Ausgangswert eintragen</source>
+        <target>Maxtest — leg vast als uitgangswaarde</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.3.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×50 % vom Maximum</source>
+        <target>Lichte dag — 2×50 % van het maximum</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.9.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 3×60 % vom Maximum</source>
+        <target>Lichte dag — 3×60 % van het maximum</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.15.desc">
+      <segment state="translated">
+        <source>5 Sätze à ~80 % vom Maximum</source>
+        <target>5 sets op ~80 % van het maximum</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.22.desc">
+      <segment state="translated">
+        <source>3 Sätze à 70 % — Qualität vor Quantität</source>
+        <target>3 sets op 70 % — kwaliteit boven kwantiteit</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.27.desc">
+      <segment state="translated">
+        <source>Aktive Erholung — Spaziergang, Mobility</source>
+        <target>Actief herstel — wandeling, mobility</target>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhe vor dem Endtest</source>
+        <target>Rust voor de eindtest</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.title">
+      <segment state="translated">
+        <source>Liegestütze ab 40 — 4-Wochen-Plan</source>
+        <target>Opdrukken vanaf 40 — 4 weken plan</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.summary">
+      <segment state="translated">
+        <source>Schonender 4-Wochen-Plan für Einsteiger ab 40: Fokus auf saubere Technik, ausreichend Pause und langsames Tempo.</source>
+        <target>Mild 4-wekenplan voor beginners 40+: focus op schone techniek, voldoende rust en rustig tempo.</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.blogSlug">
+      <segment state="translated">
+        <source>liegestuetze-ab-40</source>
+        <target>opdrukken-na-40</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.1.desc">
+      <segment state="translated">
+        <source>Maximaltest mit sauberer Technik</source>
+        <target>Maxtest met schone techniek</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.2.desc">
+      <segment state="translated">
+        <source>3×8 Knie- oder erhöhte Liegestütze</source>
+        <target>3×8 knie- of verhoogde opdrukken</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.4.desc">
+      <segment state="translated">
+        <source>3×9 saubere Liegestütze</source>
+        <target>3×9 schone opdrukken</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.5.desc">
+      <segment state="translated">
+        <source>Ruhetag — Schulter-Mobility</source>
+        <target>Rustdag — schoudermobility</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.6.desc">
+      <segment state="translated">
+        <source>3×10 saubere Liegestütze</source>
+        <target>3×10 schone opdrukken</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.8.desc">
+      <segment state="translated">
+        <source>3×11</source>
+        <target>3×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.10.desc">
+      <segment state="translated">
+        <source>3×12</source>
+        <target>3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.12.desc">
+      <segment state="translated">
+        <source>3×13</source>
+        <target>3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.22.desc">
+      <segment state="translated">
+        <source>4 Sätze, kontrolliertes Tempo</source>
+        <target>4 sets, gecontroleerd tempo</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.24.desc">
+      <segment state="translated">
+        <source>4 Sätze, langsame Exzentrik</source>
+        <target>4 sets, trage excentrische fase</target>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.28.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale Liegestütze</source>
+        <target>Eindtest: maximale opdrukken</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.title">
+      <segment state="translated">
+        <source>Daily 100 — 30 Tage zur 100er-Marke</source>
+        <target>Daily 100 — 30 dagen naar de 100-grens</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.summary">
+      <segment state="translated">
+        <source>30-Tage-Volumenplan: ramp-up von 50 auf 100 saubere Wiederholungen pro Einheit, danach zwei Wochen Konsolidierung. 5 Trainingstage + 1 leichter + 1 Ruhetag pro Woche.</source>
+        <target>30-dagen-volumeplan: opbouw van 50 naar 100 schone herhalingen per sessie, daarna twee weken consolidatie. 5 trainingsdagen + 1 lichte + 1 rustdag per week.</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.1.desc">
+      <segment state="translated">
+        <source>Baseline-Test: maximale Wiederholungen in einem Satz</source>
+        <target>Baseline-test: maximale herhalingen in één set</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.2.desc">
+      <segment state="translated">
+        <source>5×10 saubere Wiederholungen, 60 s Pause</source>
+        <target>5×10 schone herhalingen, 60 s pauze</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.3.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 s pauze</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.4.desc">
+      <segment state="translated">
+        <source>5×12, 60 s Pause</source>
+        <target>5×12, 60 s pauze</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.5.desc">
+      <segment state="translated">
+        <source>5×14, 60 s Pause</source>
+        <target>5×14, 60 s pauze</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag — 2×15 in lockerem Tempo</source>
+        <target>Lichte dag — 2×15 in rustig tempo</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.8.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.9.desc">
+      <segment state="translated">
+        <source>5×16</source>
+        <target>5×16</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.10.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.11.desc">
+      <segment state="translated">
+        <source>5×18</source>
+        <target>5×18</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.12.desc">
+      <segment state="translated">
+        <source>Erstes Hundert: 5×20</source>
+        <target>Eerste honderd: 5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.15.desc">
+      <segment state="translated">
+        <source>4×25 (weniger Sätze, mehr Wiederholungen)</source>
+        <target>4×25 (minder sets, meer herhalingen)</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.16.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.17.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.18.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.19.desc">
+      <segment state="translated">
+        <source>4×25 — Tempo bewusst verlangsamen</source>
+        <target>4×25 — vertraag het tempo bewust</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.22.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.23.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.24.desc">
+      <segment state="translated">
+        <source>5×20</source>
+        <target>5×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.25.desc">
+      <segment state="translated">
+        <source>4×25</source>
+        <target>4×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.26.desc">
+      <segment state="translated">
+        <source>Letzter 100er-Tag vor dem Test</source>
+        <target>Laatste 100-dag voor de test</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.27.desc">
+      <segment state="translated">
+        <source>Leichter Tag — Form-Check</source>
+        <target>Lichte dag — vormcheck</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.29.desc">
+      <segment state="translated">
+        <source>Ruhetag — Vorbereitung auf den Endtest</source>
+        <target>Rustdag — voorbereiding op de eindtest</target>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.30.desc">
+      <segment state="translated">
+        <source>Endtest: Maximale saubere Wiederholungen in einem Satz</source>
+        <target>Eindtest: maximale schone herhalingen in één set</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.title">
+      <segment state="translated">
+        <source>Einarmige Liegestütze — 12-Wochen-Aufbau</source>
+        <target>Eenarmige opdrukken — 12 weken opbouw</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.summary">
+      <segment state="translated">
+        <source>Vier-Phasen-Plan in Richtung saubere einarmige Liegestütze: Archer und Wand-Negativen, Bank-Negativen, partielle Einarmige, schließlich volle Einarmige im weiten Stand. 4 aktive Tage + 3 Ruhetage pro Woche.</source>
+        <target>Vierfasenplan richting een schone eenarmige opdruk: archer en muur-negatieven, bank-negatieven, partiële eenarmige, ten slotte volledige eenarmige in brede stand. 4 actieve dagen + 3 rustdagen per week.</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.1.desc">
+      <segment state="translated">
+        <source>Archer-Liegestütze 3×6</source>
+        <target>Archer-opdrukken 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.3.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×10 (langsame Exzentrik)</source>
+        <target>Muur-eenarmige 3×10 (trage excentrische fase)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.5.desc">
+      <segment state="translated">
+        <source>Standard-Liegestütze 3×20 (Volumen)</source>
+        <target>Standaard opdrukken 3×20 (volume)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.6.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×10</source>
+        <target>Lichte dag 2×10</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.8.desc">
+      <segment state="translated">
+        <source>Archer 3×8</source>
+        <target>Archer 3×8</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.10.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×12</source>
+        <target>Muur-eenarmige 3×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.12.desc">
+      <segment state="translated">
+        <source>Standard 3×22</source>
+        <target>Standaard 3×22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.13.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×12</source>
+        <target>Lichte dag 2×12</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.15.desc">
+      <segment state="translated">
+        <source>Archer 3×10 — Phase 1 abschließen</source>
+        <target>Archer 3×10 — fase 1 afsluiten</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.17.desc">
+      <segment state="translated">
+        <source>Wand-Einarmige 3×15</source>
+        <target>Muur-eenarmige 3×15</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.19.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standaard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.20.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×14</source>
+        <target>Lichte dag 2×14</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.22.desc">
+      <segment state="translated">
+        <source>Negative Einarmige von Bank 3×5 (3 s runter)</source>
+        <target>Negatieve eenarmige vanaf bank 3×5 (3 s zakkend)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.24.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×6 (Tempo 3-1-1)</source>
+        <target>Trage archer 3×6 (tempo 3-1-1)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.26.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20 (Brust-Volumen)</source>
+        <target>Brede opdrukken 3×20 (borstvolume)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.29.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×5</source>
+        <target>Negatieve eenarmige 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.31.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×7</source>
+        <target>Trage archer 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.33.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×20</source>
+        <target>Brede opdrukken 3×20</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.34.desc">
+      <segment state="translated">
+        <source>Leichter Tag 2×11</source>
+        <target>Lichte dag 2×11</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.36.desc">
+      <segment state="translated">
+        <source>Negative Einarmige 3×6</source>
+        <target>Negatieve eenarmige 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.38.desc">
+      <segment state="translated">
+        <source>Langsame Archer 3×8 — Phase 2 abschließen</source>
+        <target>Trage archer 3×8 — fase 2 afsluiten</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.40.desc">
+      <segment state="translated">
+        <source>Weite Liegestütze 3×~22</source>
+        <target>Brede opdrukken 3×~22</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.43.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige (niedrige Bank) 3×4</source>
+        <target>Partiële eenarmige (lage bank) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.45.desc">
+      <segment state="translated">
+        <source>Archer mit langem Tempo 3×6</source>
+        <target>Archer met traag tempo 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.47.desc">
+      <segment state="translated">
+        <source>Diamant-Liegestütze 3×12 (Trizeps-Volumen)</source>
+        <target>Diamant-opdrukken 3×12 (tricepsvolume)</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.50.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×4</source>
+        <target>Partiële eenarmige 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.52.desc">
+      <segment state="translated">
+        <source>Archer mit Tempo 3×6</source>
+        <target>Archer met tempo 3×6</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.54.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Diamant 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.57.desc">
+      <segment state="translated">
+        <source>Partielle Einarmige 3×5 — Phase 3 abschließen</source>
+        <target>Partiële eenarmige 3×5 — fase 3 afsluiten</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.59.desc">
+      <segment state="translated">
+        <source>Tempo-Archer 3×7</source>
+        <target>Tempo-archer 3×7</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.61.desc">
+      <segment state="translated">
+        <source>Diamant 3×13</source>
+        <target>Diamant 3×13</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.64.desc">
+      <segment state="translated">
+        <source>Volle Einarmige (weiter Stand) 3×3</source>
+        <target>Volledige eenarmige (brede stand) 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.66.desc">
+      <segment state="translated">
+        <source>Einarmige (etwas engerer Stand) 3×4</source>
+        <target>Eenarmige (iets smallere stand) 3×4</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.68.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standaard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.71.desc">
+      <segment state="translated">
+        <source>Volle Einarmige 3×3</source>
+        <target>Volledige eenarmige 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.73.desc">
+      <segment state="translated">
+        <source>Einarmige enger Stand 3×5</source>
+        <target>Eenarmige smalle stand 3×5</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.75.desc">
+      <segment state="translated">
+        <source>Standard 3×25</source>
+        <target>Standaard 3×25</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.78.desc">
+      <segment state="translated">
+        <source>Letzte schwere Einheit 3×3</source>
+        <target>Laatste zware sessie 3×3</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.80.desc">
+      <segment state="translated">
+        <source>Technik-Taper 2×4 saubere Wiederholungen</source>
+        <target>Techniek-taper 2×4 schone herhalingen</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.82.desc">
+      <segment state="translated">
+        <source>Mobility + 2×3 leichte Wiederholungen</source>
+        <target>Mobility + 2×3 lichte herhalingen</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.83.desc">
+      <segment state="translated">
+        <source>Ruhetag — bereit für Endtest</source>
+        <target>Rustdag — klaar voor de eindtest</target>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.84.desc">
+      <segment state="translated">
+        <source>Endtest: maximale saubere einarmige Liegestütze pro Seite</source>
+        <target>Eindtest: maximale schone eenarmige opdrukken per kant</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -235,7 +235,7 @@
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:67,69</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:330,331</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:199,200</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:239,240</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:459,460</note>
       </notes>
@@ -355,7 +355,7 @@
     <unit id="validate.email.required">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:61</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:89</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:85</note>
       </notes>
       <segment>
         <source>Bitte E-Mail eingeben!</source>
@@ -364,7 +364,7 @@
     <unit id="validate.email.email">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:64</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:92</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:88</note>
       </notes>
       <segment>
         <source>Bitte gültige E-Mail eingeben!</source>
@@ -373,7 +373,7 @@
     <unit id="validate.password.required">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:67</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:95</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:91</note>
       </notes>
       <segment>
         <source>Bitte Passwort eingeben!</source>
@@ -382,7 +382,7 @@
     <unit id="validate.password.minLength">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:70</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:98</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:94</note>
       </notes>
       <segment>
         <source>Passwort muss mindestens 8 Zeichen lang sein!</source>
@@ -514,7 +514,7 @@
     </unit>
     <unit id="validate.password.policy">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:104</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:100</note>
       </notes>
       <segment>
         <source>Passwort braucht Groß-/Kleinbuchstaben, Zahl und Sonderzeichen.</source>
@@ -735,6 +735,958 @@
       </notes>
       <segment>
         <source>Eintrag konnte nicht gespeichert werden.</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:61</note>
+      </notes>
+      <segment>
+        <source>Ruhetag</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.mobility">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:62</note>
+      </notes>
+      <segment>
+        <source>Ruhetag — Mobility</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.rest.prepFinal">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:63</note>
+      </notes>
+      <segment>
+        <source>Ruhetag — Vorbereitung Endtest</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.light">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:64</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.activeRecovery">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:65</note>
+      </notes>
+      <segment>
+        <source>Aktive Erholung</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.mobility.chestStretch">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:66</note>
+      </notes>
+      <segment>
+        <source>Mobility &amp; Brust-Stretching</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.finalTest.maxNoPause">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:67</note>
+      </notes>
+      <segment>
+        <source>Endtest: Maximale Liegestütze ohne Pause</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:68</note>
+      </notes>
+      <segment>
+        <source>3×AMRAP</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.3x90s">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:69</note>
+      </notes>
+      <segment>
+        <source>3×AMRAP, 90 s Pause</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:70</note>
+      </notes>
+      <segment>
+        <source>4×AMRAP</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.amrap.4x60s">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:71</note>
+      </notes>
+      <segment>
+        <source>4×AMRAP, 60 s Pause</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.targetReps.5">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:72</note>
+      </notes>
+      <segment>
+        <source>5 Sätze Zielwiederholungen</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.4x90s">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:73</note>
+      </notes>
+      <segment>
+        <source>4 Sätze, 90 s Pause</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.sets.3x70pct">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:74</note>
+      </notes>
+      <segment>
+        <source>3 Sätze à 70 %</source>
+      </segment>
+    </unit>
+    <unit id="plan.day.light.2x50pct">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:75</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag — 2×50 %</source>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.1.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:85</note>
+      </notes>
+      <segment>
+        <source>3×10 saubere Liegestütze, 90 s Pause</source>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.2.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:92</note>
+      </notes>
+      <segment>
+        <source>Ruhetag — Stretching, Mobility</source>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.3.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:99</note>
+      </notes>
+      <segment>
+        <source>3×AMRAP, 90 s Pause (Ziel ≈12-11-10)</source>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.6.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:108</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag — 50 % vom Maximum</source>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.36.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:149</note>
+      </notes>
+      <segment>
+        <source>5 Sätze, volle Bewegungsamplitude</source>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.38.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:157</note>
+      </notes>
+      <segment>
+        <source>5 Sätze, kontrolliertes Tempo</source>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.day.40.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:165</note>
+      </notes>
+      <segment>
+        <source>5 Sätze leicht</source>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.1.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:178</note>
+      </notes>
+      <segment>
+        <source>Maximaltest — als Ausgangswert eintragen</source>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.3.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:186</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag — 2×50 % vom Maximum</source>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.9.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:199</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag — 3×60 % vom Maximum</source>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.15.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:212</note>
+      </notes>
+      <segment>
+        <source>5 Sätze à ~80 % vom Maximum</source>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.22.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:226</note>
+      </notes>
+      <segment>
+        <source>3 Sätze à 70 % — Qualität vor Quantität</source>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.27.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:237</note>
+      </notes>
+      <segment>
+        <source>Aktive Erholung — Spaziergang, Mobility</source>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.day.29.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:245</note>
+      </notes>
+      <segment>
+        <source>Ruhe vor dem Endtest</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.1.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:257</note>
+      </notes>
+      <segment>
+        <source>Maximaltest mit sauberer Technik</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.2.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:264</note>
+      </notes>
+      <segment>
+        <source>3×8 Knie- oder erhöhte Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.4.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:272</note>
+      </notes>
+      <segment>
+        <source>3×9 saubere Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.5.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:279</note>
+      </notes>
+      <segment>
+        <source>Ruhetag — Schulter-Mobility</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.6.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:286</note>
+      </notes>
+      <segment>
+        <source>3×10 saubere Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.8.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:290</note>
+      </notes>
+      <segment>
+        <source>3×11</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.10.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:297</note>
+      </notes>
+      <segment>
+        <source>3×12</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.12.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:305</note>
+      </notes>
+      <segment>
+        <source>3×13</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.22.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:323</note>
+      </notes>
+      <segment>
+        <source>4 Sätze, kontrolliertes Tempo</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.24.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:331</note>
+      </notes>
+      <segment>
+        <source>4 Sätze, langsame Exzentrik</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.day.28.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:341</note>
+      </notes>
+      <segment>
+        <source>Endtest: Maximale Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.1.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:355</note>
+      </notes>
+      <segment>
+        <source>Baseline-Test: maximale Wiederholungen in einem Satz</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.2.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:362</note>
+      </notes>
+      <segment>
+        <source>5×10 saubere Wiederholungen, 60 s Pause</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.3.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:369</note>
+      </notes>
+      <segment>
+        <source>5×12, 60 s Pause</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.4.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:376</note>
+      </notes>
+      <segment>
+        <source>5×12, 60 s Pause</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.5.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:383</note>
+      </notes>
+      <segment>
+        <source>5×14, 60 s Pause</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.6.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:390</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag — 2×15 in lockerem Tempo</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.8.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:399</note>
+      </notes>
+      <segment>
+        <source>5×16</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.9.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:406</note>
+      </notes>
+      <segment>
+        <source>5×16</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.10.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:413</note>
+      </notes>
+      <segment>
+        <source>5×18</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.11.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:420</note>
+      </notes>
+      <segment>
+        <source>5×18</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.12.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:427</note>
+      </notes>
+      <segment>
+        <source>Erstes Hundert: 5×20</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.15.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:437</note>
+      </notes>
+      <segment>
+        <source>4×25 (weniger Sätze, mehr Wiederholungen)</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.16.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:444</note>
+      </notes>
+      <segment>
+        <source>5×20</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.17.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:451</note>
+      </notes>
+      <segment>
+        <source>4×25</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.18.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:458</note>
+      </notes>
+      <segment>
+        <source>5×20</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.19.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:465</note>
+      </notes>
+      <segment>
+        <source>4×25 — Tempo bewusst verlangsamen</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.22.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:475</note>
+      </notes>
+      <segment>
+        <source>5×20</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.23.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:482</note>
+      </notes>
+      <segment>
+        <source>4×25</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.24.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:489</note>
+      </notes>
+      <segment>
+        <source>5×20</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.25.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:496</note>
+      </notes>
+      <segment>
+        <source>4×25</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.26.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:503</note>
+      </notes>
+      <segment>
+        <source>Letzter 100er-Tag vor dem Test</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.27.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:510</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag — Form-Check</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.29.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:518</note>
+      </notes>
+      <segment>
+        <source>Ruhetag — Vorbereitung auf den Endtest</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.day.30.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:525</note>
+      </notes>
+      <segment>
+        <source>Endtest: Maximale saubere Wiederholungen in einem Satz</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.1.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:547</note>
+      </notes>
+      <segment>
+        <source>Archer-Liegestütze 3×6</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.3.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:555</note>
+      </notes>
+      <segment>
+        <source>Wand-Einarmige 3×10 (langsame Exzentrik)</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.5.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:563</note>
+      </notes>
+      <segment>
+        <source>Standard-Liegestütze 3×20 (Volumen)</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.6.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:570</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag 2×10</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.8.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:579</note>
+      </notes>
+      <segment>
+        <source>Archer 3×8</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.10.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:587</note>
+      </notes>
+      <segment>
+        <source>Wand-Einarmige 3×12</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.12.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:595</note>
+      </notes>
+      <segment>
+        <source>Standard 3×22</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.13.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:602</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag 2×12</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.15.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:611</note>
+      </notes>
+      <segment>
+        <source>Archer 3×10 — Phase 1 abschließen</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.17.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:619</note>
+      </notes>
+      <segment>
+        <source>Wand-Einarmige 3×15</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.19.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:627</note>
+      </notes>
+      <segment>
+        <source>Standard 3×25</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.20.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:634</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag 2×14</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.22.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:644</note>
+      </notes>
+      <segment>
+        <source>Negative Einarmige von Bank 3×5 (3 s runter)</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.24.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:652</note>
+      </notes>
+      <segment>
+        <source>Langsame Archer 3×6 (Tempo 3-1-1)</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.26.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:660</note>
+      </notes>
+      <segment>
+        <source>Weite Liegestütze 3×20 (Brust-Volumen)</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.29.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:670</note>
+      </notes>
+      <segment>
+        <source>Negative Einarmige 3×5</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.31.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:678</note>
+      </notes>
+      <segment>
+        <source>Langsame Archer 3×7</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.33.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:686</note>
+      </notes>
+      <segment>
+        <source>Weite Liegestütze 3×20</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.34.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:693</note>
+      </notes>
+      <segment>
+        <source>Leichter Tag 2×11</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.36.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:702</note>
+      </notes>
+      <segment>
+        <source>Negative Einarmige 3×6</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.38.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:710</note>
+      </notes>
+      <segment>
+        <source>Langsame Archer 3×8 — Phase 2 abschließen</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.40.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:718</note>
+      </notes>
+      <segment>
+        <source>Weite Liegestütze 3×~22</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.43.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:729</note>
+      </notes>
+      <segment>
+        <source>Partielle Einarmige (niedrige Bank) 3×4</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.45.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:737</note>
+      </notes>
+      <segment>
+        <source>Archer mit langem Tempo 3×6</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.47.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:745</note>
+      </notes>
+      <segment>
+        <source>Diamant-Liegestütze 3×12 (Trizeps-Volumen)</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.50.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:755</note>
+      </notes>
+      <segment>
+        <source>Partielle Einarmige 3×4</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.52.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:763</note>
+      </notes>
+      <segment>
+        <source>Archer mit Tempo 3×6</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.54.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:771</note>
+      </notes>
+      <segment>
+        <source>Diamant 3×13</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.57.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:781</note>
+      </notes>
+      <segment>
+        <source>Partielle Einarmige 3×5 — Phase 3 abschließen</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.59.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:789</note>
+      </notes>
+      <segment>
+        <source>Tempo-Archer 3×7</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.61.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:797</note>
+      </notes>
+      <segment>
+        <source>Diamant 3×13</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.64.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:808</note>
+      </notes>
+      <segment>
+        <source>Volle Einarmige (weiter Stand) 3×3</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.66.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:816</note>
+      </notes>
+      <segment>
+        <source>Einarmige (etwas engerer Stand) 3×4</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.68.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:824</note>
+      </notes>
+      <segment>
+        <source>Standard 3×25</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.71.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:834</note>
+      </notes>
+      <segment>
+        <source>Volle Einarmige 3×3</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.73.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:842</note>
+      </notes>
+      <segment>
+        <source>Einarmige enger Stand 3×5</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.75.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:850</note>
+      </notes>
+      <segment>
+        <source>Standard 3×25</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.78.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:860</note>
+      </notes>
+      <segment>
+        <source>Letzte schwere Einheit 3×3</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.80.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:868</note>
+      </notes>
+      <segment>
+        <source>Technik-Taper 2×4 saubere Wiederholungen</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.82.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:876</note>
+      </notes>
+      <segment>
+        <source>Mobility + 2×3 leichte Wiederholungen</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.83.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:883</note>
+      </notes>
+      <segment>
+        <source>Ruhetag — bereit für Endtest</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.day.84.desc">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:890</note>
+      </notes>
+      <segment>
+        <source>Endtest: maximale saubere einarmige Liegestütze pro Seite</source>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.title">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:898</note>
+      </notes>
+      <segment>
+        <source>Von 0 auf 100 — 6-Wochen-Aufbau</source>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.summary">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:899</note>
+      </notes>
+      <segment>
+        <source>Strukturierter Plan für Einsteiger: drei Trainingstage pro Woche, progressive Belastungssteigerung und ein Endtest in Woche 6.</source>
+      </segment>
+    </unit>
+    <unit id="plan.recruit-6w.blogSlug">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:902</note>
+      </notes>
+      <segment>
+        <source>liegestuetze-steigern</source>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.title">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:908</note>
+      </notes>
+      <segment>
+        <source>30-Tage-Challenge</source>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.summary">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:909</note>
+      </notes>
+      <segment>
+        <source>Dreißig Tage tägliches Training mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest.</source>
+      </segment>
+    </unit>
+    <unit id="plan.challenge-30d.blogSlug">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:912</note>
+      </notes>
+      <segment>
+        <source>30-tage-liegestuetze-challenge</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.title">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:918</note>
+      </notes>
+      <segment>
+        <source>Liegestütze ab 40 — 4-Wochen-Plan</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.summary">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:919</note>
+      </notes>
+      <segment>
+        <source>Schonender 4-Wochen-Plan für Einsteiger ab 40: Fokus auf saubere Technik, ausreichend Pause und langsames Tempo.</source>
+      </segment>
+    </unit>
+    <unit id="plan.over-40-4w.blogSlug">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:922</note>
+      </notes>
+      <segment>
+        <source>liegestuetze-ab-40</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.title">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:928</note>
+      </notes>
+      <segment>
+        <source>Daily 100 — 30 Tage zur 100er-Marke</source>
+      </segment>
+    </unit>
+    <unit id="plan.daily-100-30d.summary">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:929</note>
+      </notes>
+      <segment>
+        <source>30-Tage-Volumenplan: ramp-up von 50 auf 100 saubere Wiederholungen pro Einheit, danach zwei Wochen Konsolidierung. 5 Trainingstage + 1 leichter + 1 Ruhetag pro Woche.</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.title">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:937</note>
+      </notes>
+      <segment>
+        <source>Einarmige Liegestütze — 12-Wochen-Aufbau</source>
+      </segment>
+    </unit>
+    <unit id="plan.one-arm-12w.summary">
+      <notes>
+        <note category="location">libs/stats/src/lib/models/training-plan.catalog.ts:938</note>
+      </notes>
+      <segment>
+        <source>Vier-Phasen-Plan in Richtung saubere einarmige Liegestütze: Archer und Wand-Negativen, Bank-Negativen, partielle Einarmige, schließlich volle Einarmige im weiten Stand. 4 aktive Tage + 3 Ruhetage pro Woche.</source>
       </segment>
     </unit>
     <unit id="admin.title">
@@ -1148,7 +2100,7 @@
     <unit id="app.title">
       <notes>
         <note category="location">web/src/app/app.html:11,12</note>
-        <note category="location">web/src/app/app.html:143,144</note>
+        <note category="location">web/src/app/app.html:146,147</note>
       </notes>
       <segment>
         <source>Pushups</source>
@@ -1157,8 +2109,8 @@
     <unit id="nav.dashboard">
       <notes>
         <note category="location">web/src/app/app.html:23,26</note>
-        <note category="location">web/src/app/app.html:174,176</note>
-        <note category="location">web/src/app/app.html:227,229</note>
+        <note category="location">web/src/app/app.html:177,179</note>
+        <note category="location">web/src/app/app.html:236,238</note>
       </notes>
       <segment>
         <source>Dashboard</source>
@@ -1167,8 +2119,8 @@
     <unit id="nav.analysis">
       <notes>
         <note category="location">web/src/app/app.html:33,36</note>
-        <note category="location">web/src/app/app.html:178,180</note>
-        <note category="location">web/src/app/app.html:231,233</note>
+        <note category="location">web/src/app/app.html:181,183</note>
+        <note category="location">web/src/app/app.html:240,242</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -1177,8 +2129,8 @@
     <unit id="nav.leaderboard">
       <notes>
         <note category="location">web/src/app/app.html:43,47</note>
-        <note category="location">web/src/app/app.html:182,184</note>
-        <note category="location">web/src/app/app.html:235,237</note>
+        <note category="location">web/src/app/app.html:185,187</note>
+        <note category="location">web/src/app/app.html:244,246</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -1187,8 +2139,8 @@
     <unit id="nav.blog">
       <notes>
         <note category="location">web/src/app/app.html:53,56</note>
-        <note category="location">web/src/app/app.html:190,192</note>
-        <note category="location">web/src/app/app.html:243,245</note>
+        <note category="location">web/src/app/app.html:193,195</note>
+        <note category="location">web/src/app/app.html:252,254</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -1197,16 +2149,24 @@
     <unit id="nav.trainingPlans">
       <notes>
         <note category="location">web/src/app/app.html:63,67</note>
-        <note category="location">web/src/app/app.html:186,188</note>
-        <note category="location">web/src/app/app.html:239,241</note>
+        <note category="location">web/src/app/app.html:189,191</note>
+        <note category="location">web/src/app/app.html:248,250</note>
       </notes>
       <segment>
         <source>Trainingspläne</source>
       </segment>
     </unit>
+    <unit id="nav.pushupTypes">
+      <notes>
+        <note category="location">web/src/app/app.html:73,77</note>
+      </notes>
+      <segment>
+        <source>Liegestütztypen</source>
+      </segment>
+    </unit>
     <unit id="nav.history">
       <notes>
-        <note category="location">web/src/app/app.html:73,76</note>
+        <note category="location">web/src/app/app.html:83,86</note>
       </notes>
       <segment>
         <source>Historie</source>
@@ -1214,7 +2174,7 @@
     </unit>
     <unit id="nav.reminders">
       <notes>
-        <note category="location">web/src/app/app.html:84,88</note>
+        <note category="location">web/src/app/app.html:94,98</note>
       </notes>
       <segment>
         <source>Erinnerungen</source>
@@ -1222,31 +2182,15 @@
     </unit>
     <unit id="nav.language">
       <notes>
-        <note category="location">web/src/app/app.html:95,98</note>
+        <note category="location">web/src/app/app.html:107,108</note>
       </notes>
       <segment>
-        <source> Sprache </source>
-      </segment>
-    </unit>
-    <unit id="nav.lang.de">
-      <notes>
-        <note category="location">web/src/app/app.html:104,107</note>
-      </notes>
-      <segment>
-        <source>Deutsch</source>
-      </segment>
-    </unit>
-    <unit id="nav.lang.en">
-      <notes>
-        <note category="location">web/src/app/app.html:113,115</note>
-      </notes>
-      <segment>
-        <source>English</source>
+        <source>Sprache</source>
       </segment>
     </unit>
     <unit id="nav.aria">
       <notes>
-        <note category="location">web/src/app/app.html:122,123</note>
+        <note category="location">web/src/app/app.html:125,126</note>
       </notes>
       <segment>
         <source>Pushup Navigation</source>
@@ -1254,7 +2198,7 @@
     </unit>
     <unit id="nav.openMenu">
       <notes>
-        <note category="location">web/src/app/app.html:128,129</note>
+        <note category="location">web/src/app/app.html:131,132</note>
       </notes>
       <segment>
         <source>Menü öffnen</source>
@@ -1262,7 +2206,7 @@
     </unit>
     <unit id="nav.toLanding">
       <notes>
-        <note category="location">web/src/app/app.html:138,139</note>
+        <note category="location">web/src/app/app.html:141,142</note>
       </notes>
       <segment>
         <source>Zur Landingpage</source>
@@ -1270,7 +2214,7 @@
     </unit>
     <unit id="toolbarDailyGoal">
       <notes>
-        <note category="location">web/src/app/app.html:146,147</note>
+        <note category="location">web/src/app/app.html:149,150</note>
       </notes>
       <segment>
         <source>Tagesziel</source>
@@ -1278,7 +2222,7 @@
     </unit>
     <unit id="nav.admin">
       <notes>
-        <note category="location">web/src/app/app.html:154,155</note>
+        <note category="location">web/src/app/app.html:157,158</note>
       </notes>
       <segment>
         <source>Admin-Bereich</source>
@@ -1286,7 +2230,7 @@
     </unit>
     <unit id="nav.desktop.aria">
       <notes>
-        <note category="location">web/src/app/app.html:165,166</note>
+        <note category="location">web/src/app/app.html:168,169</note>
       </notes>
       <segment>
         <source>Hauptnavigation</source>
@@ -1294,15 +2238,23 @@
     </unit>
     <unit id="footer.aria">
       <notes>
-        <note category="location">web/src/app/app.html:199</note>
+        <note category="location">web/src/app/app.html:202</note>
       </notes>
       <segment>
         <source>Rechtliches</source>
       </segment>
     </unit>
+    <unit id="footer.pushupTypes">
+      <notes>
+        <note category="location">web/src/app/app.html:207,209</note>
+      </notes>
+      <segment>
+        <source>Liegestütztypen</source>
+      </segment>
+    </unit>
     <unit id="footer.impressum">
       <notes>
-        <note category="location">web/src/app/app.html:201,203</note>
+        <note category="location">web/src/app/app.html:210,212</note>
       </notes>
       <segment>
         <source>Impressum</source>
@@ -1310,7 +2262,7 @@
     </unit>
     <unit id="footer.datenschutz">
       <notes>
-        <note category="location">web/src/app/app.html:204,207</note>
+        <note category="location">web/src/app/app.html:213,216</note>
       </notes>
       <segment>
         <source>Datenschutz</source>
@@ -1318,7 +2270,7 @@
     </unit>
     <unit id="footer.cookies">
       <notes>
-        <note category="location">web/src/app/app.html:211,213</note>
+        <note category="location">web/src/app/app.html:220,222</note>
       </notes>
       <segment>
         <source> Cookie-Einstellungen </source>
@@ -1326,7 +2278,7 @@
     </unit>
     <unit id="nav.bottom.aria">
       <notes>
-        <note category="location">web/src/app/app.html:218,219</note>
+        <note category="location">web/src/app/app.html:227,228</note>
       </notes>
       <segment>
         <source>Mobile-Navigation</source>
@@ -1460,9 +2412,25 @@
         <source>Strukturierte Liegestütz-Trainingspläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung.</source>
       </segment>
     </unit>
-    <unit id="seo.reminders.title">
+    <unit id="seo.wiki.pushupTypes.title">
+      <notes>
+        <note category="location">web/src/app/app.routes.ts:115</note>
+      </notes>
+      <segment>
+        <source>Liegestütztypen erklärt – Pushup Tracker</source>
+      </segment>
+    </unit>
+    <unit id="seo.wiki.pushupTypes.description">
       <notes>
         <note category="location">web/src/app/app.routes.ts:116</note>
+      </notes>
+      <segment>
+        <source>Saubere Ausführung der wichtigsten Liegestütz-Varianten – Standard, Knie, Diamant, Archer, einarmig und mehr.</source>
+      </segment>
+    </unit>
+    <unit id="seo.reminders.title">
+      <notes>
+        <note category="location">web/src/app/app.routes.ts:127</note>
       </notes>
       <segment>
         <source>Erinnerungen – Pushup Tracker</source>
@@ -1470,7 +2438,7 @@
     </unit>
     <unit id="seo.reminders.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:117</note>
+        <note category="location">web/src/app/app.routes.ts:128</note>
       </notes>
       <segment>
         <source>Konfiguriere Liegestütz-Erinnerungen und Push-Benachrichtigungen.</source>
@@ -1478,7 +2446,7 @@
     </unit>
     <unit id="seo.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:127</note>
+        <note category="location">web/src/app/app.routes.ts:138</note>
       </notes>
       <segment>
         <source>Bestenliste – Pushup Tracker</source>
@@ -1486,7 +2454,7 @@
     </unit>
     <unit id="seo.leaderboard.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:128</note>
+        <note category="location">web/src/app/app.routes.ts:139</note>
       </notes>
       <segment>
         <source>Öffentliche Bestenliste mit Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage.</source>
@@ -1494,7 +2462,7 @@
     </unit>
     <unit id="seo.publicProfile.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:138</note>
+        <note category="location">web/src/app/app.routes.ts:149</note>
       </notes>
       <segment>
         <source>Profil – Pushup Tracker</source>
@@ -1502,7 +2470,7 @@
     </unit>
     <unit id="seo.publicProfile.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:139</note>
+        <note category="location">web/src/app/app.routes.ts:150</note>
       </notes>
       <segment>
         <source>Öffentliches Pushup-Profil mit Reps, Streak und Bestleistungen.</source>
@@ -1510,7 +2478,7 @@
     </unit>
     <unit id="seo.blog.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:153</note>
+        <note category="location">web/src/app/app.routes.ts:164</note>
       </notes>
       <segment>
         <source>Blog – Liegestütze Tipps &amp; Guides | Pushup Tracker</source>
@@ -1518,7 +2486,7 @@
     </unit>
     <unit id="seo.blog.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:154</note>
+        <note category="location">web/src/app/app.routes.ts:165</note>
       </notes>
       <segment>
         <source>Tipps, Trainingspläne und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten.</source>
@@ -1526,7 +2494,7 @@
     </unit>
     <unit id="seo.impressum.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:171</note>
+        <note category="location">web/src/app/app.routes.ts:182</note>
       </notes>
       <segment>
         <source>Impressum – Pushup Tracker</source>
@@ -1534,7 +2502,7 @@
     </unit>
     <unit id="seo.impressum.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:172</note>
+        <note category="location">web/src/app/app.routes.ts:183</note>
       </notes>
       <segment>
         <source>Impressum und Anbieterkennzeichnung von Pushup Tracker.</source>
@@ -1542,7 +2510,7 @@
     </unit>
     <unit id="seo.datenschutz.title">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:182</note>
+        <note category="location">web/src/app/app.routes.ts:193</note>
       </notes>
       <segment>
         <source>Datenschutzerklärung – Pushup Tracker</source>
@@ -1550,7 +2518,7 @@
     </unit>
     <unit id="seo.datenschutz.description">
       <notes>
-        <note category="location">web/src/app/app.routes.ts:183</note>
+        <note category="location">web/src/app/app.routes.ts:194</note>
       </notes>
       <segment>
         <source>Datenschutzerklärung von Pushup Tracker – Informationen zu Datenverarbeitung, Cookies und Ihren Rechten.</source>
@@ -1558,7 +2526,7 @@
     </unit>
     <unit id="earlyAccess.text">
       <notes>
-        <note category="location">web/src/app/app.ts:121</note>
+        <note category="location">web/src/app/app.ts:167</note>
       </notes>
       <segment>
         <source>Early Access – pushup-stats.com befindet sich noch im Aufbau. Funktionen und Design können sich jederzeit ändern.</source>
@@ -1566,7 +2534,7 @@
     </unit>
     <unit id="earlyAccess.feedback">
       <notes>
-        <note category="location">web/src/app/app.ts:122</note>
+        <note category="location">web/src/app/app.ts:168</note>
       </notes>
       <segment>
         <source>Feedback</source>
@@ -1574,7 +2542,7 @@
     </unit>
     <unit id="seo.default.title">
       <notes>
-        <note category="location">web/src/app/app.ts:221</note>
+        <note category="location">web/src/app/app.ts:284</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -1582,7 +2550,7 @@
     </unit>
     <unit id="seo.default.description">
       <notes>
-        <note category="location">web/src/app/app.ts:224</note>
+        <note category="location">web/src/app/app.ts:287</note>
       </notes>
       <segment>
         <source>Tracke Reps, Trends und Streaks mit Pushup Tracker.</source>
@@ -1590,7 +2558,7 @@
     </unit>
     <unit id="sw.update.available">
       <notes>
-        <note category="location">web/src/app/app.ts:243</note>
+        <note category="location">web/src/app/app.ts:306</note>
       </notes>
       <segment>
         <source>Neue Version verfügbar</source>
@@ -1598,7 +2566,7 @@
     </unit>
     <unit id="sw.update.reload">
       <notes>
-        <note category="location">web/src/app/app.ts:244</note>
+        <note category="location">web/src/app/app.ts:307</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -1606,7 +2574,7 @@
     </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:302</note>
+        <note category="location">web/src/app/app.ts:365</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -1614,7 +2582,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:309</note>
+        <note category="location">web/src/app/app.ts:372</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>
@@ -1622,7 +2590,7 @@
     </unit>
     <unit id="sw.update.downloading">
       <notes>
-        <note category="location">web/src/app/app.ts:347</note>
+        <note category="location">web/src/app/app.ts:410</note>
       </notes>
       <segment>
         <source>Update wird im Hintergrund geladen …</source>
@@ -2380,7 +3348,7 @@
     </unit>
     <unit id="landing.trust.bar">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:191,195</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:195,199</note>
       </notes>
       <segment>
         <source> ✓ Kostenlos · ✓ Kein Abo · ✓ Keine Kreditkarte · ✓ Datenschutz first </source>
@@ -2388,7 +3356,7 @@
     </unit>
     <unit id="landing.features.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:196,197</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:200,201</note>
       </notes>
       <segment>
         <source>Funktionen</source>
@@ -2396,7 +3364,7 @@
     </unit>
     <unit id="landing.feature.multiset.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:284,286</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:288,290</note>
       </notes>
       <segment>
         <source>Multi-Set Tracking</source>
@@ -2404,7 +3372,7 @@
     </unit>
     <unit id="landing.feature.multiset.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:288,290</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:292,294</note>
       </notes>
       <segment>
         <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
@@ -2412,7 +3380,7 @@
     </unit>
     <unit id="landing.feature.analytics.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:353,355</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,359</note>
       </notes>
       <segment>
         <source>Charts, Trends &amp; Pushup-Typen</source>
@@ -2420,7 +3388,7 @@
     </unit>
     <unit id="landing.feature.analytics.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:361,364</note>
       </notes>
       <segment>
         <source>Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder Diamond – mit frei wählbarem Zeitraum.</source>
@@ -2428,7 +3396,7 @@
     </unit>
     <unit id="landing.feature.goals.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:454,456</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:458,460</note>
       </notes>
       <segment>
         <source>Tages-, Wochen- &amp; Monatsziele</source>
@@ -2436,7 +3404,7 @@
     </unit>
     <unit id="landing.feature.goals.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:458,461</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:462,465</note>
       </notes>
       <segment>
         <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
@@ -2444,7 +3412,7 @@
     </unit>
     <unit id="landing.feature.heatmap.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:502,504</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:506,508</note>
       </notes>
       <segment>
         <source>Heatmap-Kalender</source>
@@ -2452,7 +3420,7 @@
     </unit>
     <unit id="landing.feature.heatmap.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:506,510</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:510,514</note>
       </notes>
       <segment>
         <source>Sieh auf einen Blick, an welchen Tagen du wie hart trainiert hast. Lücken werden sichtbar – Konsistenz wird zur Gewohnheit.</source>
@@ -2460,7 +3428,7 @@
     </unit>
     <unit id="landing.feature.quick.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:516,518</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:520,522</note>
       </notes>
       <segment>
         <source>Quick Logging mit FAB</source>
@@ -2468,7 +3436,7 @@
     </unit>
     <unit id="landing.feature.quick.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:520,523</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:524,527</note>
       </notes>
       <segment>
         <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
@@ -2476,7 +3444,7 @@
     </unit>
     <unit id="landing.feature.adaptive.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:530,532</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:534,536</note>
       </notes>
       <segment>
         <source>Adaptive Vorschläge</source>
@@ -2484,7 +3452,7 @@
     </unit>
     <unit id="landing.feature.adaptive.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:534,538</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:538,542</note>
       </notes>
       <segment>
         <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
@@ -2492,7 +3460,7 @@
     </unit>
     <unit id="landing.feature.pwa.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:544,546</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:548,550</note>
       </notes>
       <segment>
         <source>PWA, Live-Sync &amp; Web Share</source>
@@ -2500,7 +3468,7 @@
     </unit>
     <unit id="landing.feature.pwa.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:548,551</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:552,555</note>
       </notes>
       <segment>
         <source>Installierbar wie eine native App, Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Web Share teilen – inklusive Dark- und Light-Theme.</source>
@@ -2508,7 +3476,7 @@
     </unit>
     <unit id="landing.feature.privacy.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:558,560</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:562,564</note>
       </notes>
       <segment>
         <source>Privacy first &amp; 100 % kostenlos</source>
@@ -2516,7 +3484,7 @@
     </unit>
     <unit id="landing.feature.privacy.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:562,566</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:566,570</note>
       </notes>
       <segment>
         <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
@@ -2524,7 +3492,7 @@
     </unit>
     <unit id="ads.landing.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:568</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:572</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -2532,7 +3500,7 @@
     </unit>
     <unit id="landing.preview.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:573,575</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:581,583</note>
       </notes>
       <segment>
         <source> Deine Statistik auf einen Blick </source>
@@ -2540,7 +3508,7 @@
     </unit>
     <unit id="landing.preview.alt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:580,581</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:588,589</note>
       </notes>
       <segment>
         <source>Vorschau der Statistikansicht</source>
@@ -2548,7 +3516,7 @@
     </unit>
     <unit id="landing.discover.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:721,722</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:729,730</note>
       </notes>
       <segment>
         <source>Mehr entdecken</source>
@@ -2556,7 +3524,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:727,729</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:735,737</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -2564,7 +3532,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:731,734</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:739,742</note>
       </notes>
       <segment>
         <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
@@ -2572,7 +3540,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:741,744</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:749,752</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -2580,7 +3548,7 @@
     </unit>
     <unit id="landing.discover.blog.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:750,752</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:758,760</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -2588,7 +3556,7 @@
     </unit>
     <unit id="landing.discover.blog.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:754,757</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:762,765</note>
       </notes>
       <segment>
         <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
@@ -2596,7 +3564,7 @@
     </unit>
     <unit id="landing.discover.blog.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:764,766</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:772,774</note>
       </notes>
       <segment>
         <source>Zum Blog</source>
@@ -3278,7 +4246,7 @@
     </unit>
     <unit id="editDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:95,97</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:115,117</note>
       </notes>
       <segment>
         <source>Eintrag bearbeiten</source>
@@ -3286,7 +4254,7 @@
     </unit>
     <unit id="createDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:97,101</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:117,121</note>
       </notes>
       <segment>
         <source>Neuen Eintrag anlegen</source>
@@ -3294,7 +4262,7 @@
     </unit>
     <unit id="timestampLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:103,105</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:123,125</note>
       </notes>
       <segment>
         <source>Zeitpunkt</source>
@@ -3302,7 +4270,7 @@
     </unit>
     <unit id="setLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:117,118</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:137,138</note>
       </notes>
       <segment>
         <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -3310,7 +4278,7 @@
     </unit>
     <unit id="repsLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:119,120</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:139,140</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -3318,7 +4286,7 @@
     </unit>
     <unit id="removeSetAria">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:136,138</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:156,158</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -3326,7 +4294,7 @@
     </unit>
     <unit id="addSetAria">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:147,148</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:167,168</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -3334,7 +4302,7 @@
     </unit>
     <unit id="addSetTooltip">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:149,151</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:169,171</note>
       </notes>
       <segment>
         <source>Weiteres Set hinzufügen</source>
@@ -3342,7 +4310,7 @@
     </unit>
     <unit id="totalReps">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:158,160</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:178,180</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -3350,7 +4318,7 @@
     </unit>
     <unit id="typeLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:163,164</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:184,185</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -3358,15 +4326,23 @@
     </unit>
     <unit id="typePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:169,170</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:190,191</note>
       </notes>
       <segment>
-        <source>Pick one / Custom</source>
+        <source>Auswählen oder eintippen</source>
+      </segment>
+    </unit>
+    <unit id="typeWikiLinkAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:213,215</note>
+      </notes>
+      <segment>
+        <source>Anleitung zum Liegestütztyp öffnen</source>
       </segment>
     </unit>
     <unit id="sourceLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:180,181</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:220,221</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -3374,23 +4350,39 @@
     </unit>
     <unit id="sourcePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:186,187</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:226,227</note>
       </notes>
       <segment>
-        <source>web / whatsapp / Custom</source>
+        <source>web / whatsapp / eigene Quelle</source>
       </segment>
     </unit>
     <unit id="saveEntry">
       <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:207,209</note>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:247,249</note>
       </notes>
       <segment>
         <source> Speichern </source>
       </segment>
     </unit>
+    <unit id="typeWikiLinkTooltip.generic">
+      <notes>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:317</note>
+      </notes>
+      <segment>
+        <source>Anleitung zu Liegestütztypen öffnen</source>
+      </segment>
+    </unit>
+    <unit id="typeWikiLinkTooltip.specific">
+      <notes>
+        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:324</note>
+      </notes>
+      <segment>
+        <source>Anleitung öffnen</source>
+      </segment>
+    </unit>
     <unit id="selectRangeTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:35,38</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:40,43</note>
       </notes>
       <segment>
         <source>Zeitraum auswählen</source>
@@ -3398,7 +4390,7 @@
     </unit>
     <unit id="quickRangeAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:40,41</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:45,46</note>
       </notes>
       <segment>
         <source>Schnellwahl Zeitraum</source>
@@ -3406,7 +4398,7 @@
     </unit>
     <unit id="rangeModeDay">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:48,49</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:53,54</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -3414,7 +4406,7 @@
     </unit>
     <unit id="rangeModeWeek">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:51,52</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:56,57</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -3422,7 +4414,7 @@
     </unit>
     <unit id="rangeModeMonth">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:54,55</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:59,60</note>
       </notes>
       <segment>
         <source>Monat</source>
@@ -3430,7 +4422,7 @@
     </unit>
     <unit id="rangeModeYear">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:57,58</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:62,63</note>
       </notes>
       <segment>
         <source>Jahr</source>
@@ -3438,7 +4430,7 @@
     </unit>
     <unit id="rangeBack">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:65,67</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:74,76</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Zurück </source>
@@ -3446,7 +4438,7 @@
     </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:74,75</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:84,85</note>
       </notes>
       <segment>
         <source> Heute </source>
@@ -3454,7 +4446,7 @@
     </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:82,85</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:93,96</note>
       </notes>
       <segment>
         <source> Vor <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></source>
@@ -3462,7 +4454,7 @@
     </unit>
     <unit id="rangeLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89,90</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:100,101</note>
       </notes>
       <segment>
         <source>Zeitraum</source>
@@ -3470,7 +4462,7 @@
     </unit>
     <unit id="rangeFrom">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:95</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:106</note>
       </notes>
       <segment>
         <source>Von</source>
@@ -3478,7 +4470,7 @@
     </unit>
     <unit id="rangeTo">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112</note>
       </notes>
       <segment>
         <source>Bis</source>
@@ -3630,7 +4622,7 @@
     </unit>
     <unit id="heatmap.loading">
       <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:36,39</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:37,40</note>
       </notes>
       <segment>
         <source> Heatmap wird im Browser geladen… </source>
@@ -3638,7 +4630,7 @@
     </unit>
     <unit id="heatmap.unit.sets">
       <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:64</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:65</note>
       </notes>
       <segment>
         <source>Sätze</source>
@@ -3646,7 +4638,7 @@
     </unit>
     <unit id="heatmap.unit.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:65</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:66</note>
       </notes>
       <segment>
         <source>Wiederholungen</source>
@@ -4127,7 +5119,7 @@
     </unit>
     <unit id="analysis.avgSetSizeTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:216,217</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:218,219</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
@@ -4135,7 +5127,7 @@
     </unit>
     <unit id="analysis.repsPerSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:221,222</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:223,224</note>
       </notes>
       <segment>
         <source>Reps / Set</source>
@@ -4143,7 +5135,7 @@
     </unit>
     <unit id="analysis.setsDistTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:230,232</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:232,234</note>
       </notes>
       <segment>
         <source>Sets-Verteilung</source>
@@ -4151,7 +5143,7 @@
     </unit>
     <unit id="analysis.heatmapTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:243,245</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:247,249</note>
       </notes>
       <segment>
         <source>Heatmap (Wochentag/Uhrzeit)</source>
@@ -4159,7 +5151,7 @@
     </unit>
     <unit id="analysis.heatmapToggleAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:249,250</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:253,254</note>
       </notes>
       <segment>
         <source>Heatmap-Modus auswählen</source>
@@ -4167,7 +5159,7 @@
     </unit>
     <unit id="analysis.heatmapReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:253,255</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:257,259</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -4175,7 +5167,7 @@
     </unit>
     <unit id="analysis.heatmapSets">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:256,258</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:260,262</note>
       </notes>
       <segment>
         <source>Sets</source>
@@ -4801,7 +5793,7 @@
     <unit id="trainingPlans.day">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:70,71</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:92,93</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:91,92</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -4810,8 +5802,8 @@
     <unit id="trainingPlans.kind.rest">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:73,74</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:207,208</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:106,107</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:218,219</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:105,106</note>
       </notes>
       <segment>
         <source>Ruhetag</source>
@@ -4820,8 +5812,8 @@
     <unit id="trainingPlans.kind.light">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:76,77</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:214,216</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:109,110</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:225,227</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:108,109</note>
       </notes>
       <segment>
         <source>Leichter Tag</source>
@@ -4830,8 +5822,8 @@
     <unit id="trainingPlans.kind.test">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:78,80</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:210,212</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:112,114</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:221,223</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:111,113</note>
       </notes>
       <segment>
         <source>Maximaltest</source>
@@ -4840,9 +5832,9 @@
     <unit id="trainingPlans.reps">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:81,83</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:220,221</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:226,227</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:124,126</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:231,232</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:237,238</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:123,125</note>
       </notes>
       <segment>
         <source>Wdh.</source>
@@ -4851,7 +5843,7 @@
     <unit id="trainingPlans.openDetail">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:90,92</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:164,166</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:163,165</note>
       </notes>
       <segment>
         <source> Details öffnen </source>
@@ -4987,7 +5979,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:256,260</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:258,262</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -4995,7 +5987,7 @@
     </unit>
     <unit id="dashboard.latestEntriesLinkAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:267,268</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:269,270</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -5003,7 +5995,7 @@
     </unit>
     <unit id="dashboard.latestEntries">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:270,271</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:272,273</note>
       </notes>
       <segment>
         <source>Letzte Einträge</source>
@@ -5011,7 +6003,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:277,278</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:279,280</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -5019,7 +6011,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:281,284</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:283,286</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -5027,7 +6019,7 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:287</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:289</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -5035,7 +6027,7 @@
     </unit>
     <unit id="dashboard.share.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:71</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:70</note>
       </notes>
       <segment>
         <source>Tagesleistung teilen</source>
@@ -5043,7 +6035,7 @@
     </unit>
     <unit id="dashboard.share">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:72</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:71</note>
       </notes>
       <segment>
         <source>Teilen</source>
@@ -5051,8 +6043,8 @@
     </unit>
     <unit id="trainingPlans.back">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:53</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:282,284</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:64</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:314,316</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -5060,8 +6052,8 @@
     </unit>
     <unit id="trainingPlans.daysSuffix">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:66,68</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:179,181</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:77,79</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:178,180</note>
       </notes>
       <segment>
         <source>Tage</source>
@@ -5069,8 +6061,8 @@
     </unit>
     <unit id="trainingPlans.level.beginner">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:70,71</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:184,186</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:81,82</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:183,185</note>
       </notes>
       <segment>
         <source>Einsteiger</source>
@@ -5078,8 +6070,8 @@
     </unit>
     <unit id="trainingPlans.level.intermediate">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:72,74</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:188,190</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:83,85</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:187,189</note>
       </notes>
       <segment>
         <source>Mittelstufe</source>
@@ -5087,8 +6079,8 @@
     </unit>
     <unit id="trainingPlans.level.advanced">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:74,76</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:192,194</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:85,87</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:191,193</note>
       </notes>
       <segment>
         <source>Fortgeschritten</source>
@@ -5096,7 +6088,7 @@
     </unit>
     <unit id="trainingPlans.progress">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:83,84</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:94,95</note>
       </notes>
       <segment>
         <source>Fortschritt</source>
@@ -5104,7 +6096,7 @@
     </unit>
     <unit id="trainingPlans.currentDay">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:92,93</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:103,104</note>
       </notes>
       <segment>
         <source>Aktueller Tag:</source>
@@ -5112,8 +6104,8 @@
     </unit>
     <unit id="trainingPlans.abandon">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:104,106</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:139,141</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:115,117</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:138,140</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">cancel</pc> Plan beenden </source>
@@ -5121,7 +6113,7 @@
     </unit>
     <unit id="trainingPlans.startCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:114,116</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:125,127</note>
       </notes>
       <segment>
         <source> Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt. </source>
@@ -5129,7 +6121,7 @@
     </unit>
     <unit id="trainingPlans.signupCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:119,121</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:130,132</note>
       </notes>
       <segment>
         <source> Erstelle ein kostenloses Konto, um diesen Plan zu starten. Wir tracken deinen Fortschritt automatisch und setzen dein Tagesziel passend zum Plan. </source>
@@ -5137,7 +6129,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.tracking">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:125,127</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:136,138</note>
       </notes>
       <segment>
         <source> Automatische Fortschrittsverfolgung </source>
@@ -5145,7 +6137,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.goal">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:128,130</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:139,141</note>
       </notes>
       <segment>
         <source> Tagesziel passt sich täglich an deinen Plan an </source>
@@ -5153,7 +6145,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.streak">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:131,133</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:142,144</note>
       </notes>
       <segment>
         <source> Streaks, Statistiken und Bestenliste </source>
@@ -5161,7 +6153,7 @@
     </unit>
     <unit id="trainingPlans.replaceWarn">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:143,144</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:154,155</note>
       </notes>
       <segment>
         <source> Achtung: Dies ersetzt den aktuell aktiven Plan. </source>
@@ -5169,7 +6161,7 @@
     </unit>
     <unit id="trainingPlans.start">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:148,150</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:159,161</note>
       </notes>
       <segment>
         <source>Plan starten</source>
@@ -5177,7 +6169,7 @@
     </unit>
     <unit id="trainingPlans.signupAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:159,161</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:170,172</note>
       </notes>
       <segment>
         <source>Konto erstellen &amp; Plan starten</source>
@@ -5185,7 +6177,7 @@
     </unit>
     <unit id="trainingPlans.loginAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:167,170</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:178,181</note>
       </notes>
       <segment>
         <source>Schon Konto? Einloggen</source>
@@ -5193,7 +6185,7 @@
     </unit>
     <unit id="trainingPlans.week">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:177,178</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:188,189</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -5201,7 +6193,7 @@
     </unit>
     <unit id="trainingPlans.unmarkAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:243,244</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:275,276</note>
       </notes>
       <segment>
         <source>Als nicht erledigt markieren</source>
@@ -5209,7 +6201,7 @@
     </unit>
     <unit id="trainingPlans.logAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:286,287</note>
       </notes>
       <segment>
         <source>Plan-Sätze eintragen und als erledigt markieren</source>
@@ -5217,7 +6209,7 @@
     </unit>
     <unit id="trainingPlans.markAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:263,264</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:295,296</note>
       </notes>
       <segment>
         <source>Nur als erledigt markieren (ohne Eintrag)</source>
@@ -5225,7 +6217,7 @@
     </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:279,280</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:311,312</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -5233,7 +6225,7 @@
     </unit>
     <unit id="trainingPlans.autoStartFailed">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:492</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:561</note>
       </notes>
       <segment>
         <source>Plan-Start fehlgeschlagen — bitte erneut versuchen.</source>
@@ -5241,7 +6233,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:559</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:640</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -5249,7 +6241,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:576</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:657</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
@@ -5257,8 +6249,8 @@
     </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:602</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:359</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:683</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:347</note>
       </notes>
       <segment>
         <source>Plan-Sätze wurden eingetragen.</source>
@@ -5266,8 +6258,8 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:604</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:361</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:685</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:349</note>
       </notes>
       <segment>
         <source>Tag war schon eingetragen — als erledigt markiert.</source>
@@ -5275,8 +6267,8 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:606</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:363</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:687</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:351</note>
       </notes>
       <segment>
         <source>Daten werden noch geladen, bitte gleich noch einmal versuchen.</source>
@@ -5284,7 +6276,7 @@
     </unit>
     <unit id="trainingPlans.title">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:34,35</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:33,34</note>
       </notes>
       <segment>
         <source>Trainingspläne</source>
@@ -5292,7 +6284,7 @@
     </unit>
     <unit id="trainingPlans.intro">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:36,39</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:35,38</note>
       </notes>
       <segment>
         <source> Strukturierte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Starte einen Plan, und dein Tagesziel im Dashboard wird automatisch gesetzt. </source>
@@ -5300,7 +6292,7 @@
     </unit>
     <unit id="trainingPlans.banner.title">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:49,51</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:48,50</note>
       </notes>
       <segment>
         <source> Plan auswählen, Konto erstellen, durchstarten </source>
@@ -5308,7 +6300,7 @@
     </unit>
     <unit id="trainingPlans.banner.body">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:52,54</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:51,53</note>
       </notes>
       <segment>
         <source> Suche dir unten einen Plan aus. Mit einem kostenlosen Konto tracken wir deinen Fortschritt automatisch und passen dein Tagesziel an den gewählten Plan an. </source>
@@ -5316,7 +6308,7 @@
     </unit>
     <unit id="trainingPlans.banner.login">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:65,68</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:64,67</note>
       </notes>
       <segment>
         <source>Einloggen</source>
@@ -5324,7 +6316,7 @@
     </unit>
     <unit id="trainingPlans.banner.signup">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:73,75</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:72,74</note>
       </notes>
       <segment>
         <source>Kostenlos registrieren</source>
@@ -5332,7 +6324,7 @@
     </unit>
     <unit id="trainingPlans.active.title">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:83,84</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:82,83</note>
       </notes>
       <segment>
         <source> Aktiver Plan </source>
@@ -5340,7 +6332,7 @@
     </unit>
     <unit id="trainingPlans.kind.main">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:115,117</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:114,116</note>
       </notes>
       <segment>
         <source>Trainingstag</source>
@@ -5348,7 +6340,7 @@
     </unit>
     <unit id="trainingPlans.todayTarget">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:121,123</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:120,122</note>
       </notes>
       <segment>
         <source>Heute geplant:</source>
@@ -5356,7 +6348,7 @@
     </unit>
     <unit id="trainingPlans.logToday">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:155,157</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:154,156</note>
       </notes>
       <segment>
         <source>Heute eintragen</source>
@@ -5364,10 +6356,82 @@
     </unit>
     <unit id="trainingPlans.viewPlan">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:208,210</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:207,209</note>
       </notes>
       <segment>
         <source>Plan ansehen</source>
+      </segment>
+    </unit>
+    <unit id="wiki.pushupTypes.back">
+      <notes>
+        <note category="location">web/src/app/wiki/pushup-types-page.component.ts:50,51</note>
+      </notes>
+      <segment>
+        <source>Zurück zu den Trainingsplänen</source>
+      </segment>
+    </unit>
+    <unit id="wiki.pushupTypes.title">
+      <notes>
+        <note category="location">web/src/app/wiki/pushup-types-page.component.ts:57,59</note>
+      </notes>
+      <segment>
+        <source> Liegestütztypen — saubere Ausführung </source>
+      </segment>
+    </unit>
+    <unit id="wiki.pushupTypes.intro">
+      <notes>
+        <note category="location">web/src/app/wiki/pushup-types-page.component.ts:60,63</note>
+      </notes>
+      <segment>
+        <source> Kurzanleitungen für jede Liegestütz-Variante, die in den Trainingsplänen vorkommt. Die Tooltipps in den Plänen verlinken direkt auf den passenden Abschnitt. </source>
+      </segment>
+    </unit>
+    <unit id="wiki.pushupTypes.tocTitle">
+      <notes>
+        <note category="location">web/src/app/wiki/pushup-types-page.component.ts:69,72</note>
+      </notes>
+      <segment>
+        <source> Übersicht </source>
+      </segment>
+    </unit>
+    <unit id="wiki.pushupTypes.level.beginner">
+      <notes>
+        <note category="location">web/src/app/wiki/pushup-types-page.component.ts:100,102</note>
+      </notes>
+      <segment>
+        <source>Einsteiger</source>
+      </segment>
+    </unit>
+    <unit id="wiki.pushupTypes.level.intermediate">
+      <notes>
+        <note category="location">web/src/app/wiki/pushup-types-page.component.ts:106,108</note>
+      </notes>
+      <segment>
+        <source>Mittelstufe</source>
+      </segment>
+    </unit>
+    <unit id="wiki.pushupTypes.level.advanced">
+      <notes>
+        <note category="location">web/src/app/wiki/pushup-types-page.component.ts:112,114</note>
+      </notes>
+      <segment>
+        <source>Fortgeschritten</source>
+      </segment>
+    </unit>
+    <unit id="wiki.pushupTypes.instructionsTitle">
+      <notes>
+        <note category="location">web/src/app/wiki/pushup-types-page.component.ts:120,122</note>
+      </notes>
+      <segment>
+        <source>Ausführung</source>
+      </segment>
+    </unit>
+    <unit id="wiki.pushupTypes.tipsTitle">
+      <notes>
+        <note category="location">web/src/app/wiki/pushup-types-page.component.ts:127,128</note>
+      </notes>
+      <segment>
+        <source>Tipps</source>
       </segment>
     </unit>
   </file>


### PR DESCRIPTION
The 119 plan.* IDs from libs/stats/src/lib/models/training-plan.catalog.ts
existed only in messages.en.xlf, so non-DE/EN locales fell back to the
German source at runtime — plan titles, summaries and per-day
descriptions on /training-plans rendered in German on FR/ES/IT/NL/EL/LA.

Add the same 119 unit IDs to each locale file with locale-appropriate
targets and the per-locale blog slugs that match content/blog/*/<lang>.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localization support for training plans in Greek, Spanish, French, Italian, Latin, and Dutch, including translations for multiple plan types (6-week beginner, 30-day challenge, over-40 4-week, daily-100 30-day, and 12-week one-arm plans) and day-by-day descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->