### PR TITLE
fix(i18n): correct mistranslated strings in fr/it/nl XLIFF

### DIFF
--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -732,7 +732,7 @@
       </notes>
       <segment state="translated">
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> Reps</source>
-        <target>+ Représentants <ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/></target>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> répétitions</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.open">
@@ -1363,7 +1363,7 @@
       </notes>
       <segment state="translated">
         <source>Erinnerungen</source>
-        <target>Souvenirs</target>
+        <target>Rappels</target>
       </segment>
     </unit>
     <unit id="nav.language">
@@ -3142,7 +3142,7 @@
       </notes>
       <segment state="translated">
         <source>🔔 Erinnerungen</source>
-        <target>🔔 Souvenirs</target>
+        <target>🔔 Rappels</target>
       </segment>
     </unit>
     <unit id="reminders.page.subtitle">
@@ -3421,7 +3421,7 @@
       </notes>
       <segment state="translated">
         <source>🔔 Erinnerungen</source>
-        <target>🔔 Souvenirs</target>
+        <target>🔔 Rappels</target>
       </segment>
     </unit>
     <unit id="push.section.desc">
@@ -3630,7 +3630,7 @@
       </notes>
       <segment state="translated">
         <source>Analyse</source>
-        <target>Analysis</target>
+        <target>Analyse</target>
       </segment>
     </unit>
     <unit id="dashboard.analysisTeaserStreak">
@@ -4026,7 +4026,7 @@
       </notes>
       <segment state="translated">
         <source>Erfolg vaporisieren</source>
-        <target>Succès de vaporiser</target>
+        <target>Masquer l'animation de succès</target>
       </segment>
     </unit>
     <unit id="goalReached.snap">
@@ -5055,7 +5055,7 @@
       </notes>
       <segment state="translated">
         <source>🔔 Erinnerungen</source>
-        <target>🔔 Souvenirs</target>
+        <target>🔔 Rappels</target>
       </segment>
     </unit>
     <unit id="settings.remindersLinkDesc">
@@ -5294,7 +5294,7 @@
       </notes>
       <segment state="translated">
         <source>Leichter Tag</source>
-        <target>Jour clair</target>
+        <target>Jour léger</target>
       </segment>
     </unit>
     <unit id="trainingPlans.kind.test">
@@ -5621,7 +5621,7 @@
       </notes>
       <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">cancel</pc> Plan beenden </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">cancel</pc> Plan de fin </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">cancel</pc> Arrêter le plan </target>
       </segment>
     </unit>
     <unit id="trainingPlans.startCta">
@@ -5684,7 +5684,7 @@
       </notes>
       <segment state="translated">
         <source>Plan starten</source>
-        <target>Plan de démarrage</target>
+        <target>Démarrer le plan</target>
       </segment>
     </unit>
     <unit id="trainingPlans.signupAndStart">
@@ -5894,7 +5894,7 @@
       </notes>
       <segment state="translated">
         <source>Heute eintragen</source>
-        <target>Participez aujourd'hui</target>
+        <target>Enregistrer aujourd'hui</target>
       </segment>
     </unit>
     <unit id="trainingPlans.viewPlan">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -929,7 +929,7 @@
       </notes>
       <segment state="translated">
         <source>Anon</source>
-        <target>Subito</target>
+        <target>Anonimo</target>
       </segment>
     </unit>
     <unit id="admin.col.pushups">
@@ -2611,7 +2611,7 @@
       </notes>
       <segment state="translated">
         <source>Plan ansehen</source>
-        <target>Visualizza pianta</target>
+        <target>Visualizza piano</target>
       </segment>
     </unit>
     <unit id="landing.plans.challenge.title">
@@ -3648,7 +3648,7 @@
       </notes>
       <segment state="translated">
         <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> Reps</source>
-        <target>Questa settimana: rappresentanti <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> /<ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/></target>
+        <target>Questa settimana: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> ripetizioni</target>
       </segment>
     </unit>
     <unit id="dashboard.analysisTeaserError">
@@ -4558,7 +4558,7 @@
       </notes>
       <segment state="translated">
         <source>Bestwert Einzel-Eintrag:</source>
-        <target>Voce singola con il miglior rapporto qualità-prezzo:</target>
+        <target>Miglior singolo inserimento:</target>
       </segment>
     </unit>
     <unit id="analysis.bestDay">
@@ -5621,7 +5621,7 @@
       </notes>
       <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">cancel</pc> Plan beenden </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">cancel</pc> Piano finale </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">cancel</pc> Termina piano </target>
       </segment>
     </unit>
     <unit id="trainingPlans.startCta">
@@ -5903,7 +5903,7 @@
       </notes>
       <segment state="translated">
         <source>Plan ansehen</source>
-        <target>Visualizza pianta</target>
+        <target>Visualizza piano</target>
       </segment>
     </unit>
 

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -1669,7 +1669,7 @@
       </notes>
       <segment state="translated">
         <source>Öffentliche Bestenliste mit Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage.</source>
-        <target>Openbaar klassement met topvertegenwoordigers voor vandaag, de afgelopen 7 dagen en de afgelopen 30 dagen.</target>
+        <target>Openbaar klassement met topscores voor vandaag, de afgelopen 7 dagen en de afgelopen 30 dagen.</target>
       </segment>
     </unit>
     <unit id="seo.publicProfile.title">
@@ -2094,7 +2094,7 @@
       </notes>
       <segment state="translated">
         <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}"/> Reps </source>
-        <target> Uw positie: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}"/> vertegenwoordigers </target>
+        <target> Uw positie: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}"/> reps </target>
       </segment>
     </unit>
     <unit id="reminder.feature.eyebrow">
@@ -2611,7 +2611,7 @@
       </notes>
       <segment state="translated">
         <source>Plan ansehen</source>
-        <target>Bekijk plattegrond</target>
+        <target>Bekijk plan</target>
       </segment>
     </unit>
     <unit id="landing.plans.challenge.title">
@@ -2656,7 +2656,7 @@
       </notes>
       <segment state="translated">
         <source>Alle Pläne ansehen</source>
-        <target>Bekijk alle abonnementen</target>
+        <target>Bekijk alle plannen</target>
       </segment>
     </unit>
     <unit id="landing.plans.cta.signup">
@@ -2881,7 +2881,7 @@
       </notes>
       <segment state="translated">
         <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
-        <target> Vergelijk jezelf met de community: topvertegenwoordigers voor vandaag, de afgelopen 7 dagen en de afgelopen 30 dagen. Privacy voorop – uw naam verschijnt alleen als u dat wilt. </target>
+        <target> Vergelijk jezelf met de community: topscores voor vandaag, de afgelopen 7 dagen en de afgelopen 30 dagen. Privacy voorop – uw naam verschijnt alleen als u dat wilt. </target>
       </segment>
     </unit>
     <unit id="landing.discover.leaderboard.cta">
@@ -3304,7 +3304,7 @@
       </notes>
       <segment state="translated">
         <source>EN</source>
-        <target>NL</target>
+        <target>EN</target>
       </segment>
     </unit>
     <unit id="reminder.quickLog.label">
@@ -3322,7 +3322,7 @@
       </notes>
       <segment state="translated">
         <source> Zeigt einen &quot;Eintragen&quot;-Button auf der Push-Benachrichtigung. Wenn die App schon geöffnet ist, wird der Eintrag im Hintergrund gespeichert; ansonsten öffnet sich kurz ein Tab, der den Eintrag automatisch anlegt. </source>
-        <target> Toont een knop "Abonneren" op de pushmelding. Als de app al geopend is, wordt de invoer op de achtergrond opgeslagen; anders wordt er kort een tabblad geopend waarop automatisch het item wordt aangemaakt. </target>
+        <target> Toont een knop "Invoeren" op de pushmelding. Als de app al geopend is, wordt de invoer op de achtergrond opgeslagen; anders wordt er kort een tabblad geopend waarop automatisch het item wordt aangemaakt. </target>
       </segment>
     </unit>
     <unit id="reminder.quickLog.toggle">
@@ -3648,7 +3648,7 @@
       </notes>
       <segment state="translated">
         <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> Reps</source>
-        <target>Deze week: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> /<ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> -vertegenwoordigers</target>
+        <target>Deze week: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> reps</target>
       </segment>
     </unit>
     <unit id="dashboard.analysisTeaserError">
@@ -4309,7 +4309,7 @@
       </notes>
       <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/> Einträge</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/>-gegevens</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/> items</target>
       </segment>
     </unit>
     <unit id="sourceColumnToggle">
@@ -5399,7 +5399,7 @@
       </notes>
       <segment state="translated">
         <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/> </source>
-        <target> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/>-vertegenwoordigers · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/> </target>
+        <target> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/> </target>
       </segment>
     </unit>
     <unit id="dashboard.noEntryYet">
@@ -5408,7 +5408,7 @@
       </notes>
       <segment state="translated">
         <source>Noch kein Eintrag.</source>
-        <target>Nog geen toegang.</target>
+        <target>Nog geen invoer.</target>
       </segment>
     </unit>
     <unit id="quickActionsTitle">
@@ -5444,7 +5444,7 @@
       </notes>
       <segment state="translated">
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Rep</target>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> reps</target>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.reached">
@@ -5684,7 +5684,7 @@
       </notes>
       <segment state="translated">
         <source>Plan starten</source>
-        <target>Startplan</target>
+        <target>Plan starten</target>
       </segment>
     </unit>
     <unit id="trainingPlans.signupAndStart">
@@ -5774,7 +5774,7 @@
       </notes>
       <segment state="translated">
         <source>Plan beendet.</source>
-        <target>Plan voltooid.</target>
+        <target>Plan beëindigd.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.logged">
@@ -5831,7 +5831,7 @@
       </notes>
       <segment state="translated">
         <source> Plan auswählen, Konto erstellen, durchstarten </source>
-        <target> Selecteer een abonnement, maak een account aan en ga aan de slag </target>
+        <target> Selecteer een plan, maak een account aan en ga aan de slag </target>
       </segment>
     </unit>
     <unit id="trainingPlans.banner.body">
@@ -5840,7 +5840,7 @@
       </notes>
       <segment state="translated">
         <source> Suche dir unten einen Plan aus. Mit einem kostenlosen Konto tracken wir deinen Fortschritt automatisch und passen dein Tagesziel an den gewählten Plan an. </source>
-        <target> Kies hieronder een abonnement. Met een gratis account houden we automatisch je voortgang bij en passen we je dagelijkse doel aan het gekozen plan aan. </target>
+        <target> Kies hieronder een plan. Met een gratis account houden we automatisch je voortgang bij en passen we je dagelijkse doel aan het gekozen plan aan. </target>
       </segment>
     </unit>
     <unit id="trainingPlans.banner.login">
@@ -5903,7 +5903,7 @@
       </notes>
       <segment state="translated">
         <source>Plan ansehen</source>
-        <target>Bekijk plattegrond</target>
+        <target>Bekijk plan</target>
       </segment>
     </unit>
 

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3322,7 +3322,7 @@
       </notes>
       <segment state="translated">
         <source> Zeigt einen &quot;Eintragen&quot;-Button auf der Push-Benachrichtigung. Wenn die App schon geöffnet ist, wird der Eintrag im Hintergrund gespeichert; ansonsten öffnet sich kurz ein Tab, der den Eintrag automatisch anlegt. </source>
-        <target> Toont een knop "Invoeren" op de pushmelding. Als de app al geopend is, wordt de invoer op de achtergrond opgeslagen; anders wordt er kort een tabblad geopend waarop automatisch het item wordt aangemaakt. </target>
+        <target> Toont een knop "Invoeren" op de pushmelding. Als de app al geopend is, wordt de invoer op de achtergrond opgeslagen; anders wordt er kort een tabblad geopend waarop automatisch de invoer wordt aangemaakt. </target>
       </segment>
     </unit>
     <unit id="reminder.quickLog.toggle">
@@ -4309,7 +4309,7 @@
       </notes>
       <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/> Einträge</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/> items</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/> invoeren</target>
       </segment>
     </unit>
     <unit id="sourceColumnToggle">


### PR DESCRIPTION
## Summary

Pre-existing translation issues in `fr/it/nl` XLIFF files surfaced by CodeRabbit on #274 (outside the diff range of that PR's training-plan changes, deferred to this cleanup as agreed).

### FR (`messages.fr.xlf`)
- `nav.reminders`, `reminders.page.title` (×3): `Souvenirs` → `Rappels`
- `quickAdd.fab.quickAddReps`: `Représentants` → `répétitions` (and restore placeholder ordering)
- `trainingPlans.abandon`: `Plan de fin` → `Arrêter le plan`
- `trainingPlans.start`: `Plan de démarrage` → `Démarrer le plan`
- `trainingPlans.kind.light`: `Jour clair` → `Jour léger`
- `trainingPlans.logToday`: `Participez aujourd'hui` → `Enregistrer aujourd'hui`
- `goalReached.snapAria`: `Succès de vaporiser` → `Masquer l'animation de succès`
- `dashboard.analysisTeaserTitle`: `Analysis` (English) → `Analyse`

### IT (`messages.it.xlf`)
- `dashboard.analysisTeaserWeekReps`: `rappresentanti` → `ripetizioni` (with placeholder ordering)
- `analysis.bestSingleEntry`: `rapporto qualità-prezzo` → `Miglior singolo inserimento:`
- `landing.plans.viewPlan` + `trainingPlans.viewPlan`: `Visualizza pianta` → `Visualizza piano`
- `trainingPlans.abandon`: `Piano finale` → `Termina piano`
- `admin.col.anon`: `Subito` → `Anonimo`

### NL (`messages.nl.xlf`)
- `reminder.language.en`: `NL` → `EN`
- `reminder.quickLog.desc`: `Abonneren` → `Invoeren`
- `trainingPlans.abandoned`: `Plan voltooid.` (completed) → `Plan beëindigd.` (ended)
- `dashboard.noEntryYet`: `Nog geen toegang.` (no access) → `Nog geen invoer.`
- Plan-vs-subscription drift: `plattegrond`/`abonnement`/`Startplan` → consistent `plan`/`plannen` (6 strings)
- Reps drift: `vertegenwoordigers`/`gegevens`/singular `Rep` → consistent `reps`/`topscores`/`items` (7 strings)

## Verification

- `pnpm nx test web` ✓ all suites green
- `pnpm nx run web:build --configuration=production --localize=fr,it,nl` ✓
- Verified in built artefacts:
  - IT `dist/web/browser/it/training-plans/index.html`: `Visualizza piano` (no `pianta`)
  - NL `dist/web/browser/nl/training-plans/index.html`: `Bekijk plan` (no `plattegrond`)
  - FR `dist/web/browser/fr/training-plans/recruit-6w/index.html`: `Jour léger` (no `Jour clair`)
  - NL: `vertegenwoordigers`/`gegevens` removed from prerendered HTML
  - FR: no remaining `Souvenirs` in XLIFF

## Test plan

- [ ] CI green
- [ ] Visual spot-check on staging preview after deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtD59Q1gGMbJHdUXz7e6wh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated translations for French, Italian, and Dutch, including improvements to reminders terminology, training plan labels, leaderboard descriptions, and UI text across the application for better clarity and localization accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->