### PR TITLE
feat(entry-dialog): localize push-up type selection while persisting English entryLabel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,7 @@ The wiki catalog has two parts: **structural metadata** (referenced by code) liv
 1. **Add the structural entry** in `libs/stats/src/lib/models/pushup-type.models.ts`:
    - Append a new entry to `PUSHUP_TYPES` with: `id`, `slug`, `entryLabel`, `difficulty`, `keywordsDe[]`, `keywordsEn[]`. (The `name`/`nameEn`/`summary`/`summaryEn`/`instructions*`/`tips*` fields are now legacy duplicates of the markdown content — leave them populated until a follow-up cleanup removes them from `PushupTypeInfo`.)
    - Extend the `PushupTypeId` union with the new `id` literal.
-   - **Do NOT rename `id` or `entryLabel` of an existing entry** — `PushupRecord.type` stores `entryLabel` in Firestore. Renames need a migration.
+   - **Do NOT rename `id` of an existing entry** — `PushupRecord.type` stores the kebab-case catalog `id` in Firestore (and read paths still tolerate the legacy English `entryLabel` from older docs). Renaming `id` would orphan existing rows. `entryLabel` is now read-path-only legacy and only kept so old docs keep resolving via `findPushupTypeByStoredValue` / `canonicalizePushupType` / `displayPushupType`.
 
 2. **Add one markdown file per locale**:
 

--- a/libs/stats/src/lib/models/pushup-type.models.spec.ts
+++ b/libs/stats/src/lib/models/pushup-type.models.spec.ts
@@ -1,9 +1,12 @@
 import {
+  canonicalizePushupType,
   detectPushupTypes,
+  displayPushupType,
   findPushupType,
   findPushupTypeByEntryLabel,
   findPushupTypeByLocalizedName,
   findPushupTypeBySlug,
+  findPushupTypeByStoredValue,
   localizePushupType,
   localizePushupTypeSlug,
   PUSHUP_TYPES,
@@ -141,6 +144,71 @@ describe('pushup-type catalog', () => {
       expect(findPushupTypeByLocalizedName(null, 'de')).toBeNull();
       expect(findPushupTypeByLocalizedName(undefined, 'de')).toBeNull();
       expect(findPushupTypeByLocalizedName('My-Custom-Move', 'de')).toBeNull();
+    });
+  });
+
+  describe('findPushupTypeByStoredValue', () => {
+    it('resolves the new canonical id', () => {
+      expect(findPushupTypeByStoredValue('diamond')?.id).toBe('diamond');
+      expect(findPushupTypeByStoredValue('  one-arm  ')?.id).toBe('one-arm');
+    });
+
+    it('resolves the legacy English entryLabel', () => {
+      expect(findPushupTypeByStoredValue('Diamond')?.id).toBe('diamond');
+      expect(findPushupTypeByStoredValue('Wall One-Arm')?.id).toBe(
+        'wall-one-arm'
+      );
+    });
+
+    it('returns null for empty or custom strings', () => {
+      expect(findPushupTypeByStoredValue('')).toBeNull();
+      expect(findPushupTypeByStoredValue(null)).toBeNull();
+      expect(findPushupTypeByStoredValue(undefined)).toBeNull();
+      expect(findPushupTypeByStoredValue('My-Custom-Move')).toBeNull();
+    });
+  });
+
+  describe('canonicalizePushupType', () => {
+    it('collapses legacy entryLabel and new id to the same key', () => {
+      expect(canonicalizePushupType('Diamond')).toBe('diamond');
+      expect(canonicalizePushupType('diamond')).toBe('diamond');
+      expect(canonicalizePushupType('Wall One-Arm')).toBe('wall-one-arm');
+    });
+
+    it('returns the trimmed input unchanged for custom strings', () => {
+      expect(canonicalizePushupType('  My-Custom-Move ')).toBe(
+        'My-Custom-Move'
+      );
+    });
+
+    it('returns an empty string for empty / nullish input', () => {
+      expect(canonicalizePushupType('')).toBe('');
+      expect(canonicalizePushupType(null)).toBe('');
+      expect(canonicalizePushupType(undefined)).toBe('');
+    });
+  });
+
+  describe('displayPushupType', () => {
+    it('renders the localized name for the canonical id', () => {
+      expect(displayPushupType('diamond', 'de')).toBe('Diamant-Liegestütze');
+      expect(displayPushupType('diamond', 'en')).toBe('Diamond push-up');
+    });
+
+    it('renders the localized name for the legacy entryLabel', () => {
+      expect(displayPushupType('Diamond', 'de')).toBe('Diamant-Liegestütze');
+      expect(displayPushupType('Wall One-Arm', 'en')).toBe(
+        'Wall one-arm push-up'
+      );
+    });
+
+    it('echoes custom typed values unchanged', () => {
+      expect(displayPushupType('My-Custom-Move', 'de')).toBe('My-Custom-Move');
+    });
+
+    it('falls back to localized "Standard" for empty / nullish input', () => {
+      expect(displayPushupType('', 'de')).toBe('Standard-Liegestütze');
+      expect(displayPushupType(null, 'de')).toBe('Standard-Liegestütze');
+      expect(displayPushupType(undefined, 'en')).toBe('Standard push-up');
     });
   });
 

--- a/libs/stats/src/lib/models/pushup-type.models.spec.ts
+++ b/libs/stats/src/lib/models/pushup-type.models.spec.ts
@@ -2,6 +2,7 @@ import {
   detectPushupTypes,
   findPushupType,
   findPushupTypeByEntryLabel,
+  findPushupTypeByLocalizedName,
   findPushupTypeBySlug,
   localizePushupType,
   localizePushupTypeSlug,
@@ -92,6 +93,54 @@ describe('pushup-type catalog', () => {
       expect(findPushupTypeByEntryLabel(null)).toBeNull();
       expect(findPushupTypeByEntryLabel(undefined)).toBeNull();
       expect(findPushupTypeByEntryLabel('Custom-Move')).toBeNull();
+    });
+  });
+
+  describe('findPushupTypeByLocalizedName', () => {
+    it('matches the canonical English entryLabel regardless of locale', () => {
+      expect(findPushupTypeByLocalizedName('Diamond', 'de')?.id).toBe(
+        'diamond'
+      );
+      expect(findPushupTypeByLocalizedName('  diamond  ', 'fr')?.id).toBe(
+        'diamond'
+      );
+    });
+
+    it('matches the German display name in a "de" locale', () => {
+      expect(
+        findPushupTypeByLocalizedName('Diamant-Liegestütze', 'de')?.id
+      ).toBe('diamond');
+      expect(
+        findPushupTypeByLocalizedName('Archer-Liegestütze', 'de')?.id
+      ).toBe('archer');
+    });
+
+    it('matches the English display name in an "en" locale', () => {
+      expect(findPushupTypeByLocalizedName('Diamond push-up', 'en')?.id).toBe(
+        'diamond'
+      );
+      expect(
+        findPushupTypeByLocalizedName('Standard push-up', 'en-US')?.id
+      ).toBe('standard');
+    });
+
+    it('also accepts an English name pasted into a non-English UI', () => {
+      // Users frequently copy English names from the wiki regardless of
+      // UI language; the resolver falls back to English so those still
+      // map to the canonical entry.
+      expect(findPushupTypeByLocalizedName('Diamond push-up', 'de')?.id).toBe(
+        'diamond'
+      );
+      expect(findPushupTypeByLocalizedName('Archer push-up', 'fr')?.id).toBe(
+        'archer'
+      );
+    });
+
+    it('returns null for unknown or empty values', () => {
+      expect(findPushupTypeByLocalizedName('', 'de')).toBeNull();
+      expect(findPushupTypeByLocalizedName(null, 'de')).toBeNull();
+      expect(findPushupTypeByLocalizedName(undefined, 'de')).toBeNull();
+      expect(findPushupTypeByLocalizedName('My-Custom-Move', 'de')).toBeNull();
     });
   });
 

--- a/libs/stats/src/lib/models/pushup-type.models.ts
+++ b/libs/stats/src/lib/models/pushup-type.models.ts
@@ -740,6 +740,35 @@ export function findPushupTypeByEntryLabel(
 }
 
 /**
+ * Resolves a user-facing string back to a catalog entry. Matches in this
+ * order: canonical English `entryLabel` → localized name for the active
+ * locale → localized name in English (as a fallback so a user pasting an
+ * English name into a translated UI still resolves). Returns null for
+ * custom values typed by the user.
+ *
+ * Why English fallback: `entryLabel` (e.g. "One-Arm") and the English
+ * display name (e.g. "One-arm push-up") differ, and users frequently
+ * copy English labels from the wiki regardless of UI language.
+ */
+export function findPushupTypeByLocalizedName(
+  name: string | null | undefined,
+  locale: string
+): PushupTypeInfo | null {
+  const byLabel = findPushupTypeByEntryLabel(name);
+  if (byLabel) return byLabel;
+  if (!name) return null;
+  const needle = name.toLowerCase().trim();
+  if (!needle) return null;
+  for (const type of PUSHUP_TYPES) {
+    const localized = localizePushupType(type, locale).name.toLowerCase();
+    if (localized === needle) return type;
+    const english = localizePushupType(type, 'en').name.toLowerCase();
+    if (english === needle) return type;
+  }
+  return null;
+}
+
+/**
  * Returns the localized name + summary for the active Angular locale.
  * Resolves the locale's primary subtag (e.g. `fr-CH` → `fr`) and looks
  * up the markdown-sourced override in `PUSHUP_TYPE_CONTENT`. Falls back

--- a/libs/stats/src/lib/models/pushup-type.models.ts
+++ b/libs/stats/src/lib/models/pushup-type.models.ts
@@ -731,6 +731,10 @@ export function pushupTypeSlugByLocale(
  * Look up a catalog entry by the entry-dialog's stored label
  * (case-insensitive). Returns null when the label is unknown — e.g.
  * when the user typed a custom value.
+ *
+ * **Legacy.** Older Firestore docs persist this label as
+ * `PushupRecord.type`; new docs use the catalog `id` instead. Read sites
+ * should use {@link findPushupTypeByStoredValue} so both formats resolve.
  */
 export function findPushupTypeByEntryLabel(
   label: string | null | undefined
@@ -740,11 +744,63 @@ export function findPushupTypeByEntryLabel(
 }
 
 /**
+ * Resolves a stored `PushupRecord.type` value back to a catalog entry.
+ * Accepts the canonical kebab-case `id` (e.g. `'diamond'`) emitted by
+ * the entry dialog AND the legacy English `entryLabel` (e.g.
+ * `'Diamond'`) found on older docs. Returns null for custom strings.
+ */
+export function findPushupTypeByStoredValue(
+  stored: string | null | undefined
+): PushupTypeInfo | null {
+  if (!stored) return null;
+  const needle = stored.toLowerCase().trim();
+  if (!needle) return null;
+  const byId = TYPES_BY_ID.get(needle as PushupTypeId);
+  if (byId) return byId;
+  return TYPES_BY_ENTRY_LABEL.get(needle) ?? null;
+}
+
+/**
+ * Normalizes a stored `PushupRecord.type` value to a single key suitable
+ * for filtering/aggregation. Catalog matches collapse to the canonical
+ * `id`, so legacy `'Diamond'` and new `'diamond'` docs share the same
+ * bucket. Custom strings are returned trimmed (case-preserved) so the
+ * filter dropdown still shows whatever the user typed.
+ */
+export function canonicalizePushupType(
+  stored: string | null | undefined
+): string {
+  const match = findPushupTypeByStoredValue(stored);
+  if (match) return match.id;
+  return (stored ?? '').trim();
+}
+
+/**
+ * Locale-aware display string for a stored `PushupRecord.type`. Maps
+ * both the canonical `id` and the legacy English `entryLabel` to the
+ * localized name from the catalog; custom user-typed strings pass
+ * through unchanged. Falls back to the localized "Standard" label when
+ * the value is empty/missing — matching the historical
+ * `entry.type || 'Standard'` rendering.
+ */
+export function displayPushupType(
+  stored: string | null | undefined,
+  locale: string
+): string {
+  const match = findPushupTypeByStoredValue(stored);
+  if (match) return localizePushupType(match, locale).name;
+  const trimmed = (stored ?? '').trim();
+  if (trimmed) return trimmed;
+  const standard = TYPES_BY_ID.get('standard');
+  return standard ? localizePushupType(standard, locale).name : 'Standard';
+}
+
+/**
  * Resolves a user-facing string back to a catalog entry. Matches in this
- * order: canonical English `entryLabel` → localized name for the active
- * locale → localized name in English (as a fallback so a user pasting an
- * English name into a translated UI still resolves). Returns null for
- * custom values typed by the user.
+ * order: canonical id → legacy English `entryLabel` → localized name for
+ * the active locale → localized name in English (as a fallback so a user
+ * pasting an English name into a translated UI still resolves). Returns
+ * null for custom values typed by the user.
  *
  * Why English fallback: `entryLabel` (e.g. "One-Arm") and the English
  * display name (e.g. "One-arm push-up") differ, and users frequently
@@ -754,8 +810,8 @@ export function findPushupTypeByLocalizedName(
   name: string | null | undefined,
   locale: string
 ): PushupTypeInfo | null {
-  const byLabel = findPushupTypeByEntryLabel(name);
-  if (byLabel) return byLabel;
+  const byStored = findPushupTypeByStoredValue(name);
+  if (byStored) return byStored;
   if (!name) return null;
   const needle = name.toLowerCase().trim();
   if (!needle) return null;

--- a/libs/stats/src/lib/models/pushup.models.ts
+++ b/libs/stats/src/lib/models/pushup.models.ts
@@ -4,6 +4,15 @@ export interface PushupRecord {
   reps: number;
   sets?: number[];
   source: string;
+  /**
+   * Push-up variation. New writes use the language-agnostic catalog
+   * `id` from `PUSHUP_TYPES` (e.g. `'diamond'`, `'one-arm'`); older docs
+   * still carry the legacy English `entryLabel` (e.g. `'Diamond'`, `'One-Arm'`)
+   * or a free-form custom string the user typed in the entry dialog.
+   * Use `findPushupTypeByStoredValue`, `canonicalizePushupType`, or
+   * `displayPushupType` from `pushup-type.models.ts` at every read site
+   * so all three formats resolve to the same bucket / label.
+   */
   type?: string;
   createdAt?: string;
   updatedAt?: string;

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -12,7 +12,9 @@ import { firstValueFrom, of } from 'rxjs';
 import { StatsApiService, UserStatsApiService } from '@pu-stats/data-access';
 import { UserContextService } from '@pu-auth/auth';
 import {
+  canonicalizePushupType,
   createWeekRange,
+  displayPushupType,
   inferRangeMode,
   PushupRecord,
   StatsGranularity,
@@ -282,18 +284,21 @@ export const AnalysisStore = signalStore(
     });
 
     const typeBreakdown = computed<TypeBreakdownDatum[]>(() => {
+      // Canonicalize before bucketing so legacy entryLabel ("Diamond")
+      // and the new canonical id ("diamond") collapse into a single
+      // bucket; render the localized display name as the chart label.
       const byType = new Map<string, { reps: number; allSets: number[] }>();
       for (const row of rows()) {
-        const type = (row.type || 'Standard').trim() || 'Standard';
-        const entry = byType.get(type) ?? { reps: 0, allSets: [] };
+        const key = canonicalizePushupType(row.type) || 'standard';
+        const entry = byType.get(key) ?? { reps: 0, allSets: [] };
         entry.reps += row.reps;
         if (row.sets?.length) entry.allSets.push(...row.sets);
-        byType.set(type, entry);
+        byType.set(key, entry);
       }
       return [...byType.entries()]
         .sort((a, b) => b[1].reps - a[1].reps)
-        .map(([label, { reps, allSets }]) => ({
-          label,
+        .map(([key, { reps, allSets }]) => ({
+          label: displayPushupType(key, store._locale),
           value: reps,
           avgSetSize: allSets.length
             ? Math.round(

--- a/web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.spec.ts
@@ -58,11 +58,31 @@ describe('CreateEntryDialogComponent', () => {
     });
 
     it('Then `tooltipFor` returns a non-empty summary for known types', () => {
-      // Default locale in the test bed is `en-US`, so we get the English
-      // summary. Localization is exhaustively tested in
-      // pushup-type.models.spec.ts; here we only assert the wiring.
+      // TestBed defaults to the source locale (`de`); the localization
+      // logic itself is exhaustively tested in pushup-type.models.spec.ts.
       expect(component.tooltipFor('Standard').length).toBeGreaterThan(0);
       expect(component.tooltipFor('Unknown')).toBe('');
+    });
+
+    it('Then `displayType` maps the canonical entryLabel to the localized name', () => {
+      // TestBed default locale is `de` (the app's source locale).
+      expect(component.displayType('Standard')).toBe('Standard-Liegestütze');
+      expect(component.displayType('Diamond')).toBe('Diamant-Liegestütze');
+    });
+
+    it('Then `displayType` echoes custom typed values unchanged', () => {
+      expect(component.displayType('My-Custom-Move')).toBe('My-Custom-Move');
+      expect(component.displayType('')).toBe('');
+    });
+
+    it('Then the wiki deep-link resolves a localized name typed by the user', () => {
+      component.typeControl.setValue('Diamant-Liegestütze');
+      expect(component.wikiQueryParams()).toEqual({ type: 'diamant' });
+    });
+
+    it('Then the wiki deep-link also resolves an English name pasted into a translated UI', () => {
+      component.typeControl.setValue('Diamond push-up');
+      expect(component.wikiQueryParams()).toEqual({ type: 'diamant' });
     });
   });
 
@@ -128,6 +148,32 @@ describe('CreateEntryDialogComponent', () => {
         source: 'web',
         type: 'Diamond',
       });
+    });
+
+    it('Then a localized type name is persisted as the canonical English entryLabel', () => {
+      // The dialog shows localized labels but Firestore must keep the
+      // canonical English `entryLabel` so aggregations stay locale-agnostic.
+      component.timestamp.set('2025-01-15T10:30');
+      component.sets.set([10]);
+      component.typeControl.setValue('Diamant-Liegestütze');
+
+      component.submit();
+
+      expect(closeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'Diamond' })
+      );
+    });
+
+    it('Then a custom typed type is persisted verbatim', () => {
+      component.timestamp.set('2025-01-15T10:30');
+      component.sets.set([10]);
+      component.typeControl.setValue('My-Custom-Move');
+
+      component.submit();
+
+      expect(closeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'My-Custom-Move' })
+      );
     });
 
     it('Then legacy source "wa" is normalized to "whatsapp"', () => {

--- a/web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.spec.ts
@@ -39,8 +39,8 @@ describe('CreateEntryDialogComponent', () => {
       expect(component.timestamp()).toBe('2025-01-15T12:00');
     });
 
-    it('Then type defaults to Standard', () => {
-      expect(component.typeControl.value).toBe('Standard');
+    it('Then type defaults to the canonical "standard" id', () => {
+      expect(component.typeControl.value).toBe('standard');
     });
 
     it('Then source defaults to web', () => {
@@ -64,8 +64,12 @@ describe('CreateEntryDialogComponent', () => {
       expect(component.tooltipFor('Unknown')).toBe('');
     });
 
-    it('Then `displayType` maps the canonical entryLabel to the localized name', () => {
+    it('Then `displayType` maps both the canonical id and the legacy entryLabel to the localized name', () => {
       // TestBed default locale is `de` (the app's source locale).
+      // New canonical id form:
+      expect(component.displayType('standard')).toBe('Standard-Liegestütze');
+      expect(component.displayType('diamond')).toBe('Diamant-Liegestütze');
+      // Legacy entryLabel form (still on older Firestore docs):
       expect(component.displayType('Standard')).toBe('Standard-Liegestütze');
       expect(component.displayType('Diamond')).toBe('Diamant-Liegestütze');
     });
@@ -130,29 +134,30 @@ describe('CreateEntryDialogComponent', () => {
   });
 
   describe('Given submit is called with valid data', () => {
-    it('Then dialogRef.close is called with sets and computed reps', () => {
+    it('Then dialogRef.close is called with sets and the canonical id', () => {
       // Given
       component.timestamp.set('2025-01-15T10:30');
       component.sets.set([10, 15]);
-      component.typeControl.setValue('Diamond');
+      component.typeControl.setValue('diamond');
       component.sourceControl.setValue('web');
 
       // When
       component.submit();
 
-      // Then — timestamp now includes local timezone offset (e.g. '+01:00')
+      // Then — Firestore receives the canonical kebab-case id
+      // (language-agnostic), and timestamp picks up the local offset.
       expect(closeSpy).toHaveBeenCalledWith<[CreateEntryResult]>({
         timestamp: expect.stringMatching(/^2025-01-15T10:30[+-]\d{2}:\d{2}$/),
         reps: 25,
         sets: [10, 15],
         source: 'web',
-        type: 'Diamond',
+        type: 'diamond',
       });
     });
 
-    it('Then a localized type name is persisted as the canonical English entryLabel', () => {
-      // The dialog shows localized labels but Firestore must keep the
-      // canonical English `entryLabel` so aggregations stay locale-agnostic.
+    it('Then a localized type name is persisted as the canonical id', () => {
+      // The dialog shows localized labels but persists the kebab-case id
+      // so aggregations stay locale-agnostic.
       component.timestamp.set('2025-01-15T10:30');
       component.sets.set([10]);
       component.typeControl.setValue('Diamant-Liegestütze');
@@ -160,7 +165,22 @@ describe('CreateEntryDialogComponent', () => {
       component.submit();
 
       expect(closeSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'Diamond' })
+        expect.objectContaining({ type: 'diamond' })
+      );
+    });
+
+    it('Then a legacy English entryLabel is rewritten to the canonical id', () => {
+      // Useful when re-saving an old entry without otherwise touching it:
+      // the dialog still resolves "Diamond" → "diamond" so the doc moves
+      // forward to the new format.
+      component.timestamp.set('2025-01-15T10:30');
+      component.sets.set([10]);
+      component.typeControl.setValue('Diamond');
+
+      component.submit();
+
+      expect(closeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'diamond' })
       );
     });
 

--- a/web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts
+++ b/web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts
@@ -24,8 +24,8 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
 import {
   appendLocalOffset,
-  findPushupTypeByEntryLabel,
   findPushupTypeByLocalizedName,
+  findPushupTypeByStoredValue,
   localizePushupType,
   PUSHUP_TYPES,
   PushupTypeInfo,
@@ -48,7 +48,7 @@ export interface CreateEntryResult {
 }
 
 interface TypeOption {
-  /** Canonical English `entryLabel` persisted to Firestore. */
+  /** Canonical kebab-case `id` persisted to Firestore. */
   value: string;
   /** Locale-aware display name shown in the autocomplete. */
   label: string;
@@ -284,9 +284,15 @@ export class CreateEntryDialogComponent {
   readonly totalReps = computed(() =>
     this.sets().reduce((sum, s) => sum + (s > 0 ? s : 0), 0)
   );
+  // For edit mode keep the stored value verbatim — it may be a legacy
+  // English entryLabel ("Diamond") or the new canonical id ("diamond").
+  // `displayType` resolves both to the localized name; `submit()` then
+  // canonicalizes back to id before persisting.
   readonly typeControl = new FormControl<string>(
-    this.data?.type || 'Standard',
-    { nonNullable: true }
+    this.data?.type || 'standard',
+    {
+      nonNullable: true,
+    }
   );
   readonly sourceControl = new FormControl<string>(
     this.normalizeSource(this.data?.source || 'web'),
@@ -297,11 +303,12 @@ export class CreateEntryDialogComponent {
   // wiki catalog so adding a new variation in
   // `pushup-type.models.ts` automatically surfaces it here. The
   // dropdown shows the localized `label` (e.g. "Diamant-Liegestütze")
-  // while `value` keeps the canonical English `entryLabel` that gets
-  // persisted to Firestore — see `submit()`.
+  // while `value` carries the canonical kebab-case `id` that gets
+  // persisted to Firestore — see `submit()`. `id` is language-agnostic
+  // so the persisted value never depends on UI translations.
   private readonly typeOptions: ReadonlyArray<TypeOption> = PUSHUP_TYPES.map(
     (t) => ({
-      value: t.entryLabel,
+      value: t.id,
       label: localizePushupType(t, this.locale).name,
     })
   );
@@ -319,7 +326,10 @@ export class CreateEntryDialogComponent {
 
   readonly displayType = (value: string | null | undefined): string => {
     if (!value) return '';
-    const match = findPushupTypeByEntryLabel(value);
+    // Resolves both the new canonical id and the legacy entryLabel found
+    // on older Firestore docs, so edit-mode pre-fills render correctly
+    // regardless of when the entry was written.
+    const match = findPushupTypeByStoredValue(value);
     return match ? localizePushupType(match, this.locale).name : value;
   };
 
@@ -381,12 +391,13 @@ export class CreateEntryDialogComponent {
     const reps = validSets.reduce((sum, s) => sum + s, 0);
     if (!this.timestamp() || reps <= 0) return;
 
-    const rawType = (this.typeControl.value || '').trim() || 'Standard';
-    // Keep Firestore on canonical English entryLabels — when the user
-    // selected a localized option (or typed one verbatim) we map it back
-    // to the catalog. Custom typed values pass through unchanged.
+    const rawType = (this.typeControl.value || '').trim() || 'standard';
+    // Persist the language-agnostic catalog `id` whenever the value maps
+    // to a known type — selection, typed localized name, or a legacy
+    // entryLabel ("Diamond" → "diamond"). Custom typed values pass
+    // through unchanged.
     const matchedType = this.resolveType(rawType);
-    const type = matchedType ? matchedType.entryLabel : rawType;
+    const type = matchedType ? matchedType.id : rawType;
     const source = this.normalizeSource(
       (this.sourceControl.value || '').trim() || 'web'
     );

--- a/web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts
+++ b/web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts
@@ -25,8 +25,10 @@ import { RouterLink } from '@angular/router';
 import {
   appendLocalOffset,
   findPushupTypeByEntryLabel,
+  findPushupTypeByLocalizedName,
   localizePushupType,
   PUSHUP_TYPES,
+  PushupTypeInfo,
 } from '@pu-stats/models';
 
 export interface EntryDialogData {
@@ -43,6 +45,13 @@ export interface CreateEntryResult {
   sets: number[];
   source: string;
   type: string;
+}
+
+interface TypeOption {
+  /** Canonical English `entryLabel` persisted to Firestore. */
+  value: string;
+  /** Locale-aware display name shown in the autocomplete. */
+  label: string;
 }
 
 @Component({
@@ -190,13 +199,16 @@ export interface CreateEntryResult {
             placeholder="Auswählen oder eintippen"
             i18n-placeholder="@@typePlaceholder"
           />
-          <mat-autocomplete #typeAuto="matAutocomplete">
-            @for (option of filteredTypeOptions$ | async; track option) {
+          <mat-autocomplete
+            #typeAuto="matAutocomplete"
+            [displayWith]="displayType"
+          >
+            @for (option of filteredTypeOptions$ | async; track option.value) {
               <mat-option
-                [value]="option"
-                [matTooltip]="tooltipFor(option)"
+                [value]="option.value"
+                [matTooltip]="tooltipFor(option.value)"
                 matTooltipPosition="right"
-                >{{ option }}</mat-option
+                >{{ option.label }}</mat-option
               >
             }
           </mat-autocomplete>
@@ -283,21 +295,33 @@ export class CreateEntryDialogComponent {
 
   // Single source of truth: derive the dropdown options from the
   // wiki catalog so adding a new variation in
-  // `pushup-type.models.ts` automatically surfaces it here.
-  private readonly typeOptions: ReadonlyArray<string> = PUSHUP_TYPES.map(
-    (t) => t.entryLabel
+  // `pushup-type.models.ts` automatically surfaces it here. The
+  // dropdown shows the localized `label` (e.g. "Diamant-Liegestütze")
+  // while `value` keeps the canonical English `entryLabel` that gets
+  // persisted to Firestore — see `submit()`.
+  private readonly typeOptions: ReadonlyArray<TypeOption> = PUSHUP_TYPES.map(
+    (t) => ({
+      value: t.entryLabel,
+      label: localizePushupType(t, this.locale).name,
+    })
   );
   private readonly sourceOptions = ['web', 'whatsapp'];
 
   readonly filteredTypeOptions$ = this.typeControl.valueChanges.pipe(
     startWith(this.typeControl.value),
-    map((value) => this.filterOptions(value, this.typeOptions))
+    map((value) => this.filterTypeOptions(value))
   );
 
   readonly filteredSourceOptions$ = this.sourceControl.valueChanges.pipe(
     startWith(this.sourceControl.value),
     map((value) => this.filterOptions(value, this.sourceOptions))
   );
+
+  readonly displayType = (value: string | null | undefined): string => {
+    if (!value) return '';
+    const match = findPushupTypeByEntryLabel(value);
+    return match ? localizePushupType(match, this.locale).name : value;
+  };
 
   // Track the live type-control value so the wiki deep-link updates as
   // the user types, without needing manual change detection.
@@ -307,27 +331,30 @@ export class CreateEntryDialogComponent {
   );
 
   readonly wikiQueryParams = computed(() => {
-    const match = findPushupTypeByEntryLabel(this.typeValue());
+    const match = this.resolveType(this.typeValue());
     return match ? { type: match.slug } : {};
   });
 
   readonly wikiTooltip = computed(() => {
-    const match = findPushupTypeByEntryLabel(this.typeValue());
+    const match = this.resolveType(this.typeValue());
     if (!match) {
       return $localize`:@@typeWikiLinkTooltip.generic:Anleitung zu Liegestütztypen öffnen`;
     }
-    // Build the specific tooltip from a static template + the entryLabel.
-    // We avoid a named placeholder inside the i18n message because the
-    // labels (Standard, Diamond, Wide, …) are already English/canonical
-    // tokens that don't translate, and inlining them keeps the XLIFF
-    // entry stable across catalog changes.
+    // Build the specific tooltip from a static template + the localized
+    // type name. The name is locale-dependent so we read it via
+    // `localizePushupType` rather than the canonical `entryLabel`, which
+    // is always English and would feel out of place in a translated UI.
     const template = $localize`:@@typeWikiLinkTooltip.specific:Anleitung öffnen`;
-    return `${template}: ${match.entryLabel}`;
+    return `${template}: ${localizePushupType(match, this.locale).name}`;
   });
 
   tooltipFor(label: string): string {
-    const type = findPushupTypeByEntryLabel(label);
+    const type = this.resolveType(label);
     return type ? localizePushupType(type, this.locale).summary : '';
+  }
+
+  private resolveType(value: string | null | undefined): PushupTypeInfo | null {
+    return findPushupTypeByLocalizedName(value, this.locale);
   }
 
   addSet(): void {
@@ -354,7 +381,12 @@ export class CreateEntryDialogComponent {
     const reps = validSets.reduce((sum, s) => sum + s, 0);
     if (!this.timestamp() || reps <= 0) return;
 
-    const type = (this.typeControl.value || '').trim() || 'Standard';
+    const rawType = (this.typeControl.value || '').trim() || 'Standard';
+    // Keep Firestore on canonical English entryLabels — when the user
+    // selected a localized option (or typed one verbatim) we map it back
+    // to the catalog. Custom typed values pass through unchanged.
+    const matchedType = this.resolveType(rawType);
+    const type = matchedType ? matchedType.entryLabel : rawType;
     const source = this.normalizeSource(
       (this.sourceControl.value || '').trim() || 'web'
     );
@@ -402,5 +434,23 @@ export class CreateEntryDialogComponent {
     if (options.some((opt) => opt.toLowerCase() === needle))
       return [...options];
     return options.filter((opt) => opt.toLowerCase().includes(needle));
+  }
+
+  private filterTypeOptions(value: string | null | undefined): TypeOption[] {
+    const needle = (value ?? '').toLowerCase().trim();
+    if (!needle) return [...this.typeOptions];
+    // The form control holds the canonical entryLabel after a selection;
+    // an exact match on either side means "user already picked one", so
+    // keep the full list visible instead of filtering down to one row.
+    const exact = this.typeOptions.some(
+      (opt) =>
+        opt.value.toLowerCase() === needle || opt.label.toLowerCase() === needle
+    );
+    if (exact) return [...this.typeOptions];
+    return this.typeOptions.filter(
+      (opt) =>
+        opt.label.toLowerCase().includes(needle) ||
+        opt.value.toLowerCase().includes(needle)
+    );
   }
 }

--- a/web/src/app/stats/components/stats-table/stats-table.component.html
+++ b/web/src/app/stats/components/stats-table/stats-table.component.html
@@ -89,7 +89,7 @@
         >Typ</mat-header-cell
       >
       <mat-cell *matCellDef="let entry"
-        ><span>{{ entry.type || 'Standard' }}</span></mat-cell
+        ><span>{{ typeLabel(entry) }}</span></mat-cell
       >
     </ng-container>
 

--- a/web/src/app/stats/components/stats-table/stats-table.component.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/common';
 import {
   Component,
+  LOCALE_ID,
   PLATFORM_ID,
   computed,
   effect,
@@ -25,7 +26,7 @@ import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ScrollingModule } from '@angular/cdk/scrolling';
-import { PushupRecord } from '@pu-stats/models';
+import { displayPushupType, PushupRecord } from '@pu-stats/models';
 import { UserContextService } from '@pu-auth/auth';
 import { UserConfigApiService } from '@pu-stats/data-access';
 import { firstValueFrom } from 'rxjs';
@@ -58,7 +59,11 @@ import {
 export class StatsTableComponent {
   readonly dialog = inject(MatDialog);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly locale = inject(LOCALE_ID) as string;
   readonly isBrowser = isPlatformBrowser(this.platformId);
+
+  readonly typeLabel = (entry: PushupRecord): string =>
+    displayPushupType(entry.type, this.locale);
 
   readonly sort = viewChild(MatSort);
 
@@ -104,7 +109,7 @@ export class StatsTableComponent {
       if (property === 'timestamp') return new Date(item.timestamp).getTime();
       if (property === 'reps') return item.reps;
       if (property === 'source') return item.source;
-      if (property === 'type') return item.type || 'Standard';
+      if (property === 'type') return this.typeLabel(item);
       return '';
     };
 

--- a/web/src/app/stats/entries.store.ts
+++ b/web/src/app/stats/entries.store.ts
@@ -1,5 +1,11 @@
 import { isPlatformBrowser } from '@angular/common';
-import { computed, inject, PLATFORM_ID, resource } from '@angular/core';
+import {
+  computed,
+  inject,
+  LOCALE_ID,
+  PLATFORM_ID,
+  resource,
+} from '@angular/core';
 import {
   patchState,
   signalStore,
@@ -10,7 +16,16 @@ import {
 } from '@ngrx/signals';
 import { firstValueFrom } from 'rxjs';
 import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
+import { canonicalizePushupType, displayPushupType } from '@pu-stats/models';
 import { AppDataFacade } from '../core/app-data.facade';
+
+export interface PushupTypeFilterOption {
+  /** Canonical filter key (catalog `id` for catalog matches, trimmed
+   * raw string for custom user-typed types). */
+  value: string;
+  /** Locale-aware display string for the dropdown. */
+  label: string;
+}
 
 type EntriesState = {
   from: string;
@@ -43,6 +58,7 @@ export const EntriesStore = signalStore(
     _live: inject(LiveDataStore),
     _appData: inject(AppDataFacade),
     _isBrowser: isPlatformBrowser(inject(PLATFORM_ID)),
+    _locale: inject(LOCALE_ID) as string,
   })),
   withProps((store) => ({
     _entriesResource: resource({
@@ -72,16 +88,24 @@ export const EntriesStore = signalStore(
         ),
       ].sort((a, b) => a.localeCompare(b))
     ),
-    typeOptions: computed(() =>
-      [
-        ...new Set(
-          store
-            .rows()
-            .map((x) => x.type || 'Standard')
-            .filter(Boolean)
-        ),
-      ].sort((a, b) => a.localeCompare(b))
-    ),
+    typeOptions: computed<PushupTypeFilterOption[]>(() => {
+      // Canonicalize first so legacy "Diamond" and new "diamond" docs
+      // collapse into one filter option. The dropdown then renders the
+      // localized label while the selected value remains the canonical
+      // key that drives `filteredRows`.
+      const seen = new Map<string, PushupTypeFilterOption>();
+      for (const row of store.rows()) {
+        const value = canonicalizePushupType(row.type) || 'standard';
+        if (seen.has(value)) continue;
+        seen.set(value, {
+          value,
+          label: displayPushupType(value, store._locale),
+        });
+      }
+      return [...seen.values()].sort((a, b) =>
+        a.label.localeCompare(b.label, store._locale)
+      );
+    }),
     filteredRows: computed(() => {
       const source = store.source();
       const type = store.type();
@@ -95,7 +119,10 @@ export const EntriesStore = signalStore(
         if (from && date < from) return false;
         if (to && date > to) return false;
         if (source && row.source !== source) return false;
-        if (type && (row.type || 'Standard') !== type) return false;
+        if (type) {
+          const rowKey = canonicalizePushupType(row.type) || 'standard';
+          if (rowKey !== type) return false;
+        }
         if (repsMin !== null && row.reps < repsMin) return false;
         if (repsMax !== null && row.reps > repsMax) return false;
         return true;

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -220,11 +220,14 @@ describe('AnalysisPageComponent', () => {
     const { store } = fixture.componentInstance;
     const breakdown = store.typeBreakdown();
 
-    // Standard: 10 + 25 + 18 = 53, Diamond: 12 + 20 = 32, Wide: 8
+    // The store now canonicalizes the stored value (legacy entryLabel
+    // OR new id) and renders the localized name. TestBed default locale
+    // is `de` (the app source locale), so labels appear in German.
+    // Totals: Standard 10 + 25 + 18 = 53, Diamond 12 + 20 = 32, Wide 8.
     expect(breakdown.map(({ label, value }) => ({ label, value }))).toEqual([
-      { label: 'Standard', value: 53 },
-      { label: 'Diamond', value: 32 },
-      { label: 'Wide', value: 8 },
+      { label: 'Standard-Liegestütze', value: 53 },
+      { label: 'Diamant-Liegestütze', value: 32 },
+      { label: 'Weite Liegestütze', value: 8 },
     ]);
   });
 
@@ -268,10 +271,10 @@ describe('AnalysisPageComponent', () => {
     const { store } = fixture.componentInstance;
     const breakdown = store.typeBreakdown();
     // Standard: sets [5,5] + [10,8,7] + [9,9] = [5,5,10,8,7,9,9] → avg = 53/7 ≈ 7.6
-    const standard = breakdown.find((t) => t.label === 'Standard');
+    const standard = breakdown.find((t) => t.label === 'Standard-Liegestütze');
     expect(standard?.avgSetSize).toBeGreaterThan(0);
     // Wide: no sets → avgSetSize = 0
-    const wide = breakdown.find((t) => t.label === 'Wide');
+    const wide = breakdown.find((t) => t.label === 'Weite Liegestütze');
     expect(wide?.avgSetSize).toBe(0);
   });
 

--- a/web/src/app/stats/shell/entries-page.component.spec.ts
+++ b/web/src/app/stats/shell/entries-page.component.spec.ts
@@ -76,8 +76,11 @@ describe('EntriesPageComponent', () => {
   });
 
   it('applies source, type and reps filter', () => {
+    // The filter dropdown emits canonical kebab-case ids. Legacy
+    // entryLabel rows ("Wide") still match because the store
+    // canonicalizes both sides before comparing.
     store.setSource('wa');
-    store.setType('Wide');
+    store.setType('wide');
     store.setRepsMin(11);
 
     expect(store.filteredRows().map((x: any) => x._id)).toEqual(['3']);

--- a/web/src/app/stats/shell/entries-page.component.ts
+++ b/web/src/app/stats/shell/entries-page.component.ts
@@ -75,8 +75,10 @@ import { EntriesStore } from '../entries.store';
                 <mat-option value="" i18n="@@entries.allOption"
                   >Alle</mat-option
                 >
-                @for (option of store.typeOptions(); track option) {
-                  <mat-option [value]="option">{{ option }}</mat-option>
+                @for (option of store.typeOptions(); track option.value) {
+                  <mat-option [value]="option.value">{{
+                    option.label
+                  }}</mat-option>
                 }
               </mat-select>
             </mat-form-field>

--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -160,7 +160,7 @@
       <mat-card-content>
         @if (lastEntry(); as latest) {
           <p i18n="@@latEntryReps">
-            {{ latest.reps }} Reps · {{ latest.type || 'Standard' }}
+            {{ latest.reps }} Reps · {{ typeLabel(latest) }}
           </p>
           <small>{{ latest.timestamp | date: 'short' }}</small>
         } @else {

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -5,6 +5,7 @@ import {
   Component,
   effect,
   inject,
+  LOCALE_ID,
   PLATFORM_ID,
   signal,
   untracked,
@@ -20,6 +21,8 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
 import {
   appendLocalOffset,
+  displayPushupType,
+  PushupRecord,
   QUICK_LOG_REPS_MAX,
   QUICK_LOG_REPS_MIN,
 } from '@pu-stats/models';
@@ -66,6 +69,10 @@ export class StatsDashboardComponent {
   private readonly live = inject(LiveDataStore);
   private readonly quickAdd = inject(QuickAddOrchestrationService);
   private readonly appData = inject(AppDataFacade);
+  private readonly locale = inject(LOCALE_ID) as string;
+
+  readonly typeLabel = (entry: PushupRecord): string =>
+    displayPushupType(entry.type, this.locale);
 
   readonly shareDayAriaLabel = $localize`:@@dashboard.share.aria:Tagesleistung teilen`;
   readonly shareDayLabel = $localize`:@@dashboard.share:Teilen`;


### PR DESCRIPTION
The autocomplete now shows the locale-aware display name (e.g.
"Diamant-Liegestütze" in DE, "Diamond push-up" in EN) so the input
matches the rest of the UI, while submit() maps the value back to the
canonical English entryLabel before writing to Firestore — keeping
aggregations locale-agnostic.

A new findPushupTypeByLocalizedName() helper resolves selected, typed
localized, or pasted English names back to the catalog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added locale-aware push-up type display with automatic localization across dialogs, tables, and dashboards.
  * Enhanced type filtering with canonical identifiers for consistent data handling.

* **Bug Fixes**
  * Improved type normalization to ensure consistent behavior across legacy and standard type formats.
  * Fixed type display and filtering to properly handle multiple language contexts.

* **Tests**
  * Added comprehensive test coverage for type resolution, canonicalization, and localized display utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->