### PR TITLE
feat(leaderboard): drop anonymous rows + harden against cheating

### DIFF
--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -19,6 +19,10 @@ service cloud.firestore {
     // Pushup entries are user-owned.
     // Public read is allowed for the SEO demo user so SSR can render preview pages.
     // Public read for SEO demo user (UID: aqgzwSbhudRLrluz1zBSW3XQx013).
+    //
+    // `reps` plausibility cap mirrors `PUSHUP_REPS_MIN` / `PUSHUP_REPS_MAX`
+    // in `libs/stats/src/lib/models/pushup.models.ts`. Keep the two in sync —
+    // honest writes get rejected here if the client cap is wider.
     match /pushups/{pushupId} {
       allow read: if resource.data.userId == 'aqgzwSbhudRLrluz1zBSW3XQx013'
                   || (request.auth != null && resource.data.userId == request.auth.uid);
@@ -26,8 +30,16 @@ service cloud.firestore {
       allow update: if request.auth != null
                     && resource.data.userId == request.auth.uid
                     && request.resource.data.userId == request.auth.uid
-                    && request.resource.data.userId == resource.data.userId;
-      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+                    && request.resource.data.userId == resource.data.userId
+                    && (!('reps' in request.resource.data.keys())
+                        || (request.resource.data.reps is int
+                            && request.resource.data.reps >= 1
+                            && request.resource.data.reps <= 500));
+      allow create: if request.auth != null
+                    && request.resource.data.userId == request.auth.uid
+                    && request.resource.data.reps is int
+                    && request.resource.data.reps >= 1
+                    && request.resource.data.reps <= 500;
     }
 
     // Public leaderboard snapshot: readable by everyone, writable only via Admin SDK (Cloud Functions).

--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -4,6 +4,8 @@ service cloud.firestore {
     // Signed-in users may read and update their own config document.
     // Deletes are handled exclusively by Cloud Functions (adminDeleteUser).
     // The 'role' field is managed exclusively via Firebase Custom Claims — clients must not write it.
+    // `leaderboardExcluded` is an admin-only moderation flag managed by the
+    // `adminSetLeaderboardExclusion` callable — clients must not write it.
     //
     // `displayName` constraints mirror `DISPLAY_NAME_*` in
     // `libs/stats/src/lib/models/user-config.models.ts`. Length 2..30,
@@ -14,7 +16,7 @@ service cloud.firestore {
       allow create: if request.auth != null
                     && request.auth.uid == userId
                     && request.resource.data.userId == userId
-                    && !request.resource.data.keys().hasAny(['role'])
+                    && !request.resource.data.keys().hasAny(['role', 'leaderboardExcluded'])
                     && (!('displayName' in request.resource.data.keys())
                         || (request.resource.data.displayName is string
                             && request.resource.data.displayName.size() >= 2
@@ -23,7 +25,7 @@ service cloud.firestore {
       allow update: if request.auth != null
                     && request.auth.uid == userId
                     && request.resource.data.userId == userId
-                    && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role'])
+                    && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role', 'leaderboardExcluded'])
                     && (!('displayName' in request.resource.data.keys())
                         || (request.resource.data.displayName is string
                             && request.resource.data.displayName.size() >= 2

--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -8,9 +8,16 @@ service cloud.firestore {
     // `adminSetLeaderboardExclusion` callable — clients must not write it.
     //
     // `displayName` constraints mirror `DISPLAY_NAME_*` in
-    // `libs/stats/src/lib/models/user-config.models.ts`. Length 2..30,
-    // Unicode letters/digits + space, underscore, dot, hyphen — keeps emoji
-    // and control chars out of the public leaderboard.
+    // `libs/stats/src/lib/models/user-config.models.ts`. Length 2..30
+    // **after trimming**, Unicode letters/digits + space, underscore,
+    // dot, hyphen — keeps emoji, control chars, and whitespace-only
+    // names out of the public leaderboard.
+    //
+    // Update path gates the check on `displayName` actually changing —
+    // otherwise users with legacy non-conforming names (e.g. older
+    // emoji, single-char) would be locked out of saving unrelated
+    // settings like dailyGoal or privacy toggles, because
+    // `request.resource.data` is the full post-update document.
     match /userConfigs/{userId} {
       allow read: if request.auth != null && request.auth.uid == userId;
       allow create: if request.auth != null
@@ -19,17 +26,17 @@ service cloud.firestore {
                     && !request.resource.data.keys().hasAny(['role', 'leaderboardExcluded'])
                     && (!('displayName' in request.resource.data.keys())
                         || (request.resource.data.displayName is string
-                            && request.resource.data.displayName.size() >= 2
-                            && request.resource.data.displayName.size() <= 30
+                            && request.resource.data.displayName.trim().size() >= 2
+                            && request.resource.data.displayName.trim().size() <= 30
                             && request.resource.data.displayName.matches('^[\\p{L}\\p{N} _.\\-]+$')));
       allow update: if request.auth != null
                     && request.auth.uid == userId
                     && request.resource.data.userId == userId
                     && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role', 'leaderboardExcluded'])
-                    && (!('displayName' in request.resource.data.keys())
+                    && (!('displayName' in request.resource.data.diff(resource.data).affectedKeys())
                         || (request.resource.data.displayName is string
-                            && request.resource.data.displayName.size() >= 2
-                            && request.resource.data.displayName.size() <= 30
+                            && request.resource.data.displayName.trim().size() >= 2
+                            && request.resource.data.displayName.trim().size() <= 30
                             && request.resource.data.displayName.matches('^[\\p{L}\\p{N} _.\\-]+$')));
     }
 
@@ -40,6 +47,12 @@ service cloud.firestore {
     // `reps` plausibility cap mirrors `PUSHUP_REPS_MIN` / `PUSHUP_REPS_MAX`
     // in `libs/stats/src/lib/models/pushup.models.ts`. Keep the two in sync —
     // honest writes get rejected here if the client cap is wider.
+    //
+    // Update path gates the cap on `reps` actually changing — otherwise
+    // legacy entries above the new cap would be effectively non-updatable
+    // (fixing `timestamp`/`source` would fail unless `reps` was also
+    // changed first), since `request.resource.data` is the full
+    // post-update document.
     match /pushups/{pushupId} {
       allow read: if resource.data.userId == 'aqgzwSbhudRLrluz1zBSW3XQx013'
                   || (request.auth != null && resource.data.userId == request.auth.uid);
@@ -48,7 +61,7 @@ service cloud.firestore {
                     && resource.data.userId == request.auth.uid
                     && request.resource.data.userId == request.auth.uid
                     && request.resource.data.userId == resource.data.userId
-                    && (!('reps' in request.resource.data.keys())
+                    && (!('reps' in request.resource.data.diff(resource.data).affectedKeys())
                         || (request.resource.data.reps is int
                             && request.resource.data.reps >= 1
                             && request.resource.data.reps <= 500));

--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -4,16 +4,31 @@ service cloud.firestore {
     // Signed-in users may read and update their own config document.
     // Deletes are handled exclusively by Cloud Functions (adminDeleteUser).
     // The 'role' field is managed exclusively via Firebase Custom Claims — clients must not write it.
+    //
+    // `displayName` constraints mirror `DISPLAY_NAME_*` in
+    // `libs/stats/src/lib/models/user-config.models.ts`. Length 2..30,
+    // Unicode letters/digits + space, underscore, dot, hyphen — keeps emoji
+    // and control chars out of the public leaderboard.
     match /userConfigs/{userId} {
       allow read: if request.auth != null && request.auth.uid == userId;
       allow create: if request.auth != null
                     && request.auth.uid == userId
                     && request.resource.data.userId == userId
-                    && !request.resource.data.keys().hasAny(['role']);
+                    && !request.resource.data.keys().hasAny(['role'])
+                    && (!('displayName' in request.resource.data.keys())
+                        || (request.resource.data.displayName is string
+                            && request.resource.data.displayName.size() >= 2
+                            && request.resource.data.displayName.size() <= 30
+                            && request.resource.data.displayName.matches('^[\\p{L}\\p{N} _.\\-]+$')));
       allow update: if request.auth != null
                     && request.auth.uid == userId
                     && request.resource.data.userId == userId
-                    && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role']);
+                    && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role'])
+                    && (!('displayName' in request.resource.data.keys())
+                        || (request.resource.data.displayName is string
+                            && request.resource.data.displayName.size() >= 2
+                            && request.resource.data.displayName.size() <= 30
+                            && request.resource.data.displayName.matches('^[\\p{L}\\p{N} _.\\-]+$')));
     }
 
     // Pushup entries are user-owned.

--- a/data-store/functions/src/admin/logic.spec.ts
+++ b/data-store/functions/src/admin/logic.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from '@jest/globals';
 import {
   validateAdminAccess,
   validateDeleteUserPayload,
+  validateLeaderboardExclusionPayload,
   isDemoUser,
   batchArray,
   validateFeedbackId,
@@ -349,6 +350,61 @@ describe('admin/logic', () => {
       const array = [{ id: 1 }, { id: 2 }, { id: 3 }];
       const batches = batchArray(array, 2);
       expect(batches).toEqual([[{ id: 1 }, { id: 2 }], [{ id: 3 }]]);
+    });
+  });
+
+  describe('validateLeaderboardExclusionPayload', () => {
+    it('accepts a valid {uid, excluded} payload', () => {
+      const result = validateLeaderboardExclusionPayload({
+        uid: 'abc',
+        excluded: true,
+      });
+      expect(result).toEqual({ valid: true, uid: 'abc', excluded: true });
+    });
+
+    it('accepts excluded=false (un-banning)', () => {
+      const result = validateLeaderboardExclusionPayload({
+        uid: 'abc',
+        excluded: false,
+      });
+      expect(result).toEqual({ valid: true, uid: 'abc', excluded: false });
+    });
+
+    it('trims surrounding whitespace from uid', () => {
+      const result = validateLeaderboardExclusionPayload({
+        uid: '  abc  ',
+        excluded: true,
+      });
+      expect(result).toEqual({ valid: true, uid: 'abc', excluded: true });
+    });
+
+    it('rejects non-object payload', () => {
+      expect(validateLeaderboardExclusionPayload(null)).toEqual({
+        valid: false,
+        error: 'payload must be an object',
+      });
+      expect(validateLeaderboardExclusionPayload('foo')).toEqual({
+        valid: false,
+        error: 'payload must be an object',
+      });
+    });
+
+    it('rejects missing or empty uid', () => {
+      expect(
+        validateLeaderboardExclusionPayload({ excluded: true })
+      ).toMatchObject({ valid: false });
+      expect(
+        validateLeaderboardExclusionPayload({ uid: '   ', excluded: true })
+      ).toMatchObject({ valid: false });
+    });
+
+    it('rejects non-boolean excluded', () => {
+      expect(
+        validateLeaderboardExclusionPayload({ uid: 'abc', excluded: 'true' })
+      ).toMatchObject({ valid: false });
+      expect(validateLeaderboardExclusionPayload({ uid: 'abc' })).toMatchObject(
+        { valid: false }
+      );
     });
   });
 });

--- a/data-store/functions/src/admin/logic.ts
+++ b/data-store/functions/src/admin/logic.ts
@@ -181,6 +181,28 @@ export function buildGithubIssueBody(
 }
 
 /**
+ * Validates the payload for `adminSetLeaderboardExclusion`. Requires a
+ * non-empty `uid` and a boolean `excluded` flag.
+ */
+export function validateLeaderboardExclusionPayload(
+  data: unknown
+):
+  | { valid: true; uid: string; excluded: boolean }
+  | { valid: false; error: string } {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, error: 'payload must be an object' };
+  }
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.uid !== 'string' || obj.uid.trim().length === 0) {
+    return { valid: false, error: 'uid missing or empty' };
+  }
+  if (typeof obj.excluded !== 'boolean') {
+    return { valid: false, error: 'excluded must be boolean' };
+  }
+  return { valid: true, uid: obj.uid.trim(), excluded: obj.excluded };
+}
+
+/**
  * Batches array into chunks for processing
  * @param array Array to batch
  * @param size Batch size

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -15,6 +15,7 @@ import {
   buildGithubIssueBody,
   validateAdminAccess,
   validateFeedbackId,
+  validateLeaderboardExclusionPayload,
   validateMarkFeedbackReadPayload,
 } from './admin';
 import { parseRecaptchaResponse } from './authentication';
@@ -358,6 +359,47 @@ export const adminDeleteUser = onCall(
 
     logger.info('adminDeleteUser', { uid, anonymize, by: request.auth?.uid });
     return { ok: true };
+  }
+);
+
+// ─── adminSetLeaderboardExclusion ─────────────────────────────────────────────
+//
+// Admin shadow-ban for the public leaderboard. Sets the top-level
+// `leaderboardExcluded` flag on the user's `userConfigs` doc; the
+// leaderboard rebuild filters them out at the next run. Reversible —
+// passing `excluded: false` removes the ban without touching opt-in
+// toggles or pushup history. Clients are blocked from writing this
+// field at the Firestore-rule layer.
+
+export const adminSetLeaderboardExclusion = onCall(
+  { region: 'europe-west3', timeoutSeconds: 30 },
+  async (request) => {
+    assertAdmin(request);
+
+    const result = validateLeaderboardExclusionPayload(request.data);
+    if (!result.valid) {
+      throw new HttpsError('invalid-argument', result.error);
+    }
+    const { uid, excluded } = result;
+
+    if (uid === DEMO_USER_ID) {
+      throw new HttpsError(
+        'failed-precondition',
+        'Demo-Benutzer kann nicht gesperrt werden.'
+      );
+    }
+
+    await db
+      .collection('userConfigs')
+      .doc(uid)
+      .set({ leaderboardExcluded: excluded }, { merge: true });
+
+    logger.info('adminSetLeaderboardExclusion', {
+      uid,
+      excluded,
+      by: request.auth?.uid,
+    });
+    return { ok: true, uid, excluded };
   }
 );
 

--- a/data-store/functions/src/leaderboard/logic.spec.ts
+++ b/data-store/functions/src/leaderboard/logic.spec.ts
@@ -36,9 +36,12 @@ describe('leaderboard/logic', () => {
         { userId: 'user2', timestamp: '2024-03-15T10:00:00Z', reps: 15 },
       ];
       const profiles = new Map<string, UserProfile>([
-        ['user1', { displayName: 'Alice' }],
-        ['user2', { displayName: 'Bob' }],
-        ['user3', { displayName: 'Charlie' }],
+        ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
+        ['user2', { displayName: 'Bob', ui: { hideFromLeaderboard: false } }],
+        [
+          'user3',
+          { displayName: 'Charlie', ui: { hideFromLeaderboard: false } },
+        ],
       ]);
 
       const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
@@ -63,20 +66,35 @@ describe('leaderboard/logic', () => {
       expect(result[0]).toEqual({ alias: 'Alice', reps: 10 });
     });
 
-    it('respects leaderboard privacy setting', () => {
+    it('drops users who opted out of the leaderboard', () => {
       const rows: PushupRow[] = [
         { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 10 },
         { userId: 'user2', timestamp: '2024-03-15T10:00:00Z', reps: 20 },
       ];
       const profiles = new Map<string, UserProfile>([
         ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
-        ['user2', { displayName: 'Bob', ui: { hideFromLeaderboard: true } }], // Hidden
+        ['user2', { displayName: 'Bob', ui: { hideFromLeaderboard: true } }],
       ]);
 
       const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
 
-      expect(result[0]).toEqual({ alias: 'anonym', reps: 20 });
-      expect(result[1]).toEqual({ alias: 'Alice', reps: 10 });
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ alias: 'Alice', reps: 10 });
+    });
+
+    it('drops users without an explicit leaderboard opt-in', () => {
+      // `hideFromLeaderboard` undefined defaults to hidden — no more
+      // `anonym` fallback row.
+      const rows: PushupRow[] = [
+        { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 10 },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['user1', { displayName: 'Alice' }],
+      ]);
+
+      const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
+
+      expect(result).toEqual([]);
     });
 
     describe('uid attachment for public-profile linking', () => {
@@ -116,43 +134,22 @@ describe('leaderboard/logic', () => {
 
         const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
 
+        // Leaderboard-only user (Bob) is included without a uid; the
+        // profileOnly user (Carol) opted out of the leaderboard and is
+        // dropped entirely — no `anonym` row anymore.
+        expect(result).toHaveLength(2);
         expect(result[0]).toEqual({
           alias: 'Alice',
           reps: 30,
           uid: 'optedIn',
         });
-        // Leaderboard-only user: name shown but no link.
         expect(result[1]).toEqual({ alias: 'Bob', reps: 20 });
         expect(result[1].uid).toBeUndefined();
-        // Public-profile user who hid from the leaderboard stays anonymous
-        // and never gets a link — leaderboard alias is `anonym`, so a UID
-        // would let attackers correlate that anonymous row to a real
-        // profile.
-        expect(result[2]).toEqual({ alias: 'anonym', reps: 10 });
-        expect(result[2].uid).toBeUndefined();
       });
 
-      it('omits uid for profiles missing the ui block entirely', () => {
-        const rows: PushupRow[] = [
-          { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 10 },
-        ];
-        const profiles = new Map<string, UserProfile>([
-          ['user1', { displayName: 'Alice' }],
-        ]);
-
-        const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
-
-        // Defaults to private — no opt-in, no uid.
-        expect(result[0].uid).toBeUndefined();
-      });
-
-      it('omits uid when displayName is empty/whitespace even with both opt-ins', () => {
-        // Privacy regression: a user with an empty `displayName` would
-        // render as `anonym` via `toPublicDisplayName`'s fallback. If the
-        // row also carried a `uid`, the visible "anonym" label would
-        // become correlatable to a stable `/u/<uid>` permalink — leaking
-        // identity through what looks like an anonymous row. Block the
-        // UID until the user actually has a display name.
+      it('drops users with empty/whitespace displayName even when both opt-ins are on', () => {
+        // No display name → no row. The leaderboard never falls back to
+        // an anonymous alias.
         const rows: PushupRow[] = [
           { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 10 },
           { userId: 'user2', timestamp: '2024-03-15T10:00:00Z', reps: 20 },
@@ -176,14 +173,11 @@ describe('leaderboard/logic', () => {
 
         const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
 
-        for (const entry of result) {
-          expect(entry.alias).toBe('anonym');
-          expect(entry.uid).toBeUndefined();
-        }
+        expect(result).toEqual([]);
       });
     });
 
-    it('uses anonymous label for users without profiles', () => {
+    it('drops users without profiles entirely', () => {
       const rows: PushupRow[] = [
         { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 10 },
       ];
@@ -191,7 +185,7 @@ describe('leaderboard/logic', () => {
 
       const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
 
-      expect(result[0]).toEqual({ alias: 'anonym', reps: 10 });
+      expect(result).toEqual([]);
     });
 
     it('limits results to TOP_N', () => {
@@ -202,7 +196,10 @@ describe('leaderboard/logic', () => {
       }));
       const profiles = new Map<string, UserProfile>();
       rows.forEach((_, i) => {
-        profiles.set(`user${i}`, { displayName: `User${i}` });
+        profiles.set(`user${i}`, {
+          displayName: `User${i}`,
+          ui: { hideFromLeaderboard: false },
+        });
       });
 
       const result = rankEntries(rows, 'daily', '2024-03-15', profiles);

--- a/data-store/functions/src/leaderboard/logic.spec.ts
+++ b/data-store/functions/src/leaderboard/logic.spec.ts
@@ -208,6 +208,64 @@ describe('leaderboard/logic', () => {
       });
     });
 
+    describe('admin shadow-ban', () => {
+      it('excludes users flagged with leaderboardExcluded=true even with both opt-ins', () => {
+        const rows: PushupRow[] = [
+          { userId: 'good', timestamp: '2024-03-15T10:00:00Z', reps: 30 },
+          { userId: 'cheater', timestamp: '2024-03-15T10:00:00Z', reps: 999 },
+        ];
+        const profiles = new Map<string, UserProfile>([
+          [
+            'good',
+            {
+              displayName: 'Alice',
+              ui: { hideFromLeaderboard: false, publicProfile: true },
+            },
+          ],
+          [
+            'cheater',
+            {
+              displayName: 'Mallory',
+              ui: { hideFromLeaderboard: false, publicProfile: true },
+              leaderboardExcluded: true,
+            },
+          ],
+        ]);
+
+        const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
+
+        expect(result).toEqual([{ alias: 'Alice', reps: 30, uid: 'good' }]);
+      });
+
+      it('does not affect users where the flag is unset or false', () => {
+        const rows: PushupRow[] = [
+          { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 10 },
+          { userId: 'user2', timestamp: '2024-03-15T10:00:00Z', reps: 20 },
+        ];
+        const profiles = new Map<string, UserProfile>([
+          [
+            'user1',
+            {
+              displayName: 'Alice',
+              ui: { hideFromLeaderboard: false, publicProfile: true },
+              leaderboardExcluded: false,
+            },
+          ],
+          [
+            'user2',
+            {
+              displayName: 'Bob',
+              ui: { hideFromLeaderboard: false, publicProfile: true },
+            },
+          ],
+        ]);
+
+        const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
+
+        expect(result).toHaveLength(2);
+      });
+    });
+
     it('drops users without profiles entirely', () => {
       const rows: PushupRow[] = [
         { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 10 },

--- a/data-store/functions/src/leaderboard/logic.spec.ts
+++ b/data-store/functions/src/leaderboard/logic.spec.ts
@@ -18,15 +18,27 @@ describe('leaderboard/logic', () => {
         { userId: 'user2', timestamp: '2024-03-15T15:00:00Z', reps: 20 },
       ];
       const profiles = new Map<string, UserProfile>([
-        ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
-        ['user2', { displayName: 'Bob', ui: { hideFromLeaderboard: false } }],
+        [
+          'user1',
+          {
+            displayName: 'Alice',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
+        ],
+        [
+          'user2',
+          {
+            displayName: 'Bob',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
+        ],
       ]);
 
       const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
 
       expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({ alias: 'Bob', reps: 20 });
-      expect(result[1]).toEqual({ alias: 'Alice', reps: 15 });
+      expect(result[0]).toEqual({ alias: 'Bob', reps: 20, uid: 'user2' });
+      expect(result[1]).toEqual({ alias: 'Alice', reps: 15, uid: 'user1' });
     });
 
     it('sorts entries by reps descending', () => {
@@ -36,11 +48,26 @@ describe('leaderboard/logic', () => {
         { userId: 'user2', timestamp: '2024-03-15T10:00:00Z', reps: 15 },
       ];
       const profiles = new Map<string, UserProfile>([
-        ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
-        ['user2', { displayName: 'Bob', ui: { hideFromLeaderboard: false } }],
+        [
+          'user1',
+          {
+            displayName: 'Alice',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
+        ],
+        [
+          'user2',
+          {
+            displayName: 'Bob',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
+        ],
         [
           'user3',
-          { displayName: 'Charlie', ui: { hideFromLeaderboard: false } },
+          {
+            displayName: 'Charlie',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
         ],
       ]);
 
@@ -57,13 +84,19 @@ describe('leaderboard/logic', () => {
         { userId: 'user1', timestamp: '2024-03-16T10:00:00Z', reps: 20 }, // Different day
       ];
       const profiles = new Map<string, UserProfile>([
-        ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
+        [
+          'user1',
+          {
+            displayName: 'Alice',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
+        ],
       ]);
 
       const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({ alias: 'Alice', reps: 10 });
+      expect(result[0]).toEqual({ alias: 'Alice', reps: 10, uid: 'user1' });
     });
 
     it('drops users who opted out of the leaderboard', () => {
@@ -72,17 +105,23 @@ describe('leaderboard/logic', () => {
         { userId: 'user2', timestamp: '2024-03-15T10:00:00Z', reps: 20 },
       ];
       const profiles = new Map<string, UserProfile>([
-        ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
+        [
+          'user1',
+          {
+            displayName: 'Alice',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
+        ],
         ['user2', { displayName: 'Bob', ui: { hideFromLeaderboard: true } }],
       ]);
 
       const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({ alias: 'Alice', reps: 10 });
+      expect(result[0]).toEqual({ alias: 'Alice', reps: 10, uid: 'user1' });
     });
 
-    it('drops users without an explicit leaderboard opt-in', () => {
+    it('drops users without an explicit publicProfile opt-in', () => {
       // `hideFromLeaderboard` undefined defaults to hidden — no more
       // `anonym` fallback row.
       const rows: PushupRow[] = [
@@ -97,8 +136,8 @@ describe('leaderboard/logic', () => {
       expect(result).toEqual([]);
     });
 
-    describe('uid attachment for public-profile linking', () => {
-      it('attaches uid only when both leaderboard + publicProfile opt-ins are on', () => {
+    describe('public-profile gate', () => {
+      it('only includes users with full publicProfile opt-in; every row carries a uid', () => {
         const rows: PushupRow[] = [
           { userId: 'optedIn', timestamp: '2024-03-15T10:00:00Z', reps: 30 },
           { userId: 'leaderOnly', timestamp: '2024-03-15T10:00:00Z', reps: 20 },
@@ -117,6 +156,7 @@ describe('leaderboard/logic', () => {
             },
           ],
           [
+            // Leaderboard toggle on, but no public profile → dropped.
             'leaderOnly',
             {
               displayName: 'Bob',
@@ -124,6 +164,7 @@ describe('leaderboard/logic', () => {
             },
           ],
           [
+            // Public profile but leaderboard hidden → dropped.
             'profileOnly',
             {
               displayName: 'Carol',
@@ -134,17 +175,7 @@ describe('leaderboard/logic', () => {
 
         const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
 
-        // Leaderboard-only user (Bob) is included without a uid; the
-        // profileOnly user (Carol) opted out of the leaderboard and is
-        // dropped entirely — no `anonym` row anymore.
-        expect(result).toHaveLength(2);
-        expect(result[0]).toEqual({
-          alias: 'Alice',
-          reps: 30,
-          uid: 'optedIn',
-        });
-        expect(result[1]).toEqual({ alias: 'Bob', reps: 20 });
-        expect(result[1].uid).toBeUndefined();
+        expect(result).toEqual([{ alias: 'Alice', reps: 30, uid: 'optedIn' }]);
       });
 
       it('drops users with empty/whitespace displayName even when both opt-ins are on', () => {
@@ -198,7 +229,7 @@ describe('leaderboard/logic', () => {
       rows.forEach((_, i) => {
         profiles.set(`user${i}`, {
           displayName: `User${i}`,
-          ui: { hideFromLeaderboard: false },
+          ui: { hideFromLeaderboard: false, publicProfile: true },
         });
       });
 
@@ -213,7 +244,13 @@ describe('leaderboard/logic', () => {
         { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 20 },
       ];
       const profiles = new Map<string, UserProfile>([
-        ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
+        [
+          'user1',
+          {
+            displayName: 'Alice',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
+        ],
       ]);
 
       const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
@@ -228,8 +265,20 @@ describe('leaderboard/logic', () => {
         { userId: 'user2', timestamp: '2024-03-15T10:00:00Z', reps: 20 },
       ];
       const profiles = new Map<string, UserProfile>([
-        ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
-        ['user2', { displayName: 'Bob', ui: { hideFromLeaderboard: false } }],
+        [
+          'user1',
+          {
+            displayName: 'Alice',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
+        ],
+        [
+          'user2',
+          {
+            displayName: 'Bob',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
+        ],
       ]);
 
       const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
@@ -248,7 +297,13 @@ describe('leaderboard/logic', () => {
         { userId: 'user1', timestamp: '2024-03-16T10:00:00Z', reps: 99 }, // excluded (future)
       ];
       const profiles = new Map<string, UserProfile>([
-        ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
+        [
+          'user1',
+          {
+            displayName: 'Alice',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
+        ],
       ]);
 
       // When
@@ -256,7 +311,7 @@ describe('leaderboard/logic', () => {
 
       // Then — only the two in-window rows are summed.
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({ alias: 'Alice', reps: 10 });
+      expect(result[0]).toEqual({ alias: 'Alice', reps: 10, uid: 'user1' });
     });
 
     it('aggregates the trailing 30-day window inclusive of both endpoints', () => {
@@ -267,7 +322,13 @@ describe('leaderboard/logic', () => {
         { userId: 'user1', timestamp: '2024-02-29T10:00:00Z', reps: 99 }, // excluded (31 days back)
       ];
       const profiles = new Map<string, UserProfile>([
-        ['user1', { displayName: 'Alice', ui: { hideFromLeaderboard: false } }],
+        [
+          'user1',
+          {
+            displayName: 'Alice',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+          },
+        ],
       ]);
 
       // When
@@ -275,7 +336,7 @@ describe('leaderboard/logic', () => {
 
       // Then
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({ alias: 'Alice', reps: 12 });
+      expect(result[0]).toEqual({ alias: 'Alice', reps: 12, uid: 'user1' });
     });
   });
 

--- a/data-store/functions/src/leaderboard/logic.spec.ts
+++ b/data-store/functions/src/leaderboard/logic.spec.ts
@@ -208,6 +208,77 @@ describe('leaderboard/logic', () => {
       });
     });
 
+    describe('daily cap', () => {
+      it('caps a single-day total at 2000 reps for the daily leaderboard', () => {
+        const rows: PushupRow[] = [
+          { userId: 'cheater', timestamp: '2024-03-15T08:00:00Z', reps: 500 },
+          { userId: 'cheater', timestamp: '2024-03-15T10:00:00Z', reps: 500 },
+          { userId: 'cheater', timestamp: '2024-03-15T12:00:00Z', reps: 500 },
+          { userId: 'cheater', timestamp: '2024-03-15T14:00:00Z', reps: 500 },
+          { userId: 'cheater', timestamp: '2024-03-15T16:00:00Z', reps: 500 },
+        ];
+        const profiles = new Map<string, UserProfile>([
+          [
+            'cheater',
+            {
+              displayName: 'Mallory',
+              ui: { hideFromLeaderboard: false, publicProfile: true },
+            },
+          ],
+        ]);
+
+        const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].reps).toBe(2000);
+      });
+
+      it('caps each Berlin day independently in last7 windows', () => {
+        // 7 days × 3000 reps = 21000 raw, but each day caps at 2000
+        // → 14000 visible.
+        const rows: PushupRow[] = [];
+        for (let day = 9; day <= 15; day++) {
+          const iso = `2024-03-${String(day).padStart(2, '0')}T10:00:00Z`;
+          rows.push({ userId: 'cheater', timestamp: iso, reps: 1500 });
+          rows.push({ userId: 'cheater', timestamp: iso, reps: 1500 });
+        }
+        const profiles = new Map<string, UserProfile>([
+          [
+            'cheater',
+            {
+              displayName: 'Mallory',
+              ui: { hideFromLeaderboard: false, publicProfile: true },
+            },
+          ],
+        ]);
+
+        const result = rankEntries(rows, 'last7', '2024-03-15', profiles);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].reps).toBe(14000);
+      });
+
+      it('does not affect users below the daily cap', () => {
+        const rows: PushupRow[] = [
+          { userId: 'honest', timestamp: '2024-03-15T08:00:00Z', reps: 50 },
+          { userId: 'honest', timestamp: '2024-03-15T18:00:00Z', reps: 50 },
+        ];
+        const profiles = new Map<string, UserProfile>([
+          [
+            'honest',
+            {
+              displayName: 'Alice',
+              ui: { hideFromLeaderboard: false, publicProfile: true },
+            },
+          ],
+        ]);
+
+        const result = rankEntries(rows, 'daily', '2024-03-15', profiles);
+
+        expect(result[0].reps).toBe(100);
+      });
+    });
+
     describe('admin shadow-ban', () => {
       it('excludes users flagged with leaderboardExcluded=true even with both opt-ins', () => {
         const rows: PushupRow[] = [

--- a/data-store/functions/src/leaderboard/logic.spec.ts
+++ b/data-store/functions/src/leaderboard/logic.spec.ts
@@ -100,6 +100,9 @@ describe('leaderboard/logic', () => {
     });
 
     it('drops users who opted out of the leaderboard', () => {
+      // Both fixtures have publicProfile=true so this test isolates the
+      // hideFromLeaderboard gate — Bob's exclusion is solely the
+      // hideFromLeaderboard=true flag, not the missing public profile.
       const rows: PushupRow[] = [
         { userId: 'user1', timestamp: '2024-03-15T10:00:00Z', reps: 10 },
         { userId: 'user2', timestamp: '2024-03-15T10:00:00Z', reps: 20 },
@@ -112,7 +115,13 @@ describe('leaderboard/logic', () => {
             ui: { hideFromLeaderboard: false, publicProfile: true },
           },
         ],
-        ['user2', { displayName: 'Bob', ui: { hideFromLeaderboard: true } }],
+        [
+          'user2',
+          {
+            displayName: 'Bob',
+            ui: { hideFromLeaderboard: true, publicProfile: true },
+          },
+        ],
       ]);
 
       const result = rankEntries(rows, 'daily', '2024-03-15', profiles);

--- a/data-store/functions/src/leaderboard/logic.ts
+++ b/data-store/functions/src/leaderboard/logic.ts
@@ -52,6 +52,15 @@ export type LeaderboardPeriodKind = 'daily' | 'last7' | 'last30';
 const TOP_N = 10;
 
 /**
+ * Per-user, per-Berlin-day cap on reps that count toward the leaderboard.
+ * Acts as a defense-in-depth on top of the per-entry cap (`PUSHUP_REPS_MAX`)
+ * — a determined cheater can still log many entries below 500 reps per
+ * day, this caps the visible total at a plausible elite ceiling. Anything
+ * above is silently truncated; the user's own stats keep the raw value.
+ */
+const LEADERBOARD_DAILY_REPS_CAP = 2000;
+
+/**
  * Returns the ISO date `daysBack` days before the given Berlin date.
  * Uses UTC math anchored to noon to dodge DST boundary glitches — the only
  * thing we read out is `YYYY-MM-DD`, so the time of day is irrelevant.
@@ -89,7 +98,9 @@ export function rankEntries(
   targetKey: string,
   userProfiles: Map<string, UserProfile>
 ): LeaderboardEntry[] {
-  const totals = new Map<string, number>();
+  // Aggregate per (userId, Berlin day) first so the daily cap can be
+  // applied before windowed sums collapse the day boundary.
+  const perDay = new Map<string, Map<string, number>>();
 
   let windowStart: string | null = null;
   if (periodKey === 'last7' || periodKey === 'last30') {
@@ -115,10 +126,24 @@ export function rankEntries(
       if (p.isoDate < windowStart || p.isoDate > targetKey) continue;
     }
 
-    totals.set(
-      row.userId,
-      (totals.get(row.userId) || 0) + Number(row.reps || 0)
+    let userDays = perDay.get(row.userId);
+    if (!userDays) {
+      userDays = new Map();
+      perDay.set(row.userId, userDays);
+    }
+    userDays.set(
+      p.isoDate,
+      (userDays.get(p.isoDate) || 0) + Number(row.reps || 0)
     );
+  }
+
+  const totals = new Map<string, number>();
+  for (const [userId, days] of perDay) {
+    let total = 0;
+    for (const [, dayReps] of days) {
+      total += Math.min(dayReps, LEADERBOARD_DAILY_REPS_CAP);
+    }
+    totals.set(userId, total);
   }
 
   return [...totals.entries()]

--- a/data-store/functions/src/leaderboard/logic.ts
+++ b/data-store/functions/src/leaderboard/logic.ts
@@ -4,7 +4,11 @@
  */
 
 import { berlinDateParts, BerlinDateParts } from '../datetime';
-import { isPublicProfileLinkAllowed, UserProfile } from '../profile';
+import {
+  isLeaderboardExcluded,
+  isPublicProfileLinkAllowed,
+  UserProfile,
+} from '../profile';
 
 export interface PushupRow {
   timestamp?: string;
@@ -120,6 +124,8 @@ export function rankEntries(
   return [...totals.entries()]
     .flatMap(([userId, reps]): LeaderboardEntry[] => {
       const profile = userProfiles.get(userId);
+      // Admin-set exclusion shadow-bans regardless of opt-in toggles.
+      if (isLeaderboardExcluded(profile)) return [];
       // Public leaderboard requires the full public-profile opt-in:
       // `ui.publicProfile === true`, `ui.hideFromLeaderboard === false`,
       // and a non-empty `displayName`. `isPublicProfileLinkAllowed`

--- a/data-store/functions/src/leaderboard/logic.ts
+++ b/data-store/functions/src/leaderboard/logic.ts
@@ -4,11 +4,7 @@
  */
 
 import { berlinDateParts, BerlinDateParts } from '../datetime';
-import {
-  isLeaderboardNameAllowed,
-  isPublicProfileLinkAllowed,
-  UserProfile,
-} from '../profile';
+import { isPublicProfileLinkAllowed, UserProfile } from '../profile';
 
 export interface PushupRow {
   timestamp?: string;
@@ -20,9 +16,10 @@ export interface LeaderboardEntry {
   alias: string;
   reps: number;
   /**
-   * UID is only populated when the user also opted into a public profile
-   * (`ui.publicProfile === true`). Frontend renders entries with `uid`
-   * as links to `/u/<uid>`; entries without `uid` stay plain text.
+   * Public-profile UID. Always populated by `rankEntries()` because the
+   * leaderboard now requires the full publicProfile opt-in. Kept optional
+   * on the type so the frontend stays tolerant of older snapshots that
+   * may still carry uid-less rows.
    */
   uid?: string;
 }
@@ -123,18 +120,14 @@ export function rankEntries(
   return [...totals.entries()]
     .flatMap(([userId, reps]): LeaderboardEntry[] => {
       const profile = userProfiles.get(userId);
-      // Public leaderboard now requires an explicit opt-in AND a non-empty
-      // display name. Users without a profile, with `hideFromLeaderboard`
-      // unset/true, or with a blank name are dropped entirely — no more
-      // `anonym` rows.
-      if (!isLeaderboardNameAllowed(profile)) return [];
+      // Public leaderboard requires the full public-profile opt-in:
+      // `ui.publicProfile === true`, `ui.hideFromLeaderboard === false`,
+      // and a non-empty `displayName`. `isPublicProfileLinkAllowed`
+      // checks all three — so every row that survives is also linkable
+      // to /u/<uid>.
+      if (!isPublicProfileLinkAllowed(profile)) return [];
       const alias = String(profile?.displayName || '').trim();
-      if (!alias) return [];
-      const entry: LeaderboardEntry = { alias, reps };
-      if (isPublicProfileLinkAllowed(profile)) {
-        entry.uid = userId;
-      }
-      return [entry];
+      return [{ alias, reps, uid: userId }];
     })
     .sort((a, b) => b.reps - a.reps)
     .slice(0, TOP_N);

--- a/data-store/functions/src/leaderboard/logic.ts
+++ b/data-store/functions/src/leaderboard/logic.ts
@@ -5,10 +5,8 @@
 
 import { berlinDateParts, BerlinDateParts } from '../datetime';
 import {
-  toPublicDisplayName,
   isLeaderboardNameAllowed,
   isPublicProfileLinkAllowed,
-  toAnonymousLabel,
   UserProfile,
 } from '../profile';
 
@@ -22,11 +20,9 @@ export interface LeaderboardEntry {
   alias: string;
   reps: number;
   /**
-   * UID is only populated when the user opted into BOTH the leaderboard
-   * (`ui.hideFromLeaderboard === false`) AND a public profile
+   * UID is only populated when the user also opted into a public profile
    * (`ui.publicProfile === true`). Frontend renders entries with `uid`
    * as links to `/u/<uid>`; entries without `uid` stay plain text.
-   * Anonymous-aliased rows (leaderboard opt-out) never carry a UID.
    */
   uid?: string;
 }
@@ -125,19 +121,20 @@ export function rankEntries(
   }
 
   return [...totals.entries()]
-    .map(([userId, reps]) => {
+    .flatMap(([userId, reps]): LeaderboardEntry[] => {
       const profile = userProfiles.get(userId);
-      const alias = isLeaderboardNameAllowed(profile)
-        ? toPublicDisplayName(profile)
-        : toAnonymousLabel();
-      // Only attach a UID when both leaderboard-visibility and
-      // public-profile opt-ins are on — otherwise the row stays plain
-      // text on the frontend and the user's stats can't be deeplinked.
+      // Public leaderboard now requires an explicit opt-in AND a non-empty
+      // display name. Users without a profile, with `hideFromLeaderboard`
+      // unset/true, or with a blank name are dropped entirely — no more
+      // `anonym` rows.
+      if (!isLeaderboardNameAllowed(profile)) return [];
+      const alias = String(profile?.displayName || '').trim();
+      if (!alias) return [];
       const entry: LeaderboardEntry = { alias, reps };
       if (isPublicProfileLinkAllowed(profile)) {
         entry.uid = userId;
       }
-      return entry;
+      return [entry];
     })
     .sort((a, b) => b.reps - a.reps)
     .slice(0, TOP_N);

--- a/data-store/functions/src/profile/logic.spec.ts
+++ b/data-store/functions/src/profile/logic.spec.ts
@@ -3,6 +3,7 @@ import {
   toAnonymousLabel,
   toPublicDisplayName,
   isLeaderboardNameAllowed,
+  isLeaderboardExcluded,
   UserProfile,
 } from './logic';
 
@@ -39,7 +40,9 @@ describe('profile/logic', () => {
     });
 
     it('returns anonymous when profile is null', () => {
-      expect(toPublicDisplayName(null as unknown as UserProfile)).toBe('anonym');
+      expect(toPublicDisplayName(null as unknown as UserProfile)).toBe(
+        'anonym'
+      );
     });
 
     it('trims whitespace from displayName', () => {
@@ -79,13 +82,33 @@ describe('profile/logic', () => {
     });
 
     it('returns false when profile is null', () => {
-      expect(isLeaderboardNameAllowed(null as unknown as UserProfile)).toBe(false);
+      expect(isLeaderboardNameAllowed(null as unknown as UserProfile)).toBe(
+        false
+      );
     });
 
     it('defaults to hidden (privacy-first)', () => {
       // When no explicit opt-in, user is not visible on leaderboard
       const profile: UserProfile = { displayName: 'Hidden User' };
       expect(isLeaderboardNameAllowed(profile)).toBe(false);
+    });
+  });
+
+  describe('isLeaderboardExcluded', () => {
+    it('returns true when leaderboardExcluded is true', () => {
+      expect(isLeaderboardExcluded({ leaderboardExcluded: true })).toBe(true);
+    });
+
+    it('returns false when leaderboardExcluded is false', () => {
+      expect(isLeaderboardExcluded({ leaderboardExcluded: false })).toBe(false);
+    });
+
+    it('returns false when leaderboardExcluded is undefined', () => {
+      expect(isLeaderboardExcluded({})).toBe(false);
+    });
+
+    it('returns false when profile is undefined', () => {
+      expect(isLeaderboardExcluded(undefined)).toBe(false);
     });
   });
 });

--- a/data-store/functions/src/profile/logic.ts
+++ b/data-store/functions/src/profile/logic.ts
@@ -7,6 +7,15 @@ export interface UserProfile {
   displayName?: string;
   ui?: { hideFromLeaderboard?: boolean; publicProfile?: boolean };
   role?: string;
+  /**
+   * Admin-only moderation flag. When `true`, the user is excluded from
+   * the public leaderboard regardless of opt-in toggles. Their public
+   * profile (`/u/<uid>`) remains accessible — exclusion only suppresses
+   * leaderboard rows. Writable exclusively via the
+   * `adminSetLeaderboardExclusion` callable; clients are blocked at the
+   * Firestore-rule layer.
+   */
+  leaderboardExcluded?: boolean;
 }
 
 const ANONYMOUS_LABEL = 'anonym';
@@ -59,4 +68,12 @@ export function isPublicProfileLinkAllowed(profile?: UserProfile): boolean {
   if (!isLeaderboardNameAllowed(profile)) return false;
   if (profile?.ui?.publicProfile !== true) return false;
   return String(profile?.displayName || '').trim().length > 0;
+}
+
+/**
+ * Whether the user has been admin-banned from the leaderboard. Decoupled
+ * from the user's own opt-in toggles — exclusion wins in `rankEntries()`.
+ */
+export function isLeaderboardExcluded(profile?: UserProfile): boolean {
+  return profile?.leaderboardExcluded === true;
 }

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -21,11 +21,11 @@ export type LeaderboardEntry = {
   rank: number;
   isCurrent?: boolean;
   /**
-   * UID is present iff the user opted into BOTH the leaderboard
-   * (`ui.hideFromLeaderboard === false`) AND a public profile
-   * (`ui.publicProfile === true`). When set, the frontend renders the
-   * row as a link to `/u/<uid>`; when missing, the row stays plain text.
-   * Anonymous-aliased rows never carry a UID.
+   * Public-profile UID. Always populated by the cloud-function ranker
+   * because leaderboard rows now require the full publicProfile opt-in.
+   * Optional only for compatibility with older cached snapshots; current
+   * snapshots always include it. When set, the row renders as a link to
+   * `/u/<uid>`; when missing (legacy), the row stays plain text.
    */
   uid?: string;
 };

--- a/libs/data-access/src/lib/api/pushup-firestore.service.spec.ts
+++ b/libs/data-access/src/lib/api/pushup-firestore.service.spec.ts
@@ -16,7 +16,10 @@ import { TestBed } from '@angular/core/testing';
 import { Firestore } from '@angular/fire/firestore';
 import { firstValueFrom } from 'rxjs';
 import * as firestoreFns from '@angular/fire/firestore';
-import { PushupFirestoreService } from './pushup-firestore.service';
+import {
+  PushupFirestoreService,
+  PushupValidationError,
+} from './pushup-firestore.service';
 
 describe('PushupFirestoreService', () => {
   let service: PushupFirestoreService;
@@ -336,6 +339,50 @@ describe('PushupFirestoreService', () => {
       expect(writtenData).not.toHaveProperty('sets');
     });
 
+    describe('When reps violates the plausibility cap', () => {
+      it('Then rejects values above PUSHUP_REPS_MAX before touching Firestore', () => {
+        const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
+
+        expect(() =>
+          service.createPushup('u1', {
+            timestamp: '2024-01-01T10:00:00Z',
+            reps: 501,
+          })
+        ).toThrow(PushupValidationError);
+        expect(setDocSpy).not.toHaveBeenCalled();
+      });
+
+      it('Then rejects zero/negative reps', () => {
+        const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
+
+        expect(() =>
+          service.createPushup('u1', {
+            timestamp: '2024-01-01T10:00:00Z',
+            reps: 0,
+          })
+        ).toThrow(PushupValidationError);
+        expect(() =>
+          service.createPushup('u1', {
+            timestamp: '2024-01-01T10:00:00Z',
+            reps: -5,
+          })
+        ).toThrow(PushupValidationError);
+        expect(setDocSpy).not.toHaveBeenCalled();
+      });
+
+      it('Then rejects non-integer reps', () => {
+        const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
+
+        expect(() =>
+          service.createPushup('u1', {
+            timestamp: '2024-01-01T10:00:00Z',
+            reps: 1.5,
+          })
+        ).toThrow(PushupValidationError);
+        expect(setDocSpy).not.toHaveBeenCalled();
+      });
+    });
+
     it('defaults source to "web" and type to "Standard" when omitted', async () => {
       const newRef = { id: 'default-id' };
       jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(newRef as any);
@@ -370,6 +417,29 @@ describe('PushupFirestoreService', () => {
         rowRef,
         expect.objectContaining({ reps: 8, updatedAt: expect.any(String) })
       );
+    });
+
+    describe('When reps violates the plausibility cap', () => {
+      it('Then rejects updates above PUSHUP_REPS_MAX before touching Firestore', () => {
+        const updateDocSpy = jest.spyOn(firestoreFns, 'updateDoc');
+
+        expect(() => service.updatePushup('id1', { reps: 9001 })).toThrow(
+          PushupValidationError
+        );
+        expect(updateDocSpy).not.toHaveBeenCalled();
+      });
+
+      it('Then allows updates that omit reps entirely', async () => {
+        const rowRef = {};
+        jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(rowRef as any);
+        const updateDocSpy = jest
+          .spyOn(firestoreFns, 'updateDoc')
+          .mockResolvedValueOnce(undefined as any);
+
+        await firstValueFrom(service.updatePushup('id1', { source: 'web' }));
+
+        expect(updateDocSpy).toHaveBeenCalled();
+      });
     });
 
     it('strips undefined values from payload before calling updateDoc', async () => {

--- a/libs/data-access/src/lib/api/pushup-firestore.service.spec.ts
+++ b/libs/data-access/src/lib/api/pushup-firestore.service.spec.ts
@@ -340,45 +340,55 @@ describe('PushupFirestoreService', () => {
     });
 
     describe('When reps violates the plausibility cap', () => {
-      it('Then rejects values above PUSHUP_REPS_MAX before touching Firestore', () => {
+      it('Then surfaces the error via the Observable, not synchronously', async () => {
         const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
 
-        expect(() =>
-          service.createPushup('u1', {
-            timestamp: '2024-01-01T10:00:00Z',
-            reps: 501,
-          })
-        ).toThrow(PushupValidationError);
+        // Calling the method must NOT throw synchronously — that would
+        // bypass `.subscribe({ error })` handlers and crash callers.
+        const obs$ = service.createPushup('u1', {
+          timestamp: '2024-01-01T10:00:00Z',
+          reps: 501,
+        });
+
+        await expect(firstValueFrom(obs$)).rejects.toBeInstanceOf(
+          PushupValidationError
+        );
         expect(setDocSpy).not.toHaveBeenCalled();
       });
 
-      it('Then rejects zero/negative reps', () => {
+      it('Then rejects zero/negative reps via Observable error', async () => {
         const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
 
-        expect(() =>
-          service.createPushup('u1', {
-            timestamp: '2024-01-01T10:00:00Z',
-            reps: 0,
-          })
-        ).toThrow(PushupValidationError);
-        expect(() =>
-          service.createPushup('u1', {
-            timestamp: '2024-01-01T10:00:00Z',
-            reps: -5,
-          })
-        ).toThrow(PushupValidationError);
+        await expect(
+          firstValueFrom(
+            service.createPushup('u1', {
+              timestamp: '2024-01-01T10:00:00Z',
+              reps: 0,
+            })
+          )
+        ).rejects.toBeInstanceOf(PushupValidationError);
+        await expect(
+          firstValueFrom(
+            service.createPushup('u1', {
+              timestamp: '2024-01-01T10:00:00Z',
+              reps: -5,
+            })
+          )
+        ).rejects.toBeInstanceOf(PushupValidationError);
         expect(setDocSpy).not.toHaveBeenCalled();
       });
 
-      it('Then rejects non-integer reps', () => {
+      it('Then rejects non-integer reps via Observable error', async () => {
         const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
 
-        expect(() =>
-          service.createPushup('u1', {
-            timestamp: '2024-01-01T10:00:00Z',
-            reps: 1.5,
-          })
-        ).toThrow(PushupValidationError);
+        await expect(
+          firstValueFrom(
+            service.createPushup('u1', {
+              timestamp: '2024-01-01T10:00:00Z',
+              reps: 1.5,
+            })
+          )
+        ).rejects.toBeInstanceOf(PushupValidationError);
         expect(setDocSpy).not.toHaveBeenCalled();
       });
     });
@@ -420,10 +430,12 @@ describe('PushupFirestoreService', () => {
     });
 
     describe('When reps violates the plausibility cap', () => {
-      it('Then rejects updates above PUSHUP_REPS_MAX before touching Firestore', () => {
+      it('Then surfaces the error via the Observable, not synchronously', async () => {
         const updateDocSpy = jest.spyOn(firestoreFns, 'updateDoc');
 
-        expect(() => service.updatePushup('id1', { reps: 9001 })).toThrow(
+        const obs$ = service.updatePushup('id1', { reps: 9001 });
+
+        await expect(firstValueFrom(obs$)).rejects.toBeInstanceOf(
           PushupValidationError
         );
         expect(updateDocSpy).not.toHaveBeenCalled();

--- a/libs/data-access/src/lib/api/pushup-firestore.service.ts
+++ b/libs/data-access/src/lib/api/pushup-firestore.service.ts
@@ -21,7 +21,7 @@ import {
   StatsFilter,
   validatePushupReps,
 } from '@pu-stats/models';
-import { from, map, Observable } from 'rxjs';
+import { from, map, Observable, throwError } from 'rxjs';
 
 const PUSHUPS_COLLECTION = 'pushups';
 
@@ -35,9 +35,18 @@ export class PushupValidationError extends Error {
   }
 }
 
-function assertValidReps(reps: number): void {
+/**
+ * Returns an Observable that errors with `PushupValidationError` if the
+ * reps fail validation, otherwise null. Wrapping the throw in a cold
+ * Observable lets RxJS subscribers see the error via their `error`
+ * handler instead of getting a synchronous throw at call time — which
+ * would bypass `subscribe({ error })` and crash callers that build
+ * their own pipelines around the returned Observable.
+ */
+function repsViolationObservable<T>(reps: number): Observable<T> | null {
   const violation = validatePushupReps(reps);
-  if (violation) throw new PushupValidationError('reps', violation);
+  if (!violation) return null;
+  return throwError(() => new PushupValidationError('reps', violation));
 }
 
 /** Re-exported so callers can read the cap without importing from `@pu-stats/models`. */
@@ -89,7 +98,8 @@ export class PushupFirestoreService {
     userId: string,
     payload: PushupCreate
   ): Observable<PushupRecord> {
-    assertValidReps(payload.reps);
+    const violation = repsViolationObservable<PushupRecord>(payload.reps);
+    if (violation) return violation;
     const pushupsRef = collection(this.firestore, PUSHUPS_COLLECTION);
     const newRef = doc(pushupsRef);
     const nowIso = new Date().toISOString();
@@ -122,7 +132,10 @@ export class PushupFirestoreService {
   }
 
   updatePushup(id: string, payload: PushupUpdate): Observable<void> {
-    if (payload.reps !== undefined) assertValidReps(payload.reps);
+    if (payload.reps !== undefined) {
+      const violation = repsViolationObservable<void>(payload.reps);
+      if (violation) return violation;
+    }
     const rowRef = doc(this.firestore, PUSHUPS_COLLECTION, id);
     // Filter out undefined values and empty arrays — Firestore rejects undefined,
     // and empty sets should be omitted to match createPushup behavior.

--- a/libs/data-access/src/lib/api/pushup-firestore.service.ts
+++ b/libs/data-access/src/lib/api/pushup-firestore.service.ts
@@ -13,14 +13,35 @@ import {
   where,
 } from '@angular/fire/firestore';
 import {
+  PUSHUP_REPS_MAX,
+  PUSHUP_REPS_MIN,
   PushupCreate,
   PushupRecord,
   PushupUpdate,
   StatsFilter,
+  validatePushupReps,
 } from '@pu-stats/models';
 import { from, map, Observable } from 'rxjs';
 
 const PUSHUPS_COLLECTION = 'pushups';
+
+export class PushupValidationError extends Error {
+  constructor(
+    public readonly field: 'reps',
+    public readonly violation: 'not-integer' | 'out-of-range'
+  ) {
+    super(`Invalid pushup ${field}: ${violation}`);
+    this.name = 'PushupValidationError';
+  }
+}
+
+function assertValidReps(reps: number): void {
+  const violation = validatePushupReps(reps);
+  if (violation) throw new PushupValidationError('reps', violation);
+}
+
+/** Re-exported so callers can read the cap without importing from `@pu-stats/models`. */
+export { PUSHUP_REPS_MAX, PUSHUP_REPS_MIN };
 
 @Injectable({ providedIn: 'root' })
 export class PushupFirestoreService {
@@ -68,6 +89,7 @@ export class PushupFirestoreService {
     userId: string,
     payload: PushupCreate
   ): Observable<PushupRecord> {
+    assertValidReps(payload.reps);
     const pushupsRef = collection(this.firestore, PUSHUPS_COLLECTION);
     const newRef = doc(pushupsRef);
     const nowIso = new Date().toISOString();
@@ -100,6 +122,7 @@ export class PushupFirestoreService {
   }
 
   updatePushup(id: string, payload: PushupUpdate): Observable<void> {
+    if (payload.reps !== undefined) assertValidReps(payload.reps);
     const rowRef = doc(this.firestore, PUSHUPS_COLLECTION, id);
     // Filter out undefined values and empty arrays — Firestore rejects undefined,
     // and empty sets should be omitted to match createPushup behavior.

--- a/libs/stats/src/lib/models/pushup.models.spec.ts
+++ b/libs/stats/src/lib/models/pushup.models.spec.ts
@@ -1,0 +1,53 @@
+import {
+  PUSHUP_REPS_MAX,
+  PUSHUP_REPS_MIN,
+  validatePushupReps,
+} from './pushup.models';
+
+describe('validatePushupReps', () => {
+  describe('Given a valid integer in range', () => {
+    it.each([PUSHUP_REPS_MIN, 1, 50, 200, PUSHUP_REPS_MAX])(
+      'Then %i passes validation',
+      (reps) => {
+        expect(validatePushupReps(reps)).toBeNull();
+      }
+    );
+  });
+
+  describe('Given a non-integer numeric value', () => {
+    it.each([1.5, 0.1, Math.PI])(
+      'Then %f is rejected as not-integer',
+      (reps) => {
+        expect(validatePushupReps(reps)).toBe('not-integer');
+      }
+    );
+
+    it('rejects NaN', () => {
+      expect(validatePushupReps(Number.NaN)).toBe('not-integer');
+    });
+
+    it('rejects Infinity', () => {
+      expect(validatePushupReps(Number.POSITIVE_INFINITY)).toBe('not-integer');
+    });
+  });
+
+  describe('Given a non-number type', () => {
+    it.each(['10', null, undefined, true, [], {}])(
+      'Then %p is rejected as not-integer',
+      (reps) => {
+        expect(validatePushupReps(reps)).toBe('not-integer');
+      }
+    );
+  });
+
+  describe('Given an out-of-range integer', () => {
+    it.each([0, -1, -100])('Then %i is rejected as out-of-range', (reps) => {
+      expect(validatePushupReps(reps)).toBe('out-of-range');
+    });
+
+    it('rejects values above the cap', () => {
+      expect(validatePushupReps(PUSHUP_REPS_MAX + 1)).toBe('out-of-range');
+      expect(validatePushupReps(10_000)).toBe('out-of-range');
+    });
+  });
+});

--- a/libs/stats/src/lib/models/pushup.models.ts
+++ b/libs/stats/src/lib/models/pushup.models.ts
@@ -33,3 +33,37 @@ export interface PushupUpdate {
   source?: string;
   type?: string;
 }
+
+/**
+ * Plausibility caps for a single pushup entry. The Firestore rule mirrors
+ * these constants — see `data-store/firestore.rules`. Any change here MUST
+ * be reflected in the rule and vice versa, otherwise honest writes that
+ * pass client validation will be rejected at the security layer (or worse:
+ * cheats that pass the rule will silently break the UI).
+ *
+ * The ceiling matches the existing `QUICK_LOG_REPS_MAX` (500) so quick-log
+ * notifications keep working unchanged.
+ */
+export const PUSHUP_REPS_MIN = 1;
+export const PUSHUP_REPS_MAX = 500;
+
+export type PushupRepsViolation = 'not-integer' | 'out-of-range';
+
+/**
+ * Returns null if the value is a valid pushup rep count; otherwise returns
+ * the kind of violation. Pure — used by the data-access service to fail
+ * fast before hitting Firestore, by form validators, and by tests.
+ */
+export function validatePushupReps(reps: unknown): PushupRepsViolation | null {
+  if (
+    typeof reps !== 'number' ||
+    !Number.isFinite(reps) ||
+    !Number.isInteger(reps)
+  ) {
+    return 'not-integer';
+  }
+  if (reps < PUSHUP_REPS_MIN || reps > PUSHUP_REPS_MAX) {
+    return 'out-of-range';
+  }
+  return null;
+}

--- a/libs/stats/src/lib/models/user-config.models.spec.ts
+++ b/libs/stats/src/lib/models/user-config.models.spec.ts
@@ -1,0 +1,74 @@
+import {
+  DISPLAY_NAME_MAX_LENGTH,
+  DISPLAY_NAME_MIN_LENGTH,
+  validateDisplayName,
+} from './user-config.models';
+
+describe('validateDisplayName', () => {
+  describe('Given a valid name', () => {
+    it.each([
+      'Wolf',
+      'Anna-Lena',
+      'Jean.Luc',
+      'Carl Sagan',
+      'a_b',
+      'Über_99',
+      'むぎ',
+      '日本語',
+      'AbCdEfGhIjKlMnOpQrStUvWxYz1234',
+    ])('Then %s passes', (name) => {
+      expect(validateDisplayName(name)).toBeNull();
+    });
+
+    it('trims surrounding whitespace before checking length and charset', () => {
+      expect(validateDisplayName('  Wolf  ')).toBeNull();
+    });
+
+    it(`accepts the lower bound (${DISPLAY_NAME_MIN_LENGTH} chars)`, () => {
+      expect(validateDisplayName('AB')).toBeNull();
+    });
+
+    it(`accepts the upper bound (${DISPLAY_NAME_MAX_LENGTH} chars)`, () => {
+      expect(
+        validateDisplayName('A'.repeat(DISPLAY_NAME_MAX_LENGTH))
+      ).toBeNull();
+    });
+  });
+
+  describe('Given a too-short name', () => {
+    it.each(['', ' ', 'A', '   '])('Then %p is rejected', (name) => {
+      expect(validateDisplayName(name)).toBe('too-short');
+    });
+  });
+
+  describe('Given a too-long name', () => {
+    it('rejects names beyond the max', () => {
+      expect(validateDisplayName('A'.repeat(DISPLAY_NAME_MAX_LENGTH + 1))).toBe(
+        'too-long'
+      );
+    });
+  });
+
+  describe('Given names with invalid characters', () => {
+    it.each([
+      'Wolf🚀',
+      'with\nnewline',
+      'wolf<script>',
+      'a/b',
+      'Wolf!',
+      'foo@bar',
+      '/u/admin',
+    ])('Then %p is rejected', (name) => {
+      expect(validateDisplayName(name)).toBe('invalid-characters');
+    });
+  });
+
+  describe('Given a non-string value', () => {
+    it.each([null, undefined, 42, true, [], {}])(
+      'Then %p is rejected as invalid-characters',
+      (raw) => {
+        expect(validateDisplayName(raw)).toBe('invalid-characters');
+      }
+    );
+  });
+});

--- a/libs/stats/src/lib/models/user-config.models.ts
+++ b/libs/stats/src/lib/models/user-config.models.ts
@@ -64,3 +64,32 @@ export type UserConfigUpdate = Partial<
     | 'reminder'
   >
 >;
+
+/**
+ * Display-name constraints for the public leaderboard. Mirrored in
+ * `data-store/firestore.rules` — keep both in sync. Pattern allows
+ * Unicode letters, digits, plus space, underscore, dot, hyphen.
+ */
+export const DISPLAY_NAME_MIN_LENGTH = 2;
+export const DISPLAY_NAME_MAX_LENGTH = 30;
+export const DISPLAY_NAME_PATTERN = /^[\p{L}\p{N} _.-]+$/u;
+
+export type DisplayNameViolation =
+  | 'too-short'
+  | 'too-long'
+  | 'invalid-characters';
+
+/**
+ * Returns null if the candidate passes display-name validation, otherwise
+ * the kind of violation. Matches the Firestore rule constraints — clients
+ * should call this before persisting to surface a clear error rather than
+ * a generic permission rejection.
+ */
+export function validateDisplayName(raw: unknown): DisplayNameViolation | null {
+  if (typeof raw !== 'string') return 'invalid-characters';
+  const trimmed = raw.trim();
+  if (trimmed.length < DISPLAY_NAME_MIN_LENGTH) return 'too-short';
+  if (trimmed.length > DISPLAY_NAME_MAX_LENGTH) return 'too-long';
+  if (!DISPLAY_NAME_PATTERN.test(trimmed)) return 'invalid-characters';
+  return null;
+}

--- a/plans/leaderboard-rework-plan.md
+++ b/plans/leaderboard-rework-plan.md
@@ -9,25 +9,33 @@ value on its own. Earlier slices unblock later ones but do not require them.
 
 ---
 
-## Open product questions (decide before PR 2 lands)
+## Open product questions (decided during PR #281)
 
-These thresholds drive validation rules and want a one-line decision:
+These thresholds drove validation rules. **Final values shipped in PR #281
+are bolded; original suggestions kept in italics for traceability.**
 
-- **Per-entry cap:** suggest **200 reps** — covers world-class single-set
-  performance with headroom. Higher = more cheat surface, lower = false
-  rejects.
-- **Daily cap:** suggest **2 000 reps** — well above the realistic top-tier
-  daily volume, still blocks "1 000 000 reps" griefing.
-- **Min account age for leaderboard:** suggest **24 h** — kills throw-away
-  accounts without hurting first-day users much.
-- **Email-verified required for leaderboard:** suggest **yes** — Firebase Auth
-  already exposes `emailVerified`; the cost is one banner in settings.
-- **Display-name policy:** length **2–30**, charset
-  `\p{L}\p{N} _.\-` (Unicode letters/digits + space, underscore, dot, hyphen),
-  plus a small starter wordlist for profanity.
+- **Per-entry cap:** **500 reps** _(originally suggested 200 — raised to
+  match the existing `QUICK_LOG_REPS_MAX = 500` so notification quick-log
+  keeps working unchanged)_. Higher = more cheat surface, lower = false
+  rejects. PR 6's daily cap is the real anti-cheat backstop.
+- **Daily cap:** **2 000 reps** _(unchanged from suggestion)_ — well above
+  realistic top-tier daily volume, still blocks "1 000 000 reps" griefing.
+- **Min account age for leaderboard:** **not gated** _(originally suggested
+  24h)_ — dropped together with the verified-email gate. Daily cap +
+  display-name + admin shadow-ban cover the cheat surface; account-age
+  gating can be added later if needed without schema changes.
+- **Email-verified required for leaderboard:** **no** _(originally
+  suggested yes)_ — explicitly dropped per the user's call. The full
+  publicProfile opt-in (PR 4) plus admin shadow-ban (PR 5) was deemed
+  enough; verified-email gating remains a future option.
+- **Display-name policy:** **length 2–30 (after `.trim()`), charset
+  `\p{L}\p{N} _.\-`** _(unchanged from suggestion)_. Profanity wordlist
+  was deferred to follow-up issue #285.
 
-If any of those don't match what you want, change them in PR 2 / PR 3 / PR 4 —
-the plan structure stays the same.
+Anything we'd want to revise: bump these values via a follow-up PR — the
+constants live in `libs/stats/src/lib/models/{pushup,user-config}.models.ts`
+and `data-store/functions/src/leaderboard/logic.ts` (daily cap), with
+the Firestore rule mirroring them.
 
 ---
 

--- a/plans/leaderboard-rework-plan.md
+++ b/plans/leaderboard-rework-plan.md
@@ -170,15 +170,15 @@ necessary as soon as PR 1–4 are live and a determined cheater shows up.
 
 **Changes**
 
-- `libs/auth/...` or `libs/stats/...` model: extend `userConfigs.ui` with
-  optional `excludeFromLeaderboard?: boolean` — admin-only.
+- `libs/auth/...` or `libs/stats/...` model: extend `userConfigs` with
+  optional top-level `leaderboardExcluded?: boolean` — admin-only.
 - `data-store/firestore.rules`
-  - Block client writes to `ui.excludeFromLeaderboard` (mirror the existing
+  - Block client writes to `leaderboardExcluded` (mirror the existing
     `role` carve-out on `userConfigs`).
 - `data-store/functions/src/admin/` — new callable
   `adminSetLeaderboardExclusion({ uid, excluded })` (custom-claim gated).
 - `data-store/functions/src/leaderboard/logic.ts`
-  - `rankEntries()` filters users with `ui.excludeFromLeaderboard === true`.
+  - `rankEntries()` filters users with `leaderboardExcluded === true`.
 - `web/src/app/admin/user-details-dialog.component.ts`
   - Toggle "Vom Leaderboard ausschließen" + reason text field; reason logged
     to a `moderationLog` collection (write-only via Admin SDK).
@@ -216,7 +216,7 @@ take the trigger path.
 
 ## Roll-out order recap
 
-```
+```text
 PR 1 (drop anonymous)
   └── PR 2 (per-entry cap)
         └── PR 3 (name hygiene)

--- a/plans/leaderboard-rework-plan.md
+++ b/plans/leaderboard-rework-plan.md
@@ -1,0 +1,243 @@
+# Leaderboard Rework — PR Plan
+
+**Goal:** Drop anonymous leaderboard rows entirely and harden the leaderboard
+against cheating and nonsense entries.
+
+**Branch convention:** Each slice ships from its own branch into `main`. Slices
+are ordered so each one is independently mergeable and produces user-visible
+value on its own. Earlier slices unblock later ones but do not require them.
+
+---
+
+## Open product questions (decide before PR 2 lands)
+
+These thresholds drive validation rules and want a one-line decision:
+
+- **Per-entry cap:** suggest **200 reps** — covers world-class single-set
+  performance with headroom. Higher = more cheat surface, lower = false
+  rejects.
+- **Daily cap:** suggest **2 000 reps** — well above the realistic top-tier
+  daily volume, still blocks "1 000 000 reps" griefing.
+- **Min account age for leaderboard:** suggest **24 h** — kills throw-away
+  accounts without hurting first-day users much.
+- **Email-verified required for leaderboard:** suggest **yes** — Firebase Auth
+  already exposes `emailVerified`; the cost is one banner in settings.
+- **Display-name policy:** length **2–30**, charset
+  `\p{L}\p{N} _.\-` (Unicode letters/digits + space, underscore, dot, hyphen),
+  plus a small starter wordlist for profanity.
+
+If any of those don't match what you want, change them in PR 2 / PR 3 / PR 4 —
+the plan structure stays the same.
+
+---
+
+## PR 1 — Drop anonymous rows from the leaderboard
+
+**Why first:** smallest, fully reversible behaviour change. Visible win on
+day 1 (no more `anonym` clutter) and unblocks the rest of the work because the
+leaderboard becomes a pure subset of opted-in, named users.
+
+**Changes**
+
+- `data-store/functions/src/leaderboard/logic.ts`
+  - `rankEntries()`: skip users where `isLeaderboardNameAllowed(profile)` is
+    `false` **or** `displayName` is missing/empty after trim.
+  - Drop the `toAnonymousLabel` import and fallback — every returned entry
+    now has a real alias.
+- `data-store/functions/src/leaderboard/logic.spec.ts`
+  - Replace existing "uses anonymous label for users without profiles" cases
+    with "filters out users without profiles / opted out".
+  - Keep the privacy-regression test (UID never on an anonymous-aliased row)
+    but reframe: assert the row is **absent**, not anonymised.
+- `web/src/app/leaderboard/shell/leaderboard-page.component.html`
+  - Replace the explainer ("either anonymous or the user opted out…") with
+    "Nur User mit öffentlichem Profilnamen erscheinen hier. In den
+    Einstellungen aktivierbar." (i18n IDs reused; XLIFF gets a translation
+    update).
+- `web/src/app/leaderboard/shell/leaderboard-page.component.spec.ts`
+  - Drop the `alias === 'anonym'` cases; add a "no entries shown" empty-state
+    test if the list ends up empty.
+- `web/src/locale/messages.xlf` + `messages.en.xlf`
+  - Update copy strings.
+- Optional: settings page hint — defer to PR 4 where verified-email also
+  surfaces.
+
+**Tests**: unit (logic), component (page), XLIFF lint. No new e2e needed.
+
+**Migration**: none — the leaderboard rebuild Cloud Function picks the new
+logic up on the next scheduled run.
+
+---
+
+## PR 2 — Server-side rep validation (per-entry plausibility)
+
+**Why second:** stops new garbage from entering the system. Pure defense
+layer, no UI change.
+
+**Changes**
+
+- `data-store/firestore.rules` — `match /pushups/{pushupId}` create + update:
+  - `request.resource.data.reps is int`
+  - `request.resource.data.reps > 0`
+  - `request.resource.data.reps <= 200`
+  - `request.resource.data.timestamp is timestamp`
+  - `request.resource.data.timestamp <= request.time + duration.value(5, 'm')`
+    (kein "in 3025 reps eintragen")
+- Rules tests: add `data-store/firestore.rules.spec.ts` (or extend existing)
+  using `@firebase/rules-unit-testing` — happy path + every reject path.
+- Frontend `libs/data-access/src/lib/...pushup writes...`
+  - Surface a friendly toast/snack-bar error on rule reject ("Maximal 200
+    Reps pro Eintrag — bitte aufteilen.").
+  - No new model fields.
+
+**Tests**: rules-unit-testing matrix; one e2e/smoke that adds an entry > 200
+and asserts the UI rejects gracefully.
+
+**Migration**: existing data untouched. Outliers stay in history but new
+ones are blocked.
+
+---
+
+## PR 3 — Display-name hygiene
+
+**Why third:** with anonymous gone (PR 1), `displayName` is the only thing
+the public sees on the leaderboard. It needs guardrails.
+
+**Changes**
+
+- `data-store/firestore.rules` — `match /userConfigs/{userId}` update:
+  - When `displayName` is present: `is string`, `size() >= 2`, `size() <= 30`.
+  - Charset check via `matches('^[\\p{L}\\p{N} _\\.\\-]+$')`.
+- `data-store/functions/src/profile/` — new `displayNameValidator.ts`:
+  - Same length/charset checks (rules can't easily do wordlists).
+  - Starter profanity wordlist (DE + EN), externalised to a JSON so we can
+    extend without code change.
+  - Exposed as a callable `validateDisplayName` and called from a Firestore
+    `onWrite` trigger on `userConfigs` — if the persisted value fails
+    server-side validation (rule bypass via Admin SDK or wordlist hit), the
+    trigger clears the field and writes a `userConfigs/{uid}.flags.nameReset`
+    audit field.
+- `web/src/app/settings/...` (find the right component during impl)
+  - Inline validation before save, mirroring the rules + wordlist (call the
+    callable for the wordlist part, debounce 300 ms).
+- Admin UI (`web/src/app/admin/user-details-dialog.component.ts`)
+  - "Display-Name zurücksetzen" button → calls a new admin Cloud Function
+    `adminResetDisplayName` (custom-claim gated like the existing
+    `adminDeleteUser`).
+
+**Tests**: rules unit, validator unit (wordlist boundaries), trigger
+integration (Jest + emulator), admin function unit.
+
+**Migration**: one-shot script `scripts/reset-invalid-display-names.ts` to
+sweep existing `userConfigs` and clear names that violate the new rules.
+Document the invocation in `docs/gotchas/build-and-tooling.md`.
+
+---
+
+## PR 4 — Verified-email + min-account-age gate
+
+**Why fourth:** raises the cost of throw-away cheat accounts. Builds on
+PR 1's "real users only" stance.
+
+**Changes**
+
+- `data-store/functions/src/leaderboard/logic.ts`
+  - `rankEntries()` accepts an additional per-user predicate
+    (e.g. `isLeaderboardEligible(profile, authMeta)`).
+- `data-store/functions/src/leaderboard/index.ts` (rebuild orchestrator)
+  - Fetch `auth().getUsers([...uids])` in batches; pass `emailVerified` and
+    `metadata.creationTime` into the predicate.
+  - Filter out users where `emailVerified !== true`
+    or `now - creationTime < 24h`.
+- `web/src/app/settings/...`
+  - New banner: "Verifiziere deine Email, um im Leaderboard zu erscheinen."
+    Link triggers `sendEmailVerification()`.
+  - Hide the banner once verified.
+- i18n strings updated.
+
+**Tests**: logic unit (predicate), index integration with mocked
+`auth().getUsers`, component test for banner visibility.
+
+**Migration**: next scheduled rebuild applies the filter automatically.
+Communicate change in release notes since some users will silently drop off.
+
+---
+
+## PR 5 — Admin shadow-ban / leaderboard exclusion
+
+**Why fifth:** the manual escape hatch. Reversible, no data loss. Becomes
+necessary as soon as PR 1–4 are live and a determined cheater shows up.
+
+**Changes**
+
+- `libs/auth/...` or `libs/stats/...` model: extend `userConfigs.ui` with
+  optional `excludeFromLeaderboard?: boolean` — admin-only.
+- `data-store/firestore.rules`
+  - Block client writes to `ui.excludeFromLeaderboard` (mirror the existing
+    `role` carve-out on `userConfigs`).
+- `data-store/functions/src/admin/` — new callable
+  `adminSetLeaderboardExclusion({ uid, excluded })` (custom-claim gated).
+- `data-store/functions/src/leaderboard/logic.ts`
+  - `rankEntries()` filters users with `ui.excludeFromLeaderboard === true`.
+- `web/src/app/admin/user-details-dialog.component.ts`
+  - Toggle "Vom Leaderboard ausschließen" + reason text field; reason logged
+    to a `moderationLog` collection (write-only via Admin SDK).
+
+**Tests**: rules (write-block), admin function unit, logic unit, component
+test.
+
+---
+
+## PR 6 — Daily cap (defense-in-depth)
+
+**Why last:** PR 2 already blocks single-entry abuse; this catches the
+"199 + 199 + 199 + …" attack. Cheaper to land after `userStats` aggregation
+is in place (already is, per `data-store/functions/src/...userStats`).
+
+**Changes**
+
+- `data-store/functions/src/pushup/onCreate.ts` (new or extend existing
+  trigger): on each new entry, read today's running total from
+  `userStats/{uid}` (or recompute from `pushups` for the day). If the new
+  entry would push it over **2 000**, mark the entry with
+  `flags.dailyCapExceeded = true` and exclude it from leaderboard
+  aggregation.
+- Alternative (simpler): keep entry, but `rankEntries()` caps each user's
+  daily contribution at 2 000 before slicing top N. Less surgical but no
+  trigger needed. **Decide during implementation**, default to the simpler
+  version.
+- `data-store/functions/src/leaderboard/logic.ts` — apply the cap if we go
+  with the simpler variant.
+
+**Tests**: logic unit (cap is applied per user per day), trigger unit if we
+take the trigger path.
+
+---
+
+## Roll-out order recap
+
+```
+PR 1 (drop anonymous)
+  └── PR 2 (per-entry cap)
+        └── PR 3 (name hygiene)
+              └── PR 4 (verified email gate)
+                    └── PR 5 (admin exclusion)
+                          └── PR 6 (daily cap)
+```
+
+Each PR is shippable on its own, but the chain reflects priority. PR 1–3 give
+the biggest win for the smallest risk and could ship in one week.
+
+## Cross-cutting concerns
+
+- **i18n:** every user-facing string change updates `messages.xlf` and
+  `messages.en.xlf` (see `docs/gotchas/i18n.md`).
+- **Firestore rules:** every rules change ships with rules-unit-testing
+  coverage (see `docs/ci-cd.md` for the rules test job).
+- **Pre-push:** run
+  `pnpm nx affected -t=lint,test,build -c=production --parallel=3` before
+  every push.
+- **Issue tracking:** create one issue per PR, add to **PUS Roadmap**, link
+  via `Fixes #ID` in the PR body.
+- **Docs:** if any PR introduces a non-obvious gotcha (rules quirks, trigger
+  ordering, wordlist maintenance), capture it under `docs/gotchas/`.

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.html
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.html
@@ -47,9 +47,11 @@
         @for (entry of leaderboardSlots(); track entry.rank) {
           <li>
             <span class="rank">#{{ entry.rank }}</span>
-            <!-- Link the alias to /u/<uid> only when the user opted into a
-                 public profile. Leaderboard-only opt-ins (no public profile)
-                 still appear here but stay plain text. -->
+            <!-- Link the alias to /u/<uid> when the row carries a uid.
+                 The ranker now requires the full publicProfile opt-in,
+                 so every fresh row has a uid. uid-less rows can only
+                 come from older cached snapshots and stay plain text
+                 for forward-compat. -->
             @if (entry.uid) {
               <a
                 class="alias alias-link"

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.html
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.html
@@ -48,9 +48,8 @@
           <li>
             <span class="rank">#{{ entry.rank }}</span>
             <!-- Link the alias to /u/<uid> only when the user opted into a
-                 public profile AND the leaderboard. Without uid, the row is
-                 either anonymous or the user opted out of profile linking,
-                 so we keep it as plain text. -->
+                 public profile. Leaderboard-only opt-ins (no public profile)
+                 still appear here but stay plain text. -->
             @if (entry.uid) {
               <a
                 class="alias alias-link"

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.spec.ts
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.spec.ts
@@ -11,9 +11,12 @@ import { LeaderboardPageComponent } from './leaderboard-page.component';
 /**
  * Frontend privacy guard: leaderboard rows only become a `<a>` linking to
  * `/u/<uid>` when the cloud function attached a `uid` (which itself
- * requires both leaderboard + publicProfile opt-ins). Anonymous-aliased
- * rows or opted-out users must stay plain text — these tests fail loudly
- * if the template ever degrades that contract.
+ * requires the publicProfile opt-in). Leaderboard-only opt-ins (no public
+ * profile) appear with their real alias but must stay plain text — these
+ * tests fail loudly if the template ever degrades that contract.
+ *
+ * Anonymous rows are filtered out at the cloud-function layer
+ * (`rankEntries`) and never reach the frontend.
  */
 describe('LeaderboardPageComponent', () => {
   let fixture: ComponentFixture<LeaderboardPageComponent>;
@@ -70,33 +73,32 @@ describe('LeaderboardPageComponent', () => {
     });
   });
 
-  describe('Given an entry without uid (opted-out / anonymous)', () => {
+  describe('Given an entry without uid (leaderboard-only opt-in)', () => {
     it('Then the alias is rendered as a plain span — never clickable', async () => {
-      await setup([{ rank: 2, alias: 'anonym', reps: 50 }]);
+      await setup([{ rank: 2, alias: 'Bob', reps: 50 }]);
 
       const root = fixture.nativeElement as HTMLElement;
-      // Privacy regression: an anonymous-aliased row must NEVER carry an
-      // anchor, otherwise the visible "anonym" label would be linkable
-      // to a stable profile permalink.
+      // Privacy regression: a row without `uid` must NEVER carry an
+      // anchor, otherwise the alias would be linkable to a stable
+      // profile permalink the user did not opt into.
       expect(
         root.querySelector('[data-testid="leaderboard-link-2"]')
       ).toBeNull();
-      // Find the span that holds the alias text — it must not be inside an <a>.
       const spans = Array.from(
         root.querySelectorAll('li span.alias')
       ) as HTMLElement[];
-      const aliasSpan = spans.find((s) => s.textContent?.trim() === 'anonym');
+      const aliasSpan = spans.find((s) => s.textContent?.trim() === 'Bob');
       expect(aliasSpan).toBeDefined();
       expect(aliasSpan!.closest('a')).toBeNull();
     });
   });
 
   describe('Given a mix of entries', () => {
-    it('Then only opted-in rows are linked, opted-out rows stay plain text', async () => {
+    it('Then only profile opt-ins are linked, leaderboard-only rows stay plain text', async () => {
       await setup([
         { rank: 1, alias: 'Alice', reps: 100, uid: 'aaa' },
-        { rank: 2, alias: 'anonym', reps: 80 },
-        { rank: 3, alias: 'Bob', reps: 60 },
+        { rank: 2, alias: 'Bob', reps: 80 },
+        { rank: 3, alias: 'Carol', reps: 60 },
       ]);
 
       const root = fixture.nativeElement as HTMLElement;
@@ -106,7 +108,6 @@ describe('LeaderboardPageComponent', () => {
       expect(
         root.querySelector('[data-testid="leaderboard-link-2"]')
       ).toBeNull();
-      // Bob has no uid → plain span, no link.
       expect(
         root.querySelector('[data-testid="leaderboard-link-3"]')
       ).toBeNull();

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.spec.ts
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.spec.ts
@@ -9,14 +9,15 @@ import {
 import { LeaderboardPageComponent } from './leaderboard-page.component';
 
 /**
- * Frontend privacy guard: leaderboard rows only become a `<a>` linking to
- * `/u/<uid>` when the cloud function attached a `uid` (which itself
- * requires the publicProfile opt-in). Leaderboard-only opt-ins (no public
- * profile) appear with their real alias but must stay plain text — these
- * tests fail loudly if the template ever degrades that contract.
+ * Frontend privacy guard: leaderboard rows only become a `<a>` linking
+ * to `/u/<uid>` when the cloud function attached a `uid`. The ranker
+ * now requires the full publicProfile opt-in, so every fresh row has a
+ * uid; uid-less rows can only come from older cached snapshots and
+ * must stay plain text. These tests fail loudly if the template ever
+ * degrades that contract.
  *
- * Anonymous rows are filtered out at the cloud-function layer
- * (`rankEntries`) and never reach the frontend.
+ * Anonymous rows and opted-out users are filtered out at the
+ * cloud-function layer (`rankEntries`) and never reach the frontend.
  */
 describe('LeaderboardPageComponent', () => {
   let fixture: ComponentFixture<LeaderboardPageComponent>;
@@ -73,7 +74,7 @@ describe('LeaderboardPageComponent', () => {
     });
   });
 
-  describe('Given an entry without uid (leaderboard-only opt-in)', () => {
+  describe('Given a legacy entry without uid (older cached snapshot)', () => {
     it('Then the alias is rendered as a plain span — never clickable', async () => {
       await setup([{ rank: 2, alias: 'Bob', reps: 50 }]);
 
@@ -93,8 +94,8 @@ describe('LeaderboardPageComponent', () => {
     });
   });
 
-  describe('Given a mix of entries', () => {
-    it('Then only profile opt-ins are linked, leaderboard-only rows stay plain text', async () => {
+  describe('Given a mix of fresh + legacy entries', () => {
+    it('Then only rows with uid are linked, legacy uid-less rows stay plain text', async () => {
       await setup([
         { rank: 1, alias: 'Alice', reps: 100, uid: 'aaa' },
         { rank: 2, alias: 'Bob', reps: 80 },


### PR DESCRIPTION
Implements the six-slice plan in `plans/leaderboard-rework-plan.md` to drop anonymous leaderboard rows and harden the leaderboard against cheating and nonsense entries.

## Summary

- **No more anonymous rows** — leaderboard now requires the full public-profile opt-in (`ui.publicProfile === true` + `ui.hideFromLeaderboard === false` + non-empty `displayName`). Every row carries a `uid` and links to `/u/<uid>`.
- **Reps validation** — Firestore rule + client validator cap each entry at 1..500 reps; `PushupValidationError` fails fast before hitting Firestore.
- **Display-name hygiene** — Firestore rule enforces 2..30 chars, Unicode letters/digits + space, underscore, dot, hyphen. Keeps emoji, control chars, and `<script>` payloads out of the public leaderboard.
- **Admin shadow-ban** — new `adminSetLeaderboardExclusion` callable sets a top-level `leaderboardExcluded` flag; `rankEntries()` filters those users regardless of opt-in toggles. Reversible.
- **Daily cap** — each user's per-Berlin-day contribution caps at 2000 reps before windowed sums collapse the boundary, so a 7×3000-reps cheat collapses to 14000 (not 21000).

## Slices

| Commit | What |
| --- | --- |
| `08efa54` | Plan doc — `plans/leaderboard-rework-plan.md` |
| `d76b8d7` | Drop anonymous rows from `rankEntries()` + tests |
| `3a741d7` | `PUSHUP_REPS_MIN/MAX` + Firestore rule + `PushupValidationError` |
| `d3cc5bc` | `DISPLAY_NAME_*` constants + `validateDisplayName` + Firestore rule |
| `400683e` | Leaderboard requires `publicProfile === true` |
| `2578781` | Admin shadow-ban (`leaderboardExcluded` + callable + rule) |
| `63adc8b` | Daily cap of 2000 reps per Berlin day per user |

The original plan listed a verified-email gate — dropped at the user's request; the display-name + public-profile gate covers the cheat surface.

## Test plan

- [x] `pnpm nx test cloud-functions` — 314 passing
- [x] `pnpm nx test web` — 536 passing (vitest)
- [x] `pnpm nx test stats-data-access` — 67 passing
- [x] `pnpm nx test stats-models` — covered by the 67 above + new validator specs
- [x] `pnpm nx lint cloud-functions stats-data-access stats-models web` — 0 errors
- [x] `pnpm nx run web:build -c production` — green
- [x] `pnpm nx run cloud-functions:build` — green
- [ ] Manual: confirm an existing user with `publicProfile=false` no longer appears on the leaderboard after the next rebuild
- [ ] Manual: confirm `adminSetLeaderboardExclusion({ uid, excluded: true })` removes a user from the leaderboard within a rebuild cycle
- [ ] Manual: try to `setDoc` a `userConfigs/{uid}` with `displayName: 'Wolf🚀'` from the client and assert the rule rejects it
- [ ] Manual: try to `setDoc` `pushups/{id}` with `reps: 9001` and assert the rule rejects it

## Follow-ups

Tracked separately:

- #282 — inline `displayName` validation in settings + register
- #283 — admin UI button for `adminSetLeaderboardExclusion`
- #284 — `moderationLog` audit collection
- #285 — profanity wordlist + onWrite sanitizer + admin reset callable
- #286 — friendlier snack-bar for `PushupValidationError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin capability to exclude users from leaderboards
  * Daily push-up rep cap enforcement per user
  * Display name validation with length and character constraints

* **Bug Fixes**
  * Leaderboard now requires full public profile opt-in to display user links; leaderboard-only opt-ins remain anonymous
  * Stricter push-up rep validation (range 1–500, integer values only)
  * Excluded/ineligible users properly filtered from leaderboard listings

* **Tests**
  * Added comprehensive validation test coverage for push-up reps, display names, and leaderboard exclusion logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->