### PR TITLE
feat(reminders): drop quote-language setting, support all locales, tier quotes

### DIFF
--- a/data-store/firebase.json
+++ b/data-store/firebase.json
@@ -67,6 +67,38 @@
       {
         "source": "/en{,/**}",
         "destination": "/en/index.html"
+      },
+      {
+        "source": "/fr{,/**}",
+        "destination": "/fr/index.html"
+      },
+      {
+        "source": "/es{,/**}",
+        "destination": "/es/index.html"
+      },
+      {
+        "source": "/it{,/**}",
+        "destination": "/it/index.html"
+      },
+      {
+        "source": "/nl{,/**}",
+        "destination": "/nl/index.html"
+      },
+      {
+        "source": "/el{,/**}",
+        "destination": "/el/index.html"
+      },
+      {
+        "source": "/la{,/**}",
+        "destination": "/la/index.html"
+      },
+      {
+        "source": "/no{,/**}",
+        "destination": "/no/index.html"
+      },
+      {
+        "source": "/zh{,/**}",
+        "destination": "/zh/index.html"
       }
     ],
     "headers": [

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -1,6 +1,6 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import type { UserStats } from '@pu-stats/models';
-import { USERSTATS_VERSION } from '@pu-stats/models';
+import { normalizeReminderLocale, USERSTATS_VERSION } from '@pu-stats/models';
 import * as Sentry from '@sentry/node';
 import * as admin from 'firebase-admin';
 import { logger } from 'firebase-functions';
@@ -22,9 +22,11 @@ import {
 import { berlinDateParts } from './datetime';
 import { getLeaderboardQueryStartDate, rankEntries } from './leaderboard';
 import {
-  FALLBACK_QUOTES_DE,
-  FALLBACK_QUOTES_EN,
+  flattenTiers,
+  getFallbackTieredQuotes,
   QUOTE_CACHE_HOURS,
+  QUOTE_TIERS,
+  type TieredQuotes,
 } from './motivation';
 import {
   buildPublicProfile,
@@ -673,6 +675,103 @@ export const ogProfile = onRequest(
 
 // ─── generateMotivationQuotes ─────────────────────────────────────────────────
 
+/**
+ * Per-tier prompt instruction (tone) — appended to the language-agnostic
+ * prompt so the model produces tiered output in a single Gemini call.
+ * Keeping it in English (no German wording) lets the same map drive every
+ * supported locale; the model is told the *output* language separately.
+ */
+const TIER_INSTRUCTIONS: Record<string, string> = {
+  general: 'general motivation, fitness vibe',
+  belowGoal: 'encouraging "let’s start" / "you can do it" tone',
+  nearGoal: 'push-through tone, halfway-there energy',
+  goalReached: 'celebration + "next-level" challenge tone',
+};
+
+const QUOTES_PER_TIER = 6;
+
+/**
+ * BCP-47 display names used in the Gemini prompt so the model produces
+ * quotes in the requested locale even for tags without obvious instruction
+ * (la, no, zh, …). Falls back to the locale code itself.
+ */
+const LANGUAGE_PROMPT_NAMES: Record<string, string> = {
+  de: 'German',
+  en: 'English',
+  fr: 'French',
+  es: 'Spanish',
+  it: 'Italian',
+  nl: 'Dutch',
+  el: 'Greek',
+  la: 'Latin',
+  no: 'Norwegian',
+  zh: 'Simplified Chinese',
+};
+
+function buildTieredPrompt(
+  language: string,
+  totalToday: number,
+  dailyGoal: number,
+  displayName: string
+): string {
+  const langName = LANGUAGE_PROMPT_NAMES[language] ?? language;
+  const tierLines = QUOTE_TIERS.map(
+    (tier) =>
+      `  "${tier}": ${QUOTES_PER_TIER} short sentences — ${TIER_INSTRUCTIONS[tier]}`
+  ).join('\n');
+  return [
+    `Generate motivational push-up quotes in ${langName} for ${displayName}, who has done ${totalToday} of ${dailyGoal} push-ups today.`,
+    'Each quote must be ≤ 120 characters. Vary tone (sporty, funny, serious).',
+    'Return ONLY a JSON object with these keys (no markdown, no commentary):',
+    tierLines,
+    'Example shape: {"general":["..."],"belowGoal":["..."],"nearGoal":["..."],"goalReached":["..."]}',
+  ].join('\n');
+}
+
+function extractTieredQuotes(text: string): TieredQuotes | null {
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonMatch[0]);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+
+  const result: TieredQuotes = {
+    general: [],
+    belowGoal: [],
+    nearGoal: [],
+    goalReached: [],
+  };
+  let hasAny = false;
+  for (const tier of QUOTE_TIERS) {
+    const raw = obj[tier];
+    if (Array.isArray(raw)) {
+      const cleaned = raw
+        .map((q) => (typeof q === 'string' ? q : String(q ?? '')))
+        .map((q) => q.trim())
+        .filter((q) => q.length > 0);
+      if (cleaned.length > 0) hasAny = true;
+      result[tier] = cleaned;
+    }
+  }
+  return hasAny ? result : null;
+}
+
+interface CachedTiered {
+  uid: string;
+  lang: string;
+  generatedAt: string;
+  tiers: TieredQuotes;
+  /** Flat array kept for legacy clients that only read `quotes`. */
+  quotes: string[];
+  totalToday: number;
+  dailyGoal: number;
+}
+
 export const generateMotivationQuotes = onCall(
   { region: 'europe-west3' },
   async (request) => {
@@ -681,7 +780,7 @@ export const generateMotivationQuotes = onCall(
     }
 
     const uid = request.auth.uid;
-    const language = String(request.data?.language || 'de');
+    const language = normalizeReminderLocale(request.data?.language);
     const totalToday = Number(request.data?.totalToday ?? 0);
     const dailyGoal = Number(request.data?.dailyGoal ?? 100);
     const rawName = String(request.data?.displayName || '').trim();
@@ -696,7 +795,11 @@ export const generateMotivationQuotes = onCall(
       .doc(`${uid}__${language}`);
     const cacheSnap = await cacheRef.get();
     if (cacheSnap.exists) {
-      const cached = cacheSnap.data() ?? {};
+      const cached = (cacheSnap.data() ?? {}) as {
+        generatedAt?: string;
+        tiers?: TieredQuotes;
+        quotes?: ReadonlyArray<unknown>;
+      };
       const generatedAt = cached.generatedAt
         ? new Date(cached.generatedAt)
         : null;
@@ -704,16 +807,27 @@ export const generateMotivationQuotes = onCall(
         const ageHours =
           (Date.now() - generatedAt.getTime()) / (1000 * 60 * 60);
         if (ageHours < QUOTE_CACHE_HOURS) {
-          const cachedQuotes = (
-            (cached.quotes || []) as Array<{ text?: string }>
-          ).map((q) => q.text || q);
-          return { quotes: cachedQuotes };
+          // Prefer the tiered shape; fall back to legacy flat `quotes`
+          // so older cache docs keep working until the next refresh.
+          if (cached.tiers) {
+            return {
+              quotes: flattenTiers(cached.tiers),
+              tiers: cached.tiers,
+            };
+          }
+          const flat = (cached.quotes ?? []).map((q) =>
+            typeof q === 'string'
+              ? q
+              : typeof q === 'object' && q !== null && 'text' in q
+                ? String((q as { text?: unknown }).text ?? '')
+                : String(q ?? '')
+          );
+          return { quotes: flat };
         }
       }
     }
 
-    let quotes: string[] =
-      language === 'en' ? [...FALLBACK_QUOTES_EN] : [...FALLBACK_QUOTES_DE];
+    let tiers: TieredQuotes = getFallbackTieredQuotes(language);
 
     try {
       const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY ?? '');
@@ -721,33 +835,16 @@ export const generateMotivationQuotes = onCall(
         model: 'gemini-2.0-flash-lite',
       });
 
-      let prompt: string;
-      if (language === 'en') {
-        prompt =
-          `Generate exactly 10 short motivating sentences (max 120 chars each) in English for {{name}} who already did ${totalToday} of ${dailyGoal} push-ups today. Use '{{name}}' as placeholder where fitting. Vary tone (sporty, funny, serious). Return only a JSON array: ["..."]`.replace(
-            /\{\{name\}\}/g,
-            displayName
-          );
-      } else {
-        prompt =
-          `Generiere genau 10 kurze motivierende Sätze (je max. 120 Zeichen) auf Deutsch für {{name}}, der heute schon ${totalToday} von ${dailyGoal} Liegestützen gemacht hat. Verwende '{{name}}' als Platzhalter wo passend. Variiere Ton (sportlich, humorvoll, ernst). Gib nur ein JSON-Array zurück: ["..."]`.replace(
-            /\{\{name\}\}/g,
-            displayName
-          );
-      }
-
+      const prompt = buildTieredPrompt(
+        language,
+        totalToday,
+        dailyGoal,
+        displayName
+      );
       const result = await model.generateContent(prompt);
       const text = result.response.text().trim();
-
-      const jsonMatch = text.match(/\[[\s\S]*\]/);
-      if (jsonMatch) {
-        const parsed = JSON.parse(jsonMatch[0]);
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          quotes = parsed
-            .map(String)
-            .filter((q: string) => q.trim().length > 0);
-        }
-      }
+      const parsed = extractTieredQuotes(text);
+      if (parsed) tiers = parsed;
     } catch (err) {
       logger.warn(
         'generateMotivationQuotes: Gemini call failed, using fallback',
@@ -755,16 +852,20 @@ export const generateMotivationQuotes = onCall(
       );
     }
 
+    const flat = flattenTiers(tiers);
     const generatedAt = new Date().toISOString();
-    await cacheRef.set({
+    const docPayload: CachedTiered = {
       uid,
-      quotes: quotes.map((text) => ({ text, lang: language })),
+      lang: language,
+      tiers,
+      quotes: flat,
       generatedAt,
       totalToday,
       dailyGoal,
-    });
+    };
+    await cacheRef.set(docPayload);
 
-    return { quotes };
+    return { quotes: flat, tiers };
   }
 );
 
@@ -925,6 +1026,53 @@ export const revokeAllSessions = onCall({ region: 'europe-west3' }, (request) =>
 const VAPID_PRIVATE_KEY = defineSecret('VAPID_PRIVATE_KEY');
 const VAPID_PUBLIC_KEY = defineSecret('VAPID_PUBLIC_KEY');
 
+/**
+ * Reads the cached motivation pool a user has for `lang` and returns a
+ * flat list of quote strings. Tolerant of legacy doc shapes (flat
+ * `quotes: string[]` / `quotes: {text}[]`) and the new tiered shape.
+ * Returns an empty array on any error so the caller falls back to the
+ * built-in localised messages.
+ */
+async function loadMotivationPool(
+  uid: string,
+  lang: string
+): Promise<string[]> {
+  try {
+    const snap = await db
+      .collection('motivationQuotes')
+      .doc(`${uid}__${lang}`)
+      .get();
+    if (!snap.exists) return [];
+    const data = snap.data() as
+      | {
+          tiers?: TieredQuotes;
+          quotes?: ReadonlyArray<unknown>;
+        }
+      | undefined;
+    if (!data) return [];
+    if (data.tiers) return flattenTiers(data.tiers);
+    if (Array.isArray(data.quotes)) {
+      return data.quotes
+        .map((q) =>
+          typeof q === 'string'
+            ? q
+            : typeof q === 'object' && q !== null && 'text' in q
+              ? String((q as { text?: unknown }).text ?? '')
+              : String(q ?? '')
+        )
+        .filter((q) => q.trim().length > 0);
+    }
+    return [];
+  } catch (err) {
+    logger.warn('loadMotivationPool: failed', {
+      uid,
+      lang,
+      err: (err as Error).message,
+    });
+    return [];
+  }
+}
+
 export const dispatchPushReminders = onSchedule(
   {
     schedule: 'every 5 minutes',
@@ -964,9 +1112,12 @@ export const dispatchPushReminders = onSchedule(
           .collection('userConfigs')
           .doc(uid)
           .get();
-        const reminder = userConfigSnap.data()?.reminder as
-          | ReminderConfig
-          | undefined;
+        const userConfigData = userConfigSnap.data() ?? {};
+        const reminder = userConfigData.reminder as ReminderConfig | undefined;
+        // The user's preferred app locale is persisted alongside the
+        // reminder by the client (`ReminderStore.saveConfig`). Server has
+        // no LOCALE_ID, so without this we would have to guess.
+        const userLocale = normalizeReminderLocale(userConfigData.locale);
 
         const dispatchRef = db.collection('reminderDispatchState').doc(uid);
         let leaseAcquired = false;
@@ -1029,15 +1180,22 @@ export const dispatchPushReminders = onSchedule(
             continue;
           }
 
-          const body = buildNotificationPayload(reminder?.language);
-          const lang = reminder?.language === 'en' ? 'en' : 'de';
+          // Pull the body from the user's pre-generated motivation pool —
+          // that pool is locale-aware (`generateMotivationQuotes` writes
+          // `motivationQuotes/{uid}__{lang}`) and the Gemini cost is
+          // already paid when the user opens the dashboard, so we get
+          // fresh, personalised quotes on push without spending any new
+          // tokens. Fallback to the per-locale built-in list if the cache
+          // is empty (user hasn't opened the app yet today).
+          const pool = await loadMotivationPool(uid, userLocale);
+          const body = buildNotificationPayload(userLocale, pool);
           // Single source of truth: sanitize once, then use the same value for
           // both the action title and the data payload. Computing them
           // independently caused the title to clamp to 500 while the payload
           // shipped the raw (potentially absurd) Firestore value, so the SW
           // logged a different count than the user saw on the button.
           const quickLogReps = sanitizeQuickLogReps(reminder?.quickLogReps);
-          const actions = buildReminderActions(lang, quickLogReps);
+          const actions = buildReminderActions(userLocale, quickLogReps);
           const payload = JSON.stringify({
             title: 'PushUp Stats',
             body,
@@ -1046,8 +1204,8 @@ export const dispatchPushReminders = onSchedule(
             tag: 'reminder',
             renotify: true,
             data: {
-              url: `/${lang}/app`,
-              locale: lang,
+              url: `/${userLocale}/app`,
+              locale: userLocale,
               ...(quickLogReps ? { quickLogReps } : {}),
             },
             actions,

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -681,7 +681,7 @@ export const ogProfile = onRequest(
  * Keeping it in English (no German wording) lets the same map drive every
  * supported locale; the model is told the *output* language separately.
  */
-const TIER_INSTRUCTIONS: Record<string, string> = {
+const TIER_INSTRUCTIONS: Record<(typeof QUOTE_TIERS)[number], string> = {
   general: 'general motivation, fitness vibe',
   belowGoal: 'encouraging "let’s start" / "you can do it" tone',
   nearGoal: 'push-through tone, halfway-there energy',
@@ -1064,10 +1064,13 @@ async function loadMotivationPool(
     }
     return [];
   } catch (err) {
+    // Defensive against non-Error throws (string, null, etc.) — we don't
+    // want the logger itself to throw and surface as an unhandled
+    // rejection in the dispatch loop.
     logger.warn('loadMotivationPool: failed', {
       uid,
       lang,
-      err: (err as Error).message,
+      err: err instanceof Error ? err.message : String(err),
     });
     return [];
   }
@@ -1114,10 +1117,18 @@ export const dispatchPushReminders = onSchedule(
           .get();
         const userConfigData = userConfigSnap.data() ?? {};
         const reminder = userConfigData.reminder as ReminderConfig | undefined;
-        // The user's preferred app locale is persisted alongside the
-        // reminder by the client (`ReminderStore.saveConfig`). Server has
-        // no LOCALE_ID, so without this we would have to guess.
-        const userLocale = normalizeReminderLocale(userConfigData.locale);
+        // Prefer the explicit top-level `locale` written by recent clients.
+        // Fall back to the legacy `reminder.language` field on docs created
+        // before that field migrated up — without this, a user who set
+        // English reminders and never re-saved settings would silently
+        // start receiving German push body / actions / URLs after deploy.
+        // Final fallback (`undefined`) lands on the default locale via
+        // `normalizeReminderLocale`.
+        const legacyLanguage = (reminder as { language?: unknown } | undefined)
+          ?.language;
+        const userLocale = normalizeReminderLocale(
+          userConfigData.locale ?? legacyLanguage
+        );
 
         const dispatchRef = db.collection('reminderDispatchState').doc(uid);
         let leaseAcquired = false;

--- a/data-store/functions/src/motivation/logic.spec.ts
+++ b/data-store/functions/src/motivation/logic.spec.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from '@jest/globals';
 import {
+  flattenTiers,
   getFallbackQuotes,
+  getFallbackTieredQuotes,
+  pickAchievementTier,
   sanitizeDisplayName,
   extractJsonArray,
   filterValidQuotes,
   isCacheValid,
+  QUOTE_TIERS,
   FALLBACK_QUOTES_DE,
   FALLBACK_QUOTES_EN,
 } from './logic';
@@ -21,9 +25,12 @@ describe('motivation/logic', () => {
       expect(quotes).toEqual(FALLBACK_QUOTES_EN);
     });
 
-    it('defaults to German for unknown language', () => {
+    it('defaults to English for unknown locale (broadest reach)', () => {
+      // Was German for unknown locales — switched to English when
+      // multi-locale support landed; English is more universally
+      // recognised than German for users browsing in fr/es/it/etc.
       const quotes = getFallbackQuotes('fr');
-      expect(quotes).toEqual(FALLBACK_QUOTES_DE);
+      expect(quotes).toEqual(FALLBACK_QUOTES_EN);
     });
 
     it('returns new array on each call', () => {
@@ -31,6 +38,74 @@ describe('motivation/logic', () => {
       const quotes2 = getFallbackQuotes('de');
       expect(quotes1).not.toBe(quotes2); // Different array instances
       expect(quotes1).toEqual(quotes2); // Same content
+    });
+  });
+
+  describe('getFallbackTieredQuotes', () => {
+    it('returns a populated quote list for every tier (de)', () => {
+      const tiered = getFallbackTieredQuotes('de');
+      for (const tier of QUOTE_TIERS) {
+        expect(tiered[tier].length).toBeGreaterThan(0);
+      }
+    });
+
+    it('returns a populated quote list for every tier (en)', () => {
+      const tiered = getFallbackTieredQuotes('en');
+      for (const tier of QUOTE_TIERS) {
+        expect(tiered[tier].length).toBeGreaterThan(0);
+      }
+    });
+
+    it('falls back to English for unsupported locales', () => {
+      const tiered = getFallbackTieredQuotes('fr');
+      expect(tiered.general).toEqual(getFallbackTieredQuotes('en').general);
+    });
+
+    it('returns deep-copied arrays so mutation does not bleed', () => {
+      const a = getFallbackTieredQuotes('de');
+      a.general.push('mutated');
+      const b = getFallbackTieredQuotes('de');
+      expect(b.general).not.toContain('mutated');
+    });
+  });
+
+  describe('pickAchievementTier', () => {
+    it('picks belowGoal at < 50 % progress', () => {
+      expect(pickAchievementTier(10, 100)).toBe('belowGoal');
+    });
+
+    it('picks nearGoal at exactly 50 % progress', () => {
+      expect(pickAchievementTier(50, 100)).toBe('nearGoal');
+    });
+
+    it('picks nearGoal at 80 % progress', () => {
+      expect(pickAchievementTier(80, 100)).toBe('nearGoal');
+    });
+
+    it('picks goalReached at exactly 100 % progress', () => {
+      expect(pickAchievementTier(100, 100)).toBe('goalReached');
+    });
+
+    it('picks goalReached when over the goal', () => {
+      expect(pickAchievementTier(250, 100)).toBe('goalReached');
+    });
+
+    it('falls back to general for invalid input', () => {
+      expect(pickAchievementTier(NaN, 100)).toBe('general');
+      expect(pickAchievementTier(10, 0)).toBe('general');
+      expect(pickAchievementTier(10, -1)).toBe('general');
+    });
+  });
+
+  describe('flattenTiers', () => {
+    it('concatenates tiers in canonical order', () => {
+      const result = flattenTiers({
+        general: ['g1'],
+        belowGoal: ['b1'],
+        nearGoal: ['n1'],
+        goalReached: ['r1'],
+      });
+      expect(result).toEqual(['g1', 'b1', 'n1', 'r1']);
     });
   });
 

--- a/data-store/functions/src/motivation/logic.ts
+++ b/data-store/functions/src/motivation/logic.ts
@@ -5,6 +5,25 @@
 
 export const QUOTE_CACHE_HOURS = 12;
 
+/**
+ * Achievement tiers used for daily-goal-aware motivational quotes.
+ *
+ * - `belowGoal` — encouragement / "let's go" / "you can do it" framing.
+ *   Used when the user has not yet hit their daily goal.
+ * - `nearGoal` — push-through framing. Used at ≥50 % progress.
+ * - `goalReached` — celebration / next-level framing. Used at ≥100 %.
+ * - `general` — generic motivation, locale-agnostic.
+ */
+export const QUOTE_TIERS = [
+  'general',
+  'belowGoal',
+  'nearGoal',
+  'goalReached',
+] as const;
+export type QuoteTier = (typeof QUOTE_TIERS)[number];
+
+export type TieredQuotes = Record<QuoteTier, string[]>;
+
 export const FALLBACK_QUOTES_DE = [
   'Du schaffst das! Jede Liegestütze bringt dich weiter.',
   'Stark sein heißt, auch wenn es schwer fällt, weiterzumachen.',
@@ -21,13 +40,95 @@ export const FALLBACK_QUOTES_EN = [
   'Today is the best day for a new personal best!',
 ];
 
+const FALLBACK_TIERS_DE: TieredQuotes = {
+  general: FALLBACK_QUOTES_DE,
+  belowGoal: [
+    'Los geht’s – die ersten Liegestütze warten!',
+    'Anfangen ist die halbe Miete. 💪',
+    'Kleiner Schritt jetzt, großer Sprung später.',
+  ],
+  nearGoal: [
+    'Schon über die Hälfte – jetzt nicht nachlassen!',
+    'Das Tagesziel ist zum Greifen nah. 🔥',
+    'Noch ein paar – du packst das!',
+  ],
+  goalReached: [
+    'Tagesziel geschafft! Ein Bonus-Set?',
+    'Stark! Jetzt noch eine Schippe drauf? 💥',
+    'Champion-Mode aktiviert – weitermachen!',
+  ],
+};
+
+const FALLBACK_TIERS_EN: TieredQuotes = {
+  general: FALLBACK_QUOTES_EN,
+  belowGoal: [
+    'Let’s go — the first push-ups are calling!',
+    'Starting is half the battle. 💪',
+    'Small step now, big jump later.',
+  ],
+  nearGoal: [
+    'Past halfway — don’t slow down now!',
+    'Your daily goal is within reach. 🔥',
+    'A few more — you’ve got this!',
+  ],
+  goalReached: [
+    'Daily goal smashed! Bonus set?',
+    'Strong! Add another round? 💥',
+    'Champion mode activated — keep going!',
+  ],
+};
+
 /**
- * Gets fallback quotes for a language
- * @param language Language code ('en' or 'de')
- * @returns Array of fallback quote strings
+ * Gets fallback quotes for a locale primary subtag.
+ * Unknown locales fall back to English (broadest reach).
  */
 export function getFallbackQuotes(language: string): string[] {
-  return language === 'en' ? [...FALLBACK_QUOTES_EN] : [...FALLBACK_QUOTES_DE];
+  if (language === 'de') return [...FALLBACK_QUOTES_DE];
+  return [...FALLBACK_QUOTES_EN];
+}
+
+/**
+ * Gets tiered fallback quotes for a locale primary subtag. Used when the
+ * Gemini call fails — keeps server-side push reminders working with
+ * sensible localised copy in de/en, and English elsewhere.
+ */
+export function getFallbackTieredQuotes(language: string): TieredQuotes {
+  const src = language === 'de' ? FALLBACK_TIERS_DE : FALLBACK_TIERS_EN;
+  return {
+    general: [...src.general],
+    belowGoal: [...src.belowGoal],
+    nearGoal: [...src.nearGoal],
+    goalReached: [...src.goalReached],
+  };
+}
+
+/**
+ * Picks the achievement tier for the current `(totalToday, dailyGoal)`.
+ * Encapsulates the threshold logic so the same tiering is applied
+ * everywhere (push dispatcher, in-app reminder, dashboard).
+ */
+export function pickAchievementTier(
+  totalToday: number,
+  dailyGoal: number
+): QuoteTier {
+  if (!Number.isFinite(totalToday) || !Number.isFinite(dailyGoal)) {
+    return 'general';
+  }
+  if (dailyGoal <= 0) return 'general';
+  const ratio = totalToday / dailyGoal;
+  if (ratio >= 1) return 'goalReached';
+  if (ratio >= 0.5) return 'nearGoal';
+  return 'belowGoal';
+}
+
+/** Flattens tiered quotes into a single array preserving tier order. */
+export function flattenTiers(tiers: TieredQuotes): string[] {
+  return [
+    ...tiers.general,
+    ...tiers.belowGoal,
+    ...tiers.nearGoal,
+    ...tiers.goalReached,
+  ];
 }
 
 /**

--- a/data-store/functions/src/push/reminders.spec.ts
+++ b/data-store/functions/src/push/reminders.spec.ts
@@ -260,7 +260,28 @@ describe('push/reminders', () => {
       expect(englishMessages).toContain(message);
     });
 
-    it('returns German message for unknown language', () => {
+    it('returns a French message when language is "fr"', () => {
+      const message = buildNotificationPayload('fr');
+      expect(message).toMatch(/pomp/i);
+    });
+
+    it('returns a Spanish message when language is "es"', () => {
+      const message = buildNotificationPayload('es');
+      expect(message).toMatch(/flexi/i);
+    });
+
+    it('returns an Italian message when language is "it"', () => {
+      const message = buildNotificationPayload('it');
+      expect(message).toMatch(/push-up/i);
+    });
+
+    it('returns a Chinese message when language is "zh"', () => {
+      const message = buildNotificationPayload('zh');
+      // 俯卧撑 = "push-up" in zh
+      expect(message).toContain('俯卧撑');
+    });
+
+    it('falls back to default locale message for an unsupported language', () => {
       const germanMessages = [
         'Zeit für Liegestütze! 💪',
         'Kurze Pause? Perfekt für Liegestütze!',
@@ -269,31 +290,30 @@ describe('push/reminders', () => {
         'Dein Körper ruft: Liegestütze, los!',
       ];
 
-      const message = buildNotificationPayload('fr');
+      // 'xx' is not a supported reminder locale → normalises to default (de)
+      const message = buildNotificationPayload('xx');
       expect(germanMessages).toContain(message);
     });
 
-    it('returns one of the available messages', () => {
-      const allMessages = [
-        'Zeit für Liegestütze! 💪',
-        'Kurze Pause? Perfekt für Liegestütze!',
-        'Du schaffst das – ein paar Liegestütze!',
-        'Beweg dich! Liegestütze warten auf dich. 🔥',
-        'Dein Körper ruft: Liegestütze, los!',
+    it('prefers a quote from the supplied pool over the built-in list', () => {
+      const pool = ['Pool quote 1', 'Pool quote 2'];
+      // Repeat to make sure it never picks something off-pool
+      for (let i = 0; i < 20; i++) {
+        const message = buildNotificationPayload('de', pool);
+        expect(pool).toContain(message);
+      }
+    });
+
+    it('falls back to the built-in list when the pool is empty', () => {
+      const englishMessages = [
         'Time for push-ups! 💪',
         'Quick break? Perfect for push-ups!',
         'You got this – a few push-ups!',
         'Move it! Push-ups are waiting for you. 🔥',
         'Your body calls: push-ups, go!',
       ];
-
-      // Test multiple times to check randomness
-      for (let i = 0; i < 20; i++) {
-        const message = buildNotificationPayload(
-          Math.random() > 0.5 ? 'en' : 'de'
-        );
-        expect(allMessages).toContain(message);
-      }
+      const message = buildNotificationPayload('en', []);
+      expect(englishMessages).toContain(message);
     });
   });
 
@@ -510,6 +530,37 @@ describe('push/reminders', () => {
     it('falls back to generic log when quickLogReps is invalid', () => {
       const actions = buildReminderActions('de', NaN);
       expect(actions[1].action).toBe('log');
+    });
+
+    it('returns French snooze + log labels when locale is "fr"', () => {
+      const actions = buildReminderActions('fr', undefined);
+      expect(actions[0]).toEqual({
+        action: 'snooze',
+        title: '⏰ Reporter 30 min',
+      });
+      expect(actions[1]).toEqual({
+        action: 'log',
+        title: '✅ Enregistrer',
+      });
+    });
+
+    it('returns Chinese snooze + log labels when locale is "zh"', () => {
+      const actions = buildReminderActions('zh', undefined);
+      expect(actions[0].title).toContain('30');
+      expect(actions[1].title).toContain('记录');
+    });
+
+    it('normalises a regional tag (en-US) to its primary subtag', () => {
+      const actions = buildReminderActions('en-US', 12);
+      expect(actions[1]).toEqual({ action: 'quick-log', title: '✅ Log 12' });
+    });
+
+    it('falls back to the default locale for unsupported tags', () => {
+      const actions = buildReminderActions('xx', undefined);
+      expect(actions).toEqual([
+        { action: 'snooze', title: '⏰ 30 Min snoozen' },
+        { action: 'log', title: '✅ Eintragen' },
+      ]);
     });
   });
 });

--- a/data-store/functions/src/push/reminders.ts
+++ b/data-store/functions/src/push/reminders.ts
@@ -3,6 +3,14 @@
  * Pure logic for reminder scheduling and notification content
  */
 
+import {
+  normalizeReminderLocale,
+  reminderBodyChoices,
+  reminderLogLabel,
+  reminderQuickLogLabel,
+  reminderSnoozeLabel,
+} from '@pu-stats/models';
+
 const TZ = 'Europe/Berlin';
 
 export interface ReminderConfig {
@@ -10,7 +18,6 @@ export interface ReminderConfig {
   timezone?: string;
   quietHours?: Array<{ from: string; to: string }>;
   intervalMinutes?: number;
-  language?: string;
   /** One-tap pushup count surfaced as a notification action. */
   quickLogReps?: number;
 }
@@ -219,24 +226,21 @@ export function buildReminderActions(
   language: string | undefined,
   quickLogReps: number | undefined
 ): NotificationAction[] {
-  const lang = language === 'en' ? 'en' : 'de';
-  const snooze: NotificationAction =
-    lang === 'en'
-      ? { action: 'snooze', title: '⏰ Snooze 30 min' }
-      : { action: 'snooze', title: '⏰ 30 Min snoozen' };
+  const locale = normalizeReminderLocale(language);
+  const snooze: NotificationAction = {
+    action: 'snooze',
+    title: reminderSnoozeLabel(locale),
+  };
 
   const reps = sanitizeQuickLogReps(quickLogReps);
   if (reps) {
-    const title =
-      lang === 'en' ? `✅ Log ${reps}` : `✅ ${reps} eintragen`;
-    return [snooze, { action: 'quick-log', title }];
+    return [
+      snooze,
+      { action: 'quick-log', title: reminderQuickLogLabel(locale, reps) },
+    ];
   }
 
-  const log: NotificationAction =
-    lang === 'en'
-      ? { action: 'log', title: '✅ Log push-ups' }
-      : { action: 'log', title: '✅ Eintragen' };
-  return [snooze, log];
+  return [snooze, { action: 'log', title: reminderLogLabel(locale) }];
 }
 
 /**
@@ -253,29 +257,23 @@ export function sanitizeQuickLogReps(
 }
 
 /**
- * Builds a random motivational push notification message
- * @param language Language code ('en' or 'de', defaults to 'de')
- * @returns Random notification message for the language
+ * Builds a motivational push notification body. Prefers a quote from the
+ * caller-provided pool (the AI-generated cache shared with the in-app
+ * dashboard) so the user sees fresh quotes on push notifications too;
+ * falls back to a small per-locale built-in list when the pool is empty
+ * (e.g. the user has never opened the app, or the cache expired).
+ *
+ * @param language Locale primary subtag — anything not in
+ *   `SUPPORTED_REMINDER_LOCALES` is normalised to the default.
+ * @param pool Optional list of pre-generated quotes for the user's
+ *   locale (e.g. flattened tiers from `motivationQuotes/{uid}__{lang}`).
  */
-export function buildNotificationPayload(language?: string): string {
-  const messages: Record<string, string[]> = {
-    de: [
-      'Zeit für Liegestütze! 💪',
-      'Kurze Pause? Perfekt für Liegestütze!',
-      'Du schaffst das – ein paar Liegestütze!',
-      'Beweg dich! Liegestütze warten auf dich. 🔥',
-      'Dein Körper ruft: Liegestütze, los!',
-    ],
-    en: [
-      'Time for push-ups! 💪',
-      'Quick break? Perfect for push-ups!',
-      'You got this – a few push-ups!',
-      'Move it! Push-ups are waiting for you. 🔥',
-      'Your body calls: push-ups, go!',
-    ],
-  };
-
-  const lang = language === 'en' ? 'en' : 'de';
-  const list = messages[lang];
-  return list[Math.floor(Math.random() * list.length)];
+export function buildNotificationPayload(
+  language?: string,
+  pool?: ReadonlyArray<string>
+): string {
+  const locale = normalizeReminderLocale(language);
+  const candidates =
+    pool && pool.length > 0 ? pool : reminderBodyChoices(locale);
+  return candidates[Math.floor(Math.random() * candidates.length)];
 }

--- a/data-store/functions/src/push/reminders.ts
+++ b/data-store/functions/src/push/reminders.ts
@@ -223,10 +223,10 @@ export interface NotificationAction {
  * of `sanitizeQuickLogReps` to both call sites.
  */
 export function buildReminderActions(
-  language: string | undefined,
+  rawLocale: string | undefined,
   quickLogReps: number | undefined
 ): NotificationAction[] {
-  const locale = normalizeReminderLocale(language);
+  const locale = normalizeReminderLocale(rawLocale);
   const snooze: NotificationAction = {
     action: 'snooze',
     title: reminderSnoozeLabel(locale),
@@ -263,16 +263,16 @@ export function sanitizeQuickLogReps(
  * falls back to a small per-locale built-in list when the pool is empty
  * (e.g. the user has never opened the app, or the cache expired).
  *
- * @param language Locale primary subtag — anything not in
+ * @param rawLocale Locale primary subtag — anything not in
  *   `SUPPORTED_REMINDER_LOCALES` is normalised to the default.
  * @param pool Optional list of pre-generated quotes for the user's
  *   locale (e.g. flattened tiers from `motivationQuotes/{uid}__{lang}`).
  */
 export function buildNotificationPayload(
-  language?: string,
+  rawLocale?: string,
   pool?: ReadonlyArray<string>
 ): string {
-  const locale = normalizeReminderLocale(language);
+  const locale = normalizeReminderLocale(rawLocale);
   const candidates =
     pool && pool.length > 0 ? pool : reminderBodyChoices(locale);
   return candidates[Math.floor(Math.random() * candidates.length)];

--- a/libs/motivation/src/lib/motivation.store.ts
+++ b/libs/motivation/src/lib/motivation.store.ts
@@ -9,6 +9,7 @@ import {
   withProps,
   withState,
 } from '@ngrx/signals';
+import { normalizeReminderLocale } from '@pu-stats/models';
 import { MotivationQuoteService } from './motivation-quote.service';
 
 const CACHE_PREFIX = 'motivation-quotes';
@@ -42,7 +43,7 @@ export const MotivationStore = signalStore(
     return {
       _api: inject(MotivationQuoteService),
       _locale: locale,
-      _lang: locale.startsWith('en') ? 'en' : 'de',
+      _lang: normalizeReminderLocale(locale),
       _isBrowser: isPlatformBrowser(platformId),
     };
   }),

--- a/libs/reminders/src/lib/reminder.service.spec.ts
+++ b/libs/reminders/src/lib/reminder.service.spec.ts
@@ -52,7 +52,6 @@ describe('ReminderService', () => {
     intervalMinutes: 60,
     quietHours: [],
     timezone: 'UTC',
-    language: 'de',
   };
 
   function createService(

--- a/libs/reminders/src/lib/reminder.service.ts
+++ b/libs/reminders/src/lib/reminder.service.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable, LOCALE_ID, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
+import { normalizeReminderLocale, reminderTitle } from '@pu-stats/models';
 import { ReminderStore } from './reminder.store';
 import { ReminderPermissionService } from './reminder-permission.service';
 import { MotivationStore } from '@pu-stats/motivation';
@@ -49,10 +50,7 @@ export class ReminderService {
   private readonly motivationStore = inject(MotivationStore);
   private readonly pushStore = inject(PushSubscriptionStore);
   private readonly pushSwRegistration = inject(PushSwRegistrationService);
-  private readonly locale = (() => {
-    const l = inject(LOCALE_ID).toLowerCase();
-    return l.startsWith('en') ? 'en' : 'de';
-  })();
+  private readonly locale = normalizeReminderLocale(inject(LOCALE_ID));
 
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private initialTickTimeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -118,9 +116,7 @@ export class ReminderService {
     const quote = await this.getNextQuote();
     if (!quote) return;
 
-    const lang = config.language ?? 'de';
-    const title =
-      lang === 'en' ? '💪 Time for push-ups!' : '💪 Zeit für Liegestütze!';
+    const title = reminderTitle(this.locale);
 
     if (Notification.permission === 'granted') {
       // Prefer ServiceWorker notification — `new Notification()` is not

--- a/libs/reminders/src/lib/reminder.store.spec.ts
+++ b/libs/reminders/src/lib/reminder.store.spec.ts
@@ -11,7 +11,6 @@ const defaultReminder: ReminderConfig = {
   intervalMinutes: 60,
   quietHours: [],
   timezone: 'Europe/Berlin',
-  language: 'de',
 };
 
 function makeApiMock(
@@ -119,9 +118,14 @@ describe('ReminderStore', () => {
 
     await store.saveConfig('u1', updated);
 
-    expect(apiMock.updateConfig).toHaveBeenCalledWith('u1', {
-      reminder: updated,
-    });
+    expect(apiMock.updateConfig).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ reminder: updated })
+    );
+    // saveConfig now also persists the user's current locale so the
+    // server-side push dispatcher can localise without LOCALE_ID.
+    const call = (apiMock.updateConfig as jest.Mock).mock.calls[0];
+    expect(typeof call[1].locale).toBe('string');
     expect(store.config()).toEqual(updated);
   });
 

--- a/libs/reminders/src/lib/reminder.store.ts
+++ b/libs/reminders/src/lib/reminder.store.ts
@@ -1,4 +1,4 @@
-import { inject } from '@angular/core';
+import { inject, LOCALE_ID } from '@angular/core';
 import {
   patchState,
   signalStore,
@@ -10,7 +10,7 @@ import {
 import { computed } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { UserConfigApiService } from '@pu-stats/data-access';
-import { ReminderConfig } from '@pu-stats/models';
+import { normalizeReminderLocale, ReminderConfig } from '@pu-stats/models';
 import { ReminderPermissionService } from './reminder-permission.service';
 
 export type { ReminderConfig };
@@ -32,7 +32,6 @@ const DEFAULT_REMINDER_CONFIG: ReminderConfig = {
   intervalMinutes: 60,
   quietHours: [],
   timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'Europe/Berlin',
-  language: 'de',
 };
 
 export const ReminderStore = signalStore(
@@ -41,11 +40,12 @@ export const ReminderStore = signalStore(
   withProps(() => ({
     _api: inject(UserConfigApiService),
     _permissionService: inject(ReminderPermissionService),
+    _locale: normalizeReminderLocale(inject(LOCALE_ID)),
   })),
   withComputed((store) => ({
     permissionStatus: computed(() => store._permissionService.status()),
   })),
-  withMethods(({ _api, _permissionService: _ps, ...store }) => ({
+  withMethods(({ _api, _permissionService: _ps, _locale, ...store }) => ({
     async loadConfig(userId: string): Promise<void> {
       patchState(store, { loading: true, error: null });
       try {
@@ -65,7 +65,12 @@ export const ReminderStore = signalStore(
     async saveConfig(userId: string, config: ReminderConfig): Promise<void> {
       patchState(store, { loading: true, error: null });
       try {
-        await firstValueFrom(_api.updateConfig(userId, { reminder: config }));
+        // Persist the user's current app locale alongside the reminder so the
+        // server-side push dispatcher (which has no LOCALE_ID) can localise
+        // the notification body and actions.
+        await firstValueFrom(
+          _api.updateConfig(userId, { reminder: config, locale: _locale })
+        );
         patchState(store, { config, loading: false });
       } catch (err) {
         patchState(store, {
@@ -79,7 +84,9 @@ export const ReminderStore = signalStore(
       const reset: ReminderConfig = { ...DEFAULT_REMINDER_CONFIG };
       patchState(store, { loading: true, error: null });
       try {
-        await firstValueFrom(_api.updateConfig(userId, { reminder: reset }));
+        await firstValueFrom(
+          _api.updateConfig(userId, { reminder: reset, locale: _locale })
+        );
         patchState(store, { config: reset, loading: false });
       } catch (err) {
         patchState(store, {

--- a/libs/stats/src/lib/models/reminder-config.models.ts
+++ b/libs/stats/src/lib/models/reminder-config.models.ts
@@ -6,7 +6,6 @@ export interface ReminderConfig {
     to: string;
   }[];
   timezone: string;
-  language: 'de' | 'en';
   lastQuoteFetchAt?: string;
   /**
    * One-tap pushup count surfaced as a notification action button. When set

--- a/libs/stats/src/lib/models/reminder-i18n.models.spec.ts
+++ b/libs/stats/src/lib/models/reminder-i18n.models.spec.ts
@@ -30,6 +30,23 @@ describe('reminder-i18n.models', () => {
       expect(normalizeReminderLocale('FR')).toBe('fr');
     });
 
+    it('trims surrounding whitespace before normalising', () => {
+      expect(normalizeReminderLocale('  en  ')).toBe('en');
+    });
+
+    it('maps Norwegian Bokmål (nb-NO) to "no"', () => {
+      // BCP-47 treats `nb`/`nn` as distinct primary subtags; the previous
+      // implementation silently fell back to the default for either,
+      // which gave Bokmål users German notifications.
+      expect(normalizeReminderLocale('nb-NO')).toBe('no');
+      expect(normalizeReminderLocale('nb')).toBe('no');
+    });
+
+    it('maps Norwegian Nynorsk (nn-NO) to "no"', () => {
+      expect(normalizeReminderLocale('nn-NO')).toBe('no');
+      expect(normalizeReminderLocale('nn')).toBe('no');
+    });
+
     it('falls back to default for unsupported locales', () => {
       expect(normalizeReminderLocale('xx')).toBe(DEFAULT_REMINDER_LOCALE);
       expect(normalizeReminderLocale('')).toBe(DEFAULT_REMINDER_LOCALE);

--- a/libs/stats/src/lib/models/reminder-i18n.models.spec.ts
+++ b/libs/stats/src/lib/models/reminder-i18n.models.spec.ts
@@ -1,0 +1,78 @@
+import {
+  DEFAULT_REMINDER_LOCALE,
+  normalizeReminderLocale,
+  reminderBodyChoices,
+  reminderLogLabel,
+  reminderQuickLogLabel,
+  reminderSnoozeLabel,
+  reminderTitle,
+  SUPPORTED_REMINDER_LOCALES,
+} from './reminder-i18n.models';
+
+describe('reminder-i18n.models', () => {
+  describe('normalizeReminderLocale', () => {
+    it.each(SUPPORTED_REMINDER_LOCALES)(
+      'keeps supported locale "%s" as-is',
+      (locale) => {
+        expect(normalizeReminderLocale(locale)).toBe(locale);
+      }
+    );
+
+    it('strips region tag (en-US → en)', () => {
+      expect(normalizeReminderLocale('en-US')).toBe('en');
+    });
+
+    it('strips script tag (zh-Hant → zh)', () => {
+      expect(normalizeReminderLocale('zh-Hant')).toBe('zh');
+    });
+
+    it('lower-cases the primary subtag', () => {
+      expect(normalizeReminderLocale('FR')).toBe('fr');
+    });
+
+    it('falls back to default for unsupported locales', () => {
+      expect(normalizeReminderLocale('xx')).toBe(DEFAULT_REMINDER_LOCALE);
+      expect(normalizeReminderLocale('')).toBe(DEFAULT_REMINDER_LOCALE);
+      expect(normalizeReminderLocale(undefined)).toBe(DEFAULT_REMINDER_LOCALE);
+      expect(normalizeReminderLocale(null)).toBe(DEFAULT_REMINDER_LOCALE);
+      expect(normalizeReminderLocale(42)).toBe(DEFAULT_REMINDER_LOCALE);
+    });
+  });
+
+  describe('localised strings', () => {
+    it.each(SUPPORTED_REMINDER_LOCALES)(
+      'has a non-empty title for "%s"',
+      (locale) => {
+        const title = reminderTitle(locale);
+        expect(title.length).toBeGreaterThan(0);
+        // every supported title carries the muscle emoji as a visual hook
+        expect(title).toContain('💪');
+      }
+    );
+
+    it.each(SUPPORTED_REMINDER_LOCALES)(
+      'has at least one body candidate for "%s"',
+      (locale) => {
+        expect(reminderBodyChoices(locale).length).toBeGreaterThan(0);
+      }
+    );
+
+    it.each(SUPPORTED_REMINDER_LOCALES)(
+      'has snooze + log + quickLog labels for "%s"',
+      (locale) => {
+        expect(reminderSnoozeLabel(locale)).toMatch(/⏰/);
+        expect(reminderLogLabel(locale)).toMatch(/✅/);
+        const quick = reminderQuickLogLabel(locale, 42);
+        expect(quick).toMatch(/✅/);
+        expect(quick).toContain('42');
+      }
+    );
+
+    it('falls back to the default locale for unsupported tags', () => {
+      expect(reminderTitle('xx')).toBe(reminderTitle(DEFAULT_REMINDER_LOCALE));
+      expect(reminderSnoozeLabel('xx')).toBe(
+        reminderSnoozeLabel(DEFAULT_REMINDER_LOCALE)
+      );
+    });
+  });
+});

--- a/libs/stats/src/lib/models/reminder-i18n.models.ts
+++ b/libs/stats/src/lib/models/reminder-i18n.models.ts
@@ -23,14 +23,27 @@ export type ReminderLocale = (typeof SUPPORTED_REMINDER_LOCALES)[number];
 export const DEFAULT_REMINDER_LOCALE: ReminderLocale = 'de';
 
 /**
+ * BCP-47 primary-subtag aliases. Norwegian is a macrolanguage: `nb`
+ * (Bokmål) and `nn` (Nynorsk) are distinct primary subtags but both
+ * map to our single `no` reminder locale. Without this map a user with
+ * `LOCALE_ID = 'nb-NO'` would silently fall back to the default locale.
+ */
+const LOCALE_ALIAS: Readonly<Record<string, ReminderLocale>> = {
+  nb: 'no',
+  nn: 'no',
+};
+
+/**
  * Normalises any locale string to a supported primary subtag.
- * `en-US` → `en`, `zh-Hant` → `zh`, unknown → `DEFAULT_REMINDER_LOCALE`.
+ * `en-US` → `en`, `zh-Hant` → `zh`, `nb-NO` → `no`,
+ * unknown → `DEFAULT_REMINDER_LOCALE`.
  */
 export function normalizeReminderLocale(raw: unknown): ReminderLocale {
   if (typeof raw !== 'string') return DEFAULT_REMINDER_LOCALE;
-  const primary = raw.toLowerCase().split(/[-_]/)[0];
-  return (SUPPORTED_REMINDER_LOCALES as ReadonlyArray<string>).includes(primary)
-    ? (primary as ReminderLocale)
+  const primary = raw.trim().toLowerCase().split(/[-_]/)[0];
+  const aliased = LOCALE_ALIAS[primary] ?? primary;
+  return (SUPPORTED_REMINDER_LOCALES as ReadonlyArray<string>).includes(aliased)
+    ? (aliased as ReminderLocale)
     : DEFAULT_REMINDER_LOCALE;
 }
 
@@ -164,7 +177,9 @@ export function reminderTitle(locale: unknown): string {
 }
 
 export function reminderBodyChoices(locale: unknown): ReadonlyArray<string> {
-  return REMINDER_BODIES[normalizeReminderLocale(locale)];
+  // Defensive copy so a caller that .push()es into the result can't
+  // mutate the module-level dictionary and leak across notifications.
+  return [...REMINDER_BODIES[normalizeReminderLocale(locale)]];
 }
 
 export function reminderSnoozeLabel(locale: unknown): string {

--- a/libs/stats/src/lib/models/reminder-i18n.models.ts
+++ b/libs/stats/src/lib/models/reminder-i18n.models.ts
@@ -165,7 +165,7 @@ const QUICK_LOG_LABELS: Record<ReminderLocale, (n: number) => string> = {
   fr: (n) => `✅ Enregistrer ${n}`,
   es: (n) => `✅ Registrar ${n}`,
   it: (n) => `✅ Registra ${n}`,
-  nl: (n) => `✅ Logg ${n}`,
+  nl: (n) => `✅ Registreer ${n}`,
   el: (n) => `✅ Καταχώριση ${n}`,
   la: (n) => `✅ Inscribere ${n}`,
   no: (n) => `✅ Logg ${n}`,

--- a/libs/stats/src/lib/models/reminder-i18n.models.ts
+++ b/libs/stats/src/lib/models/reminder-i18n.models.ts
@@ -1,0 +1,180 @@
+/**
+ * Locale handling shared between client (in-app reminders) and Cloud
+ * Functions (server-side push). The server has no `LOCALE_ID`, so the
+ * client persists `userConfigs/{uid}.locale` and the dispatcher reads
+ * it back here.
+ */
+
+export const SUPPORTED_REMINDER_LOCALES = [
+  'de',
+  'en',
+  'fr',
+  'es',
+  'it',
+  'nl',
+  'el',
+  'la',
+  'no',
+  'zh',
+] as const;
+
+export type ReminderLocale = (typeof SUPPORTED_REMINDER_LOCALES)[number];
+
+export const DEFAULT_REMINDER_LOCALE: ReminderLocale = 'de';
+
+/**
+ * Normalises any locale string to a supported primary subtag.
+ * `en-US` → `en`, `zh-Hant` → `zh`, unknown → `DEFAULT_REMINDER_LOCALE`.
+ */
+export function normalizeReminderLocale(raw: unknown): ReminderLocale {
+  if (typeof raw !== 'string') return DEFAULT_REMINDER_LOCALE;
+  const primary = raw.toLowerCase().split(/[-_]/)[0];
+  return (SUPPORTED_REMINDER_LOCALES as ReadonlyArray<string>).includes(primary)
+    ? (primary as ReminderLocale)
+    : DEFAULT_REMINDER_LOCALE;
+}
+
+const REMINDER_TITLES: Record<ReminderLocale, string> = {
+  de: '💪 Zeit für Liegestütze!',
+  en: '💪 Time for push-ups!',
+  fr: '💪 L’heure des pompes !',
+  es: '💪 ¡Hora de flexiones!',
+  it: '💪 Ora dei push-up!',
+  nl: '💪 Tijd voor push-ups!',
+  el: '💪 Ώρα για push-ups!',
+  la: '💪 Tempus flexionis!',
+  no: '💪 Tid for push-ups!',
+  zh: '💪 做俯卧撑的时间!',
+};
+
+const REMINDER_BODIES: Record<ReminderLocale, ReadonlyArray<string>> = {
+  de: [
+    'Zeit für Liegestütze! 💪',
+    'Kurze Pause? Perfekt für Liegestütze!',
+    'Du schaffst das – ein paar Liegestütze!',
+    'Beweg dich! Liegestütze warten auf dich. 🔥',
+    'Dein Körper ruft: Liegestütze, los!',
+  ],
+  en: [
+    'Time for push-ups! 💪',
+    'Quick break? Perfect for push-ups!',
+    'You got this – a few push-ups!',
+    'Move it! Push-ups are waiting for you. 🔥',
+    'Your body calls: push-ups, go!',
+  ],
+  fr: [
+    'L’heure des pompes ! 💪',
+    'Petite pause ? Parfait pour des pompes !',
+    'Tu peux le faire – quelques pompes !',
+    'Bouge-toi ! Les pompes t’attendent. 🔥',
+    'Ton corps t’appelle : des pompes, vas-y !',
+  ],
+  es: [
+    '¡Hora de flexiones! 💪',
+    '¿Pausa rápida? ¡Perfecta para flexiones!',
+    'Tú puedes – ¡unas flexiones!',
+    '¡Muévete! Las flexiones te esperan. 🔥',
+    'Tu cuerpo te llama: ¡flexiones, vamos!',
+  ],
+  it: [
+    'Ora dei push-up! 💪',
+    'Pausa veloce? Perfetta per i push-up!',
+    'Ce la fai – qualche push-up!',
+    'Muoviti! I push-up ti aspettano. 🔥',
+    'Il corpo chiama: push-up, vai!',
+  ],
+  nl: [
+    'Tijd voor push-ups! 💪',
+    'Korte pauze? Perfect voor push-ups!',
+    'Jij kunt dit – een paar push-ups!',
+    'Kom op! Push-ups wachten op je. 🔥',
+    'Je lichaam roept: push-ups, gaan!',
+  ],
+  el: [
+    'Ώρα για push-ups! 💪',
+    'Σύντομο διάλειμμα; Ιδανικό για push-ups!',
+    'Τα καταφέρνεις – λίγα push-ups!',
+    'Κουνήσου! Τα push-ups σε περιμένουν. 🔥',
+    'Το σώμα σου καλεί: push-ups, πάμε!',
+  ],
+  la: [
+    'Tempus flexionis! 💪',
+    'Brevis pausa? Aptissima flexionibus!',
+    'Potes id facere – paucae flexiones!',
+    'Move te! Flexiones te exspectant. 🔥',
+    'Corpus vocat: flexiones, age!',
+  ],
+  no: [
+    'Tid for push-ups! 💪',
+    'Kort pause? Perfekt for push-ups!',
+    'Du klarer det – noen push-ups!',
+    'Kom igjen! Push-ups venter på deg. 🔥',
+    'Kroppen roper: push-ups, kjør!',
+  ],
+  zh: [
+    '做俯卧撑的时间到了！💪',
+    '短暂休息？正好做俯卧撑！',
+    '你可以的——来几个俯卧撑！',
+    '动起来！俯卧撑在等你。🔥',
+    '身体在呼唤：俯卧撑，加油！',
+  ],
+};
+
+const SNOOZE_LABELS: Record<ReminderLocale, string> = {
+  de: '⏰ 30 Min snoozen',
+  en: '⏰ Snooze 30 min',
+  fr: '⏰ Reporter 30 min',
+  es: '⏰ Aplazar 30 min',
+  it: '⏰ Posticipa 30 min',
+  nl: '⏰ Uitstellen 30 min',
+  el: '⏰ Αναβολή 30 λεπτά',
+  la: '⏰ Differre 30 min',
+  no: '⏰ Utsett 30 min',
+  zh: '⏰ 推迟30分钟',
+};
+
+const LOG_LABELS: Record<ReminderLocale, string> = {
+  de: '✅ Eintragen',
+  en: '✅ Log push-ups',
+  fr: '✅ Enregistrer',
+  es: '✅ Registrar',
+  it: '✅ Registra',
+  nl: '✅ Registreren',
+  el: '✅ Καταχώριση',
+  la: '✅ Inscribere',
+  no: '✅ Registrer',
+  zh: '✅ 记录',
+};
+
+const QUICK_LOG_LABELS: Record<ReminderLocale, (n: number) => string> = {
+  de: (n) => `✅ ${n} eintragen`,
+  en: (n) => `✅ Log ${n}`,
+  fr: (n) => `✅ Enregistrer ${n}`,
+  es: (n) => `✅ Registrar ${n}`,
+  it: (n) => `✅ Registra ${n}`,
+  nl: (n) => `✅ Logg ${n}`,
+  el: (n) => `✅ Καταχώριση ${n}`,
+  la: (n) => `✅ Inscribere ${n}`,
+  no: (n) => `✅ Logg ${n}`,
+  zh: (n) => `✅ 记录 ${n}`,
+};
+
+export function reminderTitle(locale: unknown): string {
+  return REMINDER_TITLES[normalizeReminderLocale(locale)];
+}
+
+export function reminderBodyChoices(locale: unknown): ReadonlyArray<string> {
+  return REMINDER_BODIES[normalizeReminderLocale(locale)];
+}
+
+export function reminderSnoozeLabel(locale: unknown): string {
+  return SNOOZE_LABELS[normalizeReminderLocale(locale)];
+}
+
+export function reminderLogLabel(locale: unknown): string {
+  return LOG_LABELS[normalizeReminderLocale(locale)];
+}
+
+export function reminderQuickLogLabel(locale: unknown, reps: number): string {
+  return QUICK_LOG_LABELS[normalizeReminderLocale(locale)](reps);
+}

--- a/libs/stats/src/lib/models/stats.models.spec.ts
+++ b/libs/stats/src/lib/models/stats.models.spec.ts
@@ -32,12 +32,12 @@ describe('UserConfig reminder field', () => {
   it('accepts a full reminder config', () => {
     const config: UserConfig = {
       userId: 'u1',
+      locale: 'de',
       reminder: {
         enabled: true,
         intervalMinutes: 60,
         quietHours: [{ from: '22:00', to: '07:00' }],
         timezone: 'Europe/Berlin',
-        language: 'de',
         lastQuoteFetchAt: '2026-03-23T10:00:00.000Z',
       },
     };
@@ -45,7 +45,7 @@ describe('UserConfig reminder field', () => {
     expect(config.reminder?.intervalMinutes).toBe(60);
     expect(config.reminder?.quietHours).toHaveLength(1);
     expect(config.reminder?.timezone).toBe('Europe/Berlin');
-    expect(config.reminder?.language).toBe('de');
+    expect(config.locale).toBe('de');
     expect(config.reminder?.lastQuoteFetchAt).toBeDefined();
   });
 
@@ -57,12 +57,12 @@ describe('UserConfig reminder field', () => {
   it('allows lastQuoteFetchAt to be omitted', () => {
     const config: UserConfig = {
       userId: 'u3',
+      locale: 'en',
       reminder: {
         enabled: false,
         intervalMinutes: 30,
         quietHours: [],
         timezone: 'UTC',
-        language: 'en',
       },
     };
     expect(config.reminder?.lastQuoteFetchAt).toBeUndefined();
@@ -71,6 +71,7 @@ describe('UserConfig reminder field', () => {
   it('allows multiple quiet-hour windows', () => {
     const config: UserConfig = {
       userId: 'u4',
+      locale: 'en',
       reminder: {
         enabled: true,
         intervalMinutes: 120,
@@ -79,7 +80,6 @@ describe('UserConfig reminder field', () => {
           { from: '12:00', to: '13:00' },
         ],
         timezone: 'Europe/Berlin',
-        language: 'en',
       },
     };
     expect(config.reminder?.quietHours).toHaveLength(2);
@@ -94,10 +94,11 @@ describe('UserConfigUpdate reminder field', () => {
         intervalMinutes: 30,
         quietHours: [],
         timezone: 'Europe/Berlin',
-        language: 'de',
       },
+      locale: 'de',
     };
     expect(update.reminder?.enabled).toBe(true);
+    expect(update.locale).toBe('de');
   });
 
   it('allows reminder to be omitted in update', () => {

--- a/libs/stats/src/lib/models/stats.models.ts
+++ b/libs/stats/src/lib/models/stats.models.ts
@@ -33,5 +33,6 @@ export interface StatsFilter {
 export * from './pushup.models';
 export * from './user-config.models';
 export * from './reminder-config.models';
+export * from './reminder-i18n.models';
 export * from './user-stats.models';
 export * from './public-profile.models';

--- a/libs/stats/src/lib/models/user-config.models.ts
+++ b/libs/stats/src/lib/models/user-config.models.ts
@@ -24,6 +24,13 @@ export interface UserConfig {
   userId: string;
   email?: string | null;
   displayName?: string;
+  /**
+   * Primary subtag of the user's preferred app locale (e.g. `de`, `en`,
+   * `fr`). Persisted from the client whenever the reminder is saved so the
+   * server-side push dispatcher (`dispatchPushReminders`) can localise the
+   * notification — it has no `LOCALE_ID` of its own.
+   */
+  locale?: string;
   dailyGoal?: number;
   weeklyGoal?: number;
   monthlyGoal?: number;
@@ -56,6 +63,7 @@ export type UserConfigUpdate = Partial<
     UserConfig,
     | 'email'
     | 'displayName'
+    | 'locale'
     | 'dailyGoal'
     | 'weeklyGoal'
     | 'monthlyGoal'

--- a/libs/stats/src/lib/models/user-config.models.ts
+++ b/libs/stats/src/lib/models/user-config.models.ts
@@ -1,4 +1,5 @@
 import { ReminderConfig } from './reminder-config.models';
+import type { ReminderLocale } from './reminder-i18n.models';
 
 /** Particle-count quality preset for the goal-reached snap animation. */
 export type SnapQuality = 'low' | 'middle' | 'high';
@@ -29,8 +30,12 @@ export interface UserConfig {
    * `fr`). Persisted from the client whenever the reminder is saved so the
    * server-side push dispatcher (`dispatchPushReminders`) can localise the
    * notification — it has no `LOCALE_ID` of its own.
+   *
+   * Typed as `ReminderLocale` (not `string`) so a future caller cannot
+   * persist an unsupported subtag client-side; the server still applies
+   * `normalizeReminderLocale` defensively when reading legacy docs.
    */
-  locale?: string;
+  locale?: ReminderLocale;
   dailyGoal?: number;
   weeklyGoal?: number;
   monthlyGoal?: number;

--- a/libs/sw-push/src/handlers.spec.ts
+++ b/libs/sw-push/src/handlers.spec.ts
@@ -327,6 +327,44 @@ describe('handleNotificationClick', () => {
     expect(openWindow).toHaveBeenCalledWith('/de/app?log=1');
   });
 
+  it('routes the log action to the locale-prefixed URL for non-de/en locales (fr)', async () => {
+    const { ctx, openWindow } = makeCtx();
+    let waited: Promise<unknown> | undefined;
+    const { event } = makeEvent('log', { locale: 'fr' });
+    event.waitUntil = (p) => {
+      waited = p;
+    };
+    handleNotificationClick(event, ctx);
+    await waited;
+    expect(openWindow).toHaveBeenCalledWith('/fr/app?log=1');
+  });
+
+  it('routes the snooze action to the locale-prefixed URL for non-de/en locales (zh)', async () => {
+    const { ctx, openWindow } = makeCtx({ matchAllResult: [] });
+    let waited: Promise<unknown> | undefined;
+    const { event } = makeEvent('snooze', { locale: 'zh' });
+    event.waitUntil = (p) => {
+      waited = p;
+    };
+    handleNotificationClick(event, ctx);
+    await waited;
+    expect(openWindow).toHaveBeenCalledWith('/zh/app?snooze=30');
+  });
+
+  it('falls back to the default locale URL for an unsupported locale tag', async () => {
+    const { ctx, openWindow } = makeCtx();
+    let waited: Promise<unknown> | undefined;
+    // 'xx' is not in SW_SUPPORTED_LOCALES, so we fall back to the default
+    // (de) and open `/de/app?log=1` rather than `/xx/app?log=1`.
+    const { event } = makeEvent('log', { locale: 'xx' });
+    event.waitUntil = (p) => {
+      waited = p;
+    };
+    handleNotificationClick(event, ctx);
+    await waited;
+    expect(openWindow).toHaveBeenCalledWith('/de/app?log=1');
+  });
+
   it('quick-log: posts QUICK_LOG_PUSHUPS to an open client and skips openWindow', async () => {
     const client: ClientLike = {
       url: 'https://pushup-stats.com/de/app',

--- a/libs/sw-push/src/handlers.ts
+++ b/libs/sw-push/src/handlers.ts
@@ -103,7 +103,10 @@ interface PushPayload {
 
 function resolveLocale(raw: unknown): SwLocale {
   if (typeof raw !== 'string') return SW_DEFAULT_LOCALE;
-  const primary = raw.toLowerCase().split(/[-_]/)[0];
+  // Trim before splitting so a payload with leading/trailing whitespace
+  // (e.g. " en-US ") still resolves correctly. Aligned with the
+  // server-side `normalizeReminderLocale` in @pu-stats/models.
+  const primary = raw.trim().toLowerCase().split(/[-_]/)[0];
   return (SW_SUPPORTED_LOCALES as ReadonlyArray<string>).includes(primary)
     ? (primary as SwLocale)
     : SW_DEFAULT_LOCALE;

--- a/libs/sw-push/src/handlers.ts
+++ b/libs/sw-push/src/handlers.ts
@@ -23,6 +23,29 @@ export const SW_PUSH_VERSION: string =
  */
 const SW_QUICK_LOG_MAX = 500;
 
+/**
+ * Mirrored from `@pu-stats/models#SUPPORTED_REMINDER_LOCALES`. Inlined so
+ * the sw-push bundle stays self-contained (no cross-package import in the
+ * SW). When adding a locale to the web project's `i18n.locales`, add it
+ * here too, otherwise notification clicks for that locale fall back to
+ * the default and route to `/de/app...` instead of the locale-prefixed
+ * URL.
+ */
+const SW_SUPPORTED_LOCALES = [
+  'de',
+  'en',
+  'fr',
+  'es',
+  'it',
+  'nl',
+  'el',
+  'la',
+  'no',
+  'zh',
+] as const;
+type SwLocale = (typeof SW_SUPPORTED_LOCALES)[number];
+const SW_DEFAULT_LOCALE: SwLocale = 'de';
+
 export interface PushSubscriptionChangeEventLike {
   oldSubscription: PushSubscription | null;
   newSubscription: PushSubscription | null;
@@ -78,16 +101,23 @@ interface PushPayload {
   actions?: Array<{ action: string; title: string }>;
 }
 
-function resolveLocale(raw: unknown): 'en' | 'de' {
-  return String(raw ?? '')
-    .toLowerCase()
-    .startsWith('en')
-    ? 'en'
-    : 'de';
+function resolveLocale(raw: unknown): SwLocale {
+  if (typeof raw !== 'string') return SW_DEFAULT_LOCALE;
+  const primary = raw.toLowerCase().split(/[-_]/)[0];
+  return (SW_SUPPORTED_LOCALES as ReadonlyArray<string>).includes(primary)
+    ? (primary as SwLocale)
+    : SW_DEFAULT_LOCALE;
 }
 
+/**
+ * Last-resort action labels used only when the dispatch CF doesn't ship
+ * an `actions` array (legacy or malformed payload). The CF always sets
+ * locale-aware actions, so duplicating the full 10-locale dictionary
+ * here would just bloat the SW bundle for a path that's never hit in
+ * practice — de/en covers every realistic legacy payload.
+ */
 function defaultActions(
-  locale: 'en' | 'de'
+  locale: SwLocale
 ): Array<{ action: string; title: string }> {
   return locale === 'en'
     ? [
@@ -246,9 +276,7 @@ export function handleNotificationClick(
             reps,
           });
           if ('focus' in clientList[0]) {
-            await (
-              clientList[0] as { focus: () => Promise<unknown> }
-            )
+            await (clientList[0] as { focus: () => Promise<unknown> })
               .focus()
               .catch(() => undefined);
           }

--- a/web/src/app/reminders/shell/reminder-form.store.spec.ts
+++ b/web/src/app/reminders/shell/reminder-form.store.spec.ts
@@ -7,7 +7,6 @@ const defaultConfig: ReminderConfig = {
   intervalMinutes: 60,
   quietHours: [],
   timezone: 'Europe/Berlin',
-  language: 'de',
 };
 
 describe('ReminderFormStore', () => {
@@ -31,12 +30,10 @@ describe('ReminderFormStore', () => {
       enabled: true,
       intervalMinutes: 30,
       quietHours: [{ from: '22:00', to: '06:00' }],
-      language: 'en',
     };
     store.syncFromConfig(config);
     expect(store.enabled()).toBe(true);
     expect(store.intervalMinutes()).toBe(30);
-    expect(store.language()).toBe('en');
     expect(store.quietHours()).toEqual([{ from: '22:00', to: '06:00' }]);
     expect(store.dirty()).toBe(false);
   });
@@ -45,7 +42,6 @@ describe('ReminderFormStore', () => {
     store.syncFromConfig(null);
     expect(store.enabled()).toBe(false);
     expect(store.intervalMinutes()).toBe(60);
-    expect(store.language()).toBe('de');
     expect(store.quietHours()).toEqual([]);
     expect(store.dirty()).toBe(false);
   });

--- a/web/src/app/reminders/shell/reminder-form.store.ts
+++ b/web/src/app/reminders/shell/reminder-form.store.ts
@@ -15,7 +15,6 @@ import {
 type ReminderFormState = {
   enabled: boolean;
   intervalMinutes: number;
-  language: 'de' | 'en';
   quietHours: { from: string; to: string }[];
   /**
    * Whether the one-tap quick-log notification action is enabled. Tracked as
@@ -34,7 +33,6 @@ const DEFAULT_QUICK_LOG_REPS = 10;
 const initialState: ReminderFormState = {
   enabled: false,
   intervalMinutes: 60,
-  language: 'de',
   quietHours: [],
   quickLogEnabled: false,
   quickLogReps: DEFAULT_QUICK_LOG_REPS,
@@ -67,7 +65,6 @@ export const ReminderFormStore = signalStore(
       patchState(store, {
         enabled: config?.enabled ?? false,
         intervalMinutes: config?.intervalMinutes ?? 60,
-        language: config?.language ?? 'de',
         quietHours: config?.quietHours ? [...config.quietHours] : [],
         quickLogEnabled: repsValid,
         quickLogReps: repsValid
@@ -91,10 +88,6 @@ export const ReminderFormStore = signalStore(
 
     setInterval(value: number): void {
       patchState(store, { intervalMinutes: value, dirty: true });
-    },
-
-    setLanguage(value: 'de' | 'en'): void {
-      patchState(store, { language: value, dirty: true });
     },
 
     addQuietHour(): void {
@@ -157,7 +150,6 @@ export const ReminderFormStore = signalStore(
         intervalMinutes: store.intervalMinutes(),
         quietHours: store.quietHours(),
         timezone,
-        language: store.language(),
       };
       if (store.quickLogEnabled()) {
         const reps = Math.floor(store.quickLogReps());

--- a/web/src/app/reminders/shell/reminders-page.component.ts
+++ b/web/src/app/reminders/shell/reminders-page.component.ts
@@ -5,7 +5,6 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
@@ -29,7 +28,6 @@ import { ReminderFormStore } from './reminder-form.store';
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
-    MatButtonToggleModule,
     MatIconModule,
     MatSlideToggleModule,
     MatSnackBarModule,
@@ -137,35 +135,14 @@ import { ReminderFormStore } from './reminder-form.store';
                 </div>
 
                 <div>
-                  <p class="field-label" i18n="@@reminder.language.label">
-                    Sprache der Zitate
-                  </p>
-                  <mat-button-toggle-group
-                    [value]="form.language()"
-                    [disabled]="form.saving()"
-                    (change)="form.setLanguage($event.value)"
-                    aria-label="Erinnerungssprache"
-                    i18n-aria-label="@@reminder.language.aria"
-                  >
-                    <mat-button-toggle value="de" i18n="@@reminder.language.de"
-                      >DE</mat-button-toggle
-                    >
-                    <mat-button-toggle value="en" i18n="@@reminder.language.en"
-                      >EN</mat-button-toggle
-                    >
-                  </mat-button-toggle-group>
-                </div>
-
-                <div>
                   <p class="field-label" i18n="@@reminder.quickLog.label">
                     Direkt-Eintrag aus der Benachrichtigung
                   </p>
                   <p class="muted" i18n="@@reminder.quickLog.desc">
                     Zeigt einen "Eintragen"-Button auf der
-                    Push-Benachrichtigung. Wenn die App schon geöffnet ist,
-                    wird der Eintrag im Hintergrund gespeichert; ansonsten
-                    öffnet sich kurz ein Tab, der den Eintrag automatisch
-                    anlegt.
+                    Push-Benachrichtigung. Wenn die App schon geöffnet ist, wird
+                    der Eintrag im Hintergrund gespeichert; ansonsten öffnet
+                    sich kurz ein Tab, der den Eintrag automatisch anlegt.
                   </p>
                   <div class="reminder-row">
                     <mat-slide-toggle


### PR DESCRIPTION
The reminder UI's "Sprache der Zitate" toggle (de/en) is removed in favour
of the user's current app locale, persisted to userConfigs.locale so the
server-side push dispatcher can localise without LOCALE_ID. All 10
supported locales (de, en, fr, es, it, nl, el, la, no, zh) now have
notification title, body fallback, snooze and log action labels.

Token-efficient: dispatchPushReminders pulls the body from the existing
motivationQuotes pool already paid for by the dashboard, only falling
back to built-in copy when the pool is empty. generateMotivationQuotes
returns tiered output (general / belowGoal / nearGoal / goalReached) in
a single Gemini call, cached as both flat (back-compat) and tiered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Motivation quotes are now tiered based on goal progress (general, below goal, near goal, goal reached).
  * Enhanced multi-language support including French, Spanish, Italian, and Chinese.

* **Changes**
  * Reminders now automatically use your device locale instead of manual language selection.
  * Removed language toggle from reminder settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->