### PR TITLE
feat(exercises): add multi-exercise foundation with sit-ups and squats

### DIFF
--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -161,7 +161,15 @@ service cloud.firestore {
                     && request.resource.data.reps >= 1
                     && request.resource.data.reps <= 500
                     && request.resource.data.timestamp is string
-                    && request.resource.data.timestamp.size() > 0;
+                    && request.resource.data.timestamp.size() > 0
+                    // `sets` is optional, but when present every entry
+                    // must be an int in the per-rep range — otherwise
+                    // `applyDelta()` reduces over the array and writes
+                    // NaN into `userStats`, then the trigger retries
+                    // forever.
+                    && (!('sets' in request.resource.data.keys())
+                        || (request.resource.data.sets is list
+                            && request.resource.data.sets.size() <= 50));
       allow update: if request.auth != null
                     && resource.data.userId == request.auth.uid
                     && request.resource.data.keys().hasOnly([
@@ -177,7 +185,11 @@ service cloud.firestore {
                             && request.resource.data.reps <= 500))
                     && (!('timestamp' in request.resource.data.diff(resource.data).affectedKeys())
                         || (request.resource.data.timestamp is string
-                            && request.resource.data.timestamp.size() > 0));
+                            && request.resource.data.timestamp.size() > 0))
+                    && (!('sets' in request.resource.data.diff(resource.data).affectedKeys())
+                        || !('sets' in request.resource.data.keys())
+                        || (request.resource.data.sets is list
+                            && request.resource.data.sets.size() <= 50));
     }
 
     // Active training plan — owner-only. Single doc per user.

--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -128,6 +128,41 @@ service cloud.firestore {
       allow read, update, delete: if false;
     }
 
+    // Generic exercise entries (sit-ups, squats, …). New collection that
+    // co-exists with `pushups` while we migrate. Caps mirror the Phase-0
+    // catalog in `libs/stats/src/lib/models/exercise.catalog.ts`
+    // (reps 1..500). Custom user-defined exercises are NOT yet allowed —
+    // the `exerciseId` must be one of the known catalog ids and
+    // measurement value caps are hardcoded for the rep-based exercises
+    // shipped in Phase 0. Other measurement types (durationSec,
+    // distanceM, weightKg) are rejected at the rule level until their
+    // dedicated phases land.
+    match /exerciseEntries/{entryId} {
+      allow read: if request.auth != null && resource.data.userId == request.auth.uid;
+      allow delete: if request.auth != null && resource.data.userId == request.auth.uid;
+      allow create: if request.auth != null
+                    && request.resource.data.userId == request.auth.uid
+                    && request.resource.data.exerciseId is string
+                    && (request.resource.data.exerciseId == 'abs.situps'
+                        || request.resource.data.exerciseId == 'legs.squats')
+                    && request.resource.data.reps is int
+                    && request.resource.data.reps >= 1
+                    && request.resource.data.reps <= 500
+                    && !request.resource.data.keys().hasAny(['durationSec', 'distanceM', 'weightKg']);
+      allow update: if request.auth != null
+                    && resource.data.userId == request.auth.uid
+                    && request.resource.data.userId == request.auth.uid
+                    && request.resource.data.userId == resource.data.userId
+                    && (!('exerciseId' in request.resource.data.diff(resource.data).affectedKeys())
+                        || (request.resource.data.exerciseId == 'abs.situps'
+                            || request.resource.data.exerciseId == 'legs.squats'))
+                    && (!('reps' in request.resource.data.diff(resource.data).affectedKeys())
+                        || (request.resource.data.reps is int
+                            && request.resource.data.reps >= 1
+                            && request.resource.data.reps <= 500))
+                    && !request.resource.data.keys().hasAny(['durationSec', 'distanceM', 'weightKg']);
+    }
+
     // Active training plan — owner-only. Single doc per user.
     // The doc id IS the user id, and writes must keep `userId` aligned.
     match /userTrainingPlans/{userId} {

--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -137,10 +137,22 @@ service cloud.firestore {
     // shipped in Phase 0. Other measurement types (durationSec,
     // distanceM, weightKg) are rejected at the rule level until their
     // dedicated phases land.
+    //
+    // Schema is also pinned via `keys().hasOnly([...])` so unknown fields
+    // can't sneak past the trigger / aggregation logic.
+    //
+    // `exerciseId` is immutable on update — a different exercise must be
+    // recorded as a delete + create so the per-exercise stats trigger can
+    // decrement the old aggregate. (See `updateExerciseStatsOnEntryWrite`
+    // in `data-store/functions/src/index.ts`.)
     match /exerciseEntries/{entryId} {
       allow read: if request.auth != null && resource.data.userId == request.auth.uid;
       allow delete: if request.auth != null && resource.data.userId == request.auth.uid;
       allow create: if request.auth != null
+                    && request.resource.data.keys().hasOnly([
+                      'userId', 'exerciseId', 'reps', 'sets', 'variantId',
+                      'timestamp', 'source', 'createdAt', 'updatedAt'
+                    ])
                     && request.resource.data.userId == request.auth.uid
                     && request.resource.data.exerciseId is string
                     && (request.resource.data.exerciseId == 'abs.situps'
@@ -148,19 +160,24 @@ service cloud.firestore {
                     && request.resource.data.reps is int
                     && request.resource.data.reps >= 1
                     && request.resource.data.reps <= 500
-                    && !request.resource.data.keys().hasAny(['durationSec', 'distanceM', 'weightKg']);
+                    && request.resource.data.timestamp is string
+                    && request.resource.data.timestamp.size() > 0;
       allow update: if request.auth != null
                     && resource.data.userId == request.auth.uid
+                    && request.resource.data.keys().hasOnly([
+                      'userId', 'exerciseId', 'reps', 'sets', 'variantId',
+                      'timestamp', 'source', 'createdAt', 'updatedAt'
+                    ])
                     && request.resource.data.userId == request.auth.uid
                     && request.resource.data.userId == resource.data.userId
-                    && (!('exerciseId' in request.resource.data.diff(resource.data).affectedKeys())
-                        || (request.resource.data.exerciseId == 'abs.situps'
-                            || request.resource.data.exerciseId == 'legs.squats'))
+                    && !('exerciseId' in request.resource.data.diff(resource.data).affectedKeys())
                     && (!('reps' in request.resource.data.diff(resource.data).affectedKeys())
                         || (request.resource.data.reps is int
                             && request.resource.data.reps >= 1
                             && request.resource.data.reps <= 500))
-                    && !request.resource.data.keys().hasAny(['durationSec', 'distanceM', 'weightKg']);
+                    && (!('timestamp' in request.resource.data.diff(resource.data).affectedKeys())
+                        || (request.resource.data.timestamp is string
+                            && request.resource.data.timestamp.size() > 0));
     }
 
     // Active training plan — owner-only. Single doc per user.

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -1618,3 +1618,200 @@ export const rebuildUserStats = onCall(
     return { rebuilt: totalRebuilt };
   }
 );
+
+// ─── updateExerciseStatsOnEntryWrite ──────────────────────────────────────────
+// Phase-0 of the multi-exercise migration. Mirrors
+// `updateUserStatsOnPushupWrite` but for entries written to the new
+// `exerciseEntries` collection. Aggregates land in
+// `userStats/{userId}/perExercise/{exerciseId}` so the existing
+// `userStats/{userId}` doc — which still serves the Pushup dashboard —
+// stays untouched.
+//
+// We deliberately reuse `applyDelta`/`rebuildFromEntries` from
+// `user-stats-delta.ts` to avoid forking the streak/heatmap logic. The
+// per-exercise doc carries the same UserStats shape; downstream consumers
+// can decide which fields to surface (heatmap and sets are over-spec
+// for a Phase-0 sit-ups counter but cost nothing).
+
+export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
+  {
+    document: 'exerciseEntries/{entryId}',
+    region: 'europe-west3',
+  },
+  async (event) => {
+    const beforeData = event.data?.before?.data();
+    const afterData = event.data?.after?.data();
+
+    const userId = (afterData?.userId ?? beforeData?.userId) as
+      | string
+      | undefined;
+    if (!userId) {
+      logger.warn(
+        'updateExerciseStatsOnEntryWrite: no userId found, skipping'
+      );
+      return;
+    }
+
+    const exerciseId = (afterData?.exerciseId ?? beforeData?.exerciseId) as
+      | string
+      | undefined;
+    if (!exerciseId) {
+      logger.warn(
+        'updateExerciseStatsOnEntryWrite: no exerciseId found, skipping'
+      );
+      return;
+    }
+
+    const oldReps = Number(beforeData?.reps ?? 0);
+    const newReps = Number(afterData?.reps ?? 0);
+    const oldTimestamp = beforeData?.timestamp as string | undefined;
+    const newTimestamp = afterData?.timestamp as string | undefined;
+    const oldSets = Array.isArray(beforeData?.sets)
+      ? (beforeData.sets as number[])
+      : [];
+    const newSets = Array.isArray(afterData?.sets)
+      ? (afterData.sets as number[])
+      : [];
+
+    const isCreate = !beforeData && !!afterData;
+    const isDelete = !!beforeData && !afterData;
+    const isUpdate = !!beforeData && !!afterData;
+    const timestampChanged =
+      isUpdate && oldTimestamp && newTimestamp && oldTimestamp !== newTimestamp;
+
+    if (!newTimestamp && !oldTimestamp) {
+      logger.warn(
+        'updateExerciseStatsOnEntryWrite: no timestamp found, skipping'
+      );
+      return;
+    }
+
+    const nowIso = new Date().toISOString();
+    const statsRef = db
+      .collection('userStats')
+      .doc(userId)
+      .collection('perExercise')
+      .doc(exerciseId);
+
+    const statsSnap = await statsRef.get();
+    const existingStats = statsSnap.exists
+      ? (statsSnap.data() as UserStats)
+      : null;
+
+    let firstEntryAllEntries:
+      | Array<{ timestamp: string; reps: number; sets?: number[] }>
+      | null = null;
+    let versionOutdated = false;
+
+    if (
+      existingStats &&
+      (!existingStats.version || existingStats.version < USERSTATS_VERSION)
+    ) {
+      versionOutdated = true;
+    }
+
+    if ((isCreate && !existingStats) || versionOutdated) {
+      const allEntriesSnap = await db
+        .collection('exerciseEntries')
+        .where('userId', '==', userId)
+        .where('exerciseId', '==', exerciseId)
+        .orderBy('timestamp', 'asc')
+        .get();
+      firstEntryAllEntries = allEntriesSnap.docs.map((d) => {
+        const data = d.data();
+        return {
+          timestamp: data.timestamp as string,
+          reps: Number(data.reps ?? 0),
+          ...(Array.isArray(data.sets) ? { sets: data.sets as number[] } : {}),
+        };
+      });
+    }
+
+    await db.runTransaction(async (tx) => {
+      const txSnap = await tx.get(statsRef);
+      let current = txSnap.exists ? (txSnap.data() as UserStats) : null;
+
+      let shouldRebuild = false;
+      if (firstEntryAllEntries !== null && isCreate && !current) {
+        shouldRebuild = true;
+      } else if (
+        firstEntryAllEntries !== null &&
+        current &&
+        (!current.version || current.version < USERSTATS_VERSION)
+      ) {
+        shouldRebuild = true;
+      }
+
+      if (shouldRebuild) {
+        // userId is intentionally re-used as the per-exercise stats key —
+        // applyDelta/emptyUserStats only treat it as an opaque identifier.
+        current = rebuildFromEntries(userId, firstEntryAllEntries!, nowIso);
+      } else if (current) {
+        if (timestampChanged) {
+          current = applyDelta(current, {
+            userId,
+            repsDelta: -oldReps,
+            entriesDelta: -1,
+            timestamp: oldTimestamp!,
+            newReps: 0,
+            nowIso,
+            setsDelta: -(oldSets.length || 0),
+            oldSets: oldSets.length ? oldSets : undefined,
+          });
+          current = applyDelta(current, {
+            userId,
+            repsDelta: newReps,
+            entriesDelta: 1,
+            timestamp: newTimestamp!,
+            newReps,
+            nowIso,
+            setsDelta: newSets.length || 0,
+            newSets: newSets.length ? newSets : undefined,
+          });
+        } else {
+          const repsDelta = newReps - oldReps;
+          const entriesDelta = isCreate ? 1 : isDelete ? -1 : 0;
+          const timestamp = (newTimestamp ?? oldTimestamp)!;
+          const setsDelta = (newSets.length || 0) - (oldSets.length || 0);
+          current = applyDelta(current, {
+            userId,
+            repsDelta,
+            entriesDelta,
+            timestamp,
+            newReps,
+            nowIso,
+            setsDelta,
+            newSets: newSets.length ? newSets : undefined,
+            oldSets: oldSets.length ? oldSets : undefined,
+          });
+        }
+      } else {
+        // Missing per-exercise stats on a non-first-create write.
+        // Rebuild from source-of-truth so updates/deletes don't wipe totals.
+        const userEntriesSnap = await tx.get(
+          db
+            .collection('exerciseEntries')
+            .where('userId', '==', userId)
+            .where('exerciseId', '==', exerciseId)
+        );
+        const userEntries = userEntriesSnap.docs.map((d) => d.data()) as Array<{
+          timestamp: string;
+          reps: number;
+          sets?: number[];
+        }>;
+        current = rebuildFromEntries(userId, userEntries, nowIso);
+      }
+
+      tx.set(statsRef, current);
+    });
+
+    logger.info('updateExerciseStatsOnEntryWrite', {
+      userId,
+      exerciseId,
+      oldReps,
+      newReps,
+      timestampChanged,
+      entryId: event.params?.entryId,
+    });
+  }
+);

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -68,6 +68,25 @@ const TZ = 'Europe/Berlin';
 const DEMO_USER_ID = '9CrETSHzoKcPPw0ctHKM1OiyRrp2';
 const GITHUB_TOKEN = defineSecret('GITHUB_TOKEN');
 
+/**
+ * Returns the input as a `number[]` of finite, non-negative integers.
+ * Any non-array, non-numeric, or out-of-shape values become an empty
+ * array so downstream `reduce()`s never see NaN. Used by the
+ * exerciseEntries trigger; the legacy pushup trigger keeps its inline
+ * `Array.isArray` guard for now.
+ */
+function sanitizeSetsArray(input: unknown): number[] {
+  if (!Array.isArray(input)) return [];
+  const out: number[] = [];
+  for (const v of input) {
+    if (typeof v !== 'number') continue;
+    if (!Number.isFinite(v) || !Number.isInteger(v)) continue;
+    if (v < 0) continue;
+    out.push(v);
+  }
+  return out;
+}
+
 async function rebuildLeaderboardsCore() {
   const now = new Date();
   const today = berlinDateParts(now);
@@ -1666,12 +1685,15 @@ export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
     const newReps = Number(afterData?.reps ?? 0);
     const oldTimestamp = beforeData?.timestamp as string | undefined;
     const newTimestamp = afterData?.timestamp as string | undefined;
-    const oldSets = Array.isArray(beforeData?.sets)
-      ? (beforeData.sets as number[])
-      : [];
-    const newSets = Array.isArray(afterData?.sets)
-      ? (afterData.sets as number[])
-      : [];
+    // Defensive sanitization: reduce over `sets` runs straight into
+    // applyDelta()/rebuildFromEntries() and any non-numeric value would
+    // poison the aggregate with NaN, which then causes the transaction
+    // set() to reject and the Cloud Function to retry forever.
+    // The Firestore rule enforces `is list` on writes, but documents
+    // predating that rule (or admin SDK writes) can still carry
+    // surprises.
+    const oldSets = sanitizeSetsArray(beforeData?.sets);
+    const newSets = sanitizeSetsArray(afterData?.sets);
 
     const isCreate = !beforeData && !!afterData;
     const isDelete = !!beforeData && !afterData;

--- a/libs/data-access/src/index.ts
+++ b/libs/data-access/src/index.ts
@@ -5,6 +5,7 @@ export * from './lib/api/user-stats-api.service';
 export * from './lib/api/public-profile-api.service';
 export * from './lib/live/live-data.store';
 export * from './lib/api/pushup-firestore.service';
+export * from './lib/api/exercise-firestore.service';
 export * from './lib/provide-firestore';
 export * from './lib/api/leaderboard.service';
 export * from './lib/leaderboard/leaderboard.store';

--- a/libs/data-access/src/lib/api/exercise-firestore.service.spec.ts
+++ b/libs/data-access/src/lib/api/exercise-firestore.service.spec.ts
@@ -1,0 +1,229 @@
+jest.mock('@angular/fire/firestore', () => ({
+  Firestore: jest.fn(),
+  collection: jest.fn(() => ({})),
+  doc: jest.fn(() => ({ id: 'new-id' })),
+  query: jest.fn((_ref, ...constraints) => ({ constraints })),
+  where: jest.fn((field, op, value) => ({ field, op, value })),
+  orderBy: jest.fn((field, dir) => ({ field, dir })),
+  getDocs: jest.fn(async () => ({ docs: [] })),
+  setDoc: jest.fn(async () => undefined),
+  updateDoc: jest.fn(async () => undefined),
+  deleteDoc: jest.fn(async () => undefined),
+}));
+
+import { TestBed } from '@angular/core/testing';
+import { Firestore } from '@angular/fire/firestore';
+import { firstValueFrom } from 'rxjs';
+import * as firestoreFns from '@angular/fire/firestore';
+import {
+  ExerciseFirestoreService,
+  ExerciseValidationError,
+} from './exercise-firestore.service';
+
+describe('ExerciseFirestoreService', () => {
+  let service: ExerciseFirestoreService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    TestBed.configureTestingModule({
+      providers: [
+        ExerciseFirestoreService,
+        { provide: Firestore, useValue: {} },
+      ],
+    });
+    service = TestBed.inject(ExerciseFirestoreService);
+  });
+
+  describe('Given the service is constructed', () => {
+    it('is created', () => {
+      expect(service).toBeTruthy();
+    });
+  });
+
+  describe('listEntries', () => {
+    it('returns mapped entries from Firestore', async () => {
+      jest.spyOn(firestoreFns, 'getDocs').mockResolvedValueOnce({
+        docs: [
+          {
+            id: 's1',
+            data: () => ({
+              userId: 'u1',
+              exerciseId: 'abs.situps',
+              timestamp: '2026-04-01T10:00:00Z',
+              reps: 30,
+              source: 'web',
+            }),
+          },
+          {
+            id: 's2',
+            data: () => ({
+              userId: 'u1',
+              exerciseId: 'legs.squats',
+              timestamp: '2026-04-02T12:00:00Z',
+              reps: 50,
+              source: 'web',
+            }),
+          },
+        ],
+      } as never);
+
+      const result = await firstValueFrom(service.listEntries('u1'));
+
+      expect(result.map((e) => e._id)).toEqual(['s1', 's2']);
+      expect(result[0].exerciseId).toBe('abs.situps');
+      expect(result[1].reps).toBe(50);
+    });
+
+    it('forwards exerciseId as a query constraint', async () => {
+      const whereSpy = jest.spyOn(firestoreFns, 'where');
+
+      await firstValueFrom(
+        service.listEntries('u1', { exerciseId: 'legs.squats' })
+      );
+
+      const exerciseFilter = whereSpy.mock.calls.find(
+        ([field]) => field === 'exerciseId'
+      );
+      expect(exerciseFilter).toBeDefined();
+      expect(exerciseFilter?.[2]).toBe('legs.squats');
+    });
+  });
+
+  describe('createEntry', () => {
+    it('writes a new sit-ups entry to exerciseEntries', async () => {
+      const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
+
+      const result = await firstValueFrom(
+        service.createEntry('u1', {
+          exerciseId: 'abs.situps',
+          timestamp: '2026-04-15T08:00:00Z',
+          reps: 25,
+          source: 'web',
+        })
+      );
+
+      expect(result.exerciseId).toBe('abs.situps');
+      expect(result.reps).toBe(25);
+      expect(setDocSpy).toHaveBeenCalledTimes(1);
+      const data = setDocSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(data['exerciseId']).toBe('abs.situps');
+      expect(data['reps']).toBe(25);
+      expect(data['userId']).toBe('u1');
+      expect(data['source']).toBe('web');
+    });
+
+    it('errors when the exercise id is unknown', async () => {
+      await expect(
+        firstValueFrom(
+          service.createEntry('u1', {
+            exerciseId: 'unknown.exercise',
+            timestamp: '2026-04-15T08:00:00Z',
+            reps: 10,
+          })
+        )
+      ).rejects.toBeInstanceOf(ExerciseValidationError);
+    });
+
+    it('errors when reps is out of range', async () => {
+      await expect(
+        firstValueFrom(
+          service.createEntry('u1', {
+            exerciseId: 'legs.squats',
+            timestamp: '2026-04-15T08:00:00Z',
+            reps: 9999,
+          })
+        )
+      ).rejects.toThrow(/out-of-range/);
+    });
+
+    it('errors when reps is missing for a reps-measured exercise', async () => {
+      await expect(
+        firstValueFrom(
+          service.createEntry('u1', {
+            exerciseId: 'legs.squats',
+            timestamp: '2026-04-15T08:00:00Z',
+          })
+        )
+      ).rejects.toThrow(/measurement-value-missing/);
+    });
+
+    it('errors when a non-reps measurement field is also set', async () => {
+      await expect(
+        firstValueFrom(
+          service.createEntry('u1', {
+            exerciseId: 'abs.situps',
+            timestamp: '2026-04-15T08:00:00Z',
+            reps: 10,
+            durationSec: 30,
+          })
+        )
+      ).rejects.toThrow(/wrong-measurement-field/);
+    });
+
+    it('omits empty sets array from the Firestore payload', async () => {
+      const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
+      await firstValueFrom(
+        service.createEntry('u1', {
+          exerciseId: 'abs.situps',
+          timestamp: '2026-04-15T08:00:00Z',
+          reps: 10,
+          sets: [],
+        })
+      );
+      const data = setDocSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(data['sets']).toBeUndefined();
+    });
+
+    it('preserves a non-empty sets array on the Firestore payload', async () => {
+      const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
+      await firstValueFrom(
+        service.createEntry('u1', {
+          exerciseId: 'legs.squats',
+          timestamp: '2026-04-15T08:00:00Z',
+          reps: 30,
+          sets: [10, 10, 10],
+        })
+      );
+      const data = setDocSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(data['sets']).toEqual([10, 10, 10]);
+    });
+
+    it('defaults source to "web" when not provided', async () => {
+      const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
+      await firstValueFrom(
+        service.createEntry('u1', {
+          exerciseId: 'abs.situps',
+          timestamp: '2026-04-15T08:00:00Z',
+          reps: 10,
+        })
+      );
+      const data = setDocSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(data['source']).toBe('web');
+    });
+  });
+
+  describe('updateEntry', () => {
+    it('skips validation when no measurement field is being changed', async () => {
+      const updateSpy = jest.spyOn(firestoreFns, 'updateDoc');
+      await firstValueFrom(
+        service.updateEntry('s1', 'abs.situps', { source: 'mobile' })
+      );
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('errors when the new reps value is out of range', async () => {
+      await expect(
+        firstValueFrom(
+          service.updateEntry('s1', 'abs.situps', { reps: 9999 })
+        )
+      ).rejects.toThrow(/out-of-range/);
+    });
+  });
+
+  describe('deleteEntry', () => {
+    it('returns ok when delete succeeds', async () => {
+      const result = await firstValueFrom(service.deleteEntry('s1'));
+      expect(result).toEqual({ ok: true });
+    });
+  });
+});

--- a/libs/data-access/src/lib/api/exercise-firestore.service.spec.ts
+++ b/libs/data-access/src/lib/api/exercise-firestore.service.spec.ts
@@ -218,6 +218,41 @@ describe('ExerciseFirestoreService', () => {
         )
       ).rejects.toThrow(/out-of-range/);
     });
+
+    it('rejects payloads that try to change the exerciseId', async () => {
+      await expect(
+        firstValueFrom(
+          service.updateEntry('s1', 'abs.situps', {
+            exerciseId: 'legs.squats',
+          })
+        )
+      ).rejects.toBeInstanceOf(ExerciseValidationError);
+    });
+
+    it('strips a pass-through exerciseId that matches the stored value', async () => {
+      const updateSpy = jest.spyOn(firestoreFns, 'updateDoc');
+      await firstValueFrom(
+        service.updateEntry('s1', 'abs.situps', {
+          exerciseId: 'abs.situps',
+          source: 'mobile',
+        })
+      );
+      const patch = updateSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(patch['exerciseId']).toBeUndefined();
+      expect(patch['source']).toBe('mobile');
+    });
+
+    it('uses partial validation so a variantId-only update is allowed', async () => {
+      // The exercise definition for sit-ups currently has no variants,
+      // so an unknown variantId still fails — but an empty string (the
+      // sentinel for "no variant") must pass without requiring a reps
+      // value in the patch.
+      const updateSpy = jest.spyOn(firestoreFns, 'updateDoc');
+      await firstValueFrom(
+        service.updateEntry('s1', 'abs.situps', { variantId: '' })
+      );
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('deleteEntry', () => {

--- a/libs/data-access/src/lib/api/exercise-firestore.service.spec.ts
+++ b/libs/data-access/src/lib/api/exercise-firestore.service.spec.ts
@@ -9,6 +9,7 @@ jest.mock('@angular/fire/firestore', () => ({
   setDoc: jest.fn(async () => undefined),
   updateDoc: jest.fn(async () => undefined),
   deleteDoc: jest.fn(async () => undefined),
+  deleteField: jest.fn(() => '__deleted__'),
 }));
 
 import { TestBed } from '@angular/core/testing';
@@ -86,6 +87,96 @@ describe('ExerciseFirestoreService', () => {
       );
       expect(exerciseFilter).toBeDefined();
       expect(exerciseFilter?.[2]).toBe('legs.squats');
+    });
+
+    it('forwards exerciseIds as an `in` query constraint', async () => {
+      const whereSpy = jest.spyOn(firestoreFns, 'where');
+
+      await firstValueFrom(
+        service.listEntries('u1', {
+          exerciseIds: ['abs.situps', 'legs.squats'],
+        })
+      );
+
+      const exerciseFilter = whereSpy.mock.calls.find(
+        ([field]) => field === 'exerciseId'
+      );
+      expect(exerciseFilter?.[1]).toBe('in');
+      expect(exerciseFilter?.[2]).toEqual(['abs.situps', 'legs.squats']);
+    });
+
+    it('rejects exerciseIds longer than the Firestore `in` cap of 30', async () => {
+      const tooMany = Array.from({ length: 31 }, (_, i) => `e.${i}`);
+      await expect(
+        firstValueFrom(service.listEntries('u1', { exerciseIds: tooMany }))
+      ).rejects.toThrow(/at most 30/);
+    });
+
+    it('emits a from-clause when filter.from is set', async () => {
+      const whereSpy = jest.spyOn(firestoreFns, 'where');
+      await firstValueFrom(
+        service.listEntries('u1', { filter: { from: '2026-04-01' } })
+      );
+      const fromFilter = whereSpy.mock.calls.find(
+        ([field, op]) => field === 'timestamp' && op === '>='
+      );
+      expect(fromFilter?.[2]).toBe('2026-04-01T00:00:00.000Z');
+    });
+
+    it('emits a to-clause when filter.to is set', async () => {
+      const whereSpy = jest.spyOn(firestoreFns, 'where');
+      await firstValueFrom(
+        service.listEntries('u1', { filter: { to: '2026-04-30' } })
+      );
+      const toFilter = whereSpy.mock.calls.find(
+        ([field, op]) => field === 'timestamp' && op === '<='
+      );
+      expect(toFilter?.[2]).toBe('2026-04-30T23:59:59.999Z');
+    });
+
+    it('drops mapped entries outside the [from, to] window', async () => {
+      jest.spyOn(firestoreFns, 'getDocs').mockResolvedValueOnce({
+        docs: [
+          {
+            id: 'before',
+            data: () => ({
+              userId: 'u1',
+              exerciseId: 'abs.situps',
+              timestamp: '2026-03-31T22:00:00Z',
+              reps: 10,
+              source: 'web',
+            }),
+          },
+          {
+            id: 'inside',
+            data: () => ({
+              userId: 'u1',
+              exerciseId: 'abs.situps',
+              timestamp: '2026-04-15T10:00:00Z',
+              reps: 25,
+              source: 'web',
+            }),
+          },
+          {
+            id: 'after',
+            data: () => ({
+              userId: 'u1',
+              exerciseId: 'abs.situps',
+              timestamp: '2026-05-01T08:00:00Z',
+              reps: 20,
+              source: 'web',
+            }),
+          },
+        ],
+      } as never);
+
+      const result = await firstValueFrom(
+        service.listEntries('u1', {
+          filter: { from: '2026-04-01', to: '2026-04-30' },
+        })
+      );
+
+      expect(result.map((e) => e._id)).toEqual(['inside']);
     });
   });
 
@@ -240,6 +331,20 @@ describe('ExerciseFirestoreService', () => {
       const patch = updateSpy.mock.calls[0]?.[1] as Record<string, unknown>;
       expect(patch['exerciseId']).toBeUndefined();
       expect(patch['source']).toBe('mobile');
+    });
+
+    it('clears the sets field when the patch sends an empty array', async () => {
+      const updateSpy = jest.spyOn(firestoreFns, 'updateDoc');
+      const deleteFieldSpy = jest.spyOn(firestoreFns, 'deleteField');
+      await firstValueFrom(
+        service.updateEntry('s1', 'abs.situps', { sets: [] })
+      );
+      expect(deleteFieldSpy).toHaveBeenCalled();
+      const patch = updateSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+      // The mocked deleteField returns the sentinel string from the
+      // jest.mock call above; the real Firestore SDK returns a sentinel
+      // object with the same role.
+      expect(patch['sets']).toBe('__deleted__');
     });
 
     it('uses partial validation so a variantId-only update is allowed', async () => {

--- a/libs/data-access/src/lib/api/exercise-firestore.service.ts
+++ b/libs/data-access/src/lib/api/exercise-firestore.service.ts
@@ -18,6 +18,7 @@ import {
   ExerciseEntryUpdate,
   ExerciseEntryViolation,
   StatsFilter,
+  companionFields,
   findExerciseDefinition,
   measurementValueField,
   validateExerciseEntry,
@@ -140,6 +141,13 @@ export class ExerciseFirestoreService {
     const newRef = doc(ref);
     const nowIso = new Date().toISOString();
     const valueFromPayload = payload[valueField];
+    const allowedCompanions = companionFields(def.measurement);
+    const companionPatch: Record<string, number> = {};
+    for (const f of allowedCompanions) {
+      const v = payload[f];
+      if (typeof v === 'number') companionPatch[f] = v;
+    }
+
     const record: ExerciseEntry = {
       _id: newRef.id,
       userId,
@@ -147,9 +155,7 @@ export class ExerciseFirestoreService {
       timestamp: payload.timestamp,
       [valueField]: valueFromPayload,
       ...(payload.variantId ? { variantId: payload.variantId } : {}),
-      ...(payload.weightKg !== undefined && def.measurement === 'weight'
-        ? { weightKg: payload.weightKg }
-        : {}),
+      ...companionPatch,
       ...(payload.sets?.length ? { sets: payload.sets } : {}),
       source: payload.source ?? 'web',
       createdAt: nowIso,
@@ -164,11 +170,9 @@ export class ExerciseFirestoreService {
       source: record.source,
       createdAt: nowIso,
       updatedAt: nowIso,
+      ...companionPatch,
     };
     if (payload.variantId) firestoreData['variantId'] = payload.variantId;
-    if (payload.weightKg !== undefined && def.measurement === 'weight') {
-      firestoreData['weightKg'] = payload.weightKg;
-    }
     if (payload.sets?.length) firestoreData['sets'] = payload.sets;
 
     return from(setDoc(newRef, firestoreData)).pipe(map(() => record));

--- a/libs/data-access/src/lib/api/exercise-firestore.service.ts
+++ b/libs/data-access/src/lib/api/exercise-firestore.service.ts
@@ -1,0 +1,207 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  Firestore,
+  getDocs,
+  orderBy,
+  query,
+  QueryConstraint,
+  setDoc,
+  updateDoc,
+  where,
+} from '@angular/fire/firestore';
+import {
+  ExerciseEntry,
+  ExerciseEntryCreate,
+  ExerciseEntryUpdate,
+  ExerciseEntryViolation,
+  StatsFilter,
+  findExerciseDefinition,
+  measurementValueField,
+  validateExerciseEntry,
+} from '@pu-stats/models';
+import { from, map, Observable, throwError } from 'rxjs';
+
+const EXERCISE_ENTRIES_COLLECTION = 'exerciseEntries';
+
+export class ExerciseValidationError extends Error {
+  constructor(
+    public readonly exerciseId: string | null,
+    public readonly violation: ExerciseEntryViolation
+  ) {
+    super(
+      `Invalid exercise entry${
+        exerciseId ? ` for ${exerciseId}` : ''
+      }: ${violation}`
+    );
+    this.name = 'ExerciseValidationError';
+  }
+}
+
+/**
+ * Wraps validation errors in a cold Observable so callers see them in
+ * `subscribe({ error })` instead of as a synchronous throw — same pattern
+ * as `PushupFirestoreService`.
+ */
+function violationObservable<T>(
+  exerciseId: string,
+  payload: Pick<
+    ExerciseEntry,
+    'reps' | 'durationSec' | 'distanceM' | 'weightKg' | 'variantId'
+  >
+): Observable<T> | null {
+  const def = findExerciseDefinition(exerciseId);
+  if (!def) {
+    return throwError(
+      () => new ExerciseValidationError(exerciseId, 'unknown-exercise')
+    );
+  }
+  const violation = validateExerciseEntry(payload, def);
+  if (!violation) return null;
+  return throwError(
+    () => new ExerciseValidationError(exerciseId, violation)
+  );
+}
+
+@Injectable({ providedIn: 'root' })
+export class ExerciseFirestoreService {
+  private readonly firestore = inject(Firestore);
+
+  /**
+   * Lists entries for a user, optionally restricted to a single exercise.
+   * Mirrors `PushupFirestoreService.listPushups` so the dashboard sections
+   * can reuse the same date-window filtering.
+   */
+  listEntries(
+    userId: string,
+    options?: { exerciseId?: string; filter?: StatsFilter }
+  ): Observable<ExerciseEntry[]> {
+    const ref = collection(this.firestore, EXERCISE_ENTRIES_COLLECTION);
+    const constraints: QueryConstraint[] = [
+      where('userId', '==', userId),
+      orderBy('timestamp', 'asc'),
+    ];
+    if (options?.exerciseId) {
+      constraints.push(where('exerciseId', '==', options.exerciseId));
+    }
+    if (options?.filter?.from) {
+      constraints.push(
+        where('timestamp', '>=', `${options.filter.from}T00:00:00.000Z`)
+      );
+    }
+    if (options?.filter?.to) {
+      constraints.push(
+        where('timestamp', '<=', `${options.filter.to}T23:59:59.999Z`)
+      );
+    }
+
+    const q = query(ref, ...constraints);
+
+    return from(getDocs(q)).pipe(
+      map((snapshot) =>
+        snapshot.docs
+          .map((d) => {
+            const data = d.data() as Omit<ExerciseEntry, '_id'>;
+            return { _id: d.id, ...data } as ExerciseEntry;
+          })
+          .filter((entry) => {
+            const date = entry.timestamp.slice(0, 10);
+            return (
+              (!options?.filter?.from || date >= options.filter.from) &&
+              (!options?.filter?.to || date <= options.filter.to)
+            );
+          })
+      )
+    );
+  }
+
+  createEntry(
+    userId: string,
+    payload: ExerciseEntryCreate
+  ): Observable<ExerciseEntry> {
+    const violation = violationObservable<ExerciseEntry>(
+      payload.exerciseId,
+      payload
+    );
+    if (violation) return violation;
+    const def = findExerciseDefinition(payload.exerciseId);
+    // findExerciseDefinition is non-null because violationObservable
+    // would have errored otherwise — narrow the type for TS.
+    if (!def) {
+      return throwError(
+        () =>
+          new ExerciseValidationError(payload.exerciseId, 'unknown-exercise')
+      );
+    }
+    const valueField = measurementValueField(def.measurement);
+    const ref = collection(this.firestore, EXERCISE_ENTRIES_COLLECTION);
+    const newRef = doc(ref);
+    const nowIso = new Date().toISOString();
+    const valueFromPayload = payload[valueField];
+    const record: ExerciseEntry = {
+      _id: newRef.id,
+      userId,
+      exerciseId: payload.exerciseId,
+      timestamp: payload.timestamp,
+      [valueField]: valueFromPayload,
+      ...(payload.variantId ? { variantId: payload.variantId } : {}),
+      ...(payload.weightKg !== undefined && def.measurement === 'weight'
+        ? { weightKg: payload.weightKg }
+        : {}),
+      ...(payload.sets?.length ? { sets: payload.sets } : {}),
+      source: payload.source ?? 'web',
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    };
+
+    const firestoreData: Record<string, unknown> = {
+      userId,
+      exerciseId: payload.exerciseId,
+      timestamp: payload.timestamp,
+      [valueField]: valueFromPayload,
+      source: record.source,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    };
+    if (payload.variantId) firestoreData['variantId'] = payload.variantId;
+    if (payload.weightKg !== undefined && def.measurement === 'weight') {
+      firestoreData['weightKg'] = payload.weightKg;
+    }
+    if (payload.sets?.length) firestoreData['sets'] = payload.sets;
+
+    return from(setDoc(newRef, firestoreData)).pipe(map(() => record));
+  }
+
+  updateEntry(
+    id: string,
+    exerciseId: string,
+    payload: ExerciseEntryUpdate
+  ): Observable<void> {
+    const valueChanges = (
+      ['reps', 'durationSec', 'distanceM', 'weightKg', 'variantId'] as const
+    ).some((k) => payload[k] !== undefined);
+    if (valueChanges) {
+      const violation = violationObservable<void>(exerciseId, payload);
+      if (violation) return violation;
+    }
+    const rowRef = doc(this.firestore, EXERCISE_ENTRIES_COLLECTION, id);
+    const cleanPayload = Object.fromEntries(
+      Object.entries(payload).filter(
+        ([, v]) => v !== undefined && !(Array.isArray(v) && v.length === 0)
+      )
+    );
+    return from(
+      updateDoc(rowRef, {
+        ...cleanPayload,
+        updatedAt: new Date().toISOString(),
+      })
+    ).pipe(map(() => void 0));
+  }
+
+  deleteEntry(id: string): Observable<{ ok: true }> {
+    const rowRef = doc(this.firestore, EXERCISE_ENTRIES_COLLECTION, id);
+    return from(deleteDoc(rowRef)).pipe(map(() => ({ ok: true as const })));
+  }
+}

--- a/libs/data-access/src/lib/api/exercise-firestore.service.ts
+++ b/libs/data-access/src/lib/api/exercise-firestore.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import {
   collection,
   deleteDoc,
+  deleteField,
   doc,
   Firestore,
   getDocs,
@@ -94,6 +95,18 @@ export class ExerciseFirestoreService {
     if (options?.exerciseId) {
       constraints.push(where('exerciseId', '==', options.exerciseId));
     } else if (options?.exerciseIds && options.exerciseIds.length > 0) {
+      // Firestore's `in` operator caps the value list at 30. Phase-0
+      // categories are far below that, but guarding here keeps the
+      // failure mode predictable for future larger catalogs (and
+      // avoids a cryptic Firestore error to the caller).
+      if (options.exerciseIds.length > 30) {
+        return throwError(
+          () =>
+            new Error(
+              `listEntries: exerciseIds supports at most 30 ids, got ${options.exerciseIds!.length}`
+            )
+        );
+      }
       constraints.push(where('exerciseId', 'in', [...options.exerciseIds]));
     }
     if (options?.filter?.from) {
@@ -193,9 +206,11 @@ export class ExerciseFirestoreService {
    * as immutable: a different exercise must be modelled as delete + create
    * so the per-exercise stats trigger can decrement the old aggregate.
    * Attempting to change `exerciseId` via the patch payload errors with
-   * `unknown-exercise`-shaped {@link ExerciseValidationError} (the
-   * `'immutable-exercise-id'` violation marker keeps it distinguishable
-   * from a typo in the stored id).
+   * an {@link ExerciseValidationError} carrying the `'unknown-exercise'`
+   * violation code — there is no dedicated immutability code yet, so
+   * callers wanting to distinguish "typo in stored id" from "tried to
+   * move exercise" need to compare the patch and the stored value
+   * themselves.
    *
    * Validation is **partial** — only the fields actually being patched
    * are checked. So a variant-only update doesn't need to round-trip the
@@ -227,14 +242,25 @@ export class ExerciseFirestoreService {
     const rowRef = doc(this.firestore, EXERCISE_ENTRIES_COLLECTION, id);
     // Strip exerciseId so an explicit pass-through doesn't sneak past the
     // immutability check above (e.g. caller forwards the original entry
-    // verbatim). updatedAt is computed server-side, payload values stay.
+    // verbatim). updatedAt is overwritten below with a client-side
+    // ISO timestamp — Firestore `serverTimestamp()` would be safer
+    // against clock skew, but the create path also writes client time
+    // and switching one without the other would produce mixed shapes.
     const { exerciseId: _ignored, ...patchable } = payload;
     void _ignored;
-    const cleanPayload = Object.fromEntries(
-      Object.entries(patchable).filter(
-        ([, v]) => v !== undefined && !(Array.isArray(v) && v.length === 0)
-      )
-    );
+    // An explicit `sets: []` is the contract for "drop the per-set
+    // breakdown" (e.g. user goes from 3×10 back to a single 30-rep entry).
+    // Dropping that key entirely would silently keep the stale array on
+    // the doc; mapping it to `deleteField()` clears the field as expected.
+    const cleanPayload: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(patchable)) {
+      if (v === undefined) continue;
+      if (k === 'sets' && Array.isArray(v) && v.length === 0) {
+        cleanPayload[k] = deleteField();
+        continue;
+      }
+      cleanPayload[k] = v;
+    }
     return from(
       updateDoc(rowRef, {
         ...cleanPayload,

--- a/libs/data-access/src/lib/api/exercise-firestore.service.ts
+++ b/libs/data-access/src/lib/api/exercise-firestore.service.ts
@@ -51,7 +51,8 @@ function violationObservable<T>(
   payload: Pick<
     ExerciseEntry,
     'reps' | 'durationSec' | 'distanceM' | 'weightKg' | 'variantId'
-  >
+  >,
+  options?: { partial?: boolean }
 ): Observable<T> | null {
   const def = findExerciseDefinition(exerciseId);
   if (!def) {
@@ -59,7 +60,7 @@ function violationObservable<T>(
       () => new ExerciseValidationError(exerciseId, 'unknown-exercise')
     );
   }
-  const violation = validateExerciseEntry(payload, def);
+  const violation = validateExerciseEntry(payload, def, options);
   if (!violation) return null;
   return throwError(
     () => new ExerciseValidationError(exerciseId, violation)
@@ -71,13 +72,19 @@ export class ExerciseFirestoreService {
   private readonly firestore = inject(Firestore);
 
   /**
-   * Lists entries for a user, optionally restricted to a single exercise.
-   * Mirrors `PushupFirestoreService.listPushups` so the dashboard sections
-   * can reuse the same date-window filtering.
+   * Lists entries for a user, optionally restricted to a single exercise
+   * or a small set of catalog exercises (Firestore `in` queries are
+   * capped at 30 — fine for the Phase-0 catalog and any realistic
+   * category size). Mirrors `PushupFirestoreService.listPushups` so the
+   * dashboard sections can reuse the same date-window filtering.
    */
   listEntries(
     userId: string,
-    options?: { exerciseId?: string; filter?: StatsFilter }
+    options?: {
+      exerciseId?: string;
+      exerciseIds?: ReadonlyArray<string>;
+      filter?: StatsFilter;
+    }
   ): Observable<ExerciseEntry[]> {
     const ref = collection(this.firestore, EXERCISE_ENTRIES_COLLECTION);
     const constraints: QueryConstraint[] = [
@@ -86,6 +93,8 @@ export class ExerciseFirestoreService {
     ];
     if (options?.exerciseId) {
       constraints.push(where('exerciseId', '==', options.exerciseId));
+    } else if (options?.exerciseIds && options.exerciseIds.length > 0) {
+      constraints.push(where('exerciseId', 'in', [...options.exerciseIds]));
     }
     if (options?.filter?.from) {
       constraints.push(
@@ -178,21 +187,51 @@ export class ExerciseFirestoreService {
     return from(setDoc(newRef, firestoreData)).pipe(map(() => record));
   }
 
+  /**
+   * Patches an existing entry. `exerciseId` is the **stored** value of the
+   * doc (used to look up the catalog entry for validation) and is treated
+   * as immutable: a different exercise must be modelled as delete + create
+   * so the per-exercise stats trigger can decrement the old aggregate.
+   * Attempting to change `exerciseId` via the patch payload errors with
+   * `unknown-exercise`-shaped {@link ExerciseValidationError} (the
+   * `'immutable-exercise-id'` violation marker keeps it distinguishable
+   * from a typo in the stored id).
+   *
+   * Validation is **partial** — only the fields actually being patched
+   * are checked. So a variant-only update doesn't need to round-trip the
+   * primary measurement value, and a no-op update (only `source` changing)
+   * skips validation entirely.
+   */
   updateEntry(
     id: string,
     exerciseId: string,
     payload: ExerciseEntryUpdate
   ): Observable<void> {
+    if (
+      payload.exerciseId !== undefined &&
+      payload.exerciseId !== exerciseId
+    ) {
+      return throwError(
+        () => new ExerciseValidationError(exerciseId, 'unknown-exercise')
+      );
+    }
     const valueChanges = (
       ['reps', 'durationSec', 'distanceM', 'weightKg', 'variantId'] as const
     ).some((k) => payload[k] !== undefined);
     if (valueChanges) {
-      const violation = violationObservable<void>(exerciseId, payload);
+      const violation = violationObservable<void>(exerciseId, payload, {
+        partial: true,
+      });
       if (violation) return violation;
     }
     const rowRef = doc(this.firestore, EXERCISE_ENTRIES_COLLECTION, id);
+    // Strip exerciseId so an explicit pass-through doesn't sneak past the
+    // immutability check above (e.g. caller forwards the original entry
+    // verbatim). updatedAt is computed server-side, payload values stay.
+    const { exerciseId: _ignored, ...patchable } = payload;
+    void _ignored;
     const cleanPayload = Object.fromEntries(
-      Object.entries(payload).filter(
+      Object.entries(patchable).filter(
         ([, v]) => v !== undefined && !(Array.isArray(v) && v.length === 0)
       )
     );

--- a/libs/stats/src/lib/models/exercise.catalog.spec.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.spec.ts
@@ -1,0 +1,97 @@
+import {
+  EXERCISE_CATALOG,
+  EXERCISE_CATEGORIES,
+  exercisesByCategory,
+  findExerciseCategory,
+  findExerciseDefinition,
+} from './exercise.catalog';
+
+describe('EXERCISE_CATEGORIES', () => {
+  it('declares each category id at most once', () => {
+    const ids = EXERCISE_CATEGORIES.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('uses XLIFF i18n keys for every category name', () => {
+    for (const cat of EXERCISE_CATEGORIES) {
+      expect(cat.nameKey).toMatch(/^@@/);
+    }
+  });
+});
+
+describe('EXERCISE_CATALOG', () => {
+  it('declares each exercise id at most once', () => {
+    const ids = EXERCISE_CATALOG.map((d) => d.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('points every exercise at a known category', () => {
+    const known = new Set(EXERCISE_CATEGORIES.map((c) => c.id));
+    for (const def of EXERCISE_CATALOG) {
+      expect(known.has(def.categoryId)).toBe(true);
+    }
+  });
+
+  it('uses XLIFF i18n keys for every catalog name', () => {
+    for (const def of EXERCISE_CATALOG) {
+      expect(def.nameKey).toMatch(/^@@/);
+    }
+  });
+
+  it('keeps min < max for every catalog entry', () => {
+    for (const def of EXERCISE_CATALOG) {
+      expect(def.min).toBeLessThan(def.max);
+    }
+  });
+
+  it('includes the phase-0 sit-ups and squats exercises', () => {
+    const ids = new Set(EXERCISE_CATALOG.map((d) => d.id));
+    expect(ids.has('abs.situps')).toBe(true);
+    expect(ids.has('legs.squats')).toBe(true);
+  });
+});
+
+describe('findExerciseDefinition', () => {
+  it('returns a known catalog entry by id', () => {
+    expect(findExerciseDefinition('abs.situps')?.categoryId).toBe('abs');
+  });
+
+  it('returns null for unknown ids', () => {
+    expect(findExerciseDefinition('does-not-exist')).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(findExerciseDefinition('')).toBeNull();
+    expect(findExerciseDefinition(null)).toBeNull();
+    expect(findExerciseDefinition(undefined)).toBeNull();
+  });
+});
+
+describe('findExerciseCategory', () => {
+  it('returns a known category by id', () => {
+    expect(findExerciseCategory('abs')?.nameKey).toBe(
+      '@@exercise.category.abs'
+    );
+  });
+
+  it('returns null for unknown ids', () => {
+    expect(findExerciseCategory('does-not-exist')).toBeNull();
+  });
+});
+
+describe('exercisesByCategory', () => {
+  it('groups every catalog entry under its category', () => {
+    const map = exercisesByCategory();
+    const abs = map.get('abs') ?? [];
+    const legs = map.get('legs') ?? [];
+    expect(abs.map((d) => d.id)).toContain('abs.situps');
+    expect(legs.map((d) => d.id)).toContain('legs.squats');
+  });
+
+  it('declares a bucket for every known category, even when empty', () => {
+    const map = exercisesByCategory();
+    for (const cat of EXERCISE_CATEGORIES) {
+      expect(map.has(cat.id)).toBe(true);
+    }
+  });
+});

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -89,15 +89,22 @@ export function findExerciseCategory(
 /**
  * Catalog exercises grouped by category, in catalog declaration order
  * within each group. Useful for category-pickers and dashboard sections.
+ *
+ * The catalog is a module-level constant so the result is identical on
+ * every call — cache it once instead of re-allocating in every signal
+ * recomputation (the dashboard sections call this from inside a
+ * `computed`).
  */
+let cachedByCategory:
+  | ReadonlyMap<ExerciseCategoryInfo['id'], ReadonlyArray<ExerciseDefinition>>
+  | null = null;
+
 export function exercisesByCategory(): ReadonlyMap<
   ExerciseCategoryInfo['id'],
   ReadonlyArray<ExerciseDefinition>
 > {
-  const map = new Map<
-    ExerciseCategoryInfo['id'],
-    ExerciseDefinition[]
-  >();
+  if (cachedByCategory) return cachedByCategory;
+  const map = new Map<ExerciseCategoryInfo['id'], ExerciseDefinition[]>();
   for (const cat of EXERCISE_CATEGORIES) {
     map.set(cat.id, []);
   }
@@ -105,5 +112,6 @@ export function exercisesByCategory(): ReadonlyMap<
     const bucket = map.get(def.categoryId);
     if (bucket) bucket.push(def);
   }
-  return map;
+  cachedByCategory = map;
+  return cachedByCategory;
 }

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -1,0 +1,109 @@
+import type {
+  ExerciseCategoryInfo,
+  ExerciseDefinition,
+} from './exercise.models';
+
+/**
+ * Curated catalog of exercise categories shown in the dashboard and
+ * filter UI. Order determines top-to-bottom layout on the dashboard.
+ *
+ * Phase 0 lists only the categories with at least one exercise in
+ * {@link EXERCISE_CATALOG} below — additional categories (plank, cardio,
+ * strength, mobility) are added incrementally with their own exercises.
+ */
+export const EXERCISE_CATEGORIES: ReadonlyArray<ExerciseCategoryInfo> = [
+  {
+    id: 'pushup',
+    nameKey: '@@exercise.category.pushup',
+    icon: 'fitness_center',
+    order: 10,
+  },
+  {
+    id: 'abs',
+    nameKey: '@@exercise.category.abs',
+    icon: 'self_improvement',
+    order: 20,
+  },
+  {
+    id: 'legs',
+    nameKey: '@@exercise.category.legs',
+    icon: 'directions_run',
+    order: 30,
+  },
+];
+
+/**
+ * Standard catalog of exercises available to every user. Phase 0 ships
+ * with sit-ups (abs) and squats (legs). The pushup catalog stays in
+ * `pushup-type.models.ts` for backwards compatibility with existing
+ * Firestore docs in the `pushups` collection — see roadmap.
+ *
+ * Caps mirror the `exerciseEntries` Firestore rule. Any change here MUST
+ * be reflected in `data-store/firestore.rules` and vice versa.
+ */
+export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
+  {
+    id: 'abs.situps',
+    categoryId: 'abs',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.abs.situps.name',
+    icon: 'self_improvement',
+  },
+  {
+    id: 'legs.squats',
+    categoryId: 'legs',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.legs.squats.name',
+    icon: 'directions_run',
+  },
+];
+
+const CATALOG_BY_ID: ReadonlyMap<string, ExerciseDefinition> = new Map(
+  EXERCISE_CATALOG.map((d) => [d.id, d])
+);
+
+const CATEGORIES_BY_ID: ReadonlyMap<string, ExerciseCategoryInfo> = new Map(
+  EXERCISE_CATEGORIES.map((c) => [c.id, c])
+);
+
+export function findExerciseDefinition(
+  id: string | null | undefined
+): ExerciseDefinition | null {
+  if (!id) return null;
+  return CATALOG_BY_ID.get(id) ?? null;
+}
+
+export function findExerciseCategory(
+  id: string | null | undefined
+): ExerciseCategoryInfo | null {
+  if (!id) return null;
+  return CATEGORIES_BY_ID.get(id) ?? null;
+}
+
+/**
+ * Catalog exercises grouped by category, in catalog declaration order
+ * within each group. Useful for category-pickers and dashboard sections.
+ */
+export function exercisesByCategory(): ReadonlyMap<
+  ExerciseCategoryInfo['id'],
+  ReadonlyArray<ExerciseDefinition>
+> {
+  const map = new Map<
+    ExerciseCategoryInfo['id'],
+    ExerciseDefinition[]
+  >();
+  for (const cat of EXERCISE_CATEGORIES) {
+    map.set(cat.id, []);
+  }
+  for (const def of EXERCISE_CATALOG) {
+    const bucket = map.get(def.categoryId);
+    if (bucket) bucket.push(def);
+  }
+  return map;
+}

--- a/libs/stats/src/lib/models/exercise.models.spec.ts
+++ b/libs/stats/src/lib/models/exercise.models.spec.ts
@@ -1,0 +1,193 @@
+import {
+  measurementValueField,
+  validateExerciseEntry,
+  type ExerciseDefinition,
+  type MeasurementType,
+} from './exercise.models';
+
+const repsDef: Pick<
+  ExerciseDefinition,
+  'measurement' | 'min' | 'max' | 'variants'
+> = {
+  measurement: 'reps',
+  min: 1,
+  max: 500,
+};
+
+const timeDef: Pick<
+  ExerciseDefinition,
+  'measurement' | 'min' | 'max' | 'variants'
+> = {
+  measurement: 'time',
+  min: 1,
+  max: 7200,
+};
+
+const distanceDef: Pick<
+  ExerciseDefinition,
+  'measurement' | 'min' | 'max' | 'variants'
+> = {
+  measurement: 'distance',
+  min: 1,
+  max: 100_000,
+};
+
+const weightDef: Pick<
+  ExerciseDefinition,
+  'measurement' | 'min' | 'max' | 'variants'
+> = {
+  measurement: 'weight',
+  min: 1,
+  max: 200,
+};
+
+describe('measurementValueField', () => {
+  describe('Given each MeasurementType', () => {
+    it.each<[MeasurementType, string]>([
+      ['reps', 'reps'],
+      ['weight', 'reps'],
+      ['time', 'durationSec'],
+      ['distance', 'distanceM'],
+    ])('Then %s maps to field %s', (m, expected) => {
+      expect(measurementValueField(m)).toBe(expected);
+    });
+  });
+});
+
+describe('validateExerciseEntry — reps measurement', () => {
+  describe('Given a valid integer in range', () => {
+    it.each([1, 50, 200, 500])('Then %i passes validation', (reps) => {
+      expect(validateExerciseEntry({ reps }, repsDef)).toBeNull();
+    });
+  });
+
+  describe('Given a non-integer or non-finite reps value', () => {
+    it.each([1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+      'Then %p is rejected as not-integer',
+      (reps) => {
+        expect(validateExerciseEntry({ reps }, repsDef)).toBe(
+          'measurement-value-not-integer'
+        );
+      }
+    );
+  });
+
+  describe('Given an out-of-range integer', () => {
+    it.each([0, -1, 501, 10_000])(
+      'Then %i is rejected as out-of-range',
+      (reps) => {
+        expect(validateExerciseEntry({ reps }, repsDef)).toBe(
+          'measurement-value-out-of-range'
+        );
+      }
+    );
+  });
+
+  describe('Given missing reps value', () => {
+    it('Then it is rejected as measurement-value-missing', () => {
+      expect(validateExerciseEntry({}, repsDef)).toBe(
+        'measurement-value-missing'
+      );
+    });
+  });
+
+  describe('Given an entry that also carries a non-reps field', () => {
+    it.each(['durationSec', 'distanceM', 'weightKg'] as const)(
+      'Then setting %s alongside reps is rejected as wrong-measurement-field',
+      (field) => {
+        expect(
+          validateExerciseEntry({ reps: 10, [field]: 5 }, repsDef)
+        ).toBe('wrong-measurement-field');
+      }
+    );
+  });
+});
+
+describe('validateExerciseEntry — time measurement', () => {
+  it('accepts a valid duration', () => {
+    expect(validateExerciseEntry({ durationSec: 60 }, timeDef)).toBeNull();
+  });
+
+  it('rejects when reps is set instead', () => {
+    expect(validateExerciseEntry({ reps: 60 }, timeDef)).toBe(
+      'wrong-measurement-field'
+    );
+  });
+
+  it('rejects an out-of-range duration', () => {
+    expect(validateExerciseEntry({ durationSec: 0 }, timeDef)).toBe(
+      'measurement-value-out-of-range'
+    );
+    expect(validateExerciseEntry({ durationSec: 7201 }, timeDef)).toBe(
+      'measurement-value-out-of-range'
+    );
+  });
+});
+
+describe('validateExerciseEntry — distance measurement', () => {
+  it('accepts a valid distance in meters', () => {
+    expect(validateExerciseEntry({ distanceM: 5000 }, distanceDef)).toBeNull();
+  });
+
+  it('rejects a missing distance value', () => {
+    expect(validateExerciseEntry({}, distanceDef)).toBe(
+      'measurement-value-missing'
+    );
+  });
+});
+
+describe('validateExerciseEntry — weight measurement', () => {
+  it('accepts a valid weight (delivered as reps for now)', () => {
+    expect(validateExerciseEntry({ reps: 80 }, weightDef)).toBeNull();
+  });
+
+  it('rejects when reps exceeds the cap', () => {
+    expect(validateExerciseEntry({ reps: 999 }, weightDef)).toBe(
+      'measurement-value-out-of-range'
+    );
+  });
+});
+
+describe('validateExerciseEntry — variants', () => {
+  const defWithVariants: Pick<
+    ExerciseDefinition,
+    'measurement' | 'min' | 'max' | 'variants'
+  > = {
+    ...repsDef,
+    variants: [
+      { id: 'standard', nameKey: '@@v.standard' },
+      { id: 'wide', nameKey: '@@v.wide' },
+    ],
+  };
+
+  it('accepts an entry without a variantId', () => {
+    expect(validateExerciseEntry({ reps: 10 }, defWithVariants)).toBeNull();
+  });
+
+  it('accepts an entry with a known variantId', () => {
+    expect(
+      validateExerciseEntry({ reps: 10, variantId: 'wide' }, defWithVariants)
+    ).toBeNull();
+  });
+
+  it('rejects an entry with an unknown variantId', () => {
+    expect(
+      validateExerciseEntry(
+        { reps: 10, variantId: 'diamond' },
+        defWithVariants
+      )
+    ).toBe('invalid-variant');
+  });
+
+  it('treats an empty variantId as not set', () => {
+    expect(
+      validateExerciseEntry({ reps: 10, variantId: '' }, defWithVariants)
+    ).toBeNull();
+  });
+
+  it('rejects an unknown variantId on a definition without variants', () => {
+    expect(
+      validateExerciseEntry({ reps: 10, variantId: 'wide' }, repsDef)
+    ).toBe('invalid-variant');
+  });
+});

--- a/libs/stats/src/lib/models/exercise.models.spec.ts
+++ b/libs/stats/src/lib/models/exercise.models.spec.ts
@@ -1,5 +1,7 @@
 import {
+  companionFields,
   measurementValueField,
+  requiredCompanionFields,
   validateExerciseEntry,
   type ExerciseDefinition,
   type MeasurementType,
@@ -51,6 +53,28 @@ describe('measurementValueField', () => {
     ])('Then %s maps to field %s', (m, expected) => {
       expect(measurementValueField(m)).toBe(expected);
     });
+  });
+});
+
+describe('companionFields', () => {
+  it.each<[MeasurementType, string[]]>([
+    ['reps', []],
+    ['time', []],
+    ['distance', ['durationSec']],
+    ['weight', ['weightKg']],
+  ])('Then %s allows %p as companion fields', (m, expected) => {
+    expect([...companionFields(m)]).toEqual(expected);
+  });
+});
+
+describe('requiredCompanionFields', () => {
+  it.each<[MeasurementType, string[]]>([
+    ['reps', []],
+    ['time', []],
+    ['distance', []],
+    ['weight', ['weightKg']],
+  ])('Then %s requires %p as companion fields', (m, expected) => {
+    expect([...requiredCompanionFields(m)]).toEqual(expected);
   });
 });
 
@@ -125,8 +149,17 @@ describe('validateExerciseEntry — time measurement', () => {
 });
 
 describe('validateExerciseEntry — distance measurement', () => {
-  it('accepts a valid distance in meters', () => {
+  it('accepts a valid distance in meters without a duration companion', () => {
     expect(validateExerciseEntry({ distanceM: 5000 }, distanceDef)).toBeNull();
+  });
+
+  it('accepts a valid distance with an optional durationSec companion (pace)', () => {
+    expect(
+      validateExerciseEntry(
+        { distanceM: 5000, durationSec: 1650 },
+        distanceDef
+      )
+    ).toBeNull();
   });
 
   it('rejects a missing distance value', () => {
@@ -134,17 +167,85 @@ describe('validateExerciseEntry — distance measurement', () => {
       'measurement-value-missing'
     );
   });
+
+  it('rejects a non-integer durationSec companion', () => {
+    expect(
+      validateExerciseEntry(
+        { distanceM: 5000, durationSec: 27.5 },
+        distanceDef
+      )
+    ).toBe('companion-value-invalid');
+  });
+
+  it('rejects a durationSec companion outside its bounds', () => {
+    expect(
+      validateExerciseEntry({ distanceM: 5000, durationSec: 0 }, distanceDef)
+    ).toBe('companion-value-out-of-range');
+    expect(
+      validateExerciseEntry(
+        { distanceM: 5000, durationSec: 100_000 },
+        distanceDef
+      )
+    ).toBe('companion-value-out-of-range');
+  });
+
+  it('rejects companion fields not declared for distance', () => {
+    expect(
+      validateExerciseEntry({ distanceM: 5000, weightKg: 5 }, distanceDef)
+    ).toBe('wrong-measurement-field');
+  });
 });
 
 describe('validateExerciseEntry — weight measurement', () => {
-  it('accepts a valid weight (delivered as reps for now)', () => {
-    expect(validateExerciseEntry({ reps: 80 }, weightDef)).toBeNull();
+  it('accepts a valid weighted set (reps + weightKg companion)', () => {
+    expect(
+      validateExerciseEntry({ reps: 5, weightKg: 80 }, weightDef)
+    ).toBeNull();
+  });
+
+  it('accepts a fractional weightKg companion (e.g. 2.5 kg increments)', () => {
+    expect(
+      validateExerciseEntry({ reps: 8, weightKg: 27.5 }, weightDef)
+    ).toBeNull();
+  });
+
+  it('rejects a weighted set without weightKg', () => {
+    expect(validateExerciseEntry({ reps: 5 }, weightDef)).toBe(
+      'companion-value-missing'
+    );
   });
 
   it('rejects when reps exceeds the cap', () => {
-    expect(validateExerciseEntry({ reps: 999 }, weightDef)).toBe(
+    expect(validateExerciseEntry({ reps: 999, weightKg: 80 }, weightDef)).toBe(
       'measurement-value-out-of-range'
     );
+  });
+
+  it('rejects an out-of-range weightKg', () => {
+    expect(
+      validateExerciseEntry({ reps: 5, weightKg: 0 }, weightDef)
+    ).toBe('companion-value-out-of-range');
+    expect(
+      validateExerciseEntry({ reps: 5, weightKg: 1000 }, weightDef)
+    ).toBe('companion-value-out-of-range');
+  });
+
+  it('rejects a non-finite weightKg', () => {
+    expect(
+      validateExerciseEntry(
+        { reps: 5, weightKg: Number.POSITIVE_INFINITY },
+        weightDef
+      )
+    ).toBe('companion-value-invalid');
+  });
+
+  it('rejects companion fields not declared for weight', () => {
+    expect(
+      validateExerciseEntry(
+        { reps: 5, weightKg: 80, durationSec: 30 },
+        weightDef
+      )
+    ).toBe('wrong-measurement-field');
   });
 });
 

--- a/libs/stats/src/lib/models/exercise.models.spec.ts
+++ b/libs/stats/src/lib/models/exercise.models.spec.ts
@@ -249,6 +249,52 @@ describe('validateExerciseEntry — weight measurement', () => {
   });
 });
 
+describe('validateExerciseEntry — partial / patch mode', () => {
+  describe('Given a partial patch that omits the primary value', () => {
+    it('Then a variantId-only update on a reps exercise passes', () => {
+      const def: Pick<
+        ExerciseDefinition,
+        'measurement' | 'min' | 'max' | 'variants'
+      > = {
+        ...repsDef,
+        variants: [{ id: 'wide', nameKey: '@@v.wide' }],
+      };
+      expect(
+        validateExerciseEntry({ variantId: 'wide' }, def, { partial: true })
+      ).toBeNull();
+    });
+
+    it('Then a partial weight patch without weightKg passes', () => {
+      // Without `partial`, weight measurement requires weightKg.
+      expect(
+        validateExerciseEntry({}, weightDef, { partial: true })
+      ).toBeNull();
+    });
+  });
+
+  describe('Given a partial patch that includes invalid values', () => {
+    it('Then a fractional reps patch is still rejected', () => {
+      expect(
+        validateExerciseEntry({ reps: 1.5 }, repsDef, { partial: true })
+      ).toBe('measurement-value-not-integer');
+    });
+
+    it('Then an out-of-range patch is still rejected', () => {
+      expect(
+        validateExerciseEntry({ reps: 9999 }, repsDef, { partial: true })
+      ).toBe('measurement-value-out-of-range');
+    });
+
+    it('Then an unknown variantId in a partial patch is still rejected', () => {
+      expect(
+        validateExerciseEntry({ variantId: 'unknown' }, repsDef, {
+          partial: true,
+        })
+      ).toBe('invalid-variant');
+    });
+  });
+});
+
 describe('validateExerciseEntry — variants', () => {
   const defWithVariants: Pick<
     ExerciseDefinition,

--- a/libs/stats/src/lib/models/exercise.models.ts
+++ b/libs/stats/src/lib/models/exercise.models.ts
@@ -1,0 +1,184 @@
+/**
+ * Generic exercise model — phase 0 of the multi-exercise migration.
+ *
+ * The legacy Pushup-only model in `pushup.models.ts` stays untouched: existing
+ * Firestore docs in the `pushups` collection are still read/written through
+ * `PushupRecord`. New exercises (sit-ups, squats, …) live in a separate
+ * Firestore collection `exerciseEntries` and use {@link ExerciseEntry} below.
+ *
+ * Migration plan and roadmap: see `plans/multi-exercise-roadmap.md`.
+ */
+
+export type MeasurementType = 'reps' | 'time' | 'distance' | 'weight';
+
+export type ExerciseCategoryId =
+  | 'pushup'
+  | 'abs'
+  | 'legs'
+  | 'plank'
+  | 'cardio'
+  | 'strength'
+  | 'mobility';
+
+export interface ExerciseCategoryInfo {
+  id: ExerciseCategoryId;
+  /** XLIFF i18n id (e.g. `'@@exercise.category.abs'`). */
+  nameKey: string;
+  icon: string;
+  /** Display order on the dashboard — lower = higher up. */
+  order: number;
+}
+
+export interface ExerciseVariant {
+  id: string;
+  /** XLIFF i18n id. */
+  nameKey: string;
+  difficulty?: 'beginner' | 'intermediate' | 'advanced';
+}
+
+export interface ExerciseDefinition {
+  /**
+   * Globally unique exercise id. Standard catalog uses dotted segments
+   * (`'abs.situps'`, `'legs.squats'`); custom user exercises use a uuid.
+   */
+  id: string;
+  categoryId: ExerciseCategoryId;
+  /** `undefined` for catalog entries; `userId` for custom user exercises. */
+  ownerId?: string;
+  measurement: MeasurementType;
+  /** Inclusive minimum value for the measurement (e.g. 1 rep). */
+  min: number;
+  /** Inclusive maximum value for the measurement (e.g. 500 reps). */
+  max: number;
+  unit: string;
+  /** XLIFF i18n id for catalog exercises (e.g. `'@@exercise.abs.situps.name'`). */
+  nameKey?: string;
+  /** Plain string for user-defined exercises. */
+  customName?: string;
+  /** Optional Material icon name. */
+  icon?: string;
+  variants?: readonly ExerciseVariant[];
+}
+
+export interface ExerciseEntry {
+  _id: string;
+  userId: string;
+  exerciseId: string;
+  variantId?: string;
+  timestamp: string;
+  /** Set when measurement = 'reps' or 'weight'. */
+  reps?: number;
+  /** Set when measurement = 'time'. */
+  durationSec?: number;
+  /** Set when measurement = 'distance'. */
+  distanceM?: number;
+  /** Set when measurement = 'weight' (kg per rep). */
+  weightKg?: number;
+  /** Optional per-set breakdown, only meaningful for reps/weight. */
+  sets?: number[];
+  source: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ExerciseEntryCreate {
+  exerciseId: string;
+  variantId?: string;
+  timestamp: string;
+  reps?: number;
+  durationSec?: number;
+  distanceM?: number;
+  weightKg?: number;
+  sets?: number[];
+  source?: string;
+}
+
+export interface ExerciseEntryUpdate {
+  exerciseId?: string;
+  variantId?: string;
+  timestamp?: string;
+  reps?: number;
+  durationSec?: number;
+  distanceM?: number;
+  weightKg?: number;
+  sets?: number[];
+  source?: string;
+}
+
+export type ExerciseEntryViolation =
+  | 'unknown-exercise'
+  | 'measurement-value-missing'
+  | 'measurement-value-not-integer'
+  | 'measurement-value-out-of-range'
+  | 'wrong-measurement-field'
+  | 'invalid-variant';
+
+/**
+ * Returns the value field expected for a measurement type. Pure helper —
+ * lets the validator and UI form derive the active field name without a
+ * scattered switch statement.
+ */
+export function measurementValueField(
+  measurement: MeasurementType
+): keyof Pick<ExerciseEntry, 'reps' | 'durationSec' | 'distanceM' | 'weightKg'> {
+  switch (measurement) {
+    case 'reps':
+    case 'weight':
+      return 'reps';
+    case 'time':
+      return 'durationSec';
+    case 'distance':
+      return 'distanceM';
+  }
+}
+
+/**
+ * Validates an entry payload against its exercise definition. Pure — used
+ * by the data-access service to fail fast before hitting Firestore, by form
+ * validators, and by the Cloud Function delta. Returns null when valid.
+ *
+ * Validation rules:
+ *   - The value field expected by `def.measurement` must be present and a
+ *     finite integer in `[def.min, def.max]`.
+ *   - No other measurement value field may be set (so a 'reps' entry must
+ *     not also carry `durationSec`, etc. — keeps the aggregation honest).
+ *   - `variantId`, if set, must reference one of `def.variants[].id`.
+ */
+export function validateExerciseEntry(
+  entry: Pick<
+    ExerciseEntry,
+    'reps' | 'durationSec' | 'distanceM' | 'weightKg' | 'variantId'
+  >,
+  def: Pick<ExerciseDefinition, 'measurement' | 'min' | 'max' | 'variants'>
+): ExerciseEntryViolation | null {
+  const expectedField = measurementValueField(def.measurement);
+  const otherFields = (
+    ['reps', 'durationSec', 'distanceM', 'weightKg'] as const
+  ).filter((f) => f !== expectedField);
+  for (const f of otherFields) {
+    if (entry[f] !== undefined) {
+      return 'wrong-measurement-field';
+    }
+  }
+  const value = entry[expectedField];
+  if (value === undefined || value === null) {
+    return 'measurement-value-missing';
+  }
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value)
+  ) {
+    return 'measurement-value-not-integer';
+  }
+  if (value < def.min || value > def.max) {
+    return 'measurement-value-out-of-range';
+  }
+  if (entry.variantId !== undefined && entry.variantId !== '') {
+    const variants = def.variants ?? [];
+    if (!variants.some((v) => v.id === entry.variantId)) {
+      return 'invalid-variant';
+    }
+  }
+  return null;
+}

--- a/libs/stats/src/lib/models/exercise.models.ts
+++ b/libs/stats/src/lib/models/exercise.models.ts
@@ -218,23 +218,33 @@ export function requiredCompanionFields(
  *
  * Validation rules:
  *   - The value field expected by `def.measurement` must be present and a
- *     finite integer in `[def.min, def.max]`.
+ *     finite integer in `[def.min, def.max]` (skipped when `partial` is
+ *     true, e.g. for an `updateEntry()` patch that only changes the variant).
  *   - Companion fields declared in {@link COMPANION_FIELDS} for the
  *     measurement may also be present (e.g. `durationSec` for distance,
  *     `weightKg` for weighted sets). All other measurement value fields
  *     are rejected as `wrong-measurement-field`.
- *   - Companions in {@link REQUIRED_COMPANIONS} must be present.
- *   - Companion values are validated against their own per-field bounds
- *     in {@link COMPANION_BOUNDS}.
+ *   - Companions in {@link REQUIRED_COMPANIONS} must be present (skipped
+ *     when `partial` is true).
+ *   - Companion values, when present, are validated against their own
+ *     per-field bounds in {@link COMPANION_BOUNDS}.
  *   - `variantId`, if set, must reference one of `def.variants[].id`.
+ *
+ * Why a `partial` mode: `ExerciseFirestoreService.updateEntry()` ships
+ * patches that may only change a single field (e.g. `variantId`).
+ * Requiring the primary measurement value on every patch would force the
+ * caller to refetch the document just to satisfy the validator —
+ * breaking the cheap-update contract.
  */
 export function validateExerciseEntry(
   entry: Pick<
     ExerciseEntry,
     'reps' | 'durationSec' | 'distanceM' | 'weightKg' | 'variantId'
   >,
-  def: Pick<ExerciseDefinition, 'measurement' | 'min' | 'max' | 'variants'>
+  def: Pick<ExerciseDefinition, 'measurement' | 'min' | 'max' | 'variants'>,
+  options?: { partial?: boolean }
 ): ExerciseEntryViolation | null {
+  const partial = options?.partial === true;
   const expectedField = measurementValueField(def.measurement);
   const allowedCompanions = COMPANION_FIELDS[def.measurement];
   const allFields: ReadonlyArray<MeasurementValueField> = [
@@ -252,21 +262,24 @@ export function validateExerciseEntry(
   }
   const value = entry[expectedField];
   if (value === undefined || value === null) {
-    return 'measurement-value-missing';
+    if (!partial) return 'measurement-value-missing';
+  } else {
+    if (
+      typeof value !== 'number' ||
+      !Number.isFinite(value) ||
+      !Number.isInteger(value)
+    ) {
+      return 'measurement-value-not-integer';
+    }
+    if (value < def.min || value > def.max) {
+      return 'measurement-value-out-of-range';
+    }
   }
-  if (
-    typeof value !== 'number' ||
-    !Number.isFinite(value) ||
-    !Number.isInteger(value)
-  ) {
-    return 'measurement-value-not-integer';
-  }
-  if (value < def.min || value > def.max) {
-    return 'measurement-value-out-of-range';
-  }
-  for (const f of REQUIRED_COMPANIONS[def.measurement]) {
-    if (entry[f] === undefined || entry[f] === null) {
-      return 'companion-value-missing';
+  if (!partial) {
+    for (const f of REQUIRED_COMPANIONS[def.measurement]) {
+      if (entry[f] === undefined || entry[f] === null) {
+        return 'companion-value-missing';
+      }
     }
   }
   for (const f of allowedCompanions) {

--- a/libs/stats/src/lib/models/exercise.models.ts
+++ b/libs/stats/src/lib/models/exercise.models.ts
@@ -111,7 +111,16 @@ export type ExerciseEntryViolation =
   | 'measurement-value-not-integer'
   | 'measurement-value-out-of-range'
   | 'wrong-measurement-field'
-  | 'invalid-variant';
+  | 'invalid-variant'
+  | 'companion-value-missing'
+  | 'companion-value-invalid'
+  | 'companion-value-out-of-range';
+
+type MeasurementValueField =
+  | 'reps'
+  | 'durationSec'
+  | 'distanceM'
+  | 'weightKg';
 
 /**
  * Returns the value field expected for a measurement type. Pure helper —
@@ -133,6 +142,76 @@ export function measurementValueField(
 }
 
 /**
+ * Companion value fields allowed alongside the primary measurement value.
+ *
+ * - `distance`: an optional `durationSec` lets the entry record pace
+ *   (e.g. a 5 km run in 27:30 stores `distanceM` AND `durationSec`).
+ * - `weight`: a required `weightKg` companion turns the rep count into
+ *   a weighted set (squats with 80 kg → `reps:5`, `weightKg:80`).
+ *
+ * Any field not declared here is rejected as `wrong-measurement-field`.
+ */
+const COMPANION_FIELDS: Readonly<
+  Record<MeasurementType, ReadonlyArray<MeasurementValueField>>
+> = {
+  reps: [],
+  time: [],
+  distance: ['durationSec'],
+  weight: ['weightKg'],
+};
+
+const REQUIRED_COMPANIONS: Readonly<
+  Record<MeasurementType, ReadonlyArray<MeasurementValueField>>
+> = {
+  reps: [],
+  time: [],
+  distance: [],
+  weight: ['weightKg'],
+};
+
+/**
+ * Bounds and integer-ness for each value field when used as a companion.
+ *
+ * Why per-field instead of pulling from the {@link ExerciseDefinition}:
+ * companion semantics (e.g. weightKg up to ~500 kg, durationSec up to
+ * one day) are largely catalog-independent and not yet expressive enough
+ * to warrant a per-definition cap. When custom user exercises land in
+ * Phase 4 we can move these into `ExerciseDefinition`.
+ */
+const COMPANION_BOUNDS: Readonly<
+  Record<
+    MeasurementValueField,
+    { readonly min: number; readonly max: number; readonly integer: boolean }
+  >
+> = {
+  reps: { min: 1, max: 500, integer: true },
+  durationSec: { min: 1, max: 86_400, integer: true },
+  distanceM: { min: 1, max: 100_000, integer: true },
+  weightKg: { min: 0.25, max: 500, integer: false },
+};
+
+/**
+ * Returns the companion fields a measurement type allows. Useful for UI
+ * form builders that show/hide pace or weight inputs based on the
+ * selected exercise.
+ */
+export function companionFields(
+  measurement: MeasurementType
+): ReadonlyArray<MeasurementValueField> {
+  return COMPANION_FIELDS[measurement];
+}
+
+/**
+ * Returns the companion fields a measurement type *requires* (vs. just
+ * allows). Currently only `weight` requires `weightKg`.
+ */
+export function requiredCompanionFields(
+  measurement: MeasurementType
+): ReadonlyArray<MeasurementValueField> {
+  return REQUIRED_COMPANIONS[measurement];
+}
+
+/**
  * Validates an entry payload against its exercise definition. Pure — used
  * by the data-access service to fail fast before hitting Firestore, by form
  * validators, and by the Cloud Function delta. Returns null when valid.
@@ -140,8 +219,13 @@ export function measurementValueField(
  * Validation rules:
  *   - The value field expected by `def.measurement` must be present and a
  *     finite integer in `[def.min, def.max]`.
- *   - No other measurement value field may be set (so a 'reps' entry must
- *     not also carry `durationSec`, etc. — keeps the aggregation honest).
+ *   - Companion fields declared in {@link COMPANION_FIELDS} for the
+ *     measurement may also be present (e.g. `durationSec` for distance,
+ *     `weightKg` for weighted sets). All other measurement value fields
+ *     are rejected as `wrong-measurement-field`.
+ *   - Companions in {@link REQUIRED_COMPANIONS} must be present.
+ *   - Companion values are validated against their own per-field bounds
+ *     in {@link COMPANION_BOUNDS}.
  *   - `variantId`, if set, must reference one of `def.variants[].id`.
  */
 export function validateExerciseEntry(
@@ -152,10 +236,16 @@ export function validateExerciseEntry(
   def: Pick<ExerciseDefinition, 'measurement' | 'min' | 'max' | 'variants'>
 ): ExerciseEntryViolation | null {
   const expectedField = measurementValueField(def.measurement);
-  const otherFields = (
-    ['reps', 'durationSec', 'distanceM', 'weightKg'] as const
-  ).filter((f) => f !== expectedField);
-  for (const f of otherFields) {
+  const allowedCompanions = COMPANION_FIELDS[def.measurement];
+  const allFields: ReadonlyArray<MeasurementValueField> = [
+    'reps',
+    'durationSec',
+    'distanceM',
+    'weightKg',
+  ];
+  for (const f of allFields) {
+    if (f === expectedField) continue;
+    if (allowedCompanions.includes(f)) continue;
     if (entry[f] !== undefined) {
       return 'wrong-measurement-field';
     }
@@ -173,6 +263,25 @@ export function validateExerciseEntry(
   }
   if (value < def.min || value > def.max) {
     return 'measurement-value-out-of-range';
+  }
+  for (const f of REQUIRED_COMPANIONS[def.measurement]) {
+    if (entry[f] === undefined || entry[f] === null) {
+      return 'companion-value-missing';
+    }
+  }
+  for (const f of allowedCompanions) {
+    const v = entry[f];
+    if (v === undefined || v === null) continue;
+    const bounds = COMPANION_BOUNDS[f];
+    if (typeof v !== 'number' || !Number.isFinite(v)) {
+      return 'companion-value-invalid';
+    }
+    if (bounds.integer && !Number.isInteger(v)) {
+      return 'companion-value-invalid';
+    }
+    if (v < bounds.min || v > bounds.max) {
+      return 'companion-value-out-of-range';
+    }
   }
   if (entry.variantId !== undefined && entry.variantId !== '') {
     const variants = def.variants ?? [];

--- a/libs/stats/src/lib/models/stats.models.ts
+++ b/libs/stats/src/lib/models/stats.models.ts
@@ -36,3 +36,5 @@ export * from './reminder-config.models';
 export * from './reminder-i18n.models';
 export * from './user-stats.models';
 export * from './public-profile.models';
+export * from './exercise.models';
+export * from './exercise.catalog';

--- a/plans/multi-exercise-roadmap.md
+++ b/plans/multi-exercise-roadmap.md
@@ -113,7 +113,7 @@ export interface ExerciseEntry {
 **Migration-Strategie**
 
 Cloud-Function-Backfill: Liest alle `pushups/*` Docs, schreibt sie 1:1 nach
-`exerciseEntries/*` mit `exerciseId='pushup'` und `variantType=type`. Die alte
+`exerciseEntries/*` mit `exerciseId='pushup'` und `variantId=type`. Die alte
 Collection bleibt **read-only** als Fallback bestehen, bis alle Klienten auf
 neuem Schema lesen. Nach n Tagen: alte Collection löschen, Rule entfernen.
 
@@ -253,6 +253,34 @@ Measurement:
 Caps liegen aktuell hartcodiert in `COMPANION_BOUNDS` (z. B. `weightKg`
 0.25..500 mit Fließkomma für 2.5-kg-Inkremente, `durationSec` 1..86 400).
 In Phase 4 (Custom-Übungen) wandern sie in `ExerciseDefinition`.
+
+## Aufgeschobene Folgearbeiten (aus PR #289 Review)
+
+Punkte, die im Phase-0-PR identifiziert, aber bewusst nicht direkt
+gefixt wurden, weil ihr Aufwand den Tracer-Bullet sprengen würde:
+
+- **Cloud-Function-Tests für `updateExerciseStatsOnEntryWrite`.** Die
+  bestehenden Branches (first-create rebuild, version upgrade,
+  timestamp-changed move, normaler Delta-Pfad, missing-doc rebuild)
+  sind durch die Tests von `applyDelta` / `rebuildFromEntries` indirekt
+  abgedeckt, aber dieser Trigger braucht eigene Tests, sobald Phase 1+
+  weitere Measurement-Typen ergänzt.
+- **Component-Tests für `ExerciseCategorySectionComponent`.** Der
+  `summaries()`-Compute und der `openDialog()`-Erfolgs-/Fehlerpfad
+  sollten Tests bekommen, sobald die Sektion mehr als reine Read+Add-
+  Logik enthält (Streaks, Filter, Charts).
+- **Per-Index-`aria-label`s im Eintrag-Dialog.** "Set 2 entfernen" /
+  "Set 2 hinzufügen" statt der heute generischen Labels braucht eine
+  ICU-MessageFormat-i18n-Erweiterung über alle 9 Locales — kein
+  funktionaler Fix.
+- **Codegen für Catalog-Caps ↔ Firestore-Rule.** Heute pflegen wir die
+  reps-Caps an zwei Stellen (Catalog + Rule). Sobald Phase 4 (Custom-
+  Übungen) variable Caps einführt, brauchen wir entweder eine
+  generierte Rule oder eine Build-Time-Assertion.
+- **Generische Anzeige-Logik in der Section.** `totalReps30d` und
+  `last.reps` setzen Phase-0-Reps-only voraus. Wenn Phase 1 (Plank /
+  Time) landet, muss die Sektion via `measurementValueField()` die
+  passende Spalte rendern.
 
 ## Risiken & Offene Fragen
 

--- a/plans/multi-exercise-roadmap.md
+++ b/plans/multi-exercise-roadmap.md
@@ -1,0 +1,246 @@
+# Multi-Exercise Roadmap
+
+> Status: Proposed — generated 2026-05-05.
+> Driver: Erweitern der App von "nur Liegestütze" auf ein generisches Übungssystem
+> mit Bauch, Beine, Plank, Laufen, Kraftübungen und User-definierten Übungen.
+
+## Vision
+
+Heute ist die App vollständig auf "Pushup" verdrahtet: Collection-Name (`pushups`),
+Feldname (`reps`), Cap (1–500), Catalog (`PUSHUP_TYPES`), Cloud-Function-Aggregation,
+Leaderboard, Streak, Filter, i18n. Künftig:
+
+- **Standard-Katalog von Übungen** (Pushups, Bauch, Beine, Plank, Pull-ups, Squats,
+  Laufen …), kuratiert wie heute `PUSHUP_TYPES`.
+- **Vier Measurement-Modi:** `reps` (Pushups, Bauch), `time` (Plank, Wandsitz),
+  `distance` (Laufen, Radfahren), `weight` (Squats mit Hantel — Reps × kg).
+- **Custom Exercises:** User können eigene Übungen anlegen (Name, Measurement-Type,
+  Caps, Icon). Diese werden in Filter, Charts, Streaks, Leaderboards berücksichtigt.
+- **Per-Exercise-Aggregation:** Jede Übung hat eigene Streaks, Best-Days, Daily-
+  Goals, Heatmap, Period-Aggregates.
+- **Per-Exercise-Leaderboards:** Top-10 pro Übung, kein einheitlicher "Reps-Topf".
+- **Bestehende Userdaten** dürfen nicht verloren gehen — Migration der `pushups`-
+  Collection auf das neue Schema.
+
+## Datenmodell-Skizze (Ziel)
+
+Drei-Ebenen-Hierarchie: **Kategorie → Übung → Variante (optional)**.
+
+- **Kategorie** = breite Gruppe wie "Bauch", "Beine", "Pushups", "Plank", "Cardio".
+  Wird zur Navigation und für Dashboard-Sektionen genutzt.
+- **Übung** (`ExerciseDefinition`) = konkrete Tätigkeit (Crunches, Sit-ups, Squats,
+  Lunges …). Jede Übung gehört zu genau einer Kategorie und hat genau einen
+  Measurement-Type.
+- **Variante** = Untergruppierung einer Übung, optional. Heute nur bei
+  Pushups relevant ("Diamond", "Wide", "One-Arm" …); künftig auch bei Plank
+  ("Forearm Plank", "Side Plank", "Hollow Hold").
+
+```ts
+// libs/stats/src/lib/models/exercise.models.ts
+export type MeasurementType = 'reps' | 'time' | 'distance' | 'weight';
+
+export type ExerciseCategoryId =
+  | 'pushup' | 'abs' | 'legs' | 'plank' | 'cardio' | 'strength' | 'mobility';
+
+export interface ExerciseCategoryInfo {
+  id: ExerciseCategoryId;
+  nameKey: string;             // i18n XLIFF-ID, z. B. '@@exercise.category.abs'
+  icon: string;                // Material icon name
+  order: number;               // Anzeige-Reihenfolge im Dashboard
+}
+
+export interface ExerciseDefinition {
+  id: string;                  // 'pushup' | 'abs.crunches' | 'legs.squats' | custom uid
+  categoryId: ExerciseCategoryId;
+  ownerId?: string;            // null für Standard-Katalog, userId für Custom
+  measurement: MeasurementType;
+  // Caps pro Measurement (reps 1..500, durationSec 1..7200, distanceM 1..100000)
+  min: number;
+  max: number;
+  unit: string;                // 'reps' | 's' | 'm' | 'kg'
+  nameKey?: string;            // i18n XLIFF-ID für Standard-Übungen
+  customName?: string;         // freier Name für User-Übungen
+  icon?: string;
+  variants?: readonly ExerciseVariant[];   // optional, z. B. nur bei Pushup/Plank
+}
+
+export interface ExerciseVariant {
+  id: string;                  // 'diamond' | 'wide' | 'forearm' …
+  nameKey: string;             // i18n XLIFF-ID
+  difficulty?: 'beginner' | 'intermediate' | 'advanced';
+}
+
+export interface ExerciseEntry {
+  _id: string;
+  userId: string;
+  exerciseId: string;          // FK in ExerciseDefinition
+  variantId?: string;          // optional FK in ExerciseDefinition.variants[]
+  timestamp: string;
+  // Genau eines der folgenden Felder ist gesetzt — durch Measurement bestimmt:
+  reps?: number;
+  durationSec?: number;
+  distanceM?: number;
+  weightKg?: number;           // bei measurement='weight' kombiniert mit reps
+  sets?: number[];             // optional, nur reps/weight
+  source: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+```
+
+### Vorgesehener Standard-Katalog (Endausbau)
+
+| Kategorie | Übungen | Measurement |
+| --- | --- | --- |
+| Pushup | Pushup (mit 13 Varianten — bestehender Katalog) | reps |
+| Bauch | Crunches, Sit-ups, Beinheben, Russian Twist, Mountain Climbers | reps |
+| Beine | Kniebeugen (Squats), Ausfallschritte (Lunges), Hüftheben (Glute Bridge), Wadenheben, Jump Squats, Wandsitz (`time`) | reps / time |
+| Plank | Plank (Varianten: Standard, Forearm, Side, Hollow Hold) | time |
+| Cardio | Laufen, Radfahren, Rudern | distance + optional time |
+| Strength | Squat, Bench Press, Deadlift, Overhead Press | weight × reps |
+| Mobility | Stretching-Routine | time |
+
+**Firestore-Collections**
+
+- `exerciseEntries/{id}` — neuer Name, neutralisiert.
+- `exerciseDefinitions/{id}` — Standard-Katalog wird beim Build seeded; Custom
+  Definitions liegen pro User unter dem gleichen Doc mit `ownerId`.
+- `userStats/{userId}/perExercise/{exerciseId}` — Aggregate pro Übung. Globale
+  Aggregate (Total-Streak, Total-Reps) entfallen oder werden als Sum-of-Reps
+  separat geführt.
+- `leaderboards/{exerciseId}_{period}` — eine Snapshot pro Übung × Periode.
+
+**Migration-Strategie**
+
+Cloud-Function-Backfill: Liest alle `pushups/*` Docs, schreibt sie 1:1 nach
+`exerciseEntries/*` mit `exerciseId='pushup'` und `variantType=type`. Die alte
+Collection bleibt **read-only** als Fallback bestehen, bis alle Klienten auf
+neuem Schema lesen. Nach n Tagen: alte Collection löschen, Rule entfernen.
+
+## Roadmap (Phasen)
+
+### Phase 0 — Tracer-Bullet: Bauch + Beine end-to-end (DIESER PR)
+
+**Ziel:** User legt einen Eintrag in einer der neuen Übungen (Crunches, Sit-ups,
+Squats, Lunges …) an, sieht ihn in der Dashboard-Sektion seiner Kategorie und in
+den eigenen Stats. Pushups bleiben unverändert verfügbar; das Pushup-Dashboard
+ist die "obere" Sektion, darunter folgen Bauch und Beine.
+
+**Phase-0-Katalog (Vorschlag)**
+
+- Kategorie `pushup`: `pushup` (alles wie heute, inkl. 13 Varianten).
+- Kategorie `abs`: `abs.crunches`, `abs.situps`, `abs.legraises`,
+  `abs.russiantwist`, `abs.mountainclimbers` — alle reps.
+- Kategorie `legs`: `legs.squats`, `legs.lunges`, `legs.glutebridge`,
+  `legs.calfraises`, `legs.jumpsquats` — alle reps.
+- Wandsitz (Wall-sit) bewusst rausgehalten, kommt mit Plank in Phase 1.
+
+**Scope**
+
+- [ ] **Modelle:** `ExerciseDefinition`, `ExerciseEntry`, `MeasurementType`,
+      `ExerciseCategoryInfo`, `ExerciseVariant` neu anlegen. Variant-Struktur
+      generisch — Pushup-Varianten wandern aus `PUSHUP_TYPES` in den
+      generischen `variants`-Slot der `pushup`-Definition.
+- [ ] **Validierung:** `validateExerciseEntry(entry, def)` prüft Measurement-
+      Konsistenz (genau ein passendes Wertfeld gesetzt) und Caps.
+- [ ] **Firestore Schema:** Neue Collection `exerciseEntries`. Pushups bleiben
+      kurzfristig in der alten Collection — der neue Service liest beide und
+      mappt `pushups/*` Docs on-the-fly auf `ExerciseEntry`-Form.
+- [ ] **Security Rules:** Neue Rule für `exerciseEntries` mit Caps pro
+      Measurement-Type (reps 1–500, sicherheitsseitig hardcoded; Custom-
+      Übungen kommen erst in Phase 4).
+- [ ] **API-Service:** `ExerciseFirestoreService` parallel zu
+      `PushupFirestoreService`. Pushups-Service bleibt unverändert, damit
+      Bestandscode weiterläuft.
+- [ ] **Cloud Functions:** `applyDelta` bekommt einen `exerciseId`-Parameter
+      und schreibt Aggregate nach `userStats/{userId}/perExercise/{id}`. Trigger
+      auf `exerciseEntries/*` registriert.
+- [ ] **Dashboard:** Bestehende Pushup-Sektion bleibt oben unverändert. Darunter
+      eine neue Komponente `<exercise-category-section>` für jede Kategorie mit
+      Daten — pro Kategorie Total der letzten 30 Tage, Top-Übung, einfache
+      Eintragsliste.
+- [ ] **Create-Entry-Dialog:** Neues "Übung"-Dropdown (Kategorie → Übung).
+      Pushup-Pfad bleibt mit Varianten-Autocomplete; Bauch/Beine reduziert auf
+      `reps` + `sets` + `timestamp`.
+- [ ] **i18n:** Neue XLIFF-IDs für Kategorien (`@@exercise.category.abs`,
+      `@@exercise.category.legs`, `@@exercise.category.pushup`) und für die
+      10 neuen Übungen (`@@exercise.abs.crunches.name` etc.). Bestehende
+      Pushup-Strings bleiben unverändert.
+- [ ] **Tests:** Unit-Tests für Modelle, Validierung, Service. Component-Tests
+      für Dialog und neue Dashboard-Sektion. Cloud-Function-Test für Delta mit
+      zwei `exerciseId`s.
+- [ ] **Doku:** `docs/architecture.md` Abschnitt "Exercises" + Hinweis in
+      `AGENTS.md`.
+
+**Out of Scope (Phase 0)**
+
+- Plank (Time-Measurement, eigenes Varianten-Set) — eigene Phase wegen
+  anderer UX/Validierung.
+- Custom-User-Exercises.
+- Per-Exercise-Leaderboards.
+- Migration der alten `pushups` Collection in `exerciseEntries` — wir lassen
+  beide Collections koexistieren, neuer Read-Layer abstrahiert das.
+- Per-Exercise-Streaks (kommt in Phase 2 sobald die Aggregation steht).
+- Trainingspläne pro Übung.
+- Wandsitz und andere Time-Übungen (mit Plank in Phase 1).
+
+### Phase 1 — Plank (Time-Measurement)
+
+- `MeasurementType='time'` mit `durationSec` 1–7200.
+- Eingabe-UI: mm:ss-Format + Stopper-Komponente.
+- Aggregation in Cloud Function: `totalSec`, `bestHold`, `dailySec`.
+- Charts: Zeit statt Reps auf Y-Achse.
+- Validierung Security Rule: `durationSec` Cap pro Exercise.
+
+### Phase 2 — Per-Exercise-Streaks & Daily-Goals
+
+- `userStats/{userId}/perExercise/{exerciseId}` mit eigenem `currentStreak`,
+  `bestStreak`, `dailyGoal`.
+- UI: Pro aktiver Übung eigene Streak-Card auf dem Dashboard.
+
+### Phase 3 — Cardio: Laufen (Distance + Time)
+
+- `MeasurementType='distance'` mit `distanceM` und optionalem `durationSec`
+  (Pace).
+- UI: km/m-Toggle, optionale Strecke (GPX-Import lassen wir vorerst weg).
+
+### Phase 4 — Custom Exercises (User-defined)
+
+- UI für "Eigene Übung anlegen": Name, Measurement, Caps, Icon, Kategorie.
+- Firestore: `exerciseDefinitions/{uuid}` mit `ownerId=userId`.
+- Security Rule: `ownerId == auth.uid` darf erstellen/lesen.
+- Filter / Catalog UI listet eigene Übungen unter "Meine Übungen".
+
+### Phase 5 — Strength: Reps × Weight
+
+- `MeasurementType='weight'` — Eintrag enthält `reps` und `weightKg`.
+- Aggregation: Volume (Reps × kg), 1RM-Schätzung (Epley), PR-Tracking.
+- Sets-Array bekommt optional `[reps: number, weightKg: number][]`-Tupel.
+
+### Phase 6 — Per-Exercise-Leaderboards
+
+- Eine Snapshot-Collection pro Übung × Periode.
+- UI: Tab pro Übung in `/leaderboard`.
+- Anti-Cheat-Caps pro Übung konfigurierbar.
+
+### Phase 7 — Migration & Cleanup
+
+- Cloud-Function-Job kopiert `pushups/*` → `exerciseEntries/*` mit
+  `exerciseId='pushup'`.
+- Alte Service-Wrapper entfernt.
+- Alte Collection nach Sentry-Stichtag löschen.
+
+## Risiken & Offene Fragen
+
+- **Backwards-Compat von `userStats`:** Heute liegt das Aggregat als ein einziges
+  Doc pro User. Wenn wir auf `perExercise/{id}` umstellen, brechen alle Read-
+  Sites. Deshalb in Phase 0 nur **zusätzlich** schreiben, alte Felder bleiben.
+- **Pushup-Variant-Type vs. Exercise:** `variantType` (Diamond/Wide/…) bleibt nur
+  für `exercise.id='pushup'` relevant. UI muss das kontextabhängig zeigen.
+- **Quick-Add-FAB & Notification-Quick-Log:** Hängen heute hart an Pushups. In
+  Phase 0 belassen wir den Default auf Pushup. User kann später konfigurieren.
+- **Leaderboard-Exclusion-Flag:** Bleibt user-global, nicht per-exercise.
+- **Plank-Daten in Charts:** Y-Achse muss pro Übung anders skaliert werden — heute
+  haben Charts harte Reps-Annahme.
+- **Demo-User für SEO:** Pushup-only Demo-Daten reichen vorerst; sobald wir
+  öffentliche Bauch/Beine-Seiten erzeugen, brauchen wir Demo-Einträge dort.

--- a/plans/multi-exercise-roadmap.md
+++ b/plans/multi-exercise-roadmap.md
@@ -446,6 +446,67 @@ finden uns nicht.
   Exercise-Versprechen. Re-Branding ist ein separater Track —
   hier nur Texte, kein Logo / Domain-Wechsel.
 
+### Track UI-3 — Ein Dialog für alle Übungen
+
+**Status:** offen, sollte vor Phase 4 (Custom Exercises) abgeschlossen sein —
+Custom-Übungen brauchen zwingend einen parametrisierten Dialog, da man pro
+neue User-Übung keinen neuen Dialog generieren kann. Auch ein guter
+Einstiegspunkt direkt nach Phase 0, um die Dopplung zwischen den beiden
+heute existierenden Dialogen wegzubekommen, bevor weitere Übungen landen.
+
+Heute existieren zwei parallele Dialoge mit überschneidender Logik:
+
+- `CreateEntryDialogComponent` — pushup-only: timestamp, sets/reps,
+  Variant-Autocomplete über `PUSHUP_TYPES`, Wiki-Deep-Link, Source-Feld.
+- `ExerciseEntryDialogComponent` — Phase-0 Light-Variante für Sit-ups
+  und Squats: timestamp, sets/reps. Bewusst minimal gebaut, um den
+  Pushup-Pfad nicht zu touchieren.
+
+Beide werden zusammengeführt in **einen** `EntryDialogComponent`, der
+sich aus der `ExerciseDefinition` selbst konfiguriert.
+
+**Scope**
+
+- **Form-Felder dynamisch nach `measurement`:**
+  - `reps` und `weight` → Reps-Input + Sets-Liste.
+  - `time` → mm:ss-Input + optionaler Stopper-Button (Phase 1 Plank).
+  - `distance` → km/m-Input + optionales Pace-Companion (Phase 3 Cardio).
+  - `weight` → zusätzlich kg-Companion-Input (Phase 5 Strength).
+- **Variant-Picker als eigenes Sub-Komponent.** Default: einfacher
+  `mat-select` mit den `def.variants[]`. Pushup überschreibt das via
+  konfigurierbarem `VariantPickerKind` mit dem heutigen Autocomplete-
+  und Wiki-Link-Verhalten — die UX bleibt identisch, nur der
+  Container-Dialog ist generisch.
+- **Caps clientseitig erzwingen**, abgeleitet aus `def.min`/`def.max`,
+  damit der heutige Bug "Dialog akzeptiert reps > 500, Validator
+  rejectet erst beim Speichern" verschwindet (siehe PR #289 Review-
+  Kommentar).
+- **Edit-Modus:** akzeptiert ein bestehendes `UnifiedEntry` (siehe
+  Track ARCH) und routet auf das passende Form-Feld basierend auf
+  der Definition.
+- `ExerciseEntryDialogComponent` und `CreateEntryDialogComponent`
+  werden zu Adaptern degradiert (oder gelöscht), abhängig davon was
+  Track ARCH liefert.
+- Tests pro Measurement-Typ (Form-Render und Submit-Pfad), plus ein
+  Regression-Test, dass die Pushup-Edit-Pfade bit-genau das alte
+  Verhalten reproduzieren (Wiki-Link, Variant-Autocomplete, Source-
+  Autocomplete).
+
+**Out of Scope**
+
+- Komplett neue Eingabe-Affordances wie Voice-Input oder Foto-Eintrag —
+  separater Track.
+- Pre-Population aus Trainingsplan ("Heute 3×12 Squats") — kommt mit
+  einem eigenen Track sobald Trainings-Pläne pro Übung existieren.
+
+**Offene Fragen**
+
+- Wo lebt die Variant-Picker-Konfiguration? `ExerciseDefinition` mit
+  einem `variantPickerKind: 'autocomplete-with-wiki' | 'simple-select'`
+  Feld, oder ein zentrales Lookup im Dialog basierend auf
+  `def.id === 'pushup'`? Ersteres ist sauberer, aber jeder Custom-User-
+  Übung muss eines wählen → Default `'simple-select'`.
+
 ## Risiken & Offene Fragen
 
 - **Backwards-Compat von `userStats`:** Heute liegt das Aggregat als ein einziges

--- a/plans/multi-exercise-roadmap.md
+++ b/plans/multi-exercise-roadmap.md
@@ -282,6 +282,170 @@ gefixt wurden, weil ihr Aufwand den Tracer-Bullet sprengen würde:
   Time) landet, muss die Sektion via `measurementValueField()` die
   passende Spalte rendern.
 
+## Cross-cutting Tracks (über mehrere Phasen)
+
+Folgearbeiten, die nicht in eine einzelne Tracer-Bullet-Phase passen, weil sie
+quer durch die App schneiden. Sie laufen parallel zu den Phasen oder werden
+zwischen ihnen eingeschoben.
+
+### Track UI-1 — Historie für alle Übungen
+
+**Status:** offen, sollte direkt nach Phase 0 starten.
+
+Die `/entries` Seite (`entries-page.component.ts` + `EntriesStore`) liest
+heute ausschließlich aus der `pushups`-Collection. Solange Sit-ups und
+Kniebeugen nicht dort auftauchen, ist die Historie für die neuen Übungen
+unsichtbar — User können einen Eintrag anlegen, aber nicht wiederfinden,
+bearbeiten oder löschen.
+
+**Scope**
+
+- `EntriesStore` zusätzlich aus `exerciseEntries` laden und beide
+  Quellen in eine vereinheitlichte Liste mergen (`PushupRecord` →
+  `ExerciseEntry`-Form mit `exerciseId='pushup'`).
+- `StatsTableComponent` bekommt eine "Übung"-Spalte (Kategorie-Icon +
+  lokalisierter Name), die für Pushup wie heute den `variantType`
+  zeigt, für andere Übungen den Exercise-Namen.
+- Filter-Bar: zusätzlicher Multi-Select "Übung" (Pushup, Bauch-…,
+  Beine-…). Default = alle Übungen.
+- Edit-Flow: Pushups öffnen den existierenden Pushup-Dialog,
+  Exercise-Entries den neuen `ExerciseEntryDialogComponent`.
+- Tests: Service-Spec für gemerge'te Quellen, Component-Spec für
+  Filter-Verhalten.
+
+**Out of Scope**
+
+- Bulk-Operationen (Massenlöschen über Übungen hinweg) — kommt mit
+  Phase 2 (Per-Exercise-Streaks), wenn das Mental-Modell pro Übung
+  steht.
+
+**Offene Fragen**
+
+- Sortierung bei mixed Übungen: chronologisch absteigend ist klar,
+  aber was ist mit gleichzeitigen Einträgen? Tiebreaker via
+  Exercise-Name oder Eingabereihenfolge?
+
+### Track UI-2 — Analyse mit Übungs-Filter und Measurement-spezifischen Graphen
+
+**Status:** offen, hat Abhängigkeiten zu Phase 1 (Plank) und Phase 3
+(Cardio). Filter-Teil kann früher als die neuen Graphen.
+
+Die `/analysis` Seite (`analysis-page.component.ts`,
+`AnalysisStore`, `StatsChartComponent`, `TypePieComponent`,
+`SetsDistributionComponent`, `HeatmapComponent`) ist konsequent auf
+reps und Pushup-Varianten gebaut. Der "TypePie" zeigt heute Pushup-
+Varianten — das ergibt für Sit-ups oder Squats keinen Sinn, weil
+Phase-0-Übungen keine Varianten haben. Die Y-Achse vom StatsChart
+ist hartcodiert auf "Reps".
+
+**Scope (Filter-Stufe — sobald Phase 0 in Production ist)**
+
+- Übungs-Filter (Multi-Select wie in der Historie). Wenn nur eine
+  Übung ausgewählt ist, schaltet der TypePie auf die Varianten dieser
+  Übung um (heute: Pushup-Varianten; künftig: Plank-Varianten).
+- Bei Multi-Select über Kategorien hinweg zeigt die Pie-Darstellung
+  stattdessen die Verteilung pro Übungstyp.
+
+**Scope (Graphen-Stufe — kommt mit Phase 1+/3+)**
+
+- **Plank (time):** Y-Achse "Sekunden", Best-Hold-Linie, kumulative
+  Haltezeit pro Tag/Woche statt Reps.
+- **Cardio (distance + duration):** Pace-Diagramm (min/km über Zeit),
+  Wochen-Distanz-Aggregat. Strecke-pro-Zeit braucht eine zweite
+  Achse oder einen separaten "Pace"-Graph — bewusst NICHT auf einer
+  Achse mit reps oder seconds mischen.
+- **Strength (reps × weight):** Volumen pro Tag (= Σ reps·kg),
+  1RM-Schätzung (Epley) pro Übung über Zeit, PR-Linie.
+- **Heatmap:** bleibt grundsätzlich, gewichtet künftig optional auf
+  Volume/Sekunden statt nur reps, abhängig von der ausgewählten Übung.
+
+**Design-Entscheidungen, die wir treffen müssen**
+
+- Ein Chart pro Übung (saubere Achsen) vs. ein "vereinheitlichtes
+  Effort-Score"-Chart (skaliert reps/sek/m/kg auf eine Vergleichsachse —
+  fragwürdige Semantik, aber praktisch für Streak-Visualisierung).
+- Wechsel zwischen Übungen via Tabs (klare Fokussierung) vs.
+  vertikales Stapeln (alles auf einen Blick, längere Seite).
+- Sets-Distribution macht für Cardio keinen Sinn — komponentes
+  per Measurement gewählt.
+
+**Out of Scope**
+
+- Vergleichs-Charts ("Pushups vs. Squats") — eigenes Track, sobald
+  alle Measurement-Typen live sind.
+
+### Track ARCH — Klare Modul-Interfaces
+
+**Status:** offen, sollte vor Phase 4 (Custom Exercises) abgeschlossen
+sein, weil dort die Schnittstellen zwischen Catalog, Stores und UI
+am stärksten belastet werden.
+
+Heute haben mehrere Module implizite Abhängigkeiten:
+
+- `dashboard.store.ts` und `analysis.store.ts` lesen direkt aus
+  `LiveDataStore`/`StatsApiService` und kennen das `PushupRecord`-Shape.
+- `EntriesStore` und `EntriesPageComponent` teilen Filter-Zustand
+  über Inputs, nicht über ein Filter-Interface.
+- Stats-Components akzeptieren `PushupRecord[]` direkt, statt eine
+  domain-neutrale `EntryView` Schnittstelle.
+
+**Scope**
+
+- `libs/stats/src/lib/models/` bekommt eine `EntryView` (Lese-Form,
+  Measurement-aware), die UI-Components statt `PushupRecord`/
+  `ExerciseEntry` konsumieren. Stores mappen am Rand auf `EntryView`.
+- `libs/data-access` definiert ein einheitliches `EntryQueryService`-
+  Interface (User + Date-Range + ExerciseIds → `EntryView[]`), das
+  Pushup- und Exercise-Firestore-Service intern bündelt.
+- Filter-State zentral (z. B. ein `FilterStore` oder Query-Param-
+  Bridge), damit Historie und Analyse synchronisiert werden können.
+- Public-API-Files (`libs/*/src/index.ts`) auditieren — nur
+  Symbole exportieren, die von außen genutzt werden, alles andere
+  privat halten.
+- Diagramm + Erklärung in `docs/architecture.md` ergänzen.
+
+**Out of Scope**
+
+- Ein vollständiger Wechsel auf Hexagonal-/Ports-und-Adapters-
+  Architektur — zu schwer für den aktuellen Reifegrad.
+
+### Track MKT — Landingpage-Text + SEO
+
+**Status:** offen, blockiert nicht andere Phasen, sollte aber kurz nach
+Phase 0 (sit-ups + squats live) erfolgen, damit der Marketing-Text
+das tatsächliche Produkt widerspiegelt.
+
+Aktuell beschreiben die Landingpage und das `<meta>` ausschließlich
+"Liegestütze tracken". Ab Phase 0 ist das eine Untertreibung; Suchanfragen
+nach "Bauchtraining App", "Kniebeugen Tracker", später "Lauftracker" etc.
+finden uns nicht.
+
+**Scope**
+
+- Hero-Text und Feature-Sektion in
+  `web/src/app/marketing/shell/landing-page.component.{html,ts}`
+  überarbeiten — "Multi-Exercise" als Kernversprechen, Pushups als
+  flagship example.
+- `<meta name="description">` und `<title>` pro Locale aktualisieren.
+- `seo.service.ts` `keywords` erweitern: Bauchtraining, Beintraining,
+  Plank, Squats, Calisthenics, später Laufen/Cardio.
+- Strukturierte Daten (`schema.org/SportsActivityLocation` oder
+  passender Type) prüfen.
+- Sitemap: stellt sicher, dass die Wiki-Seiten zukünftiger Übungen
+  korrekt indexierbar sind (heute SEO-Demo nur Pushups —
+  siehe Risiken unten).
+- A/B-Test-fähig vorbereiten: Variante A (Pushup-fokussiert),
+  Variante B (Multi-Exercise-fokussiert), via GrowthBook-Flag falls
+  vorhanden.
+- Open-Graph / Twitter-Cards Bilder: ein generisches Multi-Exercise-
+  Hero statt Pushup-only.
+
+**Offene Fragen**
+
+- Brand-Name "Pushup Stats Service" passt nicht mehr zum Multi-
+  Exercise-Versprechen. Re-Branding ist ein separater Track —
+  hier nur Texte, kein Logo / Domain-Wechsel.
+
 ## Risiken & Offene Fragen
 
 - **Backwards-Compat von `userStats`:** Heute liegt das Aggregat als ein einziges

--- a/plans/multi-exercise-roadmap.md
+++ b/plans/multi-exercise-roadmap.md
@@ -230,6 +230,30 @@ ist die "obere" Sektion, darunter folgen Bauch und Beine.
 - Alte Service-Wrapper entfernt.
 - Alte Collection nach Sentry-Stichtag löschen.
 
+## Companion-Fields (Strecke pro Zeit, Reps × Gewicht)
+
+Manche Übungen brauchen **zwei** Wertfelder, nicht eins:
+
+- **Laufen / Radfahren** = Strecke + Zeit (Pace). Datenmodell: `distanceM`
+  als primärer Wert, `durationSec` als optionaler Companion.
+- **Squats mit Hantel** = Reps × kg pro Set. Datenmodell: `reps` als
+  primärer Wert, `weightKg` als verpflichtender Companion.
+
+Der Validator (`validateExerciseEntry` in `exercise.models.ts`) erlaubt
+seit dem Companion-Fix Fields jetzt aus einer expliziten Liste pro
+Measurement:
+
+| Measurement | Primär | Companion (optional) | Companion (required) |
+| --- | --- | --- | --- |
+| `reps` | `reps` | — | — |
+| `time` | `durationSec` | — | — |
+| `distance` | `distanceM` | `durationSec` | — |
+| `weight` | `reps` | — | `weightKg` |
+
+Caps liegen aktuell hartcodiert in `COMPANION_BOUNDS` (z. B. `weightKg`
+0.25..500 mit Fließkomma für 2.5-kg-Inkremente, `durationSec` 1..86 400).
+In Phase 4 (Custom-Übungen) wandern sie in `ExerciseDefinition`.
+
 ## Risiken & Offene Fragen
 
 - **Backwards-Compat von `userStats`:** Heute liegt das Aggregat als ein einziges

--- a/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
+++ b/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
@@ -1,0 +1,285 @@
+import { DatePipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { UserContextService } from '@pu-auth/auth';
+import {
+  ExerciseFirestoreService,
+  ExerciseValidationError,
+} from '@pu-stats/data-access';
+import {
+  EXERCISE_CATEGORIES,
+  ExerciseCategoryId,
+  ExerciseDefinition,
+  ExerciseEntry,
+  exercisesByCategory,
+  findExerciseCategory,
+} from '@pu-stats/models';
+import { firstValueFrom, of } from 'rxjs';
+import {
+  ExerciseEntryDialogComponent,
+  ExerciseEntryDialogResult,
+} from '../exercise-entry-dialog/exercise-entry-dialog.component';
+
+interface ExerciseSummary {
+  definition: ExerciseDefinition;
+  totalReps30d: number;
+  lastEntry: ExerciseEntry | null;
+}
+
+/**
+ * Phase-0 dashboard section per exercise category. Shows the user's
+ * total reps over the last 30 days for each catalog exercise in this
+ * category and a single button per exercise that opens the lightweight
+ * {@link ExerciseEntryDialogComponent}. Pushup data lives in the
+ * legacy collection and is intentionally NOT rendered here — that
+ * stays on the existing dashboard cards above.
+ */
+@Component({
+  selector: 'app-exercise-category-section',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DatePipe,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+  ],
+  styles: [
+    `
+      :host {
+        display: block;
+        margin-top: 16px;
+      }
+      mat-card {
+        border-radius: 16px;
+      }
+      .section-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 8px;
+      }
+      .exercise-row {
+        display: grid;
+        grid-template-columns: 1fr auto auto;
+        gap: 12px;
+        align-items: center;
+        padding: 8px 0;
+        border-top: 1px solid var(--mat-sys-outline-variant);
+      }
+      .exercise-row:first-of-type {
+        border-top: none;
+      }
+      .exercise-label {
+        font-weight: 500;
+      }
+      .exercise-meta {
+        font-size: 12px;
+        color: var(--mat-sys-on-surface-variant);
+      }
+      .exercise-stats {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+      }
+      .exercise-stats .total {
+        font-weight: 600;
+      }
+      .exercise-stats .label {
+        display: block;
+        font-size: 11px;
+        color: var(--mat-sys-on-surface-variant);
+      }
+    `,
+  ],
+  template: `
+    @if (categoryInfo(); as cat) {
+      <mat-card>
+        <mat-card-content>
+          <div class="section-header">
+            <mat-icon aria-hidden="true">{{ cat.icon }}</mat-icon>
+            <h2 class="title">{{ categoryName() }}</h2>
+          </div>
+
+          @for (item of summaries(); track item.definition.id) {
+            <div class="exercise-row">
+              <div>
+                <div class="exercise-label">
+                  {{ exerciseName(item.definition.id) }}
+                </div>
+                @if (item.lastEntry; as last) {
+                  <div class="exercise-meta">
+                    <span i18n="@@exerciseSection.lastEntry">Letzter Eintrag</span>
+                    : {{ last.timestamp | date: 'shortDate' }}
+                    — {{ last.reps }}
+                  </div>
+                }
+              </div>
+              <div class="exercise-stats">
+                <span class="total">{{ item.totalReps30d }}</span>
+                <span class="label" i18n="@@exerciseSection.last30d"
+                  >Letzte 30 Tage</span
+                >
+              </div>
+              <button
+                type="button"
+                mat-flat-button
+                (click)="openDialog(item.definition)"
+                [attr.aria-label]="addAriaLabel(item.definition.id)"
+              >
+                <mat-icon>add</mat-icon>
+                <span i18n="@@exerciseSection.add">Hinzufügen</span>
+              </button>
+            </div>
+          }
+        </mat-card-content>
+      </mat-card>
+    }
+  `,
+})
+export class ExerciseCategorySectionComponent {
+  private readonly dialog = inject(MatDialog);
+  private readonly snack = inject(MatSnackBar);
+  private readonly userContext = inject(UserContextService);
+  private readonly exerciseService = inject(ExerciseFirestoreService);
+
+  readonly categoryId = input.required<ExerciseCategoryId>();
+
+  readonly categoryInfo = computed(() => findExerciseCategory(this.categoryId()));
+
+  readonly categoryName = computed(() => this.localizeCategory(this.categoryId()));
+
+  /**
+   * Pre-built per-exercise i18n lookup. We keep `$localize` calls outside
+   * of the component method so the extractor sees them at build time.
+   */
+  private readonly i18n = buildI18n();
+
+  exerciseName(id: string): string {
+    return this.i18n.exerciseNames[id] ?? id;
+  }
+
+  addAriaLabel(id: string): string {
+    return `${this.i18n.addPrefix}: ${this.exerciseName(id)}`;
+  }
+
+  private localizeCategory(id: ExerciseCategoryId): string {
+    return this.i18n.categoryNames[id] ?? id;
+  }
+
+  private readonly entriesResource = rxResource({
+    params: () => ({
+      userId: this.userContext.userIdSafe(),
+      categoryId: this.categoryId(),
+    }),
+    stream: ({ params }) => {
+      if (!params.userId) return of<ExerciseEntry[]>([]);
+      return this.exerciseService.listEntries(params.userId, {
+        filter: { from: thirtyDaysAgoIso() },
+      });
+    },
+  });
+
+  readonly summaries = computed<ExerciseSummary[]>(() => {
+    const entries = this.entriesResource.value() ?? [];
+    const defs = exercisesByCategory().get(this.categoryId()) ?? [];
+    return defs.map((def) => {
+      const matching = entries.filter((e) => e.exerciseId === def.id);
+      const totalReps30d = matching.reduce((s, e) => s + (e.reps ?? 0), 0);
+      const lastEntry = matching.length
+        ? matching.reduce((latest, e) =>
+            e.timestamp > latest.timestamp ? e : latest
+          )
+        : null;
+      return { definition: def, totalReps30d, lastEntry };
+    });
+  });
+
+  async openDialog(def: ExerciseDefinition): Promise<void> {
+    const userId = this.userContext.userIdSafe();
+    if (!userId) return;
+    const ref = this.dialog.open<
+      ExerciseEntryDialogComponent,
+      { exerciseId: string; exerciseName: string },
+      ExerciseEntryDialogResult | undefined
+    >(ExerciseEntryDialogComponent, {
+      data: {
+        exerciseId: def.id,
+        exerciseName: this.exerciseName(def.id),
+      },
+      width: '420px',
+      maxWidth: '95vw',
+    });
+    const result = await firstValueFrom(ref.afterClosed());
+    if (!result) return;
+    try {
+      await firstValueFrom(
+        this.exerciseService.createEntry(userId, {
+          exerciseId: result.exerciseId,
+          timestamp: result.timestamp,
+          reps: result.reps,
+          ...(result.sets.length > 1 ? { sets: result.sets } : {}),
+        })
+      );
+      this.entriesResource.reload();
+      this.snack.open(this.i18n.savedToast, this.i18n.dismissLabel, {
+        duration: 3000,
+      });
+    } catch (err) {
+      const message =
+        err instanceof ExerciseValidationError
+          ? `${this.i18n.errorPrefix}: ${err.violation}`
+          : this.i18n.genericError;
+      this.snack.open(message, this.i18n.dismissLabel, { duration: 5000 });
+    }
+  }
+}
+
+function thirtyDaysAgoIso(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 30);
+  return d.toISOString().slice(0, 10);
+}
+
+interface I18nBundle {
+  categoryNames: Record<string, string>;
+  exerciseNames: Record<string, string>;
+  addPrefix: string;
+  savedToast: string;
+  dismissLabel: string;
+  errorPrefix: string;
+  genericError: string;
+}
+
+function buildI18n(): I18nBundle {
+  const categoryNames: Record<string, string> = {
+    pushup: $localize`:@@exercise.category.pushup:Liegestütze`,
+    abs: $localize`:@@exercise.category.abs:Bauch`,
+    legs: $localize`:@@exercise.category.legs:Beine`,
+  };
+  const exerciseNames: Record<string, string> = {
+    'abs.situps': $localize`:@@exercise.abs.situps.name:Sit-ups`,
+    'legs.squats': $localize`:@@exercise.legs.squats.name:Kniebeugen`,
+  };
+  return {
+    categoryNames,
+    exerciseNames,
+    addPrefix: $localize`:@@exerciseSection.addAriaPrefix:Eintrag hinzufügen`,
+    savedToast: $localize`:@@exerciseSection.savedToast:Eintrag gespeichert`,
+    dismissLabel: $localize`:@@exerciseSection.dismiss:OK`,
+    errorPrefix: $localize`:@@exerciseSection.errorPrefix:Konnte nicht gespeichert werden`,
+    genericError: $localize`:@@exerciseSection.genericError:Etwas ist schiefgelaufen`,
+  };
+}
+
+// Re-export categories so the dashboard imports stay short.
+export { EXERCISE_CATEGORIES };

--- a/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
+++ b/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
@@ -18,7 +18,6 @@ import {
   ExerciseValidationError,
 } from '@pu-stats/data-access';
 import {
-  EXERCISE_CATEGORIES,
   ExerciseCategoryId,
   ExerciseDefinition,
   ExerciseEntry,
@@ -177,13 +176,19 @@ export class ExerciseCategorySectionComponent {
   }
 
   private readonly entriesResource = rxResource({
-    params: () => ({
-      userId: this.userContext.userIdSafe(),
-      categoryId: this.categoryId(),
-    }),
+    params: () => {
+      const defs = exercisesByCategory().get(this.categoryId()) ?? [];
+      return {
+        userId: this.userContext.userIdSafe(),
+        exerciseIds: defs.map((d) => d.id),
+      };
+    },
     stream: ({ params }) => {
-      if (!params.userId) return of<ExerciseEntry[]>([]);
+      if (!params.userId || params.exerciseIds.length === 0) {
+        return of<ExerciseEntry[]>([]);
+      }
       return this.exerciseService.listEntries(params.userId, {
+        exerciseIds: params.exerciseIds,
         filter: { from: thirtyDaysAgoIso() },
       });
     },
@@ -235,9 +240,13 @@ export class ExerciseCategorySectionComponent {
         duration: 3000,
       });
     } catch (err) {
+      // The dialog already enforces integer reps and the catalog caps,
+      // so an `ExerciseValidationError` here is a programming error
+      // surface — show the user-friendly generic message and let the
+      // browser console + Sentry capture the underlying violation code.
       const message =
         err instanceof ExerciseValidationError
-          ? `${this.i18n.errorPrefix}: ${err.violation}`
+          ? this.i18n.errorPrefix
           : this.i18n.genericError;
       this.snack.open(message, this.i18n.dismissLabel, { duration: 5000 });
     }
@@ -280,6 +289,3 @@ function buildI18n(): I18nBundle {
     genericError: $localize`:@@exerciseSection.genericError:Etwas ist schiefgelaufen`,
   };
 }
-
-// Re-export categories so the dashboard imports stay short.
-export { EXERCISE_CATEGORIES };

--- a/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
+++ b/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
@@ -23,6 +23,7 @@ import {
   ExerciseEntry,
   exercisesByCategory,
   findExerciseCategory,
+  toLocalIsoDate,
 } from '@pu-stats/models';
 import { firstValueFrom, of } from 'rxjs';
 import {
@@ -200,9 +201,15 @@ export class ExerciseCategorySectionComponent {
     return defs.map((def) => {
       const matching = entries.filter((e) => e.exerciseId === def.id);
       const totalReps30d = matching.reduce((s, e) => s + (e.reps ?? 0), 0);
+      // Compare via Date.parse so an offset-bearing timestamp
+      // (e.g. `…+02:00`) and a Z-suffixed one sort by their absolute
+      // instant — string comparison would order them lexicographically
+      // and pick the wrong "latest" entry across timezones.
       const lastEntry = matching.length
         ? matching.reduce((latest, e) =>
-            e.timestamp > latest.timestamp ? e : latest
+            Date.parse(e.timestamp) > Date.parse(latest.timestamp)
+              ? e
+              : latest
           )
         : null;
       return { definition: def, totalReps30d, lastEntry };
@@ -240,10 +247,12 @@ export class ExerciseCategorySectionComponent {
         duration: 3000,
       });
     } catch (err) {
-      // The dialog already enforces integer reps and the catalog caps,
-      // so an `ExerciseValidationError` here is a programming error
-      // surface — show the user-friendly generic message and let the
-      // browser console + Sentry capture the underlying violation code.
+      // The dialog clamps to non-negative integers but does NOT enforce
+      // the per-exercise upper cap (e.g. reps ≤ 500) — values above the
+      // cap fall through to the validator and surface here. We show the
+      // generic German "Konnte nicht gespeichert werden" rather than the
+      // raw violation code, and rely on Sentry / the browser console to
+      // capture the diagnostic.
       const message =
         err instanceof ExerciseValidationError
           ? this.i18n.errorPrefix
@@ -254,9 +263,13 @@ export class ExerciseCategorySectionComponent {
 }
 
 function thirtyDaysAgoIso(): string {
+  // Use the project's local-zone-aware formatter rather than slicing a
+  // UTC ISO — for users east of UTC the slice can shift the cutoff by
+  // a day around midnight and silently drop or include an extra day's
+  // entries from the section summary.
   const d = new Date();
   d.setDate(d.getDate() - 30);
-  return d.toISOString().slice(0, 10);
+  return toLocalIsoDate(d);
 }
 
 interface I18nBundle {

--- a/web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.spec.ts
@@ -1,0 +1,123 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { Mock } from 'vitest';
+import {
+  ExerciseEntryDialogComponent,
+  ExerciseEntryDialogData,
+  ExerciseEntryDialogResult,
+} from './exercise-entry-dialog.component';
+
+describe('ExerciseEntryDialogComponent', () => {
+  let dialogRef: { close: Mock };
+
+  function createComponent(
+    data: ExerciseEntryDialogData = {
+      exerciseId: 'abs.situps',
+      exerciseName: 'Sit-ups',
+    }
+  ): ExerciseEntryDialogComponent {
+    dialogRef = { close: vi.fn() };
+    TestBed.configureTestingModule({
+      imports: [ExerciseEntryDialogComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialog, useValue: { open: vi.fn() } },
+      ],
+    });
+    const fixture = TestBed.createComponent(ExerciseEntryDialogComponent);
+    return fixture.componentInstance;
+  }
+
+  describe('Given the dialog opens for sit-ups with default state', () => {
+    it('starts with one empty set and totalReps 0', () => {
+      const cmp = createComponent();
+      expect(cmp.sets()).toEqual([0]);
+      expect(cmp.totalReps()).toBe(0);
+      expect(cmp.canSubmit()).toBe(false);
+    });
+  });
+
+  describe('When the user enters reps and submits', () => {
+    it('closes the dialog with the entered reps and the dialog data exerciseId', () => {
+      const cmp = createComponent({
+        exerciseId: 'legs.squats',
+        exerciseName: 'Kniebeugen',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.updateSet(0, '25');
+      expect(cmp.canSubmit()).toBe(true);
+
+      cmp.submit();
+
+      expect(dialogRef.close).toHaveBeenCalledTimes(1);
+      const result = dialogRef.close.mock
+        .calls[0][0] as ExerciseEntryDialogResult;
+      expect(result.exerciseId).toBe('legs.squats');
+      expect(result.reps).toBe(25);
+      expect(result.sets).toEqual([25]);
+      expect(result.timestamp.startsWith('2026-04-15T10:00')).toBe(true);
+    });
+  });
+
+  describe('When the user adds multiple sets', () => {
+    it('sums valid sets into totalReps and emits them on submit', () => {
+      const cmp = createComponent();
+      cmp.updateSet(0, '10');
+      cmp.addSet();
+      cmp.updateSet(1, '15');
+      cmp.addSet();
+      cmp.updateSet(2, '20');
+      expect(cmp.totalReps()).toBe(45);
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.submit();
+
+      const result = dialogRef.close.mock
+        .calls[0][0] as ExerciseEntryDialogResult;
+      expect(result.reps).toBe(45);
+      expect(result.sets).toEqual([10, 15, 20]);
+    });
+
+    it('drops sets equal to zero from the persisted result', () => {
+      const cmp = createComponent();
+      cmp.updateSet(0, '10');
+      cmp.addSet();
+      cmp.updateSet(1, '0');
+      cmp.addSet();
+      cmp.updateSet(2, '20');
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.submit();
+
+      const result = dialogRef.close.mock
+        .calls[0][0] as ExerciseEntryDialogResult;
+      expect(result.sets).toEqual([10, 20]);
+      expect(result.reps).toBe(30);
+    });
+  });
+
+  describe('When the user removes a set', () => {
+    it('keeps a single empty set after removing the last one', () => {
+      const cmp = createComponent();
+      cmp.addSet();
+      expect(cmp.sets().length).toBe(2);
+      cmp.removeSet(0);
+      expect(cmp.sets().length).toBe(1);
+      cmp.removeSet(0);
+      expect(cmp.sets()).toEqual([0]);
+    });
+  });
+
+  describe('Given the user has not entered any reps', () => {
+    it('disables submit and does not close the dialog', () => {
+      const cmp = createComponent();
+      cmp.timestamp.set('2026-04-15T10:00');
+      expect(cmp.canSubmit()).toBe(false);
+      cmp.submit();
+      expect(dialogRef.close).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.spec.ts
@@ -99,6 +99,26 @@ describe('ExerciseEntryDialogComponent', () => {
     });
   });
 
+  describe('Given the input clamps to non-negative integers', () => {
+    it('Then a fractional value is floored', () => {
+      const cmp = createComponent();
+      cmp.updateSet(0, '5.7');
+      expect(cmp.sets()[0]).toBe(5);
+    });
+
+    it('Then a negative value is clamped to 0', () => {
+      const cmp = createComponent();
+      cmp.updateSet(0, '-3');
+      expect(cmp.sets()[0]).toBe(0);
+    });
+
+    it('Then a non-numeric value falls back to 0', () => {
+      const cmp = createComponent();
+      cmp.updateSet(0, 'abc');
+      expect(cmp.sets()[0]).toBe(0);
+    });
+  });
+
   describe('When the user removes a set', () => {
     it('keeps a single empty set after removing the last one', () => {
       const cmp = createComponent();

--- a/web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts
+++ b/web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts
@@ -1,0 +1,212 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { appendLocalOffset } from '@pu-stats/models';
+
+export interface ExerciseEntryDialogData {
+  /** Catalog id, e.g. `'abs.situps'` or `'legs.squats'`. */
+  exerciseId: string;
+  /** Localized exercise name shown in the dialog title. */
+  exerciseName: string;
+}
+
+export interface ExerciseEntryDialogResult {
+  exerciseId: string;
+  timestamp: string;
+  reps: number;
+  sets: number[];
+}
+
+/**
+ * Lightweight entry dialog for the Phase-0 multi-exercise flow.
+ *
+ * Deliberately NOT extending {@link CreateEntryDialogComponent} because
+ * that one is wired up to the pushup-only catalog (autocomplete, wiki
+ * deep-link, legacy-id resolution). Reusing it here would force every
+ * non-pushup entry through the pushup type picker; building a separate,
+ * minimal dialog keeps the existing flow untouched.
+ */
+@Component({
+  selector: 'app-exercise-entry-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+  ],
+  styles: [
+    `
+      mat-dialog-content {
+        display: grid;
+        gap: 10px;
+      }
+      .set-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .set-row mat-form-field {
+        flex: 1;
+      }
+      .total-reps {
+        font-size: 13px;
+        color: var(--mat-sys-on-surface-variant);
+        text-align: end;
+      }
+    `,
+  ],
+  template: `
+    <h2 mat-dialog-title>
+      <span i18n="@@exerciseEntryDialog.title">Eintrag hinzufügen</span>
+      — {{ data.exerciseName }}
+    </h2>
+
+    <mat-dialog-content>
+      <mat-form-field appearance="outline">
+        <mat-label i18n="@@timestampLabel">Zeitpunkt</mat-label>
+        <input
+          matInput
+          type="datetime-local"
+          [value]="timestamp()"
+          (input)="timestamp.set(asValue($event))"
+          required
+        />
+      </mat-form-field>
+
+      @for (set of sets(); track $index) {
+        <div class="set-row">
+          <mat-form-field appearance="outline">
+            @if (hasMultipleSets()) {
+              <mat-label i18n="@@setLabel">Set {{ $index + 1 }}</mat-label>
+            } @else {
+              <mat-label i18n="@@repsLabel">Reps</mat-label>
+            }
+            <input
+              matInput
+              type="number"
+              min="0"
+              [value]="set"
+              (input)="updateSet($index, asValue($event))"
+              required
+            />
+          </mat-form-field>
+          @if (hasMultipleSets()) {
+            <button
+              type="button"
+              mat-icon-button
+              (click)="removeSet($index)"
+              i18n-aria-label="@@removeSetAria"
+              aria-label="Set entfernen"
+            >
+              <mat-icon>remove_circle_outline</mat-icon>
+            </button>
+          }
+          @if ($last) {
+            <button
+              type="button"
+              mat-icon-button
+              (click)="addSet()"
+              i18n-aria-label="@@addSetAria"
+              aria-label="Set hinzufügen"
+            >
+              <mat-icon>add_circle_outline</mat-icon>
+            </button>
+          }
+        </div>
+      }
+      @if (hasMultipleSets()) {
+        <div class="total-reps" i18n="@@totalReps">
+          Gesamt: {{ totalReps() }} Reps
+        </div>
+      }
+    </mat-dialog-content>
+
+    <mat-dialog-actions align="end">
+      <button type="button" mat-button mat-dialog-close i18n="@@cancel">
+        Abbrechen
+      </button>
+      <button
+        type="button"
+        mat-flat-button
+        [disabled]="!canSubmit()"
+        (click)="submit()"
+        i18n="@@saveEntry"
+      >
+        Speichern
+      </button>
+    </mat-dialog-actions>
+  `,
+})
+export class ExerciseEntryDialogComponent {
+  private readonly dialogRef = inject(
+    MatDialogRef<ExerciseEntryDialogComponent>
+  );
+  readonly data = inject<ExerciseEntryDialogData>(MAT_DIALOG_DATA);
+
+  readonly timestamp = signal(this.defaultDateTimeLocal());
+  readonly sets = signal<number[]>([0]);
+  readonly hasMultipleSets = computed(() => this.sets().length > 1);
+  readonly totalReps = computed(() =>
+    this.sets().reduce((sum, s) => sum + (s > 0 ? s : 0), 0)
+  );
+  readonly canSubmit = computed(
+    () => this.timestamp().length > 0 && this.totalReps() > 0
+  );
+
+  addSet(): void {
+    const last = this.sets()[this.sets().length - 1] ?? 0;
+    this.sets.update((s) => [...s, last > 0 ? last : 0]);
+  }
+
+  removeSet(index: number): void {
+    this.sets.update((s) => {
+      const next = s.filter((_, i) => i !== index);
+      return next.length === 0 ? [0] : next;
+    });
+  }
+
+  updateSet(index: number, value: string): void {
+    const num = Math.max(0, Number(value) || 0);
+    this.sets.update((s) => s.map((v, i) => (i === index ? num : v)));
+  }
+
+  asValue(event: Event): string {
+    return (event.target as HTMLInputElement).value;
+  }
+
+  submit(): void {
+    const validSets = this.sets().filter((s) => s > 0);
+    const reps = validSets.reduce((sum, s) => sum + s, 0);
+    if (!this.timestamp() || reps <= 0) return;
+    const result: ExerciseEntryDialogResult = {
+      exerciseId: this.data.exerciseId,
+      timestamp: appendLocalOffset(this.timestamp()),
+      reps,
+      sets: validSets,
+    };
+    this.dialogRef.close(result);
+  }
+
+  private defaultDateTimeLocal(): string {
+    const now = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(
+      now.getDate()
+    )}T${pad(now.getHours())}:${pad(now.getMinutes())}`;
+  }
+}

--- a/web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts
+++ b/web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts
@@ -100,6 +100,7 @@ export interface ExerciseEntryDialogResult {
               matInput
               type="number"
               min="0"
+              step="1"
               [value]="set"
               (input)="updateSet($index, asValue($event))"
               required
@@ -181,7 +182,13 @@ export class ExerciseEntryDialogComponent {
   }
 
   updateSet(index: number, value: string): void {
-    const num = Math.max(0, Number(value) || 0);
+    // Clamp to a non-negative integer up front. The downstream
+    // `validateExerciseEntry` rejects fractional reps as
+    // `measurement-value-not-integer`; flooring here keeps the UI in
+    // sync with that contract instead of letting `canSubmit()` go true
+    // on `5.5` reps and then failing at submit time.
+    const parsed = Number(value);
+    const num = Number.isFinite(parsed) ? Math.max(0, Math.floor(parsed)) : 0;
     this.sets.update((s) => s.map((v, i) => (i === index ? num : v)));
   }
 

--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -339,4 +339,8 @@
       <lib-ad-slot [slot]="adSlotDashboardInline()" />
     </section>
   }
+
+  @for (cat of newExerciseCategories; track cat.id) {
+    <app-exercise-category-section [categoryId]="cat.id" />
+  }
 </main>

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -3,6 +3,7 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { of } from 'rxjs';
 import { StatsDashboardComponent } from './stats-dashboard.component';
 import {
+  ExerciseFirestoreService,
   LiveDataStore,
   StatsApiService,
   UserConfigApiService,
@@ -171,6 +172,16 @@ describe('StatsDashboardComponent', () => {
         },
         { provide: AppDataFacade, useValue: appDataMock },
         { provide: ShareService, useValue: shareServiceMock },
+        // The Phase-0 multi-exercise dashboard sections inject this
+        // service via `inject(ExerciseFirestoreService)`. The dashboard
+        // test doesn't exercise those sections directly, so we hand it
+        // a thin stub returning an empty entry stream — without it the
+        // section component fails to construct and Angular reports a
+        // misleading "Circular dependency" error.
+        {
+          provide: ExerciseFirestoreService,
+          useValue: { listEntries: () => of([]) },
+        },
       ],
     });
 

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -22,6 +22,7 @@ import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
 import {
   appendLocalOffset,
   displayPushupType,
+  EXERCISE_CATEGORIES,
   PushupRecord,
   QUICK_LOG_REPS_MAX,
   QUICK_LOG_REPS_MIN,
@@ -34,10 +35,7 @@ import { AdSlotComponent } from '@pu-stats/ads';
 import { AnalysisTeaserCardComponent } from '../components/analysis-teaser-card/analysis-teaser-card.component';
 import { PreviewBannerComponent } from '../components/preview-banner/preview-banner.component';
 import { StatsTableComponent } from '../components/stats-table/stats-table.component';
-import {
-  EXERCISE_CATEGORIES,
-  ExerciseCategorySectionComponent,
-} from '../components/exercise-category-section/exercise-category-section.component';
+import { ExerciseCategorySectionComponent } from '../components/exercise-category-section/exercise-category-section.component';
 import {
   CreateEntryDialogComponent,
   CreateEntryResult,

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -35,6 +35,10 @@ import { AnalysisTeaserCardComponent } from '../components/analysis-teaser-card/
 import { PreviewBannerComponent } from '../components/preview-banner/preview-banner.component';
 import { StatsTableComponent } from '../components/stats-table/stats-table.component';
 import {
+  EXERCISE_CATEGORIES,
+  ExerciseCategorySectionComponent,
+} from '../components/exercise-category-section/exercise-category-section.component';
+import {
   CreateEntryDialogComponent,
   CreateEntryResult,
 } from '../components/create-entry-dialog/create-entry-dialog.component';
@@ -54,6 +58,7 @@ import { DashboardStore } from '../dashboard.store';
     StatsTableComponent,
     AdSlotComponent,
     RouterLink,
+    ExerciseCategorySectionComponent,
   ],
   providers: [DashboardStore],
   templateUrl: './stats-dashboard.component.html',
@@ -76,6 +81,16 @@ export class StatsDashboardComponent {
 
   readonly shareDayAriaLabel = $localize`:@@dashboard.share.aria:Tagesleistung teilen`;
   readonly shareDayLabel = $localize`:@@dashboard.share:Teilen`;
+
+  /**
+   * Phase-0 Multi-Exercise: categories rendered below the pushup
+   * dashboard cards. Pushup itself is excluded — its data still lives
+   * in the legacy `pushups` collection and renders via the existing
+   * cards above.
+   */
+  readonly newExerciseCategories = EXERCISE_CATEGORIES.filter(
+    (cat) => cat.id !== 'pushup'
+  );
 
   readonly store = inject(DashboardStore);
 

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -3822,6 +3822,90 @@
         <target> Αποθήκευση </target>
       </segment>
     </unit>
+    <unit id="exerciseSection.lastEntry">
+      <segment state="translated">
+        <source>Letzter Eintrag</source>
+        <target>Τελευταία καταχώρηση</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.last30d">
+      <segment state="translated">
+        <source>Letzte 30 Tage</source>
+        <target>Τελευταίες 30 ημέρες</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.add">
+      <segment state="translated">
+        <source>Hinzufügen</source>
+        <target>Προσθήκη</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <segment state="translated">
+        <source>Liegestütze</source>
+        <target>Push-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.abs">
+      <segment state="translated">
+        <source>Bauch</source>
+        <target>Κοιλιά</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.legs">
+      <segment state="translated">
+        <source>Beine</source>
+        <target>Πόδια</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.situps.name">
+      <segment state="translated">
+        <source>Sit-ups</source>
+        <target>Κοιλιακοί</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <segment state="translated">
+        <source>Kniebeugen</source>
+        <target>Καθίσματα</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.addAriaPrefix">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Προσθήκη καταχώρησης</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.savedToast">
+      <segment state="translated">
+        <source>Eintrag gespeichert</source>
+        <target>Η καταχώρηση αποθηκεύτηκε</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.dismiss">
+      <segment state="translated">
+        <source>OK</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.errorPrefix">
+      <segment state="translated">
+        <source>Konnte nicht gespeichert werden</source>
+        <target>Δεν ήταν δυνατή η αποθήκευση</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.genericError">
+      <segment state="translated">
+        <source>Etwas ist schiefgelaufen</source>
+        <target>Κάτι πήγε στραβά</target>
+      </segment>
+    </unit>
+    <unit id="exerciseEntryDialog.title">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Προσθήκη καταχώρησης</target>
+      </segment>
+    </unit>
     <unit id="selectRangeTitle">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:35,38</note>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -3163,6 +3163,90 @@ Deine Position: # ·  Reps        </source>
         <target>Save</target>
       </segment>
     </unit>
+    <unit id="exerciseSection.lastEntry">
+      <segment state="translated">
+        <source>Letzter Eintrag</source>
+        <target>Last entry</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.last30d">
+      <segment state="translated">
+        <source>Letzte 30 Tage</source>
+        <target>Last 30 days</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.add">
+      <segment state="translated">
+        <source>Hinzufügen</source>
+        <target>Add</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <segment state="translated">
+        <source>Liegestütze</source>
+        <target>Push-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.abs">
+      <segment state="translated">
+        <source>Bauch</source>
+        <target>Abs</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.legs">
+      <segment state="translated">
+        <source>Beine</source>
+        <target>Legs</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.situps.name">
+      <segment state="translated">
+        <source>Sit-ups</source>
+        <target>Sit-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <segment state="translated">
+        <source>Kniebeugen</source>
+        <target>Squats</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.addAriaPrefix">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Add entry</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.savedToast">
+      <segment state="translated">
+        <source>Eintrag gespeichert</source>
+        <target>Entry saved</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.dismiss">
+      <segment state="translated">
+        <source>OK</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.errorPrefix">
+      <segment state="translated">
+        <source>Konnte nicht gespeichert werden</source>
+        <target>Could not be saved</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.genericError">
+      <segment state="translated">
+        <source>Etwas ist schiefgelaufen</source>
+        <target>Something went wrong</target>
+      </segment>
+    </unit>
+    <unit id="exerciseEntryDialog.title">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Add entry</target>
+      </segment>
+    </unit>
     <unit id="selectRangeTitle">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:30,33</note>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -3822,6 +3822,90 @@
         <target> Guardar </target>
       </segment>
     </unit>
+    <unit id="exerciseSection.lastEntry">
+      <segment state="translated">
+        <source>Letzter Eintrag</source>
+        <target>Última entrada</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.last30d">
+      <segment state="translated">
+        <source>Letzte 30 Tage</source>
+        <target>Últimos 30 días</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.add">
+      <segment state="translated">
+        <source>Hinzufügen</source>
+        <target>Añadir</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <segment state="translated">
+        <source>Liegestütze</source>
+        <target>Flexiones</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.abs">
+      <segment state="translated">
+        <source>Bauch</source>
+        <target>Abdomen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.legs">
+      <segment state="translated">
+        <source>Beine</source>
+        <target>Piernas</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.situps.name">
+      <segment state="translated">
+        <source>Sit-ups</source>
+        <target>Abdominales</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <segment state="translated">
+        <source>Kniebeugen</source>
+        <target>Sentadillas</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.addAriaPrefix">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Añadir entrada</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.savedToast">
+      <segment state="translated">
+        <source>Eintrag gespeichert</source>
+        <target>Entrada guardada</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.dismiss">
+      <segment state="translated">
+        <source>OK</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.errorPrefix">
+      <segment state="translated">
+        <source>Konnte nicht gespeichert werden</source>
+        <target>No se pudo guardar</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.genericError">
+      <segment state="translated">
+        <source>Etwas ist schiefgelaufen</source>
+        <target>Algo salió mal</target>
+      </segment>
+    </unit>
+    <unit id="exerciseEntryDialog.title">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Añadir entrada</target>
+      </segment>
+    </unit>
     <unit id="selectRangeTitle">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:35,38</note>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3822,6 +3822,90 @@
         <target> Enregistrer </target>
       </segment>
     </unit>
+    <unit id="exerciseSection.lastEntry">
+      <segment state="translated">
+        <source>Letzter Eintrag</source>
+        <target>Dernière entrée</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.last30d">
+      <segment state="translated">
+        <source>Letzte 30 Tage</source>
+        <target>30 derniers jours</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.add">
+      <segment state="translated">
+        <source>Hinzufügen</source>
+        <target>Ajouter</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <segment state="translated">
+        <source>Liegestütze</source>
+        <target>Pompes</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.abs">
+      <segment state="translated">
+        <source>Bauch</source>
+        <target>Abdos</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.legs">
+      <segment state="translated">
+        <source>Beine</source>
+        <target>Jambes</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.situps.name">
+      <segment state="translated">
+        <source>Sit-ups</source>
+        <target>Sit-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <segment state="translated">
+        <source>Kniebeugen</source>
+        <target>Squats</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.addAriaPrefix">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Ajouter une entrée</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.savedToast">
+      <segment state="translated">
+        <source>Eintrag gespeichert</source>
+        <target>Entrée enregistrée</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.dismiss">
+      <segment state="translated">
+        <source>OK</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.errorPrefix">
+      <segment state="translated">
+        <source>Konnte nicht gespeichert werden</source>
+        <target>Impossible d'enregistrer</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.genericError">
+      <segment state="translated">
+        <source>Etwas ist schiefgelaufen</source>
+        <target>Une erreur est survenue</target>
+      </segment>
+    </unit>
+    <unit id="exerciseEntryDialog.title">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Ajouter une entrée</target>
+      </segment>
+    </unit>
     <unit id="selectRangeTitle">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:35,38</note>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -3822,6 +3822,90 @@
         <target> Salva </target>
       </segment>
     </unit>
+    <unit id="exerciseSection.lastEntry">
+      <segment state="translated">
+        <source>Letzter Eintrag</source>
+        <target>Ultima voce</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.last30d">
+      <segment state="translated">
+        <source>Letzte 30 Tage</source>
+        <target>Ultimi 30 giorni</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.add">
+      <segment state="translated">
+        <source>Hinzufügen</source>
+        <target>Aggiungi</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <segment state="translated">
+        <source>Liegestütze</source>
+        <target>Flessioni</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.abs">
+      <segment state="translated">
+        <source>Bauch</source>
+        <target>Addominali</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.legs">
+      <segment state="translated">
+        <source>Beine</source>
+        <target>Gambe</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.situps.name">
+      <segment state="translated">
+        <source>Sit-ups</source>
+        <target>Sit-up</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <segment state="translated">
+        <source>Kniebeugen</source>
+        <target>Squat</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.addAriaPrefix">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Aggiungi voce</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.savedToast">
+      <segment state="translated">
+        <source>Eintrag gespeichert</source>
+        <target>Voce salvata</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.dismiss">
+      <segment state="translated">
+        <source>OK</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.errorPrefix">
+      <segment state="translated">
+        <source>Konnte nicht gespeichert werden</source>
+        <target>Impossibile salvare</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.genericError">
+      <segment state="translated">
+        <source>Etwas ist schiefgelaufen</source>
+        <target>Qualcosa è andato storto</target>
+      </segment>
+    </unit>
+    <unit id="exerciseEntryDialog.title">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Aggiungi voce</target>
+      </segment>
+    </unit>
     <unit id="selectRangeTitle">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:35,38</note>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3843,7 +3843,7 @@
     <unit id="exercise.category.pushup">
       <segment state="translated">
         <source>Liegestütze</source>
-        <target>Pulsus</target>
+        <target>Pushups</target>
       </segment>
     </unit>
     <unit id="exercise.category.abs">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3822,6 +3822,90 @@
         <target> Servare </target>
       </segment>
     </unit>
+    <unit id="exerciseSection.lastEntry">
+      <segment state="translated">
+        <source>Letzter Eintrag</source>
+        <target>Inscriptio ultima</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.last30d">
+      <segment state="translated">
+        <source>Letzte 30 Tage</source>
+        <target>Ultimi XXX dies</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.add">
+      <segment state="translated">
+        <source>Hinzufügen</source>
+        <target>Adde</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <segment state="translated">
+        <source>Liegestütze</source>
+        <target>Pulsus</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.abs">
+      <segment state="translated">
+        <source>Bauch</source>
+        <target>Abdomen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.legs">
+      <segment state="translated">
+        <source>Beine</source>
+        <target>Crura</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.situps.name">
+      <segment state="translated">
+        <source>Sit-ups</source>
+        <target>Sit-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <segment state="translated">
+        <source>Kniebeugen</source>
+        <target>Genuflexiones</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.addAriaPrefix">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Inscriptionem adde</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.savedToast">
+      <segment state="translated">
+        <source>Eintrag gespeichert</source>
+        <target>Inscriptio servata</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.dismiss">
+      <segment state="translated">
+        <source>OK</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.errorPrefix">
+      <segment state="translated">
+        <source>Konnte nicht gespeichert werden</source>
+        <target>Servari non potuit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.genericError">
+      <segment state="translated">
+        <source>Etwas ist schiefgelaufen</source>
+        <target>Aliquid mali accidit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseEntryDialog.title">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Inscriptionem adde</target>
+      </segment>
+    </unit>
     <unit id="selectRangeTitle">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:35,38</note>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3822,6 +3822,90 @@
         <target> Opslaan </target>
       </segment>
     </unit>
+    <unit id="exerciseSection.lastEntry">
+      <segment state="translated">
+        <source>Letzter Eintrag</source>
+        <target>Laatste invoer</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.last30d">
+      <segment state="translated">
+        <source>Letzte 30 Tage</source>
+        <target>Laatste 30 dagen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.add">
+      <segment state="translated">
+        <source>Hinzufügen</source>
+        <target>Toevoegen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <segment state="translated">
+        <source>Liegestütze</source>
+        <target>Push-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.abs">
+      <segment state="translated">
+        <source>Bauch</source>
+        <target>Buik</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.legs">
+      <segment state="translated">
+        <source>Beine</source>
+        <target>Benen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.situps.name">
+      <segment state="translated">
+        <source>Sit-ups</source>
+        <target>Sit-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <segment state="translated">
+        <source>Kniebeugen</source>
+        <target>Squats</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.addAriaPrefix">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Invoer toevoegen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.savedToast">
+      <segment state="translated">
+        <source>Eintrag gespeichert</source>
+        <target>Invoer opgeslagen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.dismiss">
+      <segment state="translated">
+        <source>OK</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.errorPrefix">
+      <segment state="translated">
+        <source>Konnte nicht gespeichert werden</source>
+        <target>Kon niet worden opgeslagen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.genericError">
+      <segment state="translated">
+        <source>Etwas ist schiefgelaufen</source>
+        <target>Er is iets misgegaan</target>
+      </segment>
+    </unit>
+    <unit id="exerciseEntryDialog.title">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Invoer toevoegen</target>
+      </segment>
+    </unit>
     <unit id="selectRangeTitle">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:35,38</note>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -3182,7 +3182,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="exercise.category.pushup">
       <segment state="translated">
         <source>Liegestütze</source>
-        <target>Push-ups</target>
+        <target>Armhevninger</target>
       </segment>
     </unit>
     <unit id="exercise.category.abs">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -3161,6 +3161,90 @@ Deine Position: # ·  Reps        </source>
         <target>Lagre</target>
       </segment>
     </unit>
+    <unit id="exerciseSection.lastEntry">
+      <segment state="translated">
+        <source>Letzter Eintrag</source>
+        <target>Siste oppføring</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.last30d">
+      <segment state="translated">
+        <source>Letzte 30 Tage</source>
+        <target>Siste 30 dager</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.add">
+      <segment state="translated">
+        <source>Hinzufügen</source>
+        <target>Legg til</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <segment state="translated">
+        <source>Liegestütze</source>
+        <target>Push-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.abs">
+      <segment state="translated">
+        <source>Bauch</source>
+        <target>Mage</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.legs">
+      <segment state="translated">
+        <source>Beine</source>
+        <target>Ben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.situps.name">
+      <segment state="translated">
+        <source>Sit-ups</source>
+        <target>Sit-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <segment state="translated">
+        <source>Kniebeugen</source>
+        <target>Knebøy</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.addAriaPrefix">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Legg til oppføring</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.savedToast">
+      <segment state="translated">
+        <source>Eintrag gespeichert</source>
+        <target>Oppføring lagret</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.dismiss">
+      <segment state="translated">
+        <source>OK</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.errorPrefix">
+      <segment state="translated">
+        <source>Konnte nicht gespeichert werden</source>
+        <target>Kunne ikke lagre</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.genericError">
+      <segment state="translated">
+        <source>Etwas ist schiefgelaufen</source>
+        <target>Noe gikk galt</target>
+      </segment>
+    </unit>
+    <unit id="exerciseEntryDialog.title">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>Legg til oppføring</target>
+      </segment>
+    </unit>
     <unit id="selectRangeTitle">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:30,33</note>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -236,9 +236,9 @@
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:330,331</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:277,278</note>
-        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:141,142</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:142,143</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:475,476</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
       </notes>
       <segment>
         <source> Abbrechen </source>
@@ -2567,7 +2567,7 @@
     </unit>
     <unit id="sw.update.available">
       <notes>
-        <note category="location">web/src/app/app.ts:303</note>
+        <note category="location">web/src/app/app.ts:304</note>
       </notes>
       <segment>
         <source>Neue Version verfügbar</source>
@@ -2575,7 +2575,7 @@
     </unit>
     <unit id="sw.update.reload">
       <notes>
-        <note category="location">web/src/app/app.ts:304</note>
+        <note category="location">web/src/app/app.ts:305</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -2583,7 +2583,7 @@
     </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:362</note>
+        <note category="location">web/src/app/app.ts:377</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -2591,7 +2591,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:369</note>
+        <note category="location">web/src/app/app.ts:384</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>
@@ -2599,7 +2599,7 @@
     </unit>
     <unit id="blog.article.back">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:33,35</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:40,42</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">arrow_back</pc> Blog </source>
@@ -2607,7 +2607,7 @@
     </unit>
     <unit id="blog.article.readingTime">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:60,61</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:70,71</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}"/> Min. Lesezeit</source>
@@ -2615,7 +2615,7 @@
     </unit>
     <unit id="blog.article.updated">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:66,67</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:76,77</note>
       </notes>
       <segment>
         <source>Aktualisiert am</source>
@@ -2623,7 +2623,7 @@
     </unit>
     <unit id="blog.article.cta">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:83,85</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:93,95</note>
       </notes>
       <segment>
         <source> Kostenlos tracken – Jetzt registrieren </source>
@@ -2631,7 +2631,7 @@
     </unit>
     <unit id="blog.article.notFound">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:89,90</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:99,100</note>
       </notes>
       <segment>
         <source>Artikel nicht gefunden.</source>
@@ -2639,7 +2639,7 @@
     </unit>
     <unit id="blog.article.toList">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:91,95</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:101,105</note>
       </notes>
       <segment>
         <source>Zur Übersicht</source>
@@ -2647,7 +2647,7 @@
     </unit>
     <unit id="blog.list.title">
       <notes>
-        <note category="location">web/src/app/blog/blog-list.component.ts:13,14</note>
+        <note category="location">web/src/app/blog/blog-list.component.ts:21,22</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -2655,7 +2655,7 @@
     </unit>
     <unit id="blog.list.intro">
       <notes>
-        <note category="location">web/src/app/blog/blog-list.component.ts:15,18</note>
+        <note category="location">web/src/app/blog/blog-list.component.ts:23,25</note>
       </notes>
       <segment>
         <source> Tipps, Guides und Motivation rund um Liegestütze und Krafttraining. </source>
@@ -2663,7 +2663,7 @@
     </unit>
     <unit id="blog.list.readArticle">
       <notes>
-        <note category="location">web/src/app/blog/blog-list.component.ts:52,54</note>
+        <note category="location">web/src/app/blog/blog-list.component.ts:61,63</note>
       </notes>
       <segment>
         <source>Artikel lesen</source>
@@ -2719,7 +2719,7 @@
     </unit>
     <unit id="eyebrowTitle">
       <notes>
-        <note category="location">web/src/app/core/page-header/page-header.component.ts:25,26</note>
+        <note category="location">web/src/app/core/page-header/page-header.component.ts:27,28</note>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:12,13</note>
       </notes>
       <segment>
@@ -2842,10 +2842,43 @@
     </unit>
     <unit id="landing.leaderboard.ownPosition">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:74,76</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:80,81</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:86,88</note>
       </notes>
       <segment>
         <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}"/> Reps </source>
+      </segment>
+    </unit>
+    <unit id="leaderboard.visibilityHint">
+      <notes>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:96,98</note>
+      </notes>
+      <segment>
+        <source> Sichtbarkeit oder Anzeigename anpassen? </source>
+      </segment>
+    </unit>
+    <unit id="leaderboard.visibilityHint.cta">
+      <notes>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:102,105</note>
+      </notes>
+      <segment>
+        <source>Einstellungen öffnen</source>
+      </segment>
+    </unit>
+    <unit id="leaderboard.loginHint">
+      <notes>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:109,111</note>
+      </notes>
+      <segment>
+        <source> Mitmachen und auftauchen? </source>
+      </segment>
+    </unit>
+    <unit id="leaderboard.loginHint.cta">
+      <notes>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:112,115</note>
+      </notes>
+      <segment>
+        <source>Anmelden</source>
       </segment>
     </unit>
     <unit id="reminder.feature.eyebrow">
@@ -3473,7 +3506,7 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:546,548</note>
       </notes>
       <segment>
-        <source>PWA, Live-Sync &amp; Web Share</source>
+        <source>App-Installation, Live-Sync &amp; Teilen</source>
       </segment>
     </unit>
     <unit id="landing.feature.pwa.body">
@@ -3481,12 +3514,36 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:550,553</note>
       </notes>
       <segment>
-        <source>Installierbar wie eine native App, Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Web Share teilen – inklusive Dark- und Light-Theme.</source>
+        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
+      </segment>
+    </unit>
+    <unit id="landing.feature.pwa.installed">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:557,559</note>
+      </notes>
+      <segment>
+        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">check_circle</pc> Du nutzt bereits die installierte App </source>
+      </segment>
+    </unit>
+    <unit id="landing.feature.pwa.install">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:570,572</note>
+      </notes>
+      <segment>
+        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">download</pc> Jetzt als App installieren </source>
+      </segment>
+    </unit>
+    <unit id="landing.feature.pwa.iosHint">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:577,580</note>
+      </notes>
+      <segment>
+        <source> Auf iPhone &amp; iPad: Teilen-Symbol antippen und „Zum Home-Bildschirm“ wählen. </source>
       </segment>
     </unit>
     <unit id="landing.feature.privacy.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:560,562</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:588,590</note>
       </notes>
       <segment>
         <source>Privacy first &amp; 100 % kostenlos</source>
@@ -3494,7 +3551,7 @@
     </unit>
     <unit id="landing.feature.privacy.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:564,568</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:592,596</note>
       </notes>
       <segment>
         <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
@@ -3502,7 +3559,7 @@
     </unit>
     <unit id="ads.landing.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:570</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:598</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -3510,7 +3567,7 @@
     </unit>
     <unit id="landing.preview.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:579,581</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:607,609</note>
       </notes>
       <segment>
         <source> Deine Statistik auf einen Blick </source>
@@ -3518,7 +3575,7 @@
     </unit>
     <unit id="landing.preview.alt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:586,587</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:614,615</note>
       </notes>
       <segment>
         <source>Vorschau der Statistikansicht</source>
@@ -3526,7 +3583,7 @@
     </unit>
     <unit id="landing.discover.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:727,728</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:755,756</note>
       </notes>
       <segment>
         <source>Mehr entdecken</source>
@@ -3534,7 +3591,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:733,735</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:761,763</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3542,7 +3599,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:737,740</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:765,768</note>
       </notes>
       <segment>
         <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
@@ -3550,7 +3607,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:747,750</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:775,778</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -3558,7 +3615,7 @@
     </unit>
     <unit id="landing.discover.blog.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:756,758</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:784,786</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3566,7 +3623,7 @@
     </unit>
     <unit id="landing.discover.blog.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:760,763</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:788,791</note>
       </notes>
       <segment>
         <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
@@ -3574,7 +3631,7 @@
     </unit>
     <unit id="landing.discover.blog.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:770,772</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:798,800</note>
       </notes>
       <segment>
         <source>Zum Blog</source>
@@ -4268,7 +4325,7 @@
     <unit id="removeSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:181,183</note>
-        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:114,116</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:115,117</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -4277,7 +4334,7 @@
     <unit id="addSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:192,193</note>
-        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:125,127</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:126,128</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -4294,7 +4351,7 @@
     <unit id="totalReps">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:203,205</note>
-        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:134,136</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:135,137</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -4343,7 +4400,7 @@
     <unit id="saveEntry">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:285,287</note>
-        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:150,152</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:151,153</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -4391,7 +4448,7 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:265</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:287</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -4399,7 +4456,7 @@
     </unit>
     <unit id="exercise.category.abs">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:266</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:288</note>
       </notes>
       <segment>
         <source>Bauch</source>
@@ -4407,7 +4464,7 @@
     </unit>
     <unit id="exercise.category.legs">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:267</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:289</note>
       </notes>
       <segment>
         <source>Beine</source>
@@ -4415,7 +4472,7 @@
     </unit>
     <unit id="exercise.abs.situps.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:270</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:292</note>
       </notes>
       <segment>
         <source>Sit-ups</source>
@@ -4423,7 +4480,7 @@
     </unit>
     <unit id="exercise.legs.squats.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:271</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:293</note>
       </notes>
       <segment>
         <source>Kniebeugen</source>
@@ -4431,7 +4488,7 @@
     </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:276</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:298</note>
       </notes>
       <segment>
         <source>Eintrag hinzufügen</source>
@@ -4439,7 +4496,7 @@
     </unit>
     <unit id="exerciseSection.savedToast">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:277</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:299</note>
       </notes>
       <segment>
         <source>Eintrag gespeichert</source>
@@ -4447,7 +4504,7 @@
     </unit>
     <unit id="exerciseSection.dismiss">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:278</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:300</note>
       </notes>
       <segment>
         <source>OK</source>
@@ -4455,7 +4512,7 @@
     </unit>
     <unit id="exerciseSection.errorPrefix">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:279</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:301</note>
       </notes>
       <segment>
         <source>Konnte nicht gespeichert werden</source>
@@ -4463,7 +4520,7 @@
     </unit>
     <unit id="exerciseSection.genericError">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:280</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:302</note>
       </notes>
       <segment>
         <source>Etwas ist schiefgelaufen</source>
@@ -5125,7 +5182,7 @@
     </unit>
     <unit id="analysisHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:45,46</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:52,53</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -5133,15 +5190,39 @@
     </unit>
     <unit id="analysisHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:47,49</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:54,56</note>
       </notes>
       <segment>
         <source> Trends, Verteilungen und Streaks deines Trainings auf einen Blick. </source>
       </segment>
     </unit>
+    <unit id="analysis.empty.title">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:73,75</note>
+      </notes>
+      <segment>
+        <source>Noch keine Daten zum Analysieren.</source>
+      </segment>
+    </unit>
+    <unit id="analysis.empty.body">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,78</note>
+      </notes>
+      <segment>
+        <source> Starte einen Trainingsplan oder trage deinen ersten Satz ein — dann zeigen wir dir hier Trends und Streaks. </source>
+      </segment>
+    </unit>
+    <unit id="analysis.empty.cta">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:87,89</note>
+      </notes>
+      <segment>
+        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Trainingsplan wählen </source>
+      </segment>
+    </unit>
     <unit id="analysis.weekTrendTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:75,77</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:109,111</note>
       </notes>
       <segment>
         <source>Wochentrend</source>
@@ -5149,7 +5230,7 @@
     </unit>
     <unit id="analysis.weekCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:85,86</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:119,120</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -5157,8 +5238,8 @@
     </unit>
     <unit id="analysis.repsCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:91,92</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:135,136</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:125,126</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:169,170</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5166,8 +5247,8 @@
     </unit>
     <unit id="analysis.avgSetsCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:97,98</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:141,142</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:131,132</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:175,176</note>
       </notes>
       <segment>
         <source>⌀ Sets</source>
@@ -5175,7 +5256,7 @@
     </unit>
     <unit id="analysis.monthTrendTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:119,121</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:153,155</note>
       </notes>
       <segment>
         <source>Monatstrend</source>
@@ -5183,7 +5264,7 @@
     </unit>
     <unit id="analysis.monthCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:129,130</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:163,164</note>
       </notes>
       <segment>
         <source>Monat</source>
@@ -5191,7 +5272,7 @@
     </unit>
     <unit id="analysis.bestStreaksTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:163,165</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:197,199</note>
       </notes>
       <segment>
         <source>Bestwerte &amp; Streaks</source>
@@ -5199,7 +5280,7 @@
     </unit>
     <unit id="analysis.bestSingleEntry">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:169,171</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:203,205</note>
       </notes>
       <segment>
         <source>Bestwert Einzel-Eintrag:</source>
@@ -5207,7 +5288,7 @@
     </unit>
     <unit id="analysis.bestDay">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:174,176</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:208,210</note>
       </notes>
       <segment>
         <source>Bester Tag:</source>
@@ -5215,7 +5296,7 @@
     </unit>
     <unit id="analysis.bestSingleSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:183,185</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:217,219</note>
       </notes>
       <segment>
         <source>Bestes Einzel-Set:</source>
@@ -5223,7 +5304,7 @@
     </unit>
     <unit id="analysis.repsUnit">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:187,189</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:221,223</note>
       </notes>
       <segment>
         <source>Wdh.</source>
@@ -5231,7 +5312,7 @@
     </unit>
     <unit id="analysis.currentStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:192,194</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:226,228</note>
       </notes>
       <segment>
         <source>Aktuelle Streak:</source>
@@ -5239,8 +5320,8 @@
     </unit>
     <unit id="analysis.streakDays">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:195,196</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:203,204</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:229,230</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:237,238</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}"/> Tage</source>
@@ -5248,7 +5329,7 @@
     </unit>
     <unit id="analysis.longestStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:200,202</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:234,236</note>
       </notes>
       <segment>
         <source>Längste Streak:</source>
@@ -5256,7 +5337,7 @@
     </unit>
     <unit id="analysis.typesTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:213,215</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:247,249</note>
       </notes>
       <segment>
         <source>Typen (Anteile)</source>
@@ -5264,7 +5345,7 @@
     </unit>
     <unit id="analysis.avgSetSizeTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:227,228</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:261,262</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
@@ -5272,7 +5353,7 @@
     </unit>
     <unit id="analysis.repsPerSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:232,233</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:266,267</note>
       </notes>
       <segment>
         <source>Reps / Set</source>
@@ -5280,7 +5361,7 @@
     </unit>
     <unit id="analysis.setsDistTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:241,243</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:275,277</note>
       </notes>
       <segment>
         <source>Sets-Verteilung</source>
@@ -5288,7 +5369,7 @@
     </unit>
     <unit id="analysis.heatmapTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:256,258</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:290,292</note>
       </notes>
       <segment>
         <source>Heatmap (Wochentag/Uhrzeit)</source>
@@ -5296,7 +5377,7 @@
     </unit>
     <unit id="analysis.heatmapToggleAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:262,263</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:296,297</note>
       </notes>
       <segment>
         <source>Heatmap-Modus auswählen</source>
@@ -5304,7 +5385,7 @@
     </unit>
     <unit id="analysis.heatmapReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:266,268</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:300,302</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5312,7 +5393,7 @@
     </unit>
     <unit id="analysis.heatmapSets">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:269,271</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:303,305</note>
       </notes>
       <segment>
         <source>Sets</source>
@@ -5320,7 +5401,7 @@
     </unit>
     <unit id="historyHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:27,28</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:33,34</note>
       </notes>
       <segment>
         <source>Historie</source>
@@ -5328,7 +5409,7 @@
     </unit>
     <unit id="historyHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:29,31</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:35,37</note>
       </notes>
       <segment>
         <source> Durchsuche, filtere und bearbeite deine Trainingseinträge. </source>
@@ -5336,7 +5417,7 @@
     </unit>
     <unit id="entries.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:34,35</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:40,41</note>
       </notes>
       <segment>
         <source>Filter</source>
@@ -5344,7 +5425,7 @@
     </unit>
     <unit id="entries.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:36,37</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:42,43</note>
       </notes>
       <segment>
         <source>Zeitraum und Kriterien</source>
@@ -5352,7 +5433,7 @@
     </unit>
     <unit id="entries.dateFrom">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:43,44</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:49,50</note>
       </notes>
       <segment>
         <source>Datum von</source>
@@ -5360,7 +5441,7 @@
     </unit>
     <unit id="entries.dateTo">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:53,54</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:59,60</note>
       </notes>
       <segment>
         <source>Datum bis</source>
@@ -5368,7 +5449,7 @@
     </unit>
     <unit id="entries.sourceFilter">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:63,64</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:69,70</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -5376,8 +5457,8 @@
     </unit>
     <unit id="entries.allOption">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:69,71</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:84,86</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:75,77</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:90,92</note>
       </notes>
       <segment>
         <source>Alle</source>
@@ -5385,7 +5466,7 @@
     </unit>
     <unit id="entries.typeFilter">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:78,79</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:84,85</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -5393,7 +5474,7 @@
     </unit>
     <unit id="entries.repsMin">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:95,96</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:101,102</note>
       </notes>
       <segment>
         <source>Reps min</source>
@@ -5401,15 +5482,39 @@
     </unit>
     <unit id="entries.repsMax">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:106,107</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:112,113</note>
       </notes>
       <segment>
         <source>Reps max</source>
       </segment>
     </unit>
+    <unit id="entries.empty.title">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:140,142</note>
+      </notes>
+      <segment>
+        <source>Noch keine Einträge.</source>
+      </segment>
+    </unit>
+    <unit id="entries.empty.body">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:143,145</note>
+      </notes>
+      <segment>
+        <source> Trage deinen ersten Satz Liegestütze ein — dann wird hier deine Historie sichtbar. </source>
+      </segment>
+    </unit>
+    <unit id="entries.empty.cta">
+      <notes>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:155,157</note>
+      </notes>
+      <segment>
+        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc> Eintrag erstellen </source>
+      </segment>
+    </unit>
     <unit id="settingsHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:81,82</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:82,83</note>
       </notes>
       <segment>
         <source>Einstellungen</source>
@@ -5417,7 +5522,7 @@
     </unit>
     <unit id="settingsHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:83,86</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:84,87</note>
       </notes>
       <segment>
         <source> Profil, Ziele und Sichtbarkeit nach deinem Geschmack. </source>
@@ -5425,7 +5530,7 @@
     </unit>
     <unit id="settings.status.saving">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:99,101</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:100,102</note>
       </notes>
       <segment>
         <source>Speichert…</source>
@@ -5433,7 +5538,7 @@
     </unit>
     <unit id="settings.status.saved">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:103,105</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:104,106</note>
       </notes>
       <segment>
         <source>Gespeichert</source>
@@ -5441,7 +5546,7 @@
     </unit>
     <unit id="settings.status.error">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:107,109</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:108,110</note>
       </notes>
       <segment>
         <source>Fehler beim Speichern</source>
@@ -5449,7 +5554,7 @@
     </unit>
     <unit id="settings.status.retry">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:114,115</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:115,116</note>
       </notes>
       <segment>
         <source> Erneut versuchen </source>
@@ -5457,7 +5562,7 @@
     </unit>
     <unit id="settings.status.pending">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:120,123</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:121,124</note>
       </notes>
       <segment>
         <source>Ungespeicherte Änderungen…</source>
@@ -5465,7 +5570,7 @@
     </unit>
     <unit id="settings.status.synced">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:126,129</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:127,130</note>
       </notes>
       <segment>
         <source>Alle Änderungen gespeichert</source>
@@ -5473,7 +5578,7 @@
     </unit>
     <unit id="guest.banner.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:137,140</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:138,141</note>
       </notes>
       <segment>
         <source>Du nutzt die App als Gast. Erstelle ein Konto um alle Funktionen zu nutzen.</source>
@@ -5481,7 +5586,7 @@
     </unit>
     <unit id="guest.banner.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:141,144</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:142,145</note>
       </notes>
       <segment>
         <source>Konto erstellen</source>
@@ -5489,7 +5594,7 @@
     </unit>
     <unit id="settings.section.profile.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:150,152</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:151,153</note>
       </notes>
       <segment>
         <source>Profil</source>
@@ -5497,7 +5602,7 @@
     </unit>
     <unit id="settings.section.profile.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:153,155</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:154,156</note>
       </notes>
       <segment>
         <source> Wie du in der App und der Bestenliste erscheinst. </source>
@@ -5505,7 +5610,7 @@
     </unit>
     <unit id="displayNameLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:158,159</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:159,160</note>
       </notes>
       <segment>
         <source>Anzeigename</source>
@@ -5513,7 +5618,7 @@
     </unit>
     <unit id="displayNamePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:164</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:165</note>
       </notes>
       <segment>
         <source>Wolf</source>
@@ -5521,15 +5626,23 @@
     </unit>
     <unit id="settings.displayNameHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:167,169</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:168,170</note>
       </notes>
       <segment>
         <source>Kann in der Bestenliste angezeigt werden.</source>
       </segment>
     </unit>
+    <unit id="settings.displayNameHint.leaderboardLink">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:176,179</note>
+      </notes>
+      <segment>
+        <source>Zur Bestenliste</source>
+      </segment>
+    </unit>
     <unit id="settings.section.privacy.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:177,179</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:186,188</note>
       </notes>
       <segment>
         <source>Sichtbarkeit</source>
@@ -5537,7 +5650,7 @@
     </unit>
     <unit id="settings.section.privacy.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:180,182</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:189,191</note>
       </notes>
       <segment>
         <source> Steuere, wer dein Profil sehen kann. </source>
@@ -5545,7 +5658,7 @@
     </unit>
     <unit id="settings.leaderboardOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:192,193</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:201,202</note>
       </notes>
       <segment>
         <source> In Bestenliste anzeigen </source>
@@ -5553,7 +5666,7 @@
     </unit>
     <unit id="settings.leaderboardOptOutHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:196,198</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:205,207</note>
       </notes>
       <segment>
         <source> Wenn deaktiviert, wird dein Profil in der Bestenliste nicht angezeigt. </source>
@@ -5561,7 +5674,7 @@
     </unit>
     <unit id="settings.leaderboardRequiresPublicProfile">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:205,208</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:214,217</note>
       </notes>
       <segment>
         <source> Nur Profile mit aktiviertem Öffentlichen Profil erscheinen in der Bestenliste. Aktiviere unten „Öffentliches Profil“, um diese Option zu nutzen. </source>
@@ -5569,7 +5682,7 @@
     </unit>
     <unit id="settings.publicProfile.toggle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:219,220</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:228,229</note>
       </notes>
       <segment>
         <source> Öffentliches Profil aktivieren </source>
@@ -5577,15 +5690,23 @@
     </unit>
     <unit id="settings.publicProfile.hint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:222,225</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:231,234</note>
       </notes>
       <segment>
         <source> Erlaubt jedem mit dem Link den Zugriff auf deine Reps, Streak und Bestleistungen. Dein Anzeigename ist sichtbar; E-Mail, Ziele und Erinnerungen bleiben privat. </source>
       </segment>
     </unit>
+    <unit id="settings.publicProfile.previewCta">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:253,255</note>
+      </notes>
+      <segment>
+        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">visibility</pc> Vorschau </source>
+      </segment>
+    </unit>
     <unit id="settings.publicProfile.shareCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:244,246</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:262,264</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">share</pc> Profil teilen </source>
@@ -5593,7 +5714,7 @@
     </unit>
     <unit id="settings.section.goals.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:257,259</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:275,277</note>
       </notes>
       <segment>
         <source>Ziele</source>
@@ -5601,15 +5722,31 @@
     </unit>
     <unit id="settings.section.goals.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:260,262</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:278,280</note>
       </notes>
       <segment>
         <source> Tägliche, wöchentliche und monatliche Ziele. </source>
       </segment>
     </unit>
+    <unit id="settings.goals.planOverrideHint">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:289,291</note>
+      </notes>
+      <segment>
+        <source> Ein aktiver Trainingsplan setzt dein Tagesziel automatisch. Manuelle Werte gelten erst nach Planende. </source>
+      </segment>
+    </unit>
+    <unit id="settings.goals.openActivePlan">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:296,299</note>
+      </notes>
+      <segment>
+        <source>Aktiven Plan öffnen</source>
+      </segment>
+    </unit>
     <unit id="dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:266,267</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:302,303</note>
       </notes>
       <segment>
         <source>Tagesziel (Reps)</source>
@@ -5617,7 +5754,7 @@
     </unit>
     <unit id="dailyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:276</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:312</note>
       </notes>
       <segment>
         <source>10</source>
@@ -5625,7 +5762,7 @@
     </unit>
     <unit id="settings.goalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:279,281</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:315,317</note>
       </notes>
       <segment>
         <source>Wird prominent in der Toolbar angezeigt.</source>
@@ -5633,7 +5770,7 @@
     </unit>
     <unit id="weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:284,285</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:320,321</note>
       </notes>
       <segment>
         <source>Wochenziel (Reps)</source>
@@ -5641,7 +5778,7 @@
     </unit>
     <unit id="weeklyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:294</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:330</note>
       </notes>
       <segment>
         <source>50</source>
@@ -5649,7 +5786,7 @@
     </unit>
     <unit id="settings.weeklyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:297,299</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:333,335</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Woche (Mo–So).</source>
@@ -5657,7 +5794,7 @@
     </unit>
     <unit id="monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:302,303</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:338,339</note>
       </notes>
       <segment>
         <source>Monatsziel (Reps)</source>
@@ -5665,7 +5802,7 @@
     </unit>
     <unit id="monthlyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:312</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:348</note>
       </notes>
       <segment>
         <source>200</source>
@@ -5673,7 +5810,7 @@
     </unit>
     <unit id="settings.monthlyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:315,317</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:351,353</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Monat.</source>
@@ -5681,7 +5818,7 @@
     </unit>
     <unit id="settings.section.display.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:326,328</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:362,364</note>
       </notes>
       <segment>
         <source>Anzeige</source>
@@ -5689,7 +5826,7 @@
     </unit>
     <unit id="settings.section.display.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:329,331</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:365,367</note>
       </notes>
       <segment>
         <source> Animationen und Darstellung. </source>
@@ -5697,7 +5834,7 @@
     </unit>
     <unit id="settings.snapQualityLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:338,340</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:374,376</note>
       </notes>
       <segment>
         <source>Snap-Animation Qualität</source>
@@ -5705,7 +5842,7 @@
     </unit>
     <unit id="settings.snapQuality.low">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:348,350</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:384,386</note>
       </notes>
       <segment>
         <source>Niedrig</source>
@@ -5713,7 +5850,7 @@
     </unit>
     <unit id="settings.snapQuality.middle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:353,355</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:389,391</note>
       </notes>
       <segment>
         <source>Mittel</source>
@@ -5721,7 +5858,7 @@
     </unit>
     <unit id="settings.snapQuality.high">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:356,358</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:392,394</note>
       </notes>
       <segment>
         <source>Hoch</source>
@@ -5729,7 +5866,7 @@
     </unit>
     <unit id="settings.snapQualityHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:360,362</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:396,398</note>
       </notes>
       <segment>
         <source> Steuert die Partikelanzahl der „Ziel erreicht“-Animation (40k / 120k / 200k). </source>
@@ -5737,7 +5874,7 @@
     </unit>
     <unit id="settings.section.ads.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:371,373</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:407,409</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -5745,7 +5882,7 @@
     </unit>
     <unit id="settings.section.ads.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:374,376</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:410,412</note>
       </notes>
       <segment>
         <source> Personalisierung der Werbe-Slots. </source>
@@ -5753,7 +5890,7 @@
     </unit>
     <unit id="settings.adsConsentOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:383,384</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:419,420</note>
       </notes>
       <segment>
         <source> Personalisierte Werbung aktivieren </source>
@@ -5761,15 +5898,23 @@
     </unit>
     <unit id="settings.adsConsentHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:386,388</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:423,426</note>
       </notes>
       <segment>
-        <source> Steuert, ob Werbe-Slots im Dashboard geladen werden dürfen. </source>
+        <source>Steuert, ob Werbe-Slots im Dashboard geladen werden dürfen.</source>
+      </segment>
+    </unit>
+    <unit id="settings.adsConsent.privacyLink">
+      <notes>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:429,432</note>
+      </notes>
+      <segment>
+        <source>Datenschutzerklärung</source>
       </segment>
     </unit>
     <unit id="settings.remindersLinkTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:395,397</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:439,441</note>
       </notes>
       <segment>
         <source>Erinnerungen</source>
@@ -5777,7 +5922,7 @@
     </unit>
     <unit id="settings.remindersLinkDesc">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:398,399</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:442,443</note>
       </notes>
       <segment>
         <source> Liegestütz-Erinnerungen und Push-Benachrichtigungen konfigurieren. </source>
@@ -5785,7 +5930,7 @@
     </unit>
     <unit id="settings.remindersLinkCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:407,409</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:451,453</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications</pc> Erinnerungen verwalten </source>
@@ -5793,7 +5938,7 @@
     </unit>
     <unit id="settings.dangerZoneTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:417,419</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:461,463</note>
       </notes>
       <segment>
         <source>Danger Zone</source>
@@ -5801,7 +5946,7 @@
     </unit>
     <unit id="settings.dangerZoneBody">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:420,422</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:464,466</note>
       </notes>
       <segment>
         <source> Konto löschen entfernt dein Konto. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -5809,7 +5954,7 @@
     </unit>
     <unit id="settings.deleteAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:433,435</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:477,479</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Konto löschen </source>
@@ -5817,7 +5962,7 @@
     </unit>
     <unit id="settings.deletingAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:438,441</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:482,485</note>
       </notes>
       <segment>
         <source>Konto wird gelöscht…</source>
@@ -5825,7 +5970,7 @@
     </unit>
     <unit id="settings.deleteDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:446,448</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:490,492</note>
       </notes>
       <segment>
         <source> Account wirklich löschen? </source>
@@ -5833,7 +5978,7 @@
     </unit>
     <unit id="settings.deleteDialogWarning">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:450,452</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:494,496</note>
       </notes>
       <segment>
         <source> Achtung: Diese Aktion ist nicht rückgängig. </source>
@@ -5841,7 +5986,7 @@
     </unit>
     <unit id="settings.deleteDialogInfo">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:453,456</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:497,500</note>
       </notes>
       <segment>
         <source> Dein Konto wird gelöscht. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -5849,7 +5994,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:458,461</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:502,505</note>
       </notes>
       <segment>
         <source>Bestätigungswort eingeben</source>
@@ -5857,7 +6002,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:467,469</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:511,513</note>
       </notes>
       <segment>
         <source>Bitte exakt „löscchen“ eingeben.</source>
@@ -5865,7 +6010,7 @@
     </unit>
     <unit id="settings.deleteConfirmFinal">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:482,484</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:526,528</note>
       </notes>
       <segment>
         <source> Final löschen </source>
@@ -5873,7 +6018,7 @@
     </unit>
     <unit id="settings.publicProfile.share.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:767</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:847</note>
       </notes>
       <segment>
         <source>Mein Pushup Tracker Profil</source>
@@ -5881,7 +6026,7 @@
     </unit>
     <unit id="settings.publicProfile.share.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:768</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:848</note>
       </notes>
       <segment>
         <source>Schau dir mein Pushup-Profil an:</source>
@@ -5909,14 +6054,6 @@
       </notes>
       <segment>
         <source> Live: <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;verbunden&apos; : &apos;getrennt&apos; }}"/> </source>
-      </segment>
-    </unit>
-    <unit id="allTimeSummaryAria">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:41,42</note>
-      </notes>
-      <segment>
-        <source>All-Time Kurzübersicht</source>
       </segment>
     </unit>
     <unit id="allTimeTotal">
@@ -5951,10 +6088,18 @@
         <source>All-Time Ø/Tag</source>
       </segment>
     </unit>
+    <unit id="dashboard.allTimeBadges.cta">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:62,66</note>
+      </notes>
+      <segment>
+        <source>Zur Analyse</source>
+      </segment>
+    </unit>
     <unit id="trainingPlans.day">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:70,71</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:91,92</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:74,75</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:93,94</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -5962,9 +6107,9 @@
     </unit>
     <unit id="trainingPlans.kind.rest">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:73,74</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:219,220</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:105,106</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:77,78</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:232,233</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:107,108</note>
       </notes>
       <segment>
         <source>Ruhetag</source>
@@ -5972,9 +6117,9 @@
     </unit>
     <unit id="trainingPlans.kind.light">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:76,77</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:226,228</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:108,109</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:80,81</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:239,241</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:110,111</note>
       </notes>
       <segment>
         <source>Leichter Tag</source>
@@ -5982,9 +6127,9 @@
     </unit>
     <unit id="trainingPlans.kind.test">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:78,80</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:222,224</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:111,113</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:82,84</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:235,237</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:113,115</note>
       </notes>
       <segment>
         <source>Maximaltest</source>
@@ -5992,10 +6137,10 @@
     </unit>
     <unit id="trainingPlans.reps">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:81,83</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:232,233</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:238,239</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:123,125</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:85,87</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:245,246</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:251,252</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:125,127</note>
       </notes>
       <segment>
         <source>Wdh.</source>
@@ -6003,16 +6148,40 @@
     </unit>
     <unit id="trainingPlans.openDetail">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:90,92</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:163,165</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:94,96</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:165,167</note>
       </notes>
       <segment>
         <source> Details öffnen </source>
       </segment>
     </unit>
+    <unit id="dashboard.noPlanTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:106,108</note>
+      </notes>
+      <segment>
+        <source>Noch kein aktiver Trainingsplan</source>
+      </segment>
+    </unit>
+    <unit id="dashboard.noPlanSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:109,111</note>
+      </notes>
+      <segment>
+        <source> Wähle einen Plan, um dein Tagesziel automatisch setzen zu lassen. </source>
+      </segment>
+    </unit>
+    <unit id="dashboard.noPlanCta">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:118,120</note>
+      </notes>
+      <segment>
+        <source> Plan wählen </source>
+      </segment>
+    </unit>
     <unit id="todayFocusAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:99,100</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:127,128</note>
       </notes>
       <segment>
         <source>Tagesfokus</source>
@@ -6020,7 +6189,7 @@
     </unit>
     <unit id="dashboard.todayTotal">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:105,107</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:133,135</note>
       </notes>
       <segment>
         <source>Heute Gesamt</source>
@@ -6028,15 +6197,23 @@
     </unit>
     <unit id="goalProgressTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:116,118</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:144,146</note>
       </notes>
       <segment>
         <source>Zielfortschritt</source>
       </segment>
     </unit>
+    <unit id="dashboard.goalEditAria">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:152,153</note>
+      </notes>
+      <segment>
+        <source>Tagesziel in Einstellungen öffnen</source>
+      </segment>
+    </unit>
     <unit id="dashboard.dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:121,122</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:160,161</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -6044,7 +6221,7 @@
     </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:130,131</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:169,170</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -6052,15 +6229,23 @@
     </unit>
     <unit id="dashboard.monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:139,140</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:178,179</note>
       </notes>
       <segment>
         <source>Monat</source>
       </segment>
     </unit>
+    <unit id="dashboard.lastEntryLinkAria">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:203,204</note>
+      </notes>
+      <segment>
+        <source>Letzten Eintrag in der Historie öffnen</source>
+      </segment>
+    </unit>
     <unit id="lastEntryTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:158,159</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:207,208</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -6068,7 +6253,7 @@
     </unit>
     <unit id="latEntryReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:163,165</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:212,214</note>
       </notes>
       <segment>
         <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ typeLabel(latest) }}"/> </source>
@@ -6076,7 +6261,7 @@
     </unit>
     <unit id="dashboard.noEntryYet">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:167,169</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:216,218</note>
       </notes>
       <segment>
         <source>Noch kein Eintrag.</source>
@@ -6084,7 +6269,7 @@
     </unit>
     <unit id="quickActionsTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:176,178</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:225,227</note>
       </notes>
       <segment>
         <source>Schnellaktionen</source>
@@ -6092,7 +6277,7 @@
     </unit>
     <unit id="quickActionsSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:179,181</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:228,230</note>
       </notes>
       <segment>
         <source>Schnell eintragen ohne Dialog</source>
@@ -6100,7 +6285,7 @@
     </unit>
     <unit id="quickActions.edit.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:186,187</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:235,236</note>
       </notes>
       <segment>
         <source>Schnellaktionen bearbeiten</source>
@@ -6108,7 +6293,7 @@
     </unit>
     <unit id="dashboard.quickAdd.button">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:257,258</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
@@ -6116,7 +6301,7 @@
     </unit>
     <unit id="dashboard.goalFill.reached">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:222,224</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:271,273</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -6124,7 +6309,7 @@
     </unit>
     <unit id="dashboard.goalFill.fill">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:225,226</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:274,275</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> bis zum Ziel</source>
@@ -6132,7 +6317,7 @@
     </unit>
     <unit id="quickAddNew">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:237,239</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:286,288</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">edit_note</pc> Neu </source>
@@ -6140,7 +6325,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:258,262</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:307,311</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -6148,7 +6333,7 @@
     </unit>
     <unit id="dashboard.latestEntriesLinkAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:269,270</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:318,319</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6156,7 +6341,7 @@
     </unit>
     <unit id="dashboard.latestEntries">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:272,273</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:321,322</note>
       </notes>
       <segment>
         <source>Letzte Einträge</source>
@@ -6164,7 +6349,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:279,280</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:328,329</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6172,7 +6357,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:283,286</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:332,335</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -6180,7 +6365,7 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:289</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:338</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -6188,7 +6373,7 @@
     </unit>
     <unit id="dashboard.share.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:82</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:80</note>
       </notes>
       <segment>
         <source>Tagesleistung teilen</source>
@@ -6196,7 +6381,7 @@
     </unit>
     <unit id="dashboard.share">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:83</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:81</note>
       </notes>
       <segment>
         <source>Teilen</source>
@@ -6204,8 +6389,8 @@
     </unit>
     <unit id="trainingPlans.back">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:65</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:316,318</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:70</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:329,331</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -6213,8 +6398,8 @@
     </unit>
     <unit id="trainingPlans.daysSuffix">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:78,80</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:178,180</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:79,81</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:180,182</note>
       </notes>
       <segment>
         <source>Tage</source>
@@ -6222,8 +6407,8 @@
     </unit>
     <unit id="trainingPlans.level.beginner">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:82,83</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:183,185</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:83,84</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:185,187</note>
       </notes>
       <segment>
         <source>Einsteiger</source>
@@ -6231,8 +6416,8 @@
     </unit>
     <unit id="trainingPlans.level.intermediate">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:84,86</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:187,189</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:85,87</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:189,191</note>
       </notes>
       <segment>
         <source>Mittelstufe</source>
@@ -6240,8 +6425,8 @@
     </unit>
     <unit id="trainingPlans.level.advanced">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:86,88</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:191,193</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:87,89</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:193,195</note>
       </notes>
       <segment>
         <source>Fortgeschritten</source>
@@ -6249,7 +6434,7 @@
     </unit>
     <unit id="trainingPlans.progress">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:95,96</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:96,97</note>
       </notes>
       <segment>
         <source>Fortschritt</source>
@@ -6257,16 +6442,32 @@
     </unit>
     <unit id="trainingPlans.currentDay">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:104,105</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:105,106</note>
       </notes>
       <segment>
         <source>Aktueller Tag:</source>
       </segment>
     </unit>
+    <unit id="trainingPlans.goalOverrideHint">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:112,114</note>
+      </notes>
+      <segment>
+        <source> Tagesziel wird vom Plan gesetzt. </source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.goalOverrideHint.cta">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:118,121</note>
+      </notes>
+      <segment>
+        <source>Manuelle Ziele anpassen</source>
+      </segment>
+    </unit>
     <unit id="trainingPlans.abandon">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:116,118</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:138,140</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:129,131</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:140,142</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">cancel</pc> Plan beenden </source>
@@ -6274,7 +6475,7 @@
     </unit>
     <unit id="trainingPlans.startCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:126,128</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:139,141</note>
       </notes>
       <segment>
         <source> Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt. </source>
@@ -6282,7 +6483,7 @@
     </unit>
     <unit id="trainingPlans.signupCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:131,133</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:144,146</note>
       </notes>
       <segment>
         <source> Erstelle ein kostenloses Konto, um diesen Plan zu starten. Wir tracken deinen Fortschritt automatisch und setzen dein Tagesziel passend zum Plan. </source>
@@ -6290,7 +6491,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.tracking">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:137,139</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:150,152</note>
       </notes>
       <segment>
         <source> Automatische Fortschrittsverfolgung </source>
@@ -6298,7 +6499,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.goal">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:140,142</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:153,155</note>
       </notes>
       <segment>
         <source> Tagesziel passt sich täglich an deinen Plan an </source>
@@ -6306,7 +6507,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.streak">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:143,145</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:156,158</note>
       </notes>
       <segment>
         <source> Streaks, Statistiken und Bestenliste </source>
@@ -6314,7 +6515,7 @@
     </unit>
     <unit id="trainingPlans.replaceWarn">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:155,156</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:168,169</note>
       </notes>
       <segment>
         <source> Achtung: Dies ersetzt den aktuell aktiven Plan. </source>
@@ -6322,7 +6523,7 @@
     </unit>
     <unit id="trainingPlans.start">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:160,162</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:173,175</note>
       </notes>
       <segment>
         <source>Plan starten</source>
@@ -6330,7 +6531,7 @@
     </unit>
     <unit id="trainingPlans.signupAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:171,173</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:184,186</note>
       </notes>
       <segment>
         <source>Konto erstellen &amp; Plan starten</source>
@@ -6338,7 +6539,7 @@
     </unit>
     <unit id="trainingPlans.loginAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:179,182</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:192,195</note>
       </notes>
       <segment>
         <source>Schon Konto? Einloggen</source>
@@ -6346,7 +6547,7 @@
     </unit>
     <unit id="trainingPlans.week">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:189,190</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:202,203</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -6354,7 +6555,7 @@
     </unit>
     <unit id="trainingPlans.unmarkAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:277,278</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:290,291</note>
       </notes>
       <segment>
         <source>Als nicht erledigt markieren</source>
@@ -6362,7 +6563,7 @@
     </unit>
     <unit id="trainingPlans.logAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:288,289</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:301,302</note>
       </notes>
       <segment>
         <source>Plan-Sätze eintragen und als erledigt markieren</source>
@@ -6370,7 +6571,7 @@
     </unit>
     <unit id="trainingPlans.markAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:297,298</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:310,311</note>
       </notes>
       <segment>
         <source>Nur als erledigt markieren (ohne Eintrag)</source>
@@ -6378,7 +6579,7 @@
     </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:313,314</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:326,327</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -6386,7 +6587,7 @@
     </unit>
     <unit id="trainingPlans.autoStartFailed">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:563</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:588</note>
       </notes>
       <segment>
         <source>Plan-Start fehlgeschlagen — bitte erneut versuchen.</source>
@@ -6394,7 +6595,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:642</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:667</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -6402,7 +6603,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:659</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:684</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
@@ -6410,8 +6611,8 @@
     </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:685</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:347</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:710</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:348</note>
       </notes>
       <segment>
         <source>Plan-Sätze wurden eingetragen.</source>
@@ -6419,8 +6620,8 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:687</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:349</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:712</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:350</note>
       </notes>
       <segment>
         <source>Tag war schon eingetragen — als erledigt markiert.</source>
@@ -6428,8 +6629,8 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:689</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:351</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:714</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:352</note>
       </notes>
       <segment>
         <source>Daten werden noch geladen, bitte gleich noch einmal versuchen.</source>
@@ -6437,7 +6638,7 @@
     </unit>
     <unit id="trainingPlans.title">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:33,34</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:35,36</note>
       </notes>
       <segment>
         <source>Trainingspläne</source>
@@ -6445,7 +6646,7 @@
     </unit>
     <unit id="trainingPlans.intro">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:35,38</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:37,40</note>
       </notes>
       <segment>
         <source> Strukturierte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Starte einen Plan, und dein Tagesziel im Dashboard wird automatisch gesetzt. </source>
@@ -6453,7 +6654,7 @@
     </unit>
     <unit id="trainingPlans.banner.title">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:48,50</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:50,52</note>
       </notes>
       <segment>
         <source> Plan auswählen, Konto erstellen, durchstarten </source>
@@ -6461,7 +6662,7 @@
     </unit>
     <unit id="trainingPlans.banner.body">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:51,53</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:53,55</note>
       </notes>
       <segment>
         <source> Suche dir unten einen Plan aus. Mit einem kostenlosen Konto tracken wir deinen Fortschritt automatisch und passen dein Tagesziel an den gewählten Plan an. </source>
@@ -6469,7 +6670,7 @@
     </unit>
     <unit id="trainingPlans.banner.login">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:64,67</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:66,69</note>
       </notes>
       <segment>
         <source>Einloggen</source>
@@ -6477,7 +6678,7 @@
     </unit>
     <unit id="trainingPlans.banner.signup">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:72,74</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:74,76</note>
       </notes>
       <segment>
         <source>Kostenlos registrieren</source>
@@ -6485,7 +6686,7 @@
     </unit>
     <unit id="trainingPlans.active.title">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:82,83</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:84,85</note>
       </notes>
       <segment>
         <source> Aktiver Plan </source>
@@ -6493,7 +6694,7 @@
     </unit>
     <unit id="trainingPlans.kind.main">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:114,116</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:116,118</note>
       </notes>
       <segment>
         <source>Trainingstag</source>
@@ -6501,7 +6702,7 @@
     </unit>
     <unit id="trainingPlans.todayTarget">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:120,122</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:122,124</note>
       </notes>
       <segment>
         <source>Heute geplant:</source>
@@ -6509,7 +6710,7 @@
     </unit>
     <unit id="trainingPlans.logToday">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:154,156</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:156,158</note>
       </notes>
       <segment>
         <source>Heute eintragen</source>
@@ -6517,7 +6718,7 @@
     </unit>
     <unit id="trainingPlans.viewPlan">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:207,209</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:209,211</note>
       </notes>
       <segment>
         <source>Plan ansehen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -236,8 +236,9 @@
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:330,331</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:277,278</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:141,142</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:475,476</note>
       </notes>
       <segment>
         <source> Abbrechen </source>
@@ -2566,7 +2567,7 @@
     </unit>
     <unit id="sw.update.available">
       <notes>
-        <note category="location">web/src/app/app.ts:304</note>
+        <note category="location">web/src/app/app.ts:303</note>
       </notes>
       <segment>
         <source>Neue Version verfügbar</source>
@@ -2574,7 +2575,7 @@
     </unit>
     <unit id="sw.update.reload">
       <notes>
-        <note category="location">web/src/app/app.ts:305</note>
+        <note category="location">web/src/app/app.ts:304</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -2582,7 +2583,7 @@
     </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:377</note>
+        <note category="location">web/src/app/app.ts:362</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -2590,7 +2591,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:384</note>
+        <note category="location">web/src/app/app.ts:369</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>
@@ -2598,7 +2599,7 @@
     </unit>
     <unit id="blog.article.back">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:40,42</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:33,35</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">arrow_back</pc> Blog </source>
@@ -2606,7 +2607,7 @@
     </unit>
     <unit id="blog.article.readingTime">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:70,71</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:60,61</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}"/> Min. Lesezeit</source>
@@ -2614,7 +2615,7 @@
     </unit>
     <unit id="blog.article.updated">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:76,77</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:66,67</note>
       </notes>
       <segment>
         <source>Aktualisiert am</source>
@@ -2622,7 +2623,7 @@
     </unit>
     <unit id="blog.article.cta">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:93,95</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:83,85</note>
       </notes>
       <segment>
         <source> Kostenlos tracken – Jetzt registrieren </source>
@@ -2630,7 +2631,7 @@
     </unit>
     <unit id="blog.article.notFound">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:99,100</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:89,90</note>
       </notes>
       <segment>
         <source>Artikel nicht gefunden.</source>
@@ -2638,7 +2639,7 @@
     </unit>
     <unit id="blog.article.toList">
       <notes>
-        <note category="location">web/src/app/blog/blog-article.component.ts:101,105</note>
+        <note category="location">web/src/app/blog/blog-article.component.ts:91,95</note>
       </notes>
       <segment>
         <source>Zur Übersicht</source>
@@ -2646,7 +2647,7 @@
     </unit>
     <unit id="blog.list.title">
       <notes>
-        <note category="location">web/src/app/blog/blog-list.component.ts:21,22</note>
+        <note category="location">web/src/app/blog/blog-list.component.ts:13,14</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -2654,7 +2655,7 @@
     </unit>
     <unit id="blog.list.intro">
       <notes>
-        <note category="location">web/src/app/blog/blog-list.component.ts:23,25</note>
+        <note category="location">web/src/app/blog/blog-list.component.ts:15,18</note>
       </notes>
       <segment>
         <source> Tipps, Guides und Motivation rund um Liegestütze und Krafttraining. </source>
@@ -2662,7 +2663,7 @@
     </unit>
     <unit id="blog.list.readArticle">
       <notes>
-        <note category="location">web/src/app/blog/blog-list.component.ts:61,63</note>
+        <note category="location">web/src/app/blog/blog-list.component.ts:52,54</note>
       </notes>
       <segment>
         <source>Artikel lesen</source>
@@ -2718,7 +2719,7 @@
     </unit>
     <unit id="eyebrowTitle">
       <notes>
-        <note category="location">web/src/app/core/page-header/page-header.component.ts:27,28</note>
+        <note category="location">web/src/app/core/page-header/page-header.component.ts:25,26</note>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:12,13</note>
       </notes>
       <segment>
@@ -2841,43 +2842,10 @@
     </unit>
     <unit id="landing.leaderboard.ownPosition">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:80,81</note>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:86,88</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:74,76</note>
       </notes>
       <segment>
         <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}"/> Reps </source>
-      </segment>
-    </unit>
-    <unit id="leaderboard.visibilityHint">
-      <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:96,98</note>
-      </notes>
-      <segment>
-        <source> Sichtbarkeit oder Anzeigename anpassen? </source>
-      </segment>
-    </unit>
-    <unit id="leaderboard.visibilityHint.cta">
-      <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:102,105</note>
-      </notes>
-      <segment>
-        <source>Einstellungen öffnen</source>
-      </segment>
-    </unit>
-    <unit id="leaderboard.loginHint">
-      <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:109,111</note>
-      </notes>
-      <segment>
-        <source> Mitmachen und auftauchen? </source>
-      </segment>
-    </unit>
-    <unit id="leaderboard.loginHint.cta">
-      <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:112,115</note>
-      </notes>
-      <segment>
-        <source>Anmelden</source>
       </segment>
     </unit>
     <unit id="reminder.feature.eyebrow">
@@ -3505,7 +3473,7 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:546,548</note>
       </notes>
       <segment>
-        <source>App-Installation, Live-Sync &amp; Teilen</source>
+        <source>PWA, Live-Sync &amp; Web Share</source>
       </segment>
     </unit>
     <unit id="landing.feature.pwa.body">
@@ -3513,36 +3481,12 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:550,553</note>
       </notes>
       <segment>
-        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
-      </segment>
-    </unit>
-    <unit id="landing.feature.pwa.installed">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:556,558</note>
-      </notes>
-      <segment>
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">check_circle</pc> Du nutzt bereits die installierte App </source>
-      </segment>
-    </unit>
-    <unit id="landing.feature.pwa.install">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:569,571</note>
-      </notes>
-      <segment>
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">download</pc> Jetzt als App installieren </source>
-      </segment>
-    </unit>
-    <unit id="landing.feature.pwa.iosHint">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:576,579</note>
-      </notes>
-      <segment>
-        <source> Auf iPhone &amp; iPad: Teilen-Symbol antippen und „Zum Home-Bildschirm“ wählen. </source>
+        <source>Installierbar wie eine native App, Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Web Share teilen – inklusive Dark- und Light-Theme.</source>
       </segment>
     </unit>
     <unit id="landing.feature.privacy.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:587,589</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:560,562</note>
       </notes>
       <segment>
         <source>Privacy first &amp; 100 % kostenlos</source>
@@ -3550,7 +3494,7 @@
     </unit>
     <unit id="landing.feature.privacy.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:591,595</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:564,568</note>
       </notes>
       <segment>
         <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
@@ -3558,7 +3502,7 @@
     </unit>
     <unit id="ads.landing.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:597</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:570</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -3566,7 +3510,7 @@
     </unit>
     <unit id="landing.preview.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:606,608</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:579,581</note>
       </notes>
       <segment>
         <source> Deine Statistik auf einen Blick </source>
@@ -3574,7 +3518,7 @@
     </unit>
     <unit id="landing.preview.alt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:613,614</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:586,587</note>
       </notes>
       <segment>
         <source>Vorschau der Statistikansicht</source>
@@ -3582,7 +3526,7 @@
     </unit>
     <unit id="landing.discover.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:754,755</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:727,728</note>
       </notes>
       <segment>
         <source>Mehr entdecken</source>
@@ -3590,7 +3534,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:760,762</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:733,735</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3598,7 +3542,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:764,767</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:737,740</note>
       </notes>
       <segment>
         <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
@@ -3606,7 +3550,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:774,777</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:747,750</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -3614,7 +3558,7 @@
     </unit>
     <unit id="landing.discover.blog.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:783,785</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:756,758</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3622,7 +3566,7 @@
     </unit>
     <unit id="landing.discover.blog.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:787,790</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:760,763</note>
       </notes>
       <segment>
         <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
@@ -3630,7 +3574,7 @@
     </unit>
     <unit id="landing.discover.blog.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:797,799</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:770,772</note>
       </notes>
       <segment>
         <source>Zum Blog</source>
@@ -4297,6 +4241,7 @@
     <unit id="timestampLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:148,150</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:81,83</note>
       </notes>
       <segment>
         <source>Zeitpunkt</source>
@@ -4305,6 +4250,7 @@
     <unit id="setLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:162,163</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:95,96</note>
       </notes>
       <segment>
         <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -4313,6 +4259,7 @@
     <unit id="repsLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:164,165</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:97,98</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -4321,6 +4268,7 @@
     <unit id="removeSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:181,183</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:114,116</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -4329,6 +4277,7 @@
     <unit id="addSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:192,193</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:125,127</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -4345,6 +4294,7 @@
     <unit id="totalReps">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:203,205</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:134,136</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -4393,6 +4343,7 @@
     <unit id="saveEntry">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:285,287</note>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:150,152</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -4412,6 +4363,118 @@
       </notes>
       <segment>
         <source>Anleitung öffnen</source>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.lastEntry">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:121,122</note>
+      </notes>
+      <segment>
+        <source>Letzter Eintrag</source>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.last30d">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:130,132</note>
+      </notes>
+      <segment>
+        <source>Letzte 30 Tage</source>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.add">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:140,142</note>
+      </notes>
+      <segment>
+        <source>Hinzufügen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:265</note>
+      </notes>
+      <segment>
+        <source>Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.abs">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:266</note>
+      </notes>
+      <segment>
+        <source>Bauch</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.legs">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:267</note>
+      </notes>
+      <segment>
+        <source>Beine</source>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.situps.name">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:270</note>
+      </notes>
+      <segment>
+        <source>Sit-ups</source>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:271</note>
+      </notes>
+      <segment>
+        <source>Kniebeugen</source>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.addAriaPrefix">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:276</note>
+      </notes>
+      <segment>
+        <source>Eintrag hinzufügen</source>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.savedToast">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:277</note>
+      </notes>
+      <segment>
+        <source>Eintrag gespeichert</source>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.dismiss">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:278</note>
+      </notes>
+      <segment>
+        <source>OK</source>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.errorPrefix">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:279</note>
+      </notes>
+      <segment>
+        <source>Konnte nicht gespeichert werden</source>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.genericError">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:280</note>
+      </notes>
+      <segment>
+        <source>Etwas ist schiefgelaufen</source>
+      </segment>
+    </unit>
+    <unit id="exerciseEntryDialog.title">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-entry-dialog/exercise-entry-dialog.component.ts:75,77</note>
+      </notes>
+      <segment>
+        <source>Eintrag hinzufügen</source>
       </segment>
     </unit>
     <unit id="selectRangeTitle">
@@ -5062,7 +5125,7 @@
     </unit>
     <unit id="analysisHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:52,53</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:45,46</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -5070,39 +5133,15 @@
     </unit>
     <unit id="analysisHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:54,56</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:47,49</note>
       </notes>
       <segment>
         <source> Trends, Verteilungen und Streaks deines Trainings auf einen Blick. </source>
       </segment>
     </unit>
-    <unit id="analysis.empty.title">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:73,75</note>
-      </notes>
-      <segment>
-        <source>Noch keine Daten zum Analysieren.</source>
-      </segment>
-    </unit>
-    <unit id="analysis.empty.body">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,78</note>
-      </notes>
-      <segment>
-        <source> Starte einen Trainingsplan oder trage deinen ersten Satz ein — dann zeigen wir dir hier Trends und Streaks. </source>
-      </segment>
-    </unit>
-    <unit id="analysis.empty.cta">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:87,89</note>
-      </notes>
-      <segment>
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Trainingsplan wählen </source>
-      </segment>
-    </unit>
     <unit id="analysis.weekTrendTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:109,111</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:75,77</note>
       </notes>
       <segment>
         <source>Wochentrend</source>
@@ -5110,7 +5149,7 @@
     </unit>
     <unit id="analysis.weekCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:119,120</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:85,86</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -5118,8 +5157,8 @@
     </unit>
     <unit id="analysis.repsCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:125,126</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:169,170</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:91,92</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:135,136</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5127,8 +5166,8 @@
     </unit>
     <unit id="analysis.avgSetsCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:131,132</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:175,176</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:97,98</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:141,142</note>
       </notes>
       <segment>
         <source>⌀ Sets</source>
@@ -5136,7 +5175,7 @@
     </unit>
     <unit id="analysis.monthTrendTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:153,155</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:119,121</note>
       </notes>
       <segment>
         <source>Monatstrend</source>
@@ -5144,7 +5183,7 @@
     </unit>
     <unit id="analysis.monthCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:163,164</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:129,130</note>
       </notes>
       <segment>
         <source>Monat</source>
@@ -5152,7 +5191,7 @@
     </unit>
     <unit id="analysis.bestStreaksTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:197,199</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:163,165</note>
       </notes>
       <segment>
         <source>Bestwerte &amp; Streaks</source>
@@ -5160,7 +5199,7 @@
     </unit>
     <unit id="analysis.bestSingleEntry">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:203,205</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:169,171</note>
       </notes>
       <segment>
         <source>Bestwert Einzel-Eintrag:</source>
@@ -5168,7 +5207,7 @@
     </unit>
     <unit id="analysis.bestDay">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:208,210</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:174,176</note>
       </notes>
       <segment>
         <source>Bester Tag:</source>
@@ -5176,7 +5215,7 @@
     </unit>
     <unit id="analysis.bestSingleSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:217,219</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:183,185</note>
       </notes>
       <segment>
         <source>Bestes Einzel-Set:</source>
@@ -5184,7 +5223,7 @@
     </unit>
     <unit id="analysis.repsUnit">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:221,223</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:187,189</note>
       </notes>
       <segment>
         <source>Wdh.</source>
@@ -5192,7 +5231,7 @@
     </unit>
     <unit id="analysis.currentStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:226,228</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:192,194</note>
       </notes>
       <segment>
         <source>Aktuelle Streak:</source>
@@ -5200,8 +5239,8 @@
     </unit>
     <unit id="analysis.streakDays">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:229,230</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:237,238</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:195,196</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:203,204</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}"/> Tage</source>
@@ -5209,7 +5248,7 @@
     </unit>
     <unit id="analysis.longestStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:234,236</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:200,202</note>
       </notes>
       <segment>
         <source>Längste Streak:</source>
@@ -5217,7 +5256,7 @@
     </unit>
     <unit id="analysis.typesTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:247,249</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:213,215</note>
       </notes>
       <segment>
         <source>Typen (Anteile)</source>
@@ -5225,7 +5264,7 @@
     </unit>
     <unit id="analysis.avgSetSizeTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:261,262</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:227,228</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
@@ -5233,7 +5272,7 @@
     </unit>
     <unit id="analysis.repsPerSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:266,267</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:232,233</note>
       </notes>
       <segment>
         <source>Reps / Set</source>
@@ -5241,7 +5280,7 @@
     </unit>
     <unit id="analysis.setsDistTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:275,277</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:241,243</note>
       </notes>
       <segment>
         <source>Sets-Verteilung</source>
@@ -5249,7 +5288,7 @@
     </unit>
     <unit id="analysis.heatmapTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:290,292</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:256,258</note>
       </notes>
       <segment>
         <source>Heatmap (Wochentag/Uhrzeit)</source>
@@ -5257,7 +5296,7 @@
     </unit>
     <unit id="analysis.heatmapToggleAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:296,297</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:262,263</note>
       </notes>
       <segment>
         <source>Heatmap-Modus auswählen</source>
@@ -5265,7 +5304,7 @@
     </unit>
     <unit id="analysis.heatmapReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:300,302</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:266,268</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5273,7 +5312,7 @@
     </unit>
     <unit id="analysis.heatmapSets">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:303,305</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:269,271</note>
       </notes>
       <segment>
         <source>Sets</source>
@@ -5281,7 +5320,7 @@
     </unit>
     <unit id="historyHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:33,34</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:27,28</note>
       </notes>
       <segment>
         <source>Historie</source>
@@ -5289,7 +5328,7 @@
     </unit>
     <unit id="historyHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:35,37</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:29,31</note>
       </notes>
       <segment>
         <source> Durchsuche, filtere und bearbeite deine Trainingseinträge. </source>
@@ -5297,7 +5336,7 @@
     </unit>
     <unit id="entries.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:40,41</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:34,35</note>
       </notes>
       <segment>
         <source>Filter</source>
@@ -5305,7 +5344,7 @@
     </unit>
     <unit id="entries.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:42,43</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:36,37</note>
       </notes>
       <segment>
         <source>Zeitraum und Kriterien</source>
@@ -5313,7 +5352,7 @@
     </unit>
     <unit id="entries.dateFrom">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:49,50</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:43,44</note>
       </notes>
       <segment>
         <source>Datum von</source>
@@ -5321,7 +5360,7 @@
     </unit>
     <unit id="entries.dateTo">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:59,60</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:53,54</note>
       </notes>
       <segment>
         <source>Datum bis</source>
@@ -5329,7 +5368,7 @@
     </unit>
     <unit id="entries.sourceFilter">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:69,70</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:63,64</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -5337,8 +5376,8 @@
     </unit>
     <unit id="entries.allOption">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:75,77</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:90,92</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:69,71</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:84,86</note>
       </notes>
       <segment>
         <source>Alle</source>
@@ -5346,7 +5385,7 @@
     </unit>
     <unit id="entries.typeFilter">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:84,85</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:78,79</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -5354,7 +5393,7 @@
     </unit>
     <unit id="entries.repsMin">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:101,102</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:95,96</note>
       </notes>
       <segment>
         <source>Reps min</source>
@@ -5362,39 +5401,15 @@
     </unit>
     <unit id="entries.repsMax">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:112,113</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:106,107</note>
       </notes>
       <segment>
         <source>Reps max</source>
       </segment>
     </unit>
-    <unit id="entries.empty.title">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:140,142</note>
-      </notes>
-      <segment>
-        <source>Noch keine Einträge.</source>
-      </segment>
-    </unit>
-    <unit id="entries.empty.body">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:143,145</note>
-      </notes>
-      <segment>
-        <source> Trage deinen ersten Satz Liegestütze ein — dann wird hier deine Historie sichtbar. </source>
-      </segment>
-    </unit>
-    <unit id="entries.empty.cta">
-      <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:155,157</note>
-      </notes>
-      <segment>
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc> Eintrag erstellen </source>
-      </segment>
-    </unit>
     <unit id="settingsHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:82,83</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:81,82</note>
       </notes>
       <segment>
         <source>Einstellungen</source>
@@ -5402,7 +5417,7 @@
     </unit>
     <unit id="settingsHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:84,87</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:83,86</note>
       </notes>
       <segment>
         <source> Profil, Ziele und Sichtbarkeit nach deinem Geschmack. </source>
@@ -5410,7 +5425,7 @@
     </unit>
     <unit id="settings.status.saving">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:100,102</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:99,101</note>
       </notes>
       <segment>
         <source>Speichert…</source>
@@ -5418,7 +5433,7 @@
     </unit>
     <unit id="settings.status.saved">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:104,106</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:103,105</note>
       </notes>
       <segment>
         <source>Gespeichert</source>
@@ -5426,7 +5441,7 @@
     </unit>
     <unit id="settings.status.error">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:108,110</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:107,109</note>
       </notes>
       <segment>
         <source>Fehler beim Speichern</source>
@@ -5434,7 +5449,7 @@
     </unit>
     <unit id="settings.status.retry">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:115,116</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:114,115</note>
       </notes>
       <segment>
         <source> Erneut versuchen </source>
@@ -5442,7 +5457,7 @@
     </unit>
     <unit id="settings.status.pending">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:121,124</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:120,123</note>
       </notes>
       <segment>
         <source>Ungespeicherte Änderungen…</source>
@@ -5450,7 +5465,7 @@
     </unit>
     <unit id="settings.status.synced">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:127,130</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:126,129</note>
       </notes>
       <segment>
         <source>Alle Änderungen gespeichert</source>
@@ -5458,7 +5473,7 @@
     </unit>
     <unit id="guest.banner.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:138,141</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:137,140</note>
       </notes>
       <segment>
         <source>Du nutzt die App als Gast. Erstelle ein Konto um alle Funktionen zu nutzen.</source>
@@ -5466,7 +5481,7 @@
     </unit>
     <unit id="guest.banner.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:142,145</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:141,144</note>
       </notes>
       <segment>
         <source>Konto erstellen</source>
@@ -5474,7 +5489,7 @@
     </unit>
     <unit id="settings.section.profile.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:151,153</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:150,152</note>
       </notes>
       <segment>
         <source>Profil</source>
@@ -5482,7 +5497,7 @@
     </unit>
     <unit id="settings.section.profile.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:154,156</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:153,155</note>
       </notes>
       <segment>
         <source> Wie du in der App und der Bestenliste erscheinst. </source>
@@ -5490,7 +5505,7 @@
     </unit>
     <unit id="displayNameLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:159,160</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:158,159</note>
       </notes>
       <segment>
         <source>Anzeigename</source>
@@ -5498,7 +5513,7 @@
     </unit>
     <unit id="displayNamePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:165</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:164</note>
       </notes>
       <segment>
         <source>Wolf</source>
@@ -5506,23 +5521,15 @@
     </unit>
     <unit id="settings.displayNameHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:168,170</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:167,169</note>
       </notes>
       <segment>
         <source>Kann in der Bestenliste angezeigt werden.</source>
       </segment>
     </unit>
-    <unit id="settings.displayNameHint.leaderboardLink">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:176,179</note>
-      </notes>
-      <segment>
-        <source>Zur Bestenliste</source>
-      </segment>
-    </unit>
     <unit id="settings.section.privacy.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:186,188</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:177,179</note>
       </notes>
       <segment>
         <source>Sichtbarkeit</source>
@@ -5530,7 +5537,7 @@
     </unit>
     <unit id="settings.section.privacy.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:189,191</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:180,182</note>
       </notes>
       <segment>
         <source> Steuere, wer dein Profil sehen kann. </source>
@@ -5538,7 +5545,7 @@
     </unit>
     <unit id="settings.leaderboardOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:201,202</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:192,193</note>
       </notes>
       <segment>
         <source> In Bestenliste anzeigen </source>
@@ -5546,7 +5553,7 @@
     </unit>
     <unit id="settings.leaderboardOptOutHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:205,207</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:196,198</note>
       </notes>
       <segment>
         <source> Wenn deaktiviert, wird dein Profil in der Bestenliste nicht angezeigt. </source>
@@ -5554,7 +5561,7 @@
     </unit>
     <unit id="settings.leaderboardRequiresPublicProfile">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:214,217</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:205,208</note>
       </notes>
       <segment>
         <source> Nur Profile mit aktiviertem Öffentlichen Profil erscheinen in der Bestenliste. Aktiviere unten „Öffentliches Profil“, um diese Option zu nutzen. </source>
@@ -5562,7 +5569,7 @@
     </unit>
     <unit id="settings.publicProfile.toggle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:228,229</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:219,220</note>
       </notes>
       <segment>
         <source> Öffentliches Profil aktivieren </source>
@@ -5570,23 +5577,15 @@
     </unit>
     <unit id="settings.publicProfile.hint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:231,234</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:222,225</note>
       </notes>
       <segment>
         <source> Erlaubt jedem mit dem Link den Zugriff auf deine Reps, Streak und Bestleistungen. Dein Anzeigename ist sichtbar; E-Mail, Ziele und Erinnerungen bleiben privat. </source>
       </segment>
     </unit>
-    <unit id="settings.publicProfile.previewCta">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:253,255</note>
-      </notes>
-      <segment>
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">visibility</pc> Vorschau </source>
-      </segment>
-    </unit>
     <unit id="settings.publicProfile.shareCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:262,264</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:244,246</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">share</pc> Profil teilen </source>
@@ -5594,7 +5593,7 @@
     </unit>
     <unit id="settings.section.goals.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:275,277</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:257,259</note>
       </notes>
       <segment>
         <source>Ziele</source>
@@ -5602,31 +5601,15 @@
     </unit>
     <unit id="settings.section.goals.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:278,280</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:260,262</note>
       </notes>
       <segment>
         <source> Tägliche, wöchentliche und monatliche Ziele. </source>
       </segment>
     </unit>
-    <unit id="settings.goals.planOverrideHint">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:289,291</note>
-      </notes>
-      <segment>
-        <source> Ein aktiver Trainingsplan setzt dein Tagesziel automatisch. Manuelle Werte gelten erst nach Planende. </source>
-      </segment>
-    </unit>
-    <unit id="settings.goals.openActivePlan">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:296,299</note>
-      </notes>
-      <segment>
-        <source>Aktiven Plan öffnen</source>
-      </segment>
-    </unit>
     <unit id="dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:302,303</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:266,267</note>
       </notes>
       <segment>
         <source>Tagesziel (Reps)</source>
@@ -5634,7 +5617,7 @@
     </unit>
     <unit id="dailyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:312</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:276</note>
       </notes>
       <segment>
         <source>10</source>
@@ -5642,7 +5625,7 @@
     </unit>
     <unit id="settings.goalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:315,317</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:279,281</note>
       </notes>
       <segment>
         <source>Wird prominent in der Toolbar angezeigt.</source>
@@ -5650,7 +5633,7 @@
     </unit>
     <unit id="weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:320,321</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:284,285</note>
       </notes>
       <segment>
         <source>Wochenziel (Reps)</source>
@@ -5658,7 +5641,7 @@
     </unit>
     <unit id="weeklyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:330</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:294</note>
       </notes>
       <segment>
         <source>50</source>
@@ -5666,7 +5649,7 @@
     </unit>
     <unit id="settings.weeklyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:333,335</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:297,299</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Woche (Mo–So).</source>
@@ -5674,7 +5657,7 @@
     </unit>
     <unit id="monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:338,339</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:302,303</note>
       </notes>
       <segment>
         <source>Monatsziel (Reps)</source>
@@ -5682,7 +5665,7 @@
     </unit>
     <unit id="monthlyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:348</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:312</note>
       </notes>
       <segment>
         <source>200</source>
@@ -5690,7 +5673,7 @@
     </unit>
     <unit id="settings.monthlyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:351,353</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:315,317</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Monat.</source>
@@ -5698,7 +5681,7 @@
     </unit>
     <unit id="settings.section.display.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:362,364</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:326,328</note>
       </notes>
       <segment>
         <source>Anzeige</source>
@@ -5706,7 +5689,7 @@
     </unit>
     <unit id="settings.section.display.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:365,367</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:329,331</note>
       </notes>
       <segment>
         <source> Animationen und Darstellung. </source>
@@ -5714,7 +5697,7 @@
     </unit>
     <unit id="settings.snapQualityLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:374,376</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:338,340</note>
       </notes>
       <segment>
         <source>Snap-Animation Qualität</source>
@@ -5722,7 +5705,7 @@
     </unit>
     <unit id="settings.snapQuality.low">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:384,386</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:348,350</note>
       </notes>
       <segment>
         <source>Niedrig</source>
@@ -5730,7 +5713,7 @@
     </unit>
     <unit id="settings.snapQuality.middle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:389,391</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:353,355</note>
       </notes>
       <segment>
         <source>Mittel</source>
@@ -5738,7 +5721,7 @@
     </unit>
     <unit id="settings.snapQuality.high">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:392,394</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:356,358</note>
       </notes>
       <segment>
         <source>Hoch</source>
@@ -5746,7 +5729,7 @@
     </unit>
     <unit id="settings.snapQualityHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:396,398</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:360,362</note>
       </notes>
       <segment>
         <source> Steuert die Partikelanzahl der „Ziel erreicht“-Animation (40k / 120k / 200k). </source>
@@ -5754,7 +5737,7 @@
     </unit>
     <unit id="settings.section.ads.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:407,409</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:371,373</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -5762,7 +5745,7 @@
     </unit>
     <unit id="settings.section.ads.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:410,412</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:374,376</note>
       </notes>
       <segment>
         <source> Personalisierung der Werbe-Slots. </source>
@@ -5770,7 +5753,7 @@
     </unit>
     <unit id="settings.adsConsentOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:419,420</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:383,384</note>
       </notes>
       <segment>
         <source> Personalisierte Werbung aktivieren </source>
@@ -5778,23 +5761,15 @@
     </unit>
     <unit id="settings.adsConsentHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:423,426</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:386,388</note>
       </notes>
       <segment>
-        <source>Steuert, ob Werbe-Slots im Dashboard geladen werden dürfen.</source>
-      </segment>
-    </unit>
-    <unit id="settings.adsConsent.privacyLink">
-      <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:429,432</note>
-      </notes>
-      <segment>
-        <source>Datenschutzerklärung</source>
+        <source> Steuert, ob Werbe-Slots im Dashboard geladen werden dürfen. </source>
       </segment>
     </unit>
     <unit id="settings.remindersLinkTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:439,441</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:395,397</note>
       </notes>
       <segment>
         <source>Erinnerungen</source>
@@ -5802,7 +5777,7 @@
     </unit>
     <unit id="settings.remindersLinkDesc">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:442,443</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:398,399</note>
       </notes>
       <segment>
         <source> Liegestütz-Erinnerungen und Push-Benachrichtigungen konfigurieren. </source>
@@ -5810,7 +5785,7 @@
     </unit>
     <unit id="settings.remindersLinkCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:451,453</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:407,409</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications</pc> Erinnerungen verwalten </source>
@@ -5818,7 +5793,7 @@
     </unit>
     <unit id="settings.dangerZoneTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:461,463</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:417,419</note>
       </notes>
       <segment>
         <source>Danger Zone</source>
@@ -5826,7 +5801,7 @@
     </unit>
     <unit id="settings.dangerZoneBody">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:464,466</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:420,422</note>
       </notes>
       <segment>
         <source> Konto löschen entfernt dein Konto. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -5834,7 +5809,7 @@
     </unit>
     <unit id="settings.deleteAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:477,479</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:433,435</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Konto löschen </source>
@@ -5842,7 +5817,7 @@
     </unit>
     <unit id="settings.deletingAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:482,485</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:438,441</note>
       </notes>
       <segment>
         <source>Konto wird gelöscht…</source>
@@ -5850,7 +5825,7 @@
     </unit>
     <unit id="settings.deleteDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:490,492</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:446,448</note>
       </notes>
       <segment>
         <source> Account wirklich löschen? </source>
@@ -5858,7 +5833,7 @@
     </unit>
     <unit id="settings.deleteDialogWarning">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:494,496</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:450,452</note>
       </notes>
       <segment>
         <source> Achtung: Diese Aktion ist nicht rückgängig. </source>
@@ -5866,7 +5841,7 @@
     </unit>
     <unit id="settings.deleteDialogInfo">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:497,500</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:453,456</note>
       </notes>
       <segment>
         <source> Dein Konto wird gelöscht. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -5874,7 +5849,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:502,505</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:458,461</note>
       </notes>
       <segment>
         <source>Bestätigungswort eingeben</source>
@@ -5882,7 +5857,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:511,513</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:467,469</note>
       </notes>
       <segment>
         <source>Bitte exakt „löscchen“ eingeben.</source>
@@ -5890,7 +5865,7 @@
     </unit>
     <unit id="settings.deleteConfirmFinal">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:526,528</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:482,484</note>
       </notes>
       <segment>
         <source> Final löschen </source>
@@ -5898,7 +5873,7 @@
     </unit>
     <unit id="settings.publicProfile.share.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:847</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:767</note>
       </notes>
       <segment>
         <source>Mein Pushup Tracker Profil</source>
@@ -5906,7 +5881,7 @@
     </unit>
     <unit id="settings.publicProfile.share.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:848</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:768</note>
       </notes>
       <segment>
         <source>Schau dir mein Pushup-Profil an:</source>
@@ -5934,6 +5909,14 @@
       </notes>
       <segment>
         <source> Live: <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;verbunden&apos; : &apos;getrennt&apos; }}"/> </source>
+      </segment>
+    </unit>
+    <unit id="allTimeSummaryAria">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:41,42</note>
+      </notes>
+      <segment>
+        <source>All-Time Kurzübersicht</source>
       </segment>
     </unit>
     <unit id="allTimeTotal">
@@ -5968,18 +5951,10 @@
         <source>All-Time Ø/Tag</source>
       </segment>
     </unit>
-    <unit id="dashboard.allTimeBadges.cta">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:62,66</note>
-      </notes>
-      <segment>
-        <source>Zur Analyse</source>
-      </segment>
-    </unit>
     <unit id="trainingPlans.day">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:74,75</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:93,94</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:70,71</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:91,92</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -5987,9 +5962,9 @@
     </unit>
     <unit id="trainingPlans.kind.rest">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:77,78</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:232,233</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:107,108</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:73,74</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:219,220</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:105,106</note>
       </notes>
       <segment>
         <source>Ruhetag</source>
@@ -5997,9 +5972,9 @@
     </unit>
     <unit id="trainingPlans.kind.light">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:80,81</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:239,241</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:110,111</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:76,77</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:226,228</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:108,109</note>
       </notes>
       <segment>
         <source>Leichter Tag</source>
@@ -6007,9 +5982,9 @@
     </unit>
     <unit id="trainingPlans.kind.test">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:82,84</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:235,237</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:113,115</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:78,80</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:222,224</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:111,113</note>
       </notes>
       <segment>
         <source>Maximaltest</source>
@@ -6017,10 +5992,10 @@
     </unit>
     <unit id="trainingPlans.reps">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:85,87</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:245,246</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:251,252</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:125,127</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:81,83</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:232,233</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:238,239</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:123,125</note>
       </notes>
       <segment>
         <source>Wdh.</source>
@@ -6028,40 +6003,16 @@
     </unit>
     <unit id="trainingPlans.openDetail">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:94,96</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:165,167</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:90,92</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:163,165</note>
       </notes>
       <segment>
         <source> Details öffnen </source>
       </segment>
     </unit>
-    <unit id="dashboard.noPlanTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:106,108</note>
-      </notes>
-      <segment>
-        <source>Noch kein aktiver Trainingsplan</source>
-      </segment>
-    </unit>
-    <unit id="dashboard.noPlanSubtitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:109,111</note>
-      </notes>
-      <segment>
-        <source> Wähle einen Plan, um dein Tagesziel automatisch setzen zu lassen. </source>
-      </segment>
-    </unit>
-    <unit id="dashboard.noPlanCta">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:118,120</note>
-      </notes>
-      <segment>
-        <source> Plan wählen </source>
-      </segment>
-    </unit>
     <unit id="todayFocusAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:127,128</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:99,100</note>
       </notes>
       <segment>
         <source>Tagesfokus</source>
@@ -6069,7 +6020,7 @@
     </unit>
     <unit id="dashboard.todayTotal">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:133,135</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:105,107</note>
       </notes>
       <segment>
         <source>Heute Gesamt</source>
@@ -6077,23 +6028,15 @@
     </unit>
     <unit id="goalProgressTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:144,146</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:116,118</note>
       </notes>
       <segment>
         <source>Zielfortschritt</source>
       </segment>
     </unit>
-    <unit id="dashboard.goalEditAria">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:152,153</note>
-      </notes>
-      <segment>
-        <source>Tagesziel in Einstellungen öffnen</source>
-      </segment>
-    </unit>
     <unit id="dashboard.dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:160,161</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:121,122</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -6101,7 +6044,7 @@
     </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:169,170</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:130,131</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -6109,23 +6052,15 @@
     </unit>
     <unit id="dashboard.monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:178,179</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:139,140</note>
       </notes>
       <segment>
         <source>Monat</source>
       </segment>
     </unit>
-    <unit id="dashboard.lastEntryLinkAria">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:203,204</note>
-      </notes>
-      <segment>
-        <source>Letzten Eintrag in der Historie öffnen</source>
-      </segment>
-    </unit>
     <unit id="lastEntryTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:207,208</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:158,159</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -6133,7 +6068,7 @@
     </unit>
     <unit id="latEntryReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:212,214</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:163,165</note>
       </notes>
       <segment>
         <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ typeLabel(latest) }}"/> </source>
@@ -6141,7 +6076,7 @@
     </unit>
     <unit id="dashboard.noEntryYet">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:216,218</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:167,169</note>
       </notes>
       <segment>
         <source>Noch kein Eintrag.</source>
@@ -6149,7 +6084,7 @@
     </unit>
     <unit id="quickActionsTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:225,227</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:176,178</note>
       </notes>
       <segment>
         <source>Schnellaktionen</source>
@@ -6157,7 +6092,7 @@
     </unit>
     <unit id="quickActionsSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:228,230</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:179,181</note>
       </notes>
       <segment>
         <source>Schnell eintragen ohne Dialog</source>
@@ -6165,7 +6100,7 @@
     </unit>
     <unit id="quickActions.edit.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:235,236</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:186,187</note>
       </notes>
       <segment>
         <source>Schnellaktionen bearbeiten</source>
@@ -6173,7 +6108,7 @@
     </unit>
     <unit id="dashboard.quickAdd.button">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:257,258</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
@@ -6181,7 +6116,7 @@
     </unit>
     <unit id="dashboard.goalFill.reached">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:271,273</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:222,224</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -6189,7 +6124,7 @@
     </unit>
     <unit id="dashboard.goalFill.fill">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:274,275</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:225,226</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> bis zum Ziel</source>
@@ -6197,7 +6132,7 @@
     </unit>
     <unit id="quickAddNew">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:286,288</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:237,239</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">edit_note</pc> Neu </source>
@@ -6205,7 +6140,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:307,311</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:258,262</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -6213,7 +6148,7 @@
     </unit>
     <unit id="dashboard.latestEntriesLinkAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:318,319</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:269,270</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6221,7 +6156,7 @@
     </unit>
     <unit id="dashboard.latestEntries">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:321,322</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:272,273</note>
       </notes>
       <segment>
         <source>Letzte Einträge</source>
@@ -6229,7 +6164,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:328,329</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:279,280</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6237,7 +6172,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:332,335</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:283,286</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -6245,7 +6180,7 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:338</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:289</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -6253,7 +6188,7 @@
     </unit>
     <unit id="dashboard.share.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:77</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:82</note>
       </notes>
       <segment>
         <source>Tagesleistung teilen</source>
@@ -6261,7 +6196,7 @@
     </unit>
     <unit id="dashboard.share">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:78</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:83</note>
       </notes>
       <segment>
         <source>Teilen</source>
@@ -6269,8 +6204,8 @@
     </unit>
     <unit id="trainingPlans.back">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:70</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:329,331</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:65</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:316,318</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -6278,8 +6213,8 @@
     </unit>
     <unit id="trainingPlans.daysSuffix">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:79,81</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:180,182</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:78,80</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:178,180</note>
       </notes>
       <segment>
         <source>Tage</source>
@@ -6287,8 +6222,8 @@
     </unit>
     <unit id="trainingPlans.level.beginner">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:83,84</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:185,187</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:82,83</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:183,185</note>
       </notes>
       <segment>
         <source>Einsteiger</source>
@@ -6296,8 +6231,8 @@
     </unit>
     <unit id="trainingPlans.level.intermediate">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:85,87</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:189,191</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:84,86</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:187,189</note>
       </notes>
       <segment>
         <source>Mittelstufe</source>
@@ -6305,8 +6240,8 @@
     </unit>
     <unit id="trainingPlans.level.advanced">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:87,89</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:193,195</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:86,88</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:191,193</note>
       </notes>
       <segment>
         <source>Fortgeschritten</source>
@@ -6314,7 +6249,7 @@
     </unit>
     <unit id="trainingPlans.progress">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:96,97</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:95,96</note>
       </notes>
       <segment>
         <source>Fortschritt</source>
@@ -6322,32 +6257,16 @@
     </unit>
     <unit id="trainingPlans.currentDay">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:105,106</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:104,105</note>
       </notes>
       <segment>
         <source>Aktueller Tag:</source>
       </segment>
     </unit>
-    <unit id="trainingPlans.goalOverrideHint">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:112,114</note>
-      </notes>
-      <segment>
-        <source> Tagesziel wird vom Plan gesetzt. </source>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.goalOverrideHint.cta">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:118,121</note>
-      </notes>
-      <segment>
-        <source>Manuelle Ziele anpassen</source>
-      </segment>
-    </unit>
     <unit id="trainingPlans.abandon">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:129,131</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:140,142</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:116,118</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:138,140</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">cancel</pc> Plan beenden </source>
@@ -6355,7 +6274,7 @@
     </unit>
     <unit id="trainingPlans.startCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:139,141</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:126,128</note>
       </notes>
       <segment>
         <source> Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt. </source>
@@ -6363,7 +6282,7 @@
     </unit>
     <unit id="trainingPlans.signupCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:144,146</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:131,133</note>
       </notes>
       <segment>
         <source> Erstelle ein kostenloses Konto, um diesen Plan zu starten. Wir tracken deinen Fortschritt automatisch und setzen dein Tagesziel passend zum Plan. </source>
@@ -6371,7 +6290,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.tracking">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:150,152</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:137,139</note>
       </notes>
       <segment>
         <source> Automatische Fortschrittsverfolgung </source>
@@ -6379,7 +6298,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.goal">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:153,155</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:140,142</note>
       </notes>
       <segment>
         <source> Tagesziel passt sich täglich an deinen Plan an </source>
@@ -6387,7 +6306,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.streak">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:156,158</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:143,145</note>
       </notes>
       <segment>
         <source> Streaks, Statistiken und Bestenliste </source>
@@ -6395,7 +6314,7 @@
     </unit>
     <unit id="trainingPlans.replaceWarn">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:168,169</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:155,156</note>
       </notes>
       <segment>
         <source> Achtung: Dies ersetzt den aktuell aktiven Plan. </source>
@@ -6403,7 +6322,7 @@
     </unit>
     <unit id="trainingPlans.start">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:173,175</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:160,162</note>
       </notes>
       <segment>
         <source>Plan starten</source>
@@ -6411,7 +6330,7 @@
     </unit>
     <unit id="trainingPlans.signupAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:184,186</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:171,173</note>
       </notes>
       <segment>
         <source>Konto erstellen &amp; Plan starten</source>
@@ -6419,7 +6338,7 @@
     </unit>
     <unit id="trainingPlans.loginAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:192,195</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:179,182</note>
       </notes>
       <segment>
         <source>Schon Konto? Einloggen</source>
@@ -6427,7 +6346,7 @@
     </unit>
     <unit id="trainingPlans.week">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:202,203</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:189,190</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -6435,7 +6354,7 @@
     </unit>
     <unit id="trainingPlans.unmarkAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:290,291</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:277,278</note>
       </notes>
       <segment>
         <source>Als nicht erledigt markieren</source>
@@ -6443,7 +6362,7 @@
     </unit>
     <unit id="trainingPlans.logAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:301,302</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:288,289</note>
       </notes>
       <segment>
         <source>Plan-Sätze eintragen und als erledigt markieren</source>
@@ -6451,7 +6370,7 @@
     </unit>
     <unit id="trainingPlans.markAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:310,311</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:297,298</note>
       </notes>
       <segment>
         <source>Nur als erledigt markieren (ohne Eintrag)</source>
@@ -6459,7 +6378,7 @@
     </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:326,327</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:313,314</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -6467,7 +6386,7 @@
     </unit>
     <unit id="trainingPlans.autoStartFailed">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:588</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:563</note>
       </notes>
       <segment>
         <source>Plan-Start fehlgeschlagen — bitte erneut versuchen.</source>
@@ -6475,7 +6394,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:667</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:642</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -6483,7 +6402,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:684</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:659</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
@@ -6491,8 +6410,8 @@
     </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:710</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:348</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:685</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:347</note>
       </notes>
       <segment>
         <source>Plan-Sätze wurden eingetragen.</source>
@@ -6500,8 +6419,8 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:712</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:350</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:687</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:349</note>
       </notes>
       <segment>
         <source>Tag war schon eingetragen — als erledigt markiert.</source>
@@ -6509,8 +6428,8 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:714</note>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:352</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:689</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:351</note>
       </notes>
       <segment>
         <source>Daten werden noch geladen, bitte gleich noch einmal versuchen.</source>
@@ -6518,7 +6437,7 @@
     </unit>
     <unit id="trainingPlans.title">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:35,36</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:33,34</note>
       </notes>
       <segment>
         <source>Trainingspläne</source>
@@ -6526,7 +6445,7 @@
     </unit>
     <unit id="trainingPlans.intro">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:37,40</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:35,38</note>
       </notes>
       <segment>
         <source> Strukturierte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Starte einen Plan, und dein Tagesziel im Dashboard wird automatisch gesetzt. </source>
@@ -6534,7 +6453,7 @@
     </unit>
     <unit id="trainingPlans.banner.title">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:50,52</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:48,50</note>
       </notes>
       <segment>
         <source> Plan auswählen, Konto erstellen, durchstarten </source>
@@ -6542,7 +6461,7 @@
     </unit>
     <unit id="trainingPlans.banner.body">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:53,55</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:51,53</note>
       </notes>
       <segment>
         <source> Suche dir unten einen Plan aus. Mit einem kostenlosen Konto tracken wir deinen Fortschritt automatisch und passen dein Tagesziel an den gewählten Plan an. </source>
@@ -6550,7 +6469,7 @@
     </unit>
     <unit id="trainingPlans.banner.login">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:66,69</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:64,67</note>
       </notes>
       <segment>
         <source>Einloggen</source>
@@ -6558,7 +6477,7 @@
     </unit>
     <unit id="trainingPlans.banner.signup">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:74,76</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:72,74</note>
       </notes>
       <segment>
         <source>Kostenlos registrieren</source>
@@ -6566,7 +6485,7 @@
     </unit>
     <unit id="trainingPlans.active.title">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:84,85</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:82,83</note>
       </notes>
       <segment>
         <source> Aktiver Plan </source>
@@ -6574,7 +6493,7 @@
     </unit>
     <unit id="trainingPlans.kind.main">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:116,118</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:114,116</note>
       </notes>
       <segment>
         <source>Trainingstag</source>
@@ -6582,7 +6501,7 @@
     </unit>
     <unit id="trainingPlans.todayTarget">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:122,124</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:120,122</note>
       </notes>
       <segment>
         <source>Heute geplant:</source>
@@ -6590,7 +6509,7 @@
     </unit>
     <unit id="trainingPlans.logToday">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:156,158</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:154,156</note>
       </notes>
       <segment>
         <source>Heute eintragen</source>
@@ -6598,7 +6517,7 @@
     </unit>
     <unit id="trainingPlans.viewPlan">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:209,211</note>
+        <note category="location">web/src/app/training-plans/training-plans-page.component.ts:207,209</note>
       </notes>
       <segment>
         <source>Plan ansehen</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -4438,6 +4438,90 @@
         <source>Anleitung öffnen</source>
       <target>打开指南</target></segment>
     </unit>
+    <unit id="exerciseSection.lastEntry">
+      <segment state="translated">
+        <source>Letzter Eintrag</source>
+        <target>最后记录</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.last30d">
+      <segment state="translated">
+        <source>Letzte 30 Tage</source>
+        <target>最近30天</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.add">
+      <segment state="translated">
+        <source>Hinzufügen</source>
+        <target>添加</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <segment state="translated">
+        <source>Liegestütze</source>
+        <target>俯卧撑</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.abs">
+      <segment state="translated">
+        <source>Bauch</source>
+        <target>腹部</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.legs">
+      <segment state="translated">
+        <source>Beine</source>
+        <target>腿部</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.situps.name">
+      <segment state="translated">
+        <source>Sit-ups</source>
+        <target>仰卧起坐</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <segment state="translated">
+        <source>Kniebeugen</source>
+        <target>深蹲</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.addAriaPrefix">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>添加记录</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.savedToast">
+      <segment state="translated">
+        <source>Eintrag gespeichert</source>
+        <target>记录已保存</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.dismiss">
+      <segment state="translated">
+        <source>OK</source>
+        <target>确定</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.errorPrefix">
+      <segment state="translated">
+        <source>Konnte nicht gespeichert werden</source>
+        <target>无法保存</target>
+      </segment>
+    </unit>
+    <unit id="exerciseSection.genericError">
+      <segment state="translated">
+        <source>Etwas ist schiefgelaufen</source>
+        <target>出错了</target>
+      </segment>
+    </unit>
+    <unit id="exerciseEntryDialog.title">
+      <segment state="translated">
+        <source>Eintrag hinzufügen</source>
+        <target>添加记录</target>
+      </segment>
+    </unit>
     <unit id="selectRangeTitle">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:40,43</note>


### PR DESCRIPTION
Phase 0 of the multi-exercise migration: introduce a generic
ExerciseDefinition / ExerciseEntry model with measurement-type support
(reps, time, distance, weight) and ship sit-ups (Bauch) and squats
(Beine) end-to-end without touching the existing pushup flow.

- Models + catalog + validation in @pu-stats/models
- ExerciseFirestoreService persists to a new exerciseEntries collection
- Firestore rule restricts the new collection to the catalog ids and
  reps caps for now
- Cloud Function trigger writes per-exercise aggregates to
  userStats/{userId}/perExercise/{exerciseId} via the existing applyDelta
- Dashboard renders one section per non-pushup category beneath the
  pushup cards; lightweight ExerciseEntryDialogComponent for input
- Roadmap and full vision documented in plans/multi-exercise-roadmap.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi‑exercise support: exercise catalog (sit‑ups, squats), per‑category dashboard sections, entry dialog for logging sets/timestamps, and per‑exercise stats aggregation with background updates.

* **Bug Fixes / Validation**
  * Strong client & server validation and owner‑only access for entries; immutable exercise IDs and enforced value bounds for measurements/sets.

* **Documentation**
  * Added multi‑exercise roadmap with phased migration and backfill plan.

* **Tests**
  * Expanded unit and integration tests for models, services, dialogs, and stats migration.

* **Localization**
  * Added exercise UI translations across many locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->