### PR TITLE
feat(plank+cardio): add Plank (Phase 1) + Cardio Running (Phase 2+3)

### DIFF
--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -128,42 +128,61 @@ service cloud.firestore {
       allow read, update, delete: if false;
     }
 
-    // Generic exercise entries (sit-ups, squats, …). New collection that
-    // co-exists with `pushups` while we migrate. Caps mirror the Phase-0
-    // catalog in `libs/stats/src/lib/models/exercise.catalog.ts`
-    // (reps 1..500). Custom user-defined exercises are NOT yet allowed —
-    // the `exerciseId` must be one of the known catalog ids and
-    // measurement value caps are hardcoded for the rep-based exercises
-    // shipped in Phase 0. Other measurement types (durationSec,
-    // distanceM, weightKg) are rejected at the rule level until their
-    // dedicated phases land.
+    // Generic exercise entries (sit-ups, squats, plank, …). New
+    // collection that co-exists with `pushups` while we migrate. Caps
+    // mirror the catalog in
+    // `libs/stats/src/lib/models/exercise.catalog.ts`. Custom
+    // user-defined exercises are NOT yet allowed — the `exerciseId`
+    // must be one of the known catalog ids.
     //
-    // Schema is also pinned via `keys().hasOnly([...])` so unknown fields
-    // can't sneak past the trigger / aggregation logic.
+    // Per-exercise measurement validation:
+    //   - `abs.situps`, `legs.squats` (reps): require `reps` int 1..500;
+    //     forbid `durationSec`.
+    //   - `plank.standard` (time): require `durationSec` int 1..7200;
+    //     forbid `reps` and `sets`.
     //
-    // `exerciseId` is immutable on update — a different exercise must be
-    // recorded as a delete + create so the per-exercise stats trigger can
-    // decrement the old aggregate. (See `updateExerciseStatsOnEntryWrite`
-    // in `data-store/functions/src/index.ts`.)
+    // Schema is also pinned via `keys().hasOnly([...])` so unknown
+    // fields can't sneak past the trigger / aggregation logic.
+    //
+    // `exerciseId` is immutable on update — a different exercise must
+    // be recorded as a delete + create so the per-exercise stats
+    // trigger can decrement the old aggregate. (See
+    // `updateExerciseStatsOnEntryWrite` in
+    // `data-store/functions/src/index.ts`.)
     match /exerciseEntries/{entryId} {
       allow read: if request.auth != null && resource.data.userId == request.auth.uid;
       allow delete: if request.auth != null && resource.data.userId == request.auth.uid;
       allow create: if request.auth != null
                     && request.resource.data.keys().hasOnly([
-                      'userId', 'exerciseId', 'reps', 'sets', 'variantId',
-                      'timestamp', 'source', 'createdAt', 'updatedAt'
+                      'userId', 'exerciseId', 'reps', 'durationSec', 'sets',
+                      'variantId', 'timestamp', 'source', 'createdAt', 'updatedAt'
                     ])
                     && request.resource.data.userId == request.auth.uid
                     && request.resource.data.exerciseId is string
-                    && (request.resource.data.exerciseId == 'abs.situps'
-                        || request.resource.data.exerciseId == 'legs.squats')
-                    && request.resource.data.reps is int
-                    && request.resource.data.reps >= 1
-                    && request.resource.data.reps <= 500
                     && request.resource.data.timestamp is string
                     && request.resource.data.timestamp.size() > 0
+                    && (
+                      // Reps-measured exercises.
+                      ((request.resource.data.exerciseId == 'abs.situps'
+                          || request.resource.data.exerciseId == 'legs.squats')
+                        && request.resource.data.reps is int
+                        && request.resource.data.reps >= 1
+                        && request.resource.data.reps <= 500
+                        && !('durationSec' in request.resource.data.keys()))
+                      ||
+                      // Time-measured exercises (plank). `sets` would
+                      // poison `applyDelta` because no per-set duration
+                      // breakdown is defined yet — block it at the rule
+                      // until a future phase introduces one.
+                      (request.resource.data.exerciseId == 'plank.standard'
+                        && request.resource.data.durationSec is int
+                        && request.resource.data.durationSec >= 1
+                        && request.resource.data.durationSec <= 7200
+                        && !('reps' in request.resource.data.keys())
+                        && !('sets' in request.resource.data.keys()))
+                    )
                     // `sets` is optional, but when present every entry
-                    // must be an int in the per-rep range — otherwise
+                    // must be a bounded int list — otherwise
                     // `applyDelta()` reduces over the array and writes
                     // NaN into `userStats`, then the trigger retries
                     // forever.
@@ -173,8 +192,8 @@ service cloud.firestore {
       allow update: if request.auth != null
                     && resource.data.userId == request.auth.uid
                     && request.resource.data.keys().hasOnly([
-                      'userId', 'exerciseId', 'reps', 'sets', 'variantId',
-                      'timestamp', 'source', 'createdAt', 'updatedAt'
+                      'userId', 'exerciseId', 'reps', 'durationSec', 'sets',
+                      'variantId', 'timestamp', 'source', 'createdAt', 'updatedAt'
                     ])
                     && request.resource.data.userId == request.auth.uid
                     && request.resource.data.userId == resource.data.userId
@@ -183,6 +202,10 @@ service cloud.firestore {
                         || (request.resource.data.reps is int
                             && request.resource.data.reps >= 1
                             && request.resource.data.reps <= 500))
+                    && (!('durationSec' in request.resource.data.diff(resource.data).affectedKeys())
+                        || (request.resource.data.durationSec is int
+                            && request.resource.data.durationSec >= 1
+                            && request.resource.data.durationSec <= 7200))
                     && (!('timestamp' in request.resource.data.diff(resource.data).affectedKeys())
                         || (request.resource.data.timestamp is string
                             && request.resource.data.timestamp.size() > 0))

--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -154,8 +154,9 @@ service cloud.firestore {
       allow delete: if request.auth != null && resource.data.userId == request.auth.uid;
       allow create: if request.auth != null
                     && request.resource.data.keys().hasOnly([
-                      'userId', 'exerciseId', 'reps', 'durationSec', 'sets',
-                      'variantId', 'timestamp', 'source', 'createdAt', 'updatedAt'
+                      'userId', 'exerciseId', 'reps', 'durationSec', 'distanceM',
+                      'sets', 'variantId', 'timestamp', 'source',
+                      'createdAt', 'updatedAt'
                     ])
                     && request.resource.data.userId == request.auth.uid
                     && request.resource.data.exerciseId is string
@@ -168,7 +169,8 @@ service cloud.firestore {
                         && request.resource.data.reps is int
                         && request.resource.data.reps >= 1
                         && request.resource.data.reps <= 500
-                        && !('durationSec' in request.resource.data.keys()))
+                        && !('durationSec' in request.resource.data.keys())
+                        && !('distanceM' in request.resource.data.keys()))
                       ||
                       // Time-measured exercises (plank). `sets` would
                       // poison `applyDelta` because no per-set duration
@@ -178,6 +180,20 @@ service cloud.firestore {
                         && request.resource.data.durationSec is int
                         && request.resource.data.durationSec >= 1
                         && request.resource.data.durationSec <= 7200
+                        && !('reps' in request.resource.data.keys())
+                        && !('sets' in request.resource.data.keys())
+                        && !('distanceM' in request.resource.data.keys()))
+                      ||
+                      // Distance-time-measured exercises (cardio.running).
+                      // Both fields are required; `reps`/`sets` are blocked
+                      // for the same reason as plank.
+                      (request.resource.data.exerciseId == 'cardio.running'
+                        && request.resource.data.distanceM is int
+                        && request.resource.data.distanceM >= 100
+                        && request.resource.data.distanceM <= 50000
+                        && request.resource.data.durationSec is int
+                        && request.resource.data.durationSec >= 1
+                        && request.resource.data.durationSec <= 86400
                         && !('reps' in request.resource.data.keys())
                         && !('sets' in request.resource.data.keys()))
                     )
@@ -192,8 +208,9 @@ service cloud.firestore {
       allow update: if request.auth != null
                     && resource.data.userId == request.auth.uid
                     && request.resource.data.keys().hasOnly([
-                      'userId', 'exerciseId', 'reps', 'durationSec', 'sets',
-                      'variantId', 'timestamp', 'source', 'createdAt', 'updatedAt'
+                      'userId', 'exerciseId', 'reps', 'durationSec', 'distanceM',
+                      'sets', 'variantId', 'timestamp', 'source',
+                      'createdAt', 'updatedAt'
                     ])
                     && request.resource.data.userId == request.auth.uid
                     && request.resource.data.userId == resource.data.userId
@@ -203,25 +220,42 @@ service cloud.firestore {
                     // `exerciseId` is immutable (checked above) so we
                     // pin to `resource.data.exerciseId`.
                     && (
-                      // Reps-measured exercises: reject `durationSec`
-                      // and validate reps when changed.
+                      // Reps-measured exercises: reject `durationSec`/
+                      // `distanceM` and validate reps when changed.
                       ((resource.data.exerciseId == 'abs.situps'
                           || resource.data.exerciseId == 'legs.squats')
                         && !('durationSec' in request.resource.data.keys())
+                        && !('distanceM' in request.resource.data.keys())
                         && (!('reps' in request.resource.data.diff(resource.data).affectedKeys())
                             || (request.resource.data.reps is int
                                 && request.resource.data.reps >= 1
                                 && request.resource.data.reps <= 500)))
                       ||
-                      // Time-measured exercises (plank): reject `reps`
-                      // and `sets`, validate durationSec when changed.
+                      // Time-measured exercises (plank): reject `reps`,
+                      // `sets`, `distanceM`; validate durationSec when changed.
                       (resource.data.exerciseId == 'plank.standard'
                         && !('reps' in request.resource.data.keys())
                         && !('sets' in request.resource.data.keys())
+                        && !('distanceM' in request.resource.data.keys())
                         && (!('durationSec' in request.resource.data.diff(resource.data).affectedKeys())
                             || (request.resource.data.durationSec is int
                                 && request.resource.data.durationSec >= 1
                                 && request.resource.data.durationSec <= 7200)))
+                      ||
+                      // Distance-time-measured exercises (cardio.running):
+                      // reject `reps`/`sets`; validate distanceM and
+                      // durationSec when changed.
+                      (resource.data.exerciseId == 'cardio.running'
+                        && !('reps' in request.resource.data.keys())
+                        && !('sets' in request.resource.data.keys())
+                        && (!('distanceM' in request.resource.data.diff(resource.data).affectedKeys())
+                            || (request.resource.data.distanceM is int
+                                && request.resource.data.distanceM >= 100
+                                && request.resource.data.distanceM <= 50000))
+                        && (!('durationSec' in request.resource.data.diff(resource.data).affectedKeys())
+                            || (request.resource.data.durationSec is int
+                                && request.resource.data.durationSec >= 1
+                                && request.resource.data.durationSec <= 86400)))
                     )
                     && (!('timestamp' in request.resource.data.diff(resource.data).affectedKeys())
                         || (request.resource.data.timestamp is string

--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -198,14 +198,31 @@ service cloud.firestore {
                     && request.resource.data.userId == request.auth.uid
                     && request.resource.data.userId == resource.data.userId
                     && !('exerciseId' in request.resource.data.diff(resource.data).affectedKeys())
-                    && (!('reps' in request.resource.data.diff(resource.data).affectedKeys())
-                        || (request.resource.data.reps is int
-                            && request.resource.data.reps >= 1
-                            && request.resource.data.reps <= 500))
-                    && (!('durationSec' in request.resource.data.diff(resource.data).affectedKeys())
-                        || (request.resource.data.durationSec is int
-                            && request.resource.data.durationSec >= 1
-                            && request.resource.data.durationSec <= 7200))
+                    // Mirror the create branching so an update can't
+                    // sneak the wrong measurement field onto an entry.
+                    // `exerciseId` is immutable (checked above) so we
+                    // pin to `resource.data.exerciseId`.
+                    && (
+                      // Reps-measured exercises: reject `durationSec`
+                      // and validate reps when changed.
+                      ((resource.data.exerciseId == 'abs.situps'
+                          || resource.data.exerciseId == 'legs.squats')
+                        && !('durationSec' in request.resource.data.keys())
+                        && (!('reps' in request.resource.data.diff(resource.data).affectedKeys())
+                            || (request.resource.data.reps is int
+                                && request.resource.data.reps >= 1
+                                && request.resource.data.reps <= 500)))
+                      ||
+                      // Time-measured exercises (plank): reject `reps`
+                      // and `sets`, validate durationSec when changed.
+                      (resource.data.exerciseId == 'plank.standard'
+                        && !('reps' in request.resource.data.keys())
+                        && !('sets' in request.resource.data.keys())
+                        && (!('durationSec' in request.resource.data.diff(resource.data).affectedKeys())
+                            || (request.resource.data.durationSec is int
+                                && request.resource.data.durationSec >= 1
+                                && request.resource.data.durationSec <= 7200)))
+                    )
                     && (!('timestamp' in request.resource.data.diff(resource.data).affectedKeys())
                         || (request.resource.data.timestamp is string
                             && request.resource.data.timestamp.size() > 0))

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -1683,12 +1683,20 @@ export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
 
     // The aggregation slot stays named `reps` for backwards
     // compatibility with the existing UserStats schema, but for
-    // time-measurement exercises (plank) we feed `durationSec` into
-    // the same slot. The per-exercise stats doc is exercise-scoped, so
-    // `total` carries seconds for plank and rep counts for sit-ups —
-    // the display layer formats accordingly.
-    const oldReps = Number(beforeData?.reps ?? beforeData?.durationSec ?? 0);
-    const newReps = Number(afterData?.reps ?? afterData?.durationSec ?? 0);
+    // non-rep exercises we feed the primary measurement field
+    // (`durationSec` for plank, `distanceM` for cardio.running) into
+    // the same slot. The per-exercise stats doc is exercise-scoped,
+    // so `total` carries seconds for plank, meters for a tracked run,
+    // and rep counts for sit-ups — the display layer formats
+    // accordingly. For composite measurements ('distance-time') the
+    // companion duration is left to the live entries query in the
+    // dashboard summary; the aggregated slot stays single-valued.
+    const oldReps = Number(
+      beforeData?.reps ?? beforeData?.durationSec ?? beforeData?.distanceM ?? 0
+    );
+    const newReps = Number(
+      afterData?.reps ?? afterData?.durationSec ?? afterData?.distanceM ?? 0
+    );
     const oldTimestamp = beforeData?.timestamp as string | undefined;
     const newTimestamp = afterData?.timestamp as string | undefined;
     // Defensive sanitization: reduce over `sets` runs straight into
@@ -1749,11 +1757,11 @@ export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
         const data = d.data();
         return {
           timestamp: data.timestamp as string,
-          // Time-measurement entries (plank) carry the value in
-          // `durationSec`; reuse the rebuild path's `reps` slot so the
-          // per-exercise total ends up correct (seconds for plank,
-          // reps for sit-ups/squats).
-          reps: Number(data.reps ?? data.durationSec ?? 0),
+          // Non-rep entries reuse the rebuild path's `reps` slot for
+          // their primary measurement value: seconds for plank, meters
+          // for cardio.running. The slot is exercise-scoped so it
+          // never mixes units across exercises.
+          reps: Number(data.reps ?? data.durationSec ?? data.distanceM ?? 0),
           ...(Array.isArray(data.sets) ? { sets: data.sets as number[] } : {}),
         };
       });
@@ -1830,10 +1838,10 @@ export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
           const data = d.data();
           return {
             timestamp: data.timestamp as string,
-            // Time-measurement entries write the primary value to
-            // `durationSec`; fold it back into the `reps` slot the
-            // rebuild expects.
-            reps: Number(data.reps ?? data.durationSec ?? 0),
+            // Non-rep entries fold their primary measurement into the
+            // `reps` slot the rebuild expects: durationSec for plank,
+            // distanceM for cardio.running.
+            reps: Number(data.reps ?? data.durationSec ?? data.distanceM ?? 0),
             ...(Array.isArray(data.sets)
               ? { sets: data.sets as number[] }
               : {}),

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -1691,11 +1691,15 @@ export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
     // accordingly. For composite measurements ('distance-time') the
     // companion duration is left to the live entries query in the
     // dashboard summary; the aggregated slot stays single-valued.
+    //
+    // Fallback ordering matters: `distanceM` MUST come before
+    // `durationSec` because cardio.running entries carry both, and
+    // the primary value (distance) needs to win the `??` chain.
     const oldReps = Number(
-      beforeData?.reps ?? beforeData?.durationSec ?? beforeData?.distanceM ?? 0
+      beforeData?.reps ?? beforeData?.distanceM ?? beforeData?.durationSec ?? 0
     );
     const newReps = Number(
-      afterData?.reps ?? afterData?.durationSec ?? afterData?.distanceM ?? 0
+      afterData?.reps ?? afterData?.distanceM ?? afterData?.durationSec ?? 0
     );
     const oldTimestamp = beforeData?.timestamp as string | undefined;
     const newTimestamp = afterData?.timestamp as string | undefined;
@@ -1760,8 +1764,10 @@ export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
           // Non-rep entries reuse the rebuild path's `reps` slot for
           // their primary measurement value: seconds for plank, meters
           // for cardio.running. The slot is exercise-scoped so it
-          // never mixes units across exercises.
-          reps: Number(data.reps ?? data.durationSec ?? data.distanceM ?? 0),
+          // never mixes units across exercises. `distanceM` precedes
+          // `durationSec` so a cardio.running entry (both fields set)
+          // aggregates the distance, not the companion duration.
+          reps: Number(data.reps ?? data.distanceM ?? data.durationSec ?? 0),
           ...(Array.isArray(data.sets) ? { sets: data.sets as number[] } : {}),
         };
       });
@@ -1840,8 +1846,9 @@ export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
             timestamp: data.timestamp as string,
             // Non-rep entries fold their primary measurement into the
             // `reps` slot the rebuild expects: durationSec for plank,
-            // distanceM for cardio.running.
-            reps: Number(data.reps ?? data.durationSec ?? data.distanceM ?? 0),
+            // distanceM for cardio.running. Same ordering as the live
+            // trigger — distance wins over duration when both exist.
+            reps: Number(data.reps ?? data.distanceM ?? data.durationSec ?? 0),
             ...(Array.isArray(data.sets)
               ? { sets: data.sets as number[] }
               : {}),

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -1681,8 +1681,14 @@ export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
       return;
     }
 
-    const oldReps = Number(beforeData?.reps ?? 0);
-    const newReps = Number(afterData?.reps ?? 0);
+    // The aggregation slot stays named `reps` for backwards
+    // compatibility with the existing UserStats schema, but for
+    // time-measurement exercises (plank) we feed `durationSec` into
+    // the same slot. The per-exercise stats doc is exercise-scoped, so
+    // `total` carries seconds for plank and rep counts for sit-ups —
+    // the display layer formats accordingly.
+    const oldReps = Number(beforeData?.reps ?? beforeData?.durationSec ?? 0);
+    const newReps = Number(afterData?.reps ?? afterData?.durationSec ?? 0);
     const oldTimestamp = beforeData?.timestamp as string | undefined;
     const newTimestamp = afterData?.timestamp as string | undefined;
     // Defensive sanitization: reduce over `sets` runs straight into
@@ -1743,7 +1749,11 @@ export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
         const data = d.data();
         return {
           timestamp: data.timestamp as string,
-          reps: Number(data.reps ?? 0),
+          // Time-measurement entries (plank) carry the value in
+          // `durationSec`; reuse the rebuild path's `reps` slot so the
+          // per-exercise total ends up correct (seconds for plank,
+          // reps for sit-ups/squats).
+          reps: Number(data.reps ?? data.durationSec ?? 0),
           ...(Array.isArray(data.sets) ? { sets: data.sets as number[] } : {}),
         };
       });
@@ -1816,11 +1826,19 @@ export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
             .where('userId', '==', userId)
             .where('exerciseId', '==', exerciseId)
         );
-        const userEntries = userEntriesSnap.docs.map((d) => d.data()) as Array<{
-          timestamp: string;
-          reps: number;
-          sets?: number[];
-        }>;
+        const userEntries = userEntriesSnap.docs.map((d) => {
+          const data = d.data();
+          return {
+            timestamp: data.timestamp as string,
+            // Time-measurement entries write the primary value to
+            // `durationSec`; fold it back into the `reps` slot the
+            // rebuild expects.
+            reps: Number(data.reps ?? data.durationSec ?? 0),
+            ...(Array.isArray(data.sets)
+              ? { sets: data.sets as number[] }
+              : {}),
+          };
+        });
         current = rebuildFromEntries(userId, userEntries, nowIso);
       }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,7 +127,7 @@ Split into focused files under `libs/stats/src/lib/models/`:
 
 `ExerciseDefinition` separates three concerns deliberately:
 
-- **`measurement`** - which entry field carries the primary value. Drives validation (range checks against `def.min`/`def.max`), aggregation (which field summer roll up), and storage. `MeasurementType` is `'reps' | 'time' | 'distance' | 'weight' | 'distance-time'`.
+- **`measurement`** - which entry field carries the primary value. Drives validation (range checks against `def.min`/`def.max`), aggregation (which field sums roll up), and storage. `MeasurementType` is `'reps' | 'time' | 'distance' | 'weight' | 'distance-time'`.
 - **`unit`** - the rendering hint. `formatExerciseValue(value, unit)` switches on this string so a single measurement type can carry alternate display units later (kg vs. lb, km vs. mi). The catalog currently uses `'reps' | 's' | 'm' | 'kg'`.
 - **Companion fields** - secondary values an entry may (or must) carry alongside the primary. Declared in `COMPANION_FIELDS` / `REQUIRED_COMPANIONS` per measurement. `'distance'` allows an optional `durationSec`; `'distance-time'` requires it; `'weight'` requires `weightKg`.
 
@@ -136,4 +136,4 @@ Split into focused files under `libs/stats/src/lib/models/`:
 - For `'distance-time'`: renders the composite `"5.00 km · 25:00 (5:00 /km)"` via `formatDistanceTime`.
 - For everything else: reads the field that `measurementValueField(measurement)` returns and pipes it through `formatExerciseValue(value, def.unit)`.
 
-`measurementCompanionValueField(measurement)` returns the secondary display field for composite measurements (currently only `'durationSec'` for `'distance-time'`). Aggregation paths use it to sum a second total alongside the primary, so a 30-day card for a tracked run can show `"42.00 km · 3:30:00 (5:00 /km)"`. Phase 3 (cardio catalog entries) plugs into this without any further infrastructure work — only a `cardio.running` definition + tighter companion bounds need to be added.
+`measurementCompanionValueField(measurement)` returns the secondary display field for composite measurements (currently only `'durationSec'` for `'distance-time'`). Aggregation paths use it to sum a second total alongside the primary, so a 30-day card for a tracked run can show `"42.00 km · 3:30:00 (5:00 /km)"`. The first composite catalog entry is `cardio.running`; later cardio types (cycling, swimming, …) and tighter per-exercise companion bounds plug into the same path without further infrastructure work.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,3 +122,18 @@ Split into focused files under `libs/stats/src/lib/models/`:
 - `training-plan.models.ts` - TrainingPlan, TrainingPlanDay, UserTrainingPlan, `localizePlan()`, `currentPlanDayIndex()`, `planDayByIndex()`, `isPlanCompleted()`. `parseIsoDate` round-trips Y/M/D after `new Date()` to reject impossible dates like `2026-02-30`.
 - `training-plan.catalog.ts` - curated `TRAINING_PLANS` array + `findPlanById()` / `findPlanBySlug()` lookups. Test invariant: every plan's day indexes form a contiguous `1..totalDays` sequence and rest days have `targetReps === 0`.
   - UserStats includes a `version` field for migration support. See [`gotchas/cloud-functions.md`](gotchas/cloud-functions.md) for the versioning strategy.
+
+### Generic exercise model — measurement vs. unit vs. companion
+
+`ExerciseDefinition` separates three concerns deliberately:
+
+- **`measurement`** - which entry field carries the primary value. Drives validation (range checks against `def.min`/`def.max`), aggregation (which field summer roll up), and storage. `MeasurementType` is `'reps' | 'time' | 'distance' | 'weight' | 'distance-time'`.
+- **`unit`** - the rendering hint. `formatExerciseValue(value, unit)` switches on this string so a single measurement type can carry alternate display units later (kg vs. lb, km vs. mi). The catalog currently uses `'reps' | 's' | 'm' | 'kg'`.
+- **Companion fields** - secondary values an entry may (or must) carry alongside the primary. Declared in `COMPANION_FIELDS` / `REQUIRED_COMPANIONS` per measurement. `'distance'` allows an optional `durationSec`; `'distance-time'` requires it; `'weight'` requires `weightKg`.
+
+**Display routing.** Components don't branch on `measurement` themselves — they call `formatEntryDisplay(entry, def)` / `formatEntryTotal({ primary, companion }, def)`, which:
+
+- For `'distance-time'`: renders the composite `"5.00 km · 25:00 (5:00 /km)"` via `formatDistanceTime`.
+- For everything else: reads the field that `measurementValueField(measurement)` returns and pipes it through `formatExerciseValue(value, def.unit)`.
+
+`measurementCompanionValueField(measurement)` returns the secondary display field for composite measurements (currently only `'durationSec'` for `'distance-time'`). Aggregation paths use it to sum a second total alongside the primary, so a 30-day card for a tracked run can show `"42.00 km · 3:30:00 (5:00 /km)"`. Phase 3 (cardio catalog entries) plugs into this without any further infrastructure work — only a `cardio.running` definition + tighter companion bounds need to be added.

--- a/libs/stats/src/lib/models/exercise-format.spec.ts
+++ b/libs/stats/src/lib/models/exercise-format.spec.ts
@@ -1,4 +1,16 @@
-import { formatExerciseValue } from './exercise-format';
+import {
+  formatDistanceTime,
+  formatEntryDisplay,
+  formatEntryTotal,
+  formatExerciseValue,
+  formatPaceMinPerKm,
+} from './exercise-format';
+import type { ExerciseDefinition } from './exercise.models';
+
+const def = (
+  measurement: ExerciseDefinition['measurement'],
+  unit: string
+): Pick<ExerciseDefinition, 'measurement' | 'unit'> => ({ measurement, unit });
 
 describe('formatExerciseValue', () => {
   describe('reps unit', () => {
@@ -63,5 +75,109 @@ describe('formatExerciseValue', () => {
       expect(formatExerciseValue(Number.NaN, 'reps')).toBe('');
       expect(formatExerciseValue(Number.POSITIVE_INFINITY, 'kg')).toBe('');
     });
+  });
+});
+
+describe('formatPaceMinPerKm', () => {
+  it.each<[number, number, string]>([
+    [5000, 1500, '5:00 /km'],
+    [5000, 1530, '5:06 /km'],
+    [10_000, 3000, '5:00 /km'],
+    [1000, 360, '6:00 /km'],
+  ])('%i m in %i s -> %s', (distance, duration, expected) => {
+    expect(formatPaceMinPerKm(distance, duration)).toBe(expected);
+  });
+
+  it.each<[number, number]>([
+    [0, 1500],
+    [5000, 0],
+    [-100, 600],
+    [Number.NaN, 600],
+    [5000, Number.POSITIVE_INFINITY],
+  ])('returns empty string for %p / %p', (distance, duration) => {
+    expect(formatPaceMinPerKm(distance, duration)).toBe('');
+  });
+});
+
+describe('formatDistanceTime', () => {
+  it('renders distance, duration and pace for a tracked run', () => {
+    expect(formatDistanceTime(5000, 1500)).toBe('5.00 km · 25:00 (5:00 /km)');
+  });
+
+  it('drops the pace suffix when distance is 0', () => {
+    expect(formatDistanceTime(0, 600)).toBe('10:00');
+  });
+
+  it('drops the pace suffix when duration is 0', () => {
+    expect(formatDistanceTime(800, 0)).toBe('800 m');
+  });
+
+  it('renders short distances in meters', () => {
+    expect(formatDistanceTime(800, 240)).toBe('800 m · 4:00 (5:00 /km)');
+  });
+
+  it('returns empty string when both inputs are zero', () => {
+    expect(formatDistanceTime(0, 0)).toBe('');
+  });
+});
+
+describe('formatEntryDisplay', () => {
+  it('routes distance-time entries through the composite formatter', () => {
+    expect(
+      formatEntryDisplay(
+        { distanceM: 5000, durationSec: 1500 },
+        def('distance-time', 'm')
+      )
+    ).toBe('5.00 km · 25:00 (5:00 /km)');
+  });
+
+  it('reads durationSec for time-only exercises', () => {
+    expect(
+      formatEntryDisplay({ durationSec: 90 }, def('time', 's'))
+    ).toBe('1:30');
+  });
+
+  it('reads reps for rep-based exercises', () => {
+    expect(formatEntryDisplay({ reps: 30 }, def('reps', 'reps'))).toBe('30');
+  });
+
+  it('reads reps for weight exercises (the rep count is the primary)', () => {
+    expect(formatEntryDisplay({ reps: 5, weightKg: 80 }, def('weight', 'reps'))).toBe(
+      '5'
+    );
+  });
+
+  it('reads distanceM for plain distance exercises', () => {
+    expect(formatEntryDisplay({ distanceM: 1500 }, def('distance', 'm'))).toBe(
+      '1.50 km'
+    );
+  });
+
+  it('treats a missing distance-time companion as zero (no pace)', () => {
+    expect(
+      formatEntryDisplay({ distanceM: 5000 }, def('distance-time', 'm'))
+    ).toBe('5.00 km');
+  });
+});
+
+describe('formatEntryTotal', () => {
+  it('combines distance and duration totals for distance-time', () => {
+    expect(
+      formatEntryTotal(
+        { primary: 42_000, companion: 12_600 },
+        def('distance-time', 'm')
+      )
+    ).toBe('42.00 km · 210:00 (5:00 /km)');
+  });
+
+  it('falls back to single-value formatting for other measurements', () => {
+    expect(formatEntryTotal({ primary: 600 }, def('reps', 'reps'))).toBe('600');
+    expect(formatEntryTotal({ primary: 1800 }, def('time', 's'))).toBe('30:00');
+  });
+
+  it('handles distance-time without a companion total (cardio with 0 s)', () => {
+    expect(
+      formatEntryTotal({ primary: 5000 }, def('distance-time', 'm'))
+    ).toBe('5.00 km');
   });
 });

--- a/libs/stats/src/lib/models/exercise-format.spec.ts
+++ b/libs/stats/src/lib/models/exercise-format.spec.ts
@@ -1,0 +1,67 @@
+import { formatExerciseValue } from './exercise-format';
+
+describe('formatExerciseValue', () => {
+  describe('reps unit', () => {
+    it.each([0, 1, 30, 500])('renders %i as a bare number', (value) => {
+      expect(formatExerciseValue(value, 'reps')).toBe(String(value));
+    });
+  });
+
+  describe('seconds unit', () => {
+    it.each<[number, string]>([
+      [0, '0:00'],
+      [5, '0:05'],
+      [60, '1:00'],
+      [90, '1:30'],
+      [125, '2:05'],
+      [3600, '60:00'],
+      [7200, '120:00'],
+    ])('renders %i s as %s', (value, expected) => {
+      expect(formatExerciseValue(value, 's')).toBe(expected);
+    });
+
+    it('returns empty for non-finite seconds', () => {
+      expect(formatExerciseValue(Number.NaN, 's')).toBe('');
+      expect(formatExerciseValue(Number.POSITIVE_INFINITY, 's')).toBe('');
+    });
+  });
+
+  describe('kg unit', () => {
+    it('renders integer weights with the unit suffix', () => {
+      expect(formatExerciseValue(80, 'kg')).toBe('80 kg');
+    });
+
+    it('renders fractional weights with two decimals', () => {
+      expect(formatExerciseValue(27.5, 'kg')).toBe('27.50 kg');
+    });
+  });
+
+  describe('m unit', () => {
+    it('renders short distances in meters', () => {
+      expect(formatExerciseValue(800, 'm')).toBe('800 m');
+    });
+
+    it('switches to km at the 1000 m boundary', () => {
+      expect(formatExerciseValue(1000, 'm')).toBe('1.00 km');
+      expect(formatExerciseValue(5000, 'm')).toBe('5.00 km');
+      expect(formatExerciseValue(5125, 'm')).toBe('5.13 km');
+    });
+  });
+
+  describe('unknown unit', () => {
+    it('falls back to a value + unit suffix when a unit is provided', () => {
+      expect(formatExerciseValue(42, 'foo')).toBe('42 foo');
+    });
+
+    it('falls back to a bare number when no unit is provided', () => {
+      expect(formatExerciseValue(42, '')).toBe('42');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns an empty string for non-finite values', () => {
+      expect(formatExerciseValue(Number.NaN, 'reps')).toBe('');
+      expect(formatExerciseValue(Number.POSITIVE_INFINITY, 'kg')).toBe('');
+    });
+  });
+});

--- a/libs/stats/src/lib/models/exercise-format.spec.ts
+++ b/libs/stats/src/lib/models/exercise-format.spec.ts
@@ -75,6 +75,13 @@ describe('formatExerciseValue', () => {
       expect(formatExerciseValue(Number.NaN, 'reps')).toBe('');
       expect(formatExerciseValue(Number.POSITIVE_INFINITY, 'kg')).toBe('');
     });
+
+    it('returns an empty string for negative values across all units', () => {
+      expect(formatExerciseValue(-1, 'reps')).toBe('');
+      expect(formatExerciseValue(-100, 'm')).toBe('');
+      expect(formatExerciseValue(-5, 'kg')).toBe('');
+      expect(formatExerciseValue(-30, 's')).toBe('');
+    });
   });
 });
 

--- a/libs/stats/src/lib/models/exercise-format.ts
+++ b/libs/stats/src/lib/models/exercise-format.ts
@@ -1,3 +1,6 @@
+import type { ExerciseDefinition, ExerciseEntry } from './exercise.models';
+import { measurementValueField } from './exercise.models';
+
 /**
  * Render an exercise's primary value as a localized-ish display string,
  * driven by `ExerciseDefinition.unit`. The shape is:
@@ -44,3 +47,97 @@ function roundForDisplay(value: number): string {
   if (Number.isInteger(value)) return String(value);
   return value.toFixed(2);
 }
+
+/**
+ * Pace as `m:ss /km` for the given distance/duration pair, or empty
+ * string when either input is non-positive (pace is meaningless for a
+ * 0 m or 0 s entry — and dividing by zero would produce `Infinity`).
+ *
+ * The result is rounded to whole seconds; sub-second precision would
+ * be noise on a hand-stopped run timer.
+ */
+export function formatPaceMinPerKm(
+  distanceM: number,
+  durationSec: number
+): string {
+  if (
+    !Number.isFinite(distanceM) ||
+    !Number.isFinite(durationSec) ||
+    distanceM <= 0 ||
+    durationSec <= 0
+  ) {
+    return '';
+  }
+  const secPerKm = Math.round((durationSec * 1000) / distanceM);
+  const m = Math.floor(secPerKm / 60);
+  const s = secPerKm % 60;
+  return `${m}:${String(s).padStart(2, '0')} /km`;
+}
+
+/**
+ * Render a distance + duration pair as `"<distance> · <time> (<pace>)"`,
+ * dropping the pace suffix when either value is missing. Used for
+ * `'distance-time'` exercises like a tracked run, where both values
+ * carry equal display weight.
+ */
+export function formatDistanceTime(
+  distanceM: number,
+  durationSec: number
+): string {
+  // Check the raw values, not the formatted strings: a 0 m / 0 s
+  // entry formats to "0 m" / "0:00" (which are valid display strings
+  // for non-cardio contexts), but in a composite they're noise.
+  const hasDistance = Number.isFinite(distanceM) && distanceM > 0;
+  const hasDuration = Number.isFinite(durationSec) && durationSec > 0;
+  if (!hasDistance && !hasDuration) return '';
+  if (!hasDistance) return formatExerciseValue(durationSec, 's');
+  if (!hasDuration) return formatExerciseValue(distanceM, 'm');
+  const distance = formatExerciseValue(distanceM, 'm');
+  const time = formatExerciseValue(durationSec, 's');
+  const pace = formatPaceMinPerKm(distanceM, durationSec);
+  return pace ? `${distance} · ${time} (${pace})` : `${distance} · ${time}`;
+}
+
+/**
+ * High-level "what does this entry read as on a card or row" helper.
+ * Routes through the right formatter based on `def.measurement`:
+ *
+ *   - `'distance-time'`: composite (`5.00 km · 25:00 (5:00 /km)`)
+ *   - everything else: single value via {@link formatExerciseValue} +
+ *     `def.unit`, reading the field that {@link measurementValueField}
+ *     designates.
+ *
+ * Components should call this instead of branching on measurement
+ * themselves — keeps the composite/single switch in one place.
+ */
+export function formatEntryDisplay(
+  entry: Pick<
+    ExerciseEntry,
+    'reps' | 'durationSec' | 'distanceM' | 'weightKg'
+  >,
+  def: Pick<ExerciseDefinition, 'measurement' | 'unit'>
+): string {
+  if (def.measurement === 'distance-time') {
+    return formatDistanceTime(entry.distanceM ?? 0, entry.durationSec ?? 0);
+  }
+  const valueField = measurementValueField(def.measurement);
+  const raw = (entry[valueField] as number | undefined) ?? 0;
+  return formatExerciseValue(raw, def.unit);
+}
+
+/**
+ * Same shape as {@link formatEntryDisplay} but for an aggregated total
+ * (e.g. 30-day sum). For composite measurements the caller passes both
+ * the distance total and the duration total; for single measurements
+ * only the primary total is read.
+ */
+export function formatEntryTotal(
+  totals: { primary: number; companion?: number },
+  def: Pick<ExerciseDefinition, 'measurement' | 'unit'>
+): string {
+  if (def.measurement === 'distance-time') {
+    return formatDistanceTime(totals.primary, totals.companion ?? 0);
+  }
+  return formatExerciseValue(totals.primary, def.unit);
+}
+

--- a/libs/stats/src/lib/models/exercise-format.ts
+++ b/libs/stats/src/lib/models/exercise-format.ts
@@ -7,9 +7,9 @@ import { measurementValueField } from './exercise.models';
  *
  *   - `'reps'`  → bare number (`"30"`)
  *   - `'s'`     → `m:ss` so a 90 s plank reads `"1:30"`
- *   - `'kg'`    → `"<n> kg"` (Phase 5 strength)
+ *   - `'kg'`    → `"<n> kg"`
  *   - `'m'`     → `"<n> m"` for short distances; ≥1000 m render as
- *                 `"<n.nn> km"` so a 5 km run reads cleanly (Phase 3)
+ *                 `"<n.nn> km"` so a 5 km run reads cleanly
  *   - any other → bare number, unit-suffixed if non-empty
  *
  * Why unit and not `measurement`: a single measurement type can have
@@ -17,9 +17,14 @@ import { measurementValueField } from './exercise.models';
  * decisions live with the unit. `measurement` keeps driving which
  * data field on an entry actually carries the value (see
  * {@link measurementValueField}).
+ *
+ * Negative values return `''` rather than a unit-suffixed nonsense
+ * string ("-100 m"). The validator already enforces `>= def.min` for
+ * persisted entries, but this helper is also called from form
+ * previews where a half-typed input could briefly be negative.
  */
 export function formatExerciseValue(value: number, unit: string): string {
-  if (!Number.isFinite(value)) return '';
+  if (!Number.isFinite(value) || value < 0) return '';
   switch (unit) {
     case 'reps':
       return String(value);
@@ -94,8 +99,10 @@ export function formatDistanceTime(
   if (!hasDuration) return formatExerciseValue(distanceM, 'm');
   const distance = formatExerciseValue(distanceM, 'm');
   const time = formatExerciseValue(durationSec, 's');
+  // Both inputs are positive and finite at this point, so
+  // `formatPaceMinPerKm` will always return a non-empty string.
   const pace = formatPaceMinPerKm(distanceM, durationSec);
-  return pace ? `${distance} · ${time} (${pace})` : `${distance} · ${time}`;
+  return `${distance} · ${time} (${pace})`;
 }
 
 /**

--- a/libs/stats/src/lib/models/exercise-format.ts
+++ b/libs/stats/src/lib/models/exercise-format.ts
@@ -1,0 +1,46 @@
+/**
+ * Render an exercise's primary value as a localized-ish display string,
+ * driven by `ExerciseDefinition.unit`. The shape is:
+ *
+ *   - `'reps'`  → bare number (`"30"`)
+ *   - `'s'`     → `m:ss` so a 90 s plank reads `"1:30"`
+ *   - `'kg'`    → `"<n> kg"` (Phase 5 strength)
+ *   - `'m'`     → `"<n> m"` for short distances; ≥1000 m render as
+ *                 `"<n.nn> km"` so a 5 km run reads cleanly (Phase 3)
+ *   - any other → bare number, unit-suffixed if non-empty
+ *
+ * Why unit and not `measurement`: a single measurement type can have
+ * multiple display units later (kg vs lb, km vs mi), so rendering
+ * decisions live with the unit. `measurement` keeps driving which
+ * data field on an entry actually carries the value (see
+ * {@link measurementValueField}).
+ */
+export function formatExerciseValue(value: number, unit: string): string {
+  if (!Number.isFinite(value)) return '';
+  switch (unit) {
+    case 'reps':
+      return String(value);
+    case 's':
+      return formatSecondsAsMmSs(value);
+    case 'kg':
+      return `${roundForDisplay(value)} kg`;
+    case 'm':
+      return value >= 1000
+        ? `${(value / 1000).toFixed(2)} km`
+        : `${Math.round(value)} m`;
+    default:
+      return unit ? `${roundForDisplay(value)} ${unit}` : String(value);
+  }
+}
+
+function formatSecondsAsMmSs(totalSec: number): string {
+  if (!Number.isFinite(totalSec) || totalSec < 0) return '';
+  const m = Math.floor(totalSec / 60);
+  const s = Math.floor(totalSec % 60);
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+function roundForDisplay(value: number): string {
+  if (Number.isInteger(value)) return String(value);
+  return value.toFixed(2);
+}

--- a/libs/stats/src/lib/models/exercise.catalog.spec.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.spec.ts
@@ -49,6 +49,21 @@ describe('EXERCISE_CATALOG', () => {
     expect(ids.has('abs.situps')).toBe(true);
     expect(ids.has('legs.squats')).toBe(true);
   });
+
+  it('exposes plank.standard as the time-measurement entry point', () => {
+    const plank = EXERCISE_CATALOG.find((d) => d.id === 'plank.standard');
+    expect(plank?.measurement).toBe('time');
+    expect(plank?.unit).toBe('s');
+  });
+
+  it('exposes cardio.running as the first distance-time exercise', () => {
+    const running = EXERCISE_CATALOG.find((d) => d.id === 'cardio.running');
+    expect(running?.measurement).toBe('distance-time');
+    expect(running?.unit).toBe('m');
+    expect(running?.categoryId).toBe('cardio');
+    expect(running?.min).toBeGreaterThan(0);
+    expect(running?.max).toBeGreaterThanOrEqual(50_000);
+  });
 });
 
 describe('findExerciseDefinition', () => {

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -92,9 +92,9 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     // First composite-measurement entry: a tracked run carries both
     // distance and duration. `min`/`max` constrain `distanceM`
     // (100 m sprint up to 50 km ultra); the required duration
-    // companion is bounded by COMPANION_BOUNDS in `exercise.models.ts`
-    // (1..86400 s) — Phase 3 polish can tighten that to a per-exercise
-    // range once user data shows what's plausible.
+    // companion is bounded globally by COMPANION_BOUNDS in
+    // `exercise.models.ts` (1..86400 s) because no user data exists
+    // yet to establish a tighter per-exercise ceiling.
     id: 'cardio.running',
     categoryId: 'cardio',
     measurement: 'distance-time',

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -30,13 +30,19 @@ export const EXERCISE_CATEGORIES: ReadonlyArray<ExerciseCategoryInfo> = [
     icon: 'directions_run',
     order: 30,
   },
+  {
+    id: 'plank',
+    nameKey: '@@exercise.category.plank',
+    icon: 'horizontal_rule',
+    order: 40,
+  },
 ];
 
 /**
- * Standard catalog of exercises available to every user. Phase 0 ships
- * with sit-ups (abs) and squats (legs). The pushup catalog stays in
- * `pushup-type.models.ts` for backwards compatibility with existing
- * Firestore docs in the `pushups` collection — see roadmap.
+ * Standard catalog of exercises available to every user. The pushup
+ * catalog stays in `pushup-type.models.ts` for backwards compatibility
+ * with existing Firestore docs in the `pushups` collection — see
+ * roadmap.
  *
  * Caps mirror the `exerciseEntries` Firestore rule. Any change here MUST
  * be reflected in `data-store/firestore.rules` and vice versa.
@@ -61,6 +67,20 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     unit: 'reps',
     nameKey: '@@exercise.legs.squats.name',
     icon: 'directions_run',
+  },
+  {
+    // Standard plank — the time-measurement entry point. Variants
+    // (forearm / side / hollow hold) ship with their own catalog ids
+    // once the variant picker grows the autocomplete-with-wiki path
+    // (see UI-3 Phase B in the roadmap).
+    id: 'plank.standard',
+    categoryId: 'plank',
+    measurement: 'time',
+    min: 1,
+    max: 7200,
+    unit: 's',
+    nameKey: '@@exercise.plank.standard.name',
+    icon: 'horizontal_rule',
   },
 ];
 

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -36,6 +36,12 @@ export const EXERCISE_CATEGORIES: ReadonlyArray<ExerciseCategoryInfo> = [
     icon: 'horizontal_rule',
     order: 40,
   },
+  {
+    id: 'cardio',
+    nameKey: '@@exercise.category.cardio',
+    icon: 'directions_run',
+    order: 50,
+  },
 ];
 
 /**
@@ -81,6 +87,22 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     unit: 's',
     nameKey: '@@exercise.plank.standard.name',
     icon: 'horizontal_rule',
+  },
+  {
+    // First composite-measurement entry: a tracked run carries both
+    // distance and duration. `min`/`max` constrain `distanceM`
+    // (100 m sprint up to 50 km ultra); the required duration
+    // companion is bounded by COMPANION_BOUNDS in `exercise.models.ts`
+    // (1..86400 s) — Phase 3 polish can tighten that to a per-exercise
+    // range once user data shows what's plausible.
+    id: 'cardio.running',
+    categoryId: 'cardio',
+    measurement: 'distance-time',
+    min: 100,
+    max: 50_000,
+    unit: 'm',
+    nameKey: '@@exercise.cardio.running.name',
+    icon: 'directions_run',
   },
 ];
 

--- a/libs/stats/src/lib/models/exercise.models.spec.ts
+++ b/libs/stats/src/lib/models/exercise.models.spec.ts
@@ -279,6 +279,16 @@ describe('validateExerciseEntry — distance-time measurement', () => {
       )
     ).toBeNull();
   });
+
+  it('accepts a duration-only patch in partial-update mode (no primary)', () => {
+    expect(
+      validateExerciseEntry(
+        { durationSec: 1500 },
+        distanceTimeDef,
+        { partial: true }
+      )
+    ).toBeNull();
+  });
 });
 
 describe('validateExerciseEntry — weight measurement', () => {

--- a/libs/stats/src/lib/models/exercise.models.spec.ts
+++ b/libs/stats/src/lib/models/exercise.models.spec.ts
@@ -1,5 +1,6 @@
 import {
   companionFields,
+  measurementCompanionValueField,
   measurementValueField,
   requiredCompanionFields,
   validateExerciseEntry,
@@ -43,6 +44,15 @@ const weightDef: Pick<
   max: 200,
 };
 
+const distanceTimeDef: Pick<
+  ExerciseDefinition,
+  'measurement' | 'min' | 'max' | 'variants'
+> = {
+  measurement: 'distance-time',
+  min: 100,
+  max: 100_000,
+};
+
 describe('measurementValueField', () => {
   describe('Given each MeasurementType', () => {
     it.each<[MeasurementType, string]>([
@@ -50,9 +60,22 @@ describe('measurementValueField', () => {
       ['weight', 'reps'],
       ['time', 'durationSec'],
       ['distance', 'distanceM'],
+      ['distance-time', 'distanceM'],
     ])('Then %s maps to field %s', (m, expected) => {
       expect(measurementValueField(m)).toBe(expected);
     });
+  });
+});
+
+describe('measurementCompanionValueField', () => {
+  it.each<[MeasurementType, string | undefined]>([
+    ['reps', undefined],
+    ['time', undefined],
+    ['distance', undefined],
+    ['weight', undefined],
+    ['distance-time', 'durationSec'],
+  ])('Then %s maps to companion display field %s', (m, expected) => {
+    expect(measurementCompanionValueField(m)).toBe(expected);
   });
 });
 
@@ -61,6 +84,7 @@ describe('companionFields', () => {
     ['reps', []],
     ['time', []],
     ['distance', ['durationSec']],
+    ['distance-time', ['durationSec']],
     ['weight', ['weightKg']],
   ])('Then %s allows %p as companion fields', (m, expected) => {
     expect([...companionFields(m)]).toEqual(expected);
@@ -72,6 +96,7 @@ describe('requiredCompanionFields', () => {
     ['reps', []],
     ['time', []],
     ['distance', []],
+    ['distance-time', ['durationSec']],
     ['weight', ['weightKg']],
   ])('Then %s requires %p as companion fields', (m, expected) => {
     expect([...requiredCompanionFields(m)]).toEqual(expected);
@@ -193,6 +218,66 @@ describe('validateExerciseEntry — distance measurement', () => {
     expect(
       validateExerciseEntry({ distanceM: 5000, weightKg: 5 }, distanceDef)
     ).toBe('wrong-measurement-field');
+  });
+});
+
+describe('validateExerciseEntry — distance-time measurement', () => {
+  it('accepts a tracked run with both distance and duration', () => {
+    expect(
+      validateExerciseEntry(
+        { distanceM: 5000, durationSec: 1500 },
+        distanceTimeDef
+      )
+    ).toBeNull();
+  });
+
+  it('rejects when the duration companion is missing', () => {
+    expect(validateExerciseEntry({ distanceM: 5000 }, distanceTimeDef)).toBe(
+      'companion-value-missing'
+    );
+  });
+
+  it('rejects when the primary distance is missing', () => {
+    expect(validateExerciseEntry({ durationSec: 1500 }, distanceTimeDef)).toBe(
+      'measurement-value-missing'
+    );
+  });
+
+  it('rejects out-of-range distances against the catalog cap', () => {
+    expect(
+      validateExerciseEntry(
+        { distanceM: 200_000, durationSec: 36_000 },
+        distanceTimeDef
+      )
+    ).toBe('measurement-value-out-of-range');
+  });
+
+  it('rejects out-of-range durations against companion bounds', () => {
+    expect(
+      validateExerciseEntry(
+        { distanceM: 5000, durationSec: 200_000 },
+        distanceTimeDef
+      )
+    ).toBe('companion-value-out-of-range');
+  });
+
+  it('rejects entries that also carry an unrelated value field', () => {
+    expect(
+      validateExerciseEntry(
+        { distanceM: 5000, durationSec: 1500, reps: 10 },
+        distanceTimeDef
+      )
+    ).toBe('wrong-measurement-field');
+  });
+
+  it('skips the duration-required check in partial-update mode', () => {
+    expect(
+      validateExerciseEntry(
+        { distanceM: 5000 },
+        distanceTimeDef,
+        { partial: true }
+      )
+    ).toBeNull();
   });
 });
 

--- a/libs/stats/src/lib/models/exercise.models.ts
+++ b/libs/stats/src/lib/models/exercise.models.ts
@@ -225,7 +225,7 @@ const REQUIRED_COMPANIONS: Readonly<
  * to warrant a per-definition cap. When custom user exercises land in
  * Phase 4 we can move these into `ExerciseDefinition`.
  */
-const COMPANION_BOUNDS: Readonly<
+export const COMPANION_BOUNDS: Readonly<
   Record<
     MeasurementValueField,
     { readonly min: number; readonly max: number; readonly integer: boolean }

--- a/libs/stats/src/lib/models/exercise.models.ts
+++ b/libs/stats/src/lib/models/exercise.models.ts
@@ -73,9 +73,17 @@ export interface ExerciseEntry {
   timestamp: string;
   /** Set when measurement = 'reps' or 'weight'. */
   reps?: number;
-  /** Set when measurement = 'time'. */
+  /**
+   * Primary value for `measurement = 'time'` (plank) and required
+   * companion for `measurement = 'distance-time'` (a tracked run
+   * carries both a distance and a duration).
+   */
   durationSec?: number;
-  /** Set when measurement = 'distance'. */
+  /**
+   * Primary value for `measurement = 'distance'` and
+   * `measurement = 'distance-time'`. The catalog `min`/`max`
+   * constrain this field; the duration companion has its own bounds.
+   */
   distanceM?: number;
   /** Set when measurement = 'weight' (kg per rep). */
   weightKg?: number;

--- a/libs/stats/src/lib/models/exercise.models.ts
+++ b/libs/stats/src/lib/models/exercise.models.ts
@@ -9,7 +9,12 @@
  * Migration plan and roadmap: see `plans/multi-exercise-roadmap.md`.
  */
 
-export type MeasurementType = 'reps' | 'time' | 'distance' | 'weight';
+export type MeasurementType =
+  | 'reps'
+  | 'time'
+  | 'distance'
+  | 'weight'
+  | 'distance-time';
 
 export type ExerciseCategoryId =
   | 'pushup'
@@ -146,8 +151,31 @@ export function measurementValueField(
     case 'time':
       return 'durationSec';
     case 'distance':
+    case 'distance-time':
+      // For distance-time the primary value is the distance — that's what
+      // the catalog `min`/`max` constrain, what Aggregations sum, and what
+      // headline displays read. The duration is a required companion
+      // (see {@link COMPANION_FIELDS}/{@link REQUIRED_COMPANIONS}).
       return 'distanceM';
   }
+}
+
+/**
+ * Returns the secondary (companion) value field that carries equal
+ * display weight to the primary value, or `undefined` when there isn't
+ * one. Currently only `'distance-time'` qualifies — the duration is
+ * just as important to display as the distance, and {@link
+ * formatEntryDisplay} renders both.
+ *
+ * Distinct from {@link companionFields}, which lists *allowed* companions
+ * for validation. A field can be a validation companion without being
+ * a display companion (e.g. `'distance'` may carry an optional
+ * duration but renders as distance-only).
+ */
+export function measurementCompanionValueField(
+  measurement: MeasurementType
+): MeasurementValueField | undefined {
+  return measurement === 'distance-time' ? 'durationSec' : undefined;
 }
 
 /**
@@ -166,6 +194,7 @@ const COMPANION_FIELDS: Readonly<
   reps: [],
   time: [],
   distance: ['durationSec'],
+  'distance-time': ['durationSec'],
   weight: ['weightKg'],
 };
 
@@ -175,6 +204,7 @@ const REQUIRED_COMPANIONS: Readonly<
   reps: [],
   time: [],
   distance: [],
+  'distance-time': ['durationSec'],
   weight: ['weightKg'],
 };
 

--- a/libs/stats/src/lib/models/stats.models.ts
+++ b/libs/stats/src/lib/models/stats.models.ts
@@ -38,4 +38,5 @@ export * from './user-stats.models';
 export * from './public-profile.models';
 export * from './exercise.models';
 export * from './exercise.catalog';
+export * from './exercise-format';
 export * from './unified-entry.models';

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.spec.ts
@@ -30,6 +30,15 @@ const plankDef: ExerciseDefinition = {
   unit: 's',
 };
 
+const runningDef: ExerciseDefinition = {
+  id: 'cardio.running',
+  categoryId: 'cardio',
+  measurement: 'distance-time',
+  min: 100,
+  max: 50_000,
+  unit: 'm',
+};
+
 const pushupWithVariantsDef: ExerciseDefinition = {
   id: 'pushup',
   categoryId: 'pushup',
@@ -397,6 +406,136 @@ describe('EntryDialogComponent', () => {
       });
       // 95 s → 1:35
       expect(cmp.durationInput()).toBe('1:35');
+    });
+  });
+
+  describe('Distance-time measurement (cardio.running)', () => {
+    it('marks the form as distance-time and starts with both fields empty', () => {
+      const cmp = createComponent({
+        definition: runningDef,
+        exerciseName: 'Laufen',
+      });
+      expect(cmp.isDistanceTimeMeasurement()).toBe(true);
+      expect(cmp.distanceInput()).toBe('');
+      expect(cmp.durationInput()).toBe('');
+      expect(cmp.canSubmit()).toBe(false);
+    });
+
+    it('parses km input into integer meters', () => {
+      const cmp = createComponent({
+        definition: runningDef,
+        exerciseName: 'Laufen',
+      });
+      cmp.distanceInput.set('5.25');
+      expect(cmp.distanceM()).toBe(5250);
+    });
+
+    it('tolerates a comma decimal separator', () => {
+      const cmp = createComponent({
+        definition: runningDef,
+        exerciseName: 'Laufen',
+      });
+      cmp.distanceInput.set('5,25');
+      expect(cmp.distanceM()).toBe(5250);
+    });
+
+    it('rejects empty, non-numeric, and non-positive distance', () => {
+      const cmp = createComponent({
+        definition: runningDef,
+        exerciseName: 'Laufen',
+      });
+      cmp.distanceInput.set('');
+      expect(cmp.distanceM()).toBeNull();
+      cmp.distanceInput.set('garbage');
+      expect(cmp.distanceM()).toBeNull();
+      cmp.distanceInput.set('0');
+      expect(cmp.distanceM()).toBeNull();
+      cmp.distanceInput.set('-3');
+      expect(cmp.distanceM()).toBeNull();
+    });
+
+    it('keeps submit disabled until both distance and duration are valid', () => {
+      const cmp = createComponent({
+        definition: runningDef,
+        exerciseName: 'Laufen',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+
+      cmp.distanceInput.set('5.00');
+      expect(cmp.canSubmit()).toBe(false);
+
+      cmp.durationInput.set('25:00');
+      expect(cmp.canSubmit()).toBe(true);
+
+      // Clearing the duration locks submit again.
+      cmp.durationInput.set('');
+      expect(cmp.canSubmit()).toBe(false);
+    });
+
+    it('disables submit below def.min and above def.max', () => {
+      const cmp = createComponent({
+        definition: runningDef,
+        exerciseName: 'Laufen',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.durationInput.set('25:00');
+
+      cmp.distanceInput.set('0.05');
+      expect(cmp.canSubmit()).toBe(false);
+
+      cmp.distanceInput.set('60');
+      expect(cmp.overCap()).toBe(true);
+      expect(cmp.canSubmit()).toBe(false);
+
+      cmp.distanceInput.set('5.00');
+      expect(cmp.overCap()).toBe(false);
+      expect(cmp.canSubmit()).toBe(true);
+    });
+
+    it('submits distanceM (rounded) and durationSec, with empty reps/sets', () => {
+      const cmp = createComponent({
+        definition: runningDef,
+        exerciseName: 'Laufen',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.distanceInput.set('5.25');
+      cmp.durationInput.set('25:00');
+      expect(cmp.canSubmit()).toBe(true);
+
+      cmp.submit();
+
+      const result = dialogRef.close.mock
+        .calls[0][0] as EntryDialogResult;
+      expect(result.measurement).toBe('distance-time');
+      expect(result.exerciseId).toBe('cardio.running');
+      expect(result.distanceM).toBe(5250);
+      expect(result.durationSec).toBe(25 * 60);
+      expect(result.reps).toBe(0);
+      expect(result.sets).toEqual([]);
+    });
+
+    it('pre-fills distance + duration in edit mode', () => {
+      const cmp = createComponent({
+        definition: runningDef,
+        exerciseName: 'Laufen',
+        initial: {
+          timestamp: '2026-04-15T10:00:00+02:00',
+          reps: 0,
+          distanceM: 5250,
+          durationSec: 25 * 60 + 30,
+        },
+      });
+      expect(cmp.distanceInput()).toBe('5.25');
+      expect(cmp.durationInput()).toBe('25:30');
+    });
+
+    it('exposes minKm/maxKm derived from def.min/def.max', () => {
+      const cmp = createComponent({
+        definition: runningDef,
+        exerciseName: 'Laufen',
+      });
+      expect(cmp.minKm()).toBeCloseTo(0.1);
+      expect(cmp.maxKm()).toBe(50);
     });
   });
 });

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.spec.ts
@@ -21,6 +21,15 @@ const situpsDef: ExerciseDefinition = {
   unit: 'reps',
 };
 
+const plankDef: ExerciseDefinition = {
+  id: 'plank.standard',
+  categoryId: 'plank',
+  measurement: 'time',
+  min: 1,
+  max: 7200,
+  unit: 's',
+};
+
 const pushupWithVariantsDef: ExerciseDefinition = {
   id: 'pushup',
   categoryId: 'pushup',
@@ -319,6 +328,75 @@ describe('EntryDialogComponent', () => {
       expect(cmp.canSubmit()).toBe(false);
       cmp.submit();
       expect(dialogRef.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Time measurement (plank)', () => {
+    it('marks the form as time-measurement and starts with empty mm:ss', () => {
+      const cmp = createComponent({
+        definition: plankDef,
+        exerciseName: 'Plank',
+      });
+      expect(cmp.isTimeMeasurement()).toBe(true);
+      expect(cmp.durationInput()).toBe('');
+      expect(cmp.canSubmit()).toBe(false);
+    });
+
+    it('parses mm:ss into seconds and submits durationSec', () => {
+      const cmp = createComponent({
+        definition: plankDef,
+        exerciseName: 'Plank',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.durationInput.set('1:30');
+      expect(cmp.durationSec()).toBe(90);
+      expect(cmp.canSubmit()).toBe(true);
+
+      cmp.submit();
+
+      const result = dialogRef.close.mock
+        .calls[0][0] as EntryDialogResult;
+      expect(result.measurement).toBe('time');
+      expect(result.durationSec).toBe(90);
+      expect(result.exerciseId).toBe('plank.standard');
+      expect(result.reps).toBe(0);
+      expect(result.sets).toEqual([]);
+    });
+
+    it('rejects malformed mm:ss strings', () => {
+      const cmp = createComponent({
+        definition: plankDef,
+        exerciseName: 'Plank',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.durationInput.set('not-a-time');
+      expect(cmp.durationSec()).toBeNull();
+      expect(cmp.canSubmit()).toBe(false);
+    });
+
+    it('disables submit when the duration exceeds the per-exercise cap', () => {
+      const cmp = createComponent({
+        definition: { ...plankDef, max: 60 },
+        exerciseName: 'Plank',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.durationInput.set('5:00');
+      expect(cmp.overCap()).toBe(true);
+      expect(cmp.canSubmit()).toBe(false);
+    });
+
+    it('pre-fills mm:ss in edit mode from the entry durationSec', () => {
+      const cmp = createComponent({
+        definition: plankDef,
+        exerciseName: 'Plank',
+        initial: {
+          timestamp: '2026-04-15T10:00:00+02:00',
+          reps: 0,
+          durationSec: 95,
+        },
+      });
+      // 95 s → 1:35
+      expect(cmp.durationInput()).toBe('1:35');
     });
   });
 });

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.spec.ts
@@ -492,6 +492,19 @@ describe('EntryDialogComponent', () => {
       expect(cmp.canSubmit()).toBe(true);
     });
 
+    it('flags overCap when the duration exceeds the companion bound', () => {
+      const cmp = createComponent({
+        definition: runningDef,
+        exerciseName: 'Laufen',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.distanceInput.set('5.00');
+      // 86_400 s is the companion ceiling; 1500:00 = 90_000 s clears it.
+      cmp.durationInput.set('1500:00');
+      expect(cmp.overCap()).toBe(true);
+      expect(cmp.canSubmit()).toBe(false);
+    });
+
     it('submits distanceM (rounded) and durationSec, with empty reps/sets', () => {
       const cmp = createComponent({
         definition: runningDef,

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
@@ -261,7 +261,13 @@ export interface EntryDialogResult {
       }
       @if (overCap()) {
         <div class="total-reps">
-          @if (isTimeMeasurement() || isDistanceTimeMeasurement()) {
+          @if (overCapKind() === 'duration') {
+            <span i18n="@@entryDialog.overCapDuration"
+              >Maximum-Dauer: {{ formattedDurationMax() }}</span
+            >
+          } @else if (
+            overCapKind() === 'distance' || isTimeMeasurement()
+          ) {
             <span i18n="@@entryDialog.overCapTime"
               >Maximum: {{ formattedMax() }}</span
             >
@@ -368,26 +374,36 @@ export class EntryDialogComponent {
     formatExerciseValue(this.data.definition.max, this.data.definition.unit)
   );
 
-  readonly overCap = computed(() => {
-    if (this.isDistanceTimeMeasurement()) {
-      const m = this.distanceM();
-      const sec = this.durationSec();
-      // Distance ceiling comes from the catalog (`def.max` in meters);
-      // duration ceiling from the global companion bound. Either side
-      // tripping the cap should surface the over-cap hint, not just
-      // distance — a 99:59:59 entry on a 50 km cap should not silently
-      // disable submit with no UI feedback.
-      const distanceOver = m !== null && m > this.data.definition.max;
-      const durationOver =
-        sec !== null && sec > COMPANION_BOUNDS.durationSec.max;
-      return distanceOver || durationOver;
+  /** Companion-duration ceiling display for the distance-time hint. */
+  readonly formattedDurationMax = computed(() =>
+    formatExerciseValue(COMPANION_BOUNDS.durationSec.max, 's')
+  );
+
+  /**
+   * Which cap (if any) is currently exceeded. Lets the template show a
+   * distance-specific or duration-specific message for distance-time
+   * entries instead of always rendering `def.max` (which is the
+   * distance ceiling and would mislead when only the duration is over).
+   */
+  readonly overCapKind = computed<'distance' | 'duration' | 'value' | null>(
+    () => {
+      if (this.isDistanceTimeMeasurement()) {
+        const m = this.distanceM();
+        const sec = this.durationSec();
+        if (m !== null && m > this.data.definition.max) return 'distance';
+        if (sec !== null && sec > COMPANION_BOUNDS.durationSec.max)
+          return 'duration';
+        return null;
+      }
+      if (this.isTimeMeasurement()) {
+        const sec = this.durationSec();
+        return sec !== null && sec > this.data.definition.max ? 'value' : null;
+      }
+      return this.totalReps() > this.data.definition.max ? 'value' : null;
     }
-    if (this.isTimeMeasurement()) {
-      const sec = this.durationSec();
-      return sec !== null && sec > this.data.definition.max;
-    }
-    return this.totalReps() > this.data.definition.max;
-  });
+  );
+
+  readonly overCap = computed(() => this.overCapKind() !== null);
 
   readonly canSubmit = computed(() => {
     if (this.timestamp().length === 0) return false;

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
@@ -19,7 +19,7 @@ import { MatSelectModule } from '@angular/material/select';
 import {
   appendLocalOffset,
   ExerciseDefinition,
-  UnifiedEntry,
+  MeasurementType,
 } from '@pu-stats/models';
 
 export interface EntryDialogData {
@@ -30,14 +30,23 @@ export interface EntryDialogData {
    *  Track-ARCH will move them into a shared service. */
   exerciseName: string;
   /** Optional pre-fill for edit mode. The dialog only reads fields
-   *  matching `definition.measurement` — today reps + sets. */
-  initial?: Pick<UnifiedEntry, 'timestamp' | 'reps' | 'sets'> & {
+   *  matching `definition.measurement` — reps + sets for reps-measured
+   *  exercises, durationSec for time-measured ones. */
+  initial?: {
+    timestamp: string;
+    reps: number;
+    sets?: number[];
+    durationSec?: number;
     variantId?: string;
   };
 }
 
 export interface EntryDialogResult {
   exerciseId: string;
+  /** Discriminator the caller switches on when shaping the create /
+   *  update payload — saves a second `findExerciseDefinition` lookup
+   *  on the consumer side. */
+  measurement: MeasurementType;
   /**
    * Variant id, if the user picked one. Tri-state semantics so callers
    * can distinguish "no change" from "explicitly clear":
@@ -49,8 +58,12 @@ export interface EntryDialogResult {
    */
   variantId?: string | null;
   timestamp: string;
+  /** Populated for `'reps'` and `'weight'` measurement; `0` otherwise. */
   reps: number;
+  /** Populated for `'reps'` and `'weight'` measurement; `[]` otherwise. */
   sets: number[];
+  /** Populated for `'time'` measurement; `undefined` otherwise. */
+  durationSec?: number;
 }
 
 /**
@@ -58,15 +71,18 @@ export interface EntryDialogResult {
  * its form fields off the catalog definition so any new exercise drops
  * in without component-level changes.
  *
- * Only the `'reps'` measurement is wired here; `validateExerciseEntry`
- * rejects a `'weight'` payload without a `weightKg` companion, so a
- * weight-measurement definition cannot be opened in this dialog without
- * a separate field path.
+ * Two measurement paths are wired:
+ *   - `'reps'` — reps + sets list, sums into the entry total.
+ *   - `'time'` — single mm:ss duration input.
+ *
+ * `'weight'` and `'distance'` measurements still need their own
+ * companion fields (weightKg / distanceM + optional pace) — the form
+ * branches off `def.measurement` so adding them is additive.
  *
  * Caps come from `def.min` / `def.max` so the input clamps and
- * `canSubmit()` locks at the ceiling — closes the
- * "validator rejects after canSubmit() said yes" gap that the
- * pushup-only `CreateEntryDialogComponent` had.
+ * `canSubmit()` locks at the ceiling — closes the "validator rejects
+ * after canSubmit() said yes" gap that the pushup-only
+ * `CreateEntryDialogComponent` had.
  */
 @Component({
   selector: 'app-entry-dialog',
@@ -139,57 +155,81 @@ export interface EntryDialogResult {
         </mat-form-field>
       }
 
-      @for (set of sets(); track $index) {
-        <div class="set-row">
-          <mat-form-field appearance="outline">
+      @if (isTimeMeasurement()) {
+        <mat-form-field appearance="outline">
+          <mat-label i18n="@@entryDialog.duration">Dauer (mm:ss)</mat-label>
+          <input
+            matInput
+            type="text"
+            inputmode="numeric"
+            placeholder="01:30"
+            pattern="^[0-9]+:[0-5][0-9]$"
+            [value]="durationInput()"
+            (input)="durationInput.set(asValue($event))"
+            required
+          />
+        </mat-form-field>
+      } @else {
+        @for (set of sets(); track $index) {
+          <div class="set-row">
+            <mat-form-field appearance="outline">
+              @if (hasMultipleSets()) {
+                <mat-label i18n="@@setLabel">Set {{ $index + 1 }}</mat-label>
+              } @else {
+                <mat-label i18n="@@repsLabel">Reps</mat-label>
+              }
+              <input
+                matInput
+                type="number"
+                [min]="0"
+                [max]="data.definition.max"
+                step="1"
+                [value]="set"
+                (input)="updateSet($index, asValue($event))"
+                required
+              />
+            </mat-form-field>
             @if (hasMultipleSets()) {
-              <mat-label i18n="@@setLabel">Set {{ $index + 1 }}</mat-label>
-            } @else {
-              <mat-label i18n="@@repsLabel">Reps</mat-label>
+              <button
+                type="button"
+                mat-icon-button
+                (click)="removeSet($index)"
+                i18n-aria-label="@@removeSetAria"
+                aria-label="Set entfernen"
+              >
+                <mat-icon>remove_circle_outline</mat-icon>
+              </button>
             }
-            <input
-              matInput
-              type="number"
-              [min]="0"
-              [max]="data.definition.max"
-              step="1"
-              [value]="set"
-              (input)="updateSet($index, asValue($event))"
-              required
-            />
-          </mat-form-field>
-          @if (hasMultipleSets()) {
-            <button
-              type="button"
-              mat-icon-button
-              (click)="removeSet($index)"
-              i18n-aria-label="@@removeSetAria"
-              aria-label="Set entfernen"
-            >
-              <mat-icon>remove_circle_outline</mat-icon>
-            </button>
-          }
-          @if ($last) {
-            <button
-              type="button"
-              mat-icon-button
-              (click)="addSet()"
-              i18n-aria-label="@@addSetAria"
-              aria-label="Set hinzufügen"
-            >
-              <mat-icon>add_circle_outline</mat-icon>
-            </button>
-          }
-        </div>
-      }
-      @if (hasMultipleSets()) {
-        <div class="total-reps" i18n="@@totalReps">
-          Gesamt: {{ totalReps() }} Reps
-        </div>
+            @if ($last) {
+              <button
+                type="button"
+                mat-icon-button
+                (click)="addSet()"
+                i18n-aria-label="@@addSetAria"
+                aria-label="Set hinzufügen"
+              >
+                <mat-icon>add_circle_outline</mat-icon>
+              </button>
+            }
+          </div>
+        }
+        @if (hasMultipleSets()) {
+          <div class="total-reps" i18n="@@totalReps">
+            Gesamt: {{ totalReps() }} Reps
+          </div>
+        }
       }
       @if (overCap()) {
-        <div class="total-reps" i18n="@@entryDialog.overCap">
-          Maximum: {{ data.definition.max }} pro Eintrag
+        <div class="total-reps">
+          @if (isTimeMeasurement()) {
+            <span i18n="@@entryDialog.overCapTime"
+              >Maximum: {{ formattedMax() }}</span
+            >
+          } @else {
+            <span i18n="@@entryDialog.overCap"
+              >Maximum: {{ data.definition.max }} pro Eintrag</span
+            >
+          }
         </div>
       }
     </mat-dialog-content>
@@ -222,12 +262,30 @@ export class EntryDialogComponent {
       : this.defaultDateTimeLocal()
   );
 
+  readonly isTimeMeasurement = computed(
+    () => this.data.definition.measurement === 'time'
+  );
+
   readonly sets = signal<number[]>(
     this.data.initial?.sets?.length
       ? [...this.data.initial.sets]
-      : this.data.initial
+      : this.data.initial && this.data.initial.reps > 0
         ? [this.data.initial.reps]
         : [0]
+  );
+
+  /**
+   * Free-text mm:ss input for time-measurement exercises (plank).
+   * Pre-filled from `initial.durationSec` in edit mode.
+   */
+  readonly durationInput = signal(
+    this.data.initial?.durationSec !== undefined
+      ? formatSecondsAsMmSs(this.data.initial.durationSec)
+      : ''
+  );
+
+  readonly durationSec = computed(() =>
+    parseDurationToSeconds(this.durationInput())
   );
 
   readonly variantControl = new FormControl<string>(
@@ -241,16 +299,31 @@ export class EntryDialogComponent {
     this.sets().reduce((sum, s) => sum + (s > 0 ? s : 0), 0)
   );
 
-  readonly overCap = computed(
-    () => this.totalReps() > this.data.definition.max
+  /** Localized form of `def.max` for the over-cap hint when the
+   *  measurement is `'time'` — surfaces "5:00" instead of "300". */
+  readonly formattedMax = computed(() =>
+    formatSecondsAsMmSs(this.data.definition.max)
   );
 
-  readonly canSubmit = computed(
-    () =>
-      this.timestamp().length > 0 &&
-      this.totalReps() >= this.data.definition.min &&
-      !this.overCap()
+  readonly overCap = computed(() =>
+    this.isTimeMeasurement()
+      ? this.durationSec() !== null &&
+        this.durationSec()! > this.data.definition.max
+      : this.totalReps() > this.data.definition.max
   );
+
+  readonly canSubmit = computed(() => {
+    if (this.timestamp().length === 0) return false;
+    if (this.isTimeMeasurement()) {
+      const sec = this.durationSec();
+      return (
+        sec !== null && sec >= this.data.definition.min && !this.overCap()
+      );
+    }
+    return (
+      this.totalReps() >= this.data.definition.min && !this.overCap()
+    );
+  });
 
   readonly showVariantPicker = computed(
     () => (this.data.definition.variants?.length ?? 0) > 0
@@ -290,9 +363,6 @@ export class EntryDialogComponent {
 
   submit(): void {
     if (!this.canSubmit()) return;
-    const validSets = this.sets().filter((s) => s > 0);
-    const reps = validSets.reduce((sum, s) => sum + s, 0);
-    if (reps <= 0) return;
 
     // Preserve the original ISO timestamp when the user didn't touch
     // the field in edit mode, mirroring CreateEntryDialogComponent's
@@ -322,8 +392,31 @@ export class EntryDialogComponent {
             ? { variantId: null }
             : {};
 
+    const measurement = this.data.definition.measurement;
+
+    if (measurement === 'time') {
+      const sec = this.durationSec();
+      if (sec === null || sec <= 0) return;
+      const result: EntryDialogResult = {
+        exerciseId: this.data.definition.id,
+        measurement,
+        ...variantPatch,
+        timestamp,
+        reps: 0,
+        sets: [],
+        durationSec: sec,
+      };
+      this.dialogRef.close(result);
+      return;
+    }
+
+    const validSets = this.sets().filter((s) => s > 0);
+    const reps = validSets.reduce((sum, s) => sum + s, 0);
+    if (reps <= 0) return;
+
     const result: EntryDialogResult = {
       exerciseId: this.data.definition.id,
+      measurement,
       ...variantPatch,
       timestamp,
       reps,
@@ -342,3 +435,33 @@ export class EntryDialogComponent {
 }
 
 const VARIANT_LABELS: Record<string, string> = {};
+
+/**
+ * Parse mm:ss (or m:ss / hh:mm:ss with the leading "h" parsed as
+ * minutes — single colon is the contract for plank's typical hold
+ * range) into integer seconds. Returns null for malformed input so the
+ * caller can disable submit instead of writing NaN to Firestore.
+ */
+function parseDurationToSeconds(input: string): number | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const match = /^(\d+):([0-5]\d)$/.exec(trimmed);
+  if (!match) return null;
+  const minutes = Number(match[1]);
+  const seconds = Number(match[2]);
+  if (!Number.isFinite(minutes) || !Number.isFinite(seconds)) return null;
+  return minutes * 60 + seconds;
+}
+
+/**
+ * Inverse of {@link parseDurationToSeconds}: formats seconds back into
+ * the `mm:ss` string the input field expects. Pads seconds to two
+ * digits; minutes are not padded so a 30-second hold renders as
+ * `0:30` and a 12-minute one as `12:00`.
+ */
+function formatSecondsAsMmSs(totalSec: number): string {
+  if (!Number.isFinite(totalSec) || totalSec < 0) return '0:00';
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
@@ -32,12 +32,14 @@ export interface EntryDialogData {
   exerciseName: string;
   /** Optional pre-fill for edit mode. The dialog only reads fields
    *  matching `definition.measurement` — reps + sets for reps-measured
-   *  exercises, durationSec for time-measured ones. */
+   *  exercises, durationSec for time-measured ones, distanceM +
+   *  durationSec for distance-time-measured ones. */
   initial?: {
     timestamp: string;
     reps: number;
     sets?: number[];
     durationSec?: number;
+    distanceM?: number;
     variantId?: string;
   };
 }
@@ -63,8 +65,12 @@ export interface EntryDialogResult {
   reps: number;
   /** Populated for `'reps'` and `'weight'` measurement; `[]` otherwise. */
   sets: number[];
-  /** Populated for `'time'` measurement; `undefined` otherwise. */
+  /** Populated for `'time'` and `'distance-time'` measurement;
+   *  `undefined` otherwise. */
   durationSec?: number;
+  /** Populated for `'distance-time'` measurement; `undefined`
+   *  otherwise. Always rounded to whole meters. */
+  distanceM?: number;
 }
 
 /**
@@ -72,13 +78,16 @@ export interface EntryDialogResult {
  * its form fields off the catalog definition so any new exercise drops
  * in without component-level changes.
  *
- * Two measurement paths are wired:
+ * Three measurement paths are wired:
  *   - `'reps'` — reps + sets list, sums into the entry total.
  *   - `'time'` — single mm:ss duration input.
+ *   - `'distance-time'` — distance (km) + companion duration (mm:ss).
+ *     Both required; the catalog `min`/`max` constrain `distanceM`,
+ *     the duration uses the same parser as the plank path.
  *
  * `'weight'` and `'distance'` measurements still need their own
- * companion fields (weightKg / distanceM + optional pace) — the form
- * branches off `def.measurement` so adding them is additive.
+ * companion fields (weightKg / distanceM-only) — the form branches
+ * off `def.measurement` so adding them is additive.
  *
  * Caps come from `def.min` / `def.max` so the input clamps and
  * `canSubmit()` locks at the ceiling — closes the "validator rejects
@@ -156,7 +165,36 @@ export interface EntryDialogResult {
         </mat-form-field>
       }
 
-      @if (isTimeMeasurement()) {
+      @if (isDistanceTimeMeasurement()) {
+        <mat-form-field appearance="outline">
+          <mat-label i18n="@@entryDialog.distance">Distanz (km)</mat-label>
+          <input
+            matInput
+            type="number"
+            inputmode="decimal"
+            placeholder="5.00"
+            [min]="minKm()"
+            [max]="maxKm()"
+            step="0.01"
+            [value]="distanceInput()"
+            (input)="distanceInput.set(asValue($event))"
+            required
+          />
+        </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label i18n="@@entryDialog.duration">Dauer (mm:ss)</mat-label>
+          <input
+            matInput
+            type="text"
+            inputmode="numeric"
+            placeholder="25:00"
+            pattern="^[0-9]+:[0-5][0-9]$"
+            [value]="durationInput()"
+            (input)="durationInput.set(asValue($event))"
+            required
+          />
+        </mat-form-field>
+      } @else if (isTimeMeasurement()) {
         <mat-form-field appearance="outline">
           <mat-label i18n="@@entryDialog.duration">Dauer (mm:ss)</mat-label>
           <input
@@ -222,7 +260,7 @@ export interface EntryDialogResult {
       }
       @if (overCap()) {
         <div class="total-reps">
-          @if (isTimeMeasurement()) {
+          @if (isTimeMeasurement() || isDistanceTimeMeasurement()) {
             <span i18n="@@entryDialog.overCapTime"
               >Maximum: {{ formattedMax() }}</span
             >
@@ -267,6 +305,10 @@ export class EntryDialogComponent {
     () => this.data.definition.measurement === 'time'
   );
 
+  readonly isDistanceTimeMeasurement = computed(
+    () => this.data.definition.measurement === 'distance-time'
+  );
+
   readonly sets = signal<number[]>(
     this.data.initial?.sets?.length
       ? [...this.data.initial.sets]
@@ -276,7 +318,8 @@ export class EntryDialogComponent {
   );
 
   /**
-   * Free-text mm:ss input for time-measurement exercises (plank).
+   * Free-text mm:ss input for time-measurement exercises (plank) and
+   * the duration companion of distance-time exercises (cardio.running).
    * Pre-filled from `initial.durationSec` in edit mode.
    */
   readonly durationInput = signal(
@@ -288,6 +331,23 @@ export class EntryDialogComponent {
   readonly durationSec = computed(() =>
     parseDurationToSeconds(this.durationInput())
   );
+
+  /**
+   * Distance input in km (decimal) for distance-time exercises. Stored
+   * persistently as integer meters via `distanceM` — the catalog
+   * `min`/`max` are also meters, so we render them as km here only for
+   * the user-facing input.
+   */
+  readonly distanceInput = signal(
+    this.data.initial?.distanceM !== undefined
+      ? formatKmInput(this.data.initial.distanceM)
+      : ''
+  );
+
+  readonly distanceM = computed(() => parseKmToMeters(this.distanceInput()));
+
+  readonly minKm = computed(() => this.data.definition.min / 1000);
+  readonly maxKm = computed(() => this.data.definition.max / 1000);
 
   readonly variantControl = new FormControl<string>(
     this.data.initial?.variantId ?? '',
@@ -307,15 +367,31 @@ export class EntryDialogComponent {
     formatExerciseValue(this.data.definition.max, this.data.definition.unit)
   );
 
-  readonly overCap = computed(() =>
-    this.isTimeMeasurement()
-      ? this.durationSec() !== null &&
-        this.durationSec()! > this.data.definition.max
-      : this.totalReps() > this.data.definition.max
-  );
+  readonly overCap = computed(() => {
+    if (this.isDistanceTimeMeasurement()) {
+      const m = this.distanceM();
+      return m !== null && m > this.data.definition.max;
+    }
+    if (this.isTimeMeasurement()) {
+      const sec = this.durationSec();
+      return sec !== null && sec > this.data.definition.max;
+    }
+    return this.totalReps() > this.data.definition.max;
+  });
 
   readonly canSubmit = computed(() => {
     if (this.timestamp().length === 0) return false;
+    if (this.isDistanceTimeMeasurement()) {
+      const m = this.distanceM();
+      const sec = this.durationSec();
+      return (
+        m !== null &&
+        m >= this.data.definition.min &&
+        sec !== null &&
+        sec > 0 &&
+        !this.overCap()
+      );
+    }
     if (this.isTimeMeasurement()) {
       const sec = this.durationSec();
       return (
@@ -412,6 +488,24 @@ export class EntryDialogComponent {
       return;
     }
 
+    if (measurement === 'distance-time') {
+      const m = this.distanceM();
+      const sec = this.durationSec();
+      if (m === null || m <= 0 || sec === null || sec <= 0) return;
+      const result: EntryDialogResult = {
+        exerciseId: this.data.definition.id,
+        measurement,
+        ...variantPatch,
+        timestamp,
+        reps: 0,
+        sets: [],
+        distanceM: m,
+        durationSec: sec,
+      };
+      this.dialogRef.close(result);
+      return;
+    }
+
     const validSets = this.sets().filter((s) => s > 0);
     const reps = validSets.reduce((sum, s) => sum + s, 0);
     if (reps <= 0) return;
@@ -455,4 +549,30 @@ function parseDurationToSeconds(input: string): number | null {
   const seconds = Number(match[2]);
   if (!Number.isFinite(minutes) || !Number.isFinite(seconds)) return null;
   return minutes * 60 + seconds;
+}
+
+/**
+ * Parse a free-text km input ("5", "5.25", "0.10") into integer
+ * meters. Returns `null` for empty/non-numeric/non-positive input so
+ * the caller can disable submit instead of writing `NaN` or `0` to
+ * Firestore. Locale-specific separators ("5,25") are tolerated by
+ * normalising the comma to a dot — `Number()` itself is en-locale.
+ */
+function parseKmToMeters(input: string): number | null {
+  const trimmed = input.trim().replace(',', '.');
+  if (!trimmed) return null;
+  const km = Number(trimmed);
+  if (!Number.isFinite(km) || km <= 0) return null;
+  return Math.round(km * 1000);
+}
+
+/**
+ * Render a stored `distanceM` as a km string for the form input.
+ * Always uses dot as decimal separator because the `<input
+ * type="number">` element binds to dot-locale regardless of the
+ * surrounding `LOCALE_ID`.
+ */
+function formatKmInput(distanceM: number): string {
+  if (!Number.isFinite(distanceM) || distanceM <= 0) return '';
+  return (distanceM / 1000).toFixed(2);
 }

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
@@ -18,6 +18,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import {
   appendLocalOffset,
+  COMPANION_BOUNDS,
   ExerciseDefinition,
   formatExerciseValue,
   MeasurementType,
@@ -370,7 +371,16 @@ export class EntryDialogComponent {
   readonly overCap = computed(() => {
     if (this.isDistanceTimeMeasurement()) {
       const m = this.distanceM();
-      return m !== null && m > this.data.definition.max;
+      const sec = this.durationSec();
+      // Distance ceiling comes from the catalog (`def.max` in meters);
+      // duration ceiling from the global companion bound. Either side
+      // tripping the cap should surface the over-cap hint, not just
+      // distance — a 99:59:59 entry on a 50 km cap should not silently
+      // disable submit with no UI feedback.
+      const distanceOver = m !== null && m > this.data.definition.max;
+      const durationOver =
+        sec !== null && sec > COMPANION_BOUNDS.durationSec.max;
+      return distanceOver || durationOver;
     }
     if (this.isTimeMeasurement()) {
       const sec = this.durationSec();

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
@@ -19,6 +19,7 @@ import { MatSelectModule } from '@angular/material/select';
 import {
   appendLocalOffset,
   ExerciseDefinition,
+  formatExerciseValue,
   MeasurementType,
 } from '@pu-stats/models';
 
@@ -280,7 +281,7 @@ export class EntryDialogComponent {
    */
   readonly durationInput = signal(
     this.data.initial?.durationSec !== undefined
-      ? formatSecondsAsMmSs(this.data.initial.durationSec)
+      ? formatExerciseValue(this.data.initial.durationSec, 's')
       : ''
   );
 
@@ -299,10 +300,11 @@ export class EntryDialogComponent {
     this.sets().reduce((sum, s) => sum + (s > 0 ? s : 0), 0)
   );
 
-  /** Localized form of `def.max` for the over-cap hint when the
-   *  measurement is `'time'` — surfaces "5:00" instead of "300". */
+  /** Display form of `def.max` for the over-cap hint, using the same
+   *  unit-aware formatter as the section card and stats table — a
+   *  300 s plank cap renders as "5:00". */
   readonly formattedMax = computed(() =>
-    formatSecondsAsMmSs(this.data.definition.max)
+    formatExerciseValue(this.data.definition.max, this.data.definition.unit)
   );
 
   readonly overCap = computed(() =>
@@ -453,17 +455,4 @@ function parseDurationToSeconds(input: string): number | null {
   const seconds = Number(match[2]);
   if (!Number.isFinite(minutes) || !Number.isFinite(seconds)) return null;
   return minutes * 60 + seconds;
-}
-
-/**
- * Inverse of {@link parseDurationToSeconds}: formats seconds back into
- * the `mm:ss` string the input field expects. Pads seconds to two
- * digits; minutes are not padded so a 30-second hold renders as
- * `0:30` and a 12-minute one as `12:00`.
- */
-function formatSecondsAsMmSs(totalSec: number): string {
-  if (!Number.isFinite(totalSec) || totalSec < 0) return '0:00';
-  const m = Math.floor(totalSec / 60);
-  const s = totalSec % 60;
-  return `${m}:${String(s).padStart(2, '0')}`;
 }

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
@@ -437,10 +437,12 @@ export class EntryDialogComponent {
 const VARIANT_LABELS: Record<string, string> = {};
 
 /**
- * Parse mm:ss (or m:ss / hh:mm:ss with the leading "h" parsed as
- * minutes — single colon is the contract for plank's typical hold
- * range) into integer seconds. Returns null for malformed input so the
- * caller can disable submit instead of writing NaN to Firestore.
+ * Parse `m+:ss` (single colon, any number of minute digits, exactly two
+ * second digits in the 0–59 range) into integer seconds. Returns `null`
+ * for malformed input so the caller can disable submit instead of
+ * writing `NaN` to Firestore. Hours are out of scope — the plank cap
+ * tops out at 7200 s ("120:00") and we want the shortest format that
+ * still covers it.
  */
 function parseDurationToSeconds(input: string): number | null {
   const trimmed = input.trim();

--- a/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
+++ b/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
@@ -350,11 +350,13 @@ function buildI18n(): I18nBundle {
     abs: $localize`:@@exercise.category.abs:Bauch`,
     legs: $localize`:@@exercise.category.legs:Beine`,
     plank: $localize`:@@exercise.category.plank:Plank`,
+    cardio: $localize`:@@exercise.category.cardio:Ausdauer`,
   };
   const exerciseNames: Record<string, string> = {
     'abs.situps': $localize`:@@exercise.abs.situps.name:Sit-ups`,
     'legs.squats': $localize`:@@exercise.legs.squats.name:Kniebeugen`,
     'plank.standard': $localize`:@@exercise.plank.standard.name:Plank`,
+    'cardio.running': $localize`:@@exercise.cardio.running.name:Laufen`,
   };
   return {
     categoryNames,

--- a/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
+++ b/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
@@ -23,7 +23,9 @@ import {
   ExerciseEntry,
   exercisesByCategory,
   findExerciseCategory,
-  formatExerciseValue,
+  formatEntryDisplay,
+  formatEntryTotal,
+  measurementCompanionValueField,
   measurementValueField,
   toLocalIsoDate,
 } from '@pu-stats/models';
@@ -36,7 +38,15 @@ import {
 
 interface ExerciseSummary {
   definition: ExerciseDefinition;
+  /** Sum of the primary measurement value over the last 30 days. */
   totalValue30d: number;
+  /**
+   * Sum of the secondary (companion) display value over the same
+   * window — only set for composite measurements like
+   * `'distance-time'`, where the duration matters as much as the
+   * distance. `undefined` for single-value exercises.
+   */
+  totalCompanionValue30d?: number;
   lastEntry: ExerciseEntry | null;
 }
 
@@ -128,9 +138,7 @@ interface ExerciseSummary {
                 }
               </div>
               <div class="exercise-stats">
-                <span class="total">{{
-                  formatTotal(item.definition, item.totalValue30d)
-                }}</span>
+                <span class="total">{{ formatTotal(item) }}</span>
                 <span class="label" i18n="@@exerciseSection.last30d"
                   >Letzte 30 Tage</span
                 >
@@ -178,18 +186,23 @@ export class ExerciseCategorySectionComponent {
   }
 
   /**
-   * Format the per-row "last entry" value. Reads the right entry field
-   * via the catalog's `measurement` (data flow) and formats according
-   * to `def.unit` (display) — keeps the two concerns separated.
+   * Format the per-row "last entry" value. Delegates to
+   * `formatEntryDisplay` which handles single-value AND composite
+   * measurements (e.g. distance-time renders as
+   * `"5.00 km · 25:00 (5:00 /km)"`).
    */
   formatValue(def: ExerciseDefinition, entry: ExerciseEntry): string {
-    const valueField = measurementValueField(def.measurement);
-    const raw = (entry[valueField] as number | undefined) ?? 0;
-    return formatExerciseValue(raw, def.unit);
+    return formatEntryDisplay(entry, def);
   }
 
-  formatTotal(def: ExerciseDefinition, total: number): string {
-    return formatExerciseValue(total, def.unit);
+  formatTotal(summary: ExerciseSummary): string {
+    return formatEntryTotal(
+      {
+        primary: summary.totalValue30d,
+        companion: summary.totalCompanionValue30d,
+      },
+      summary.definition
+    );
   }
 
   private localizeCategory(id: ExerciseCategoryId): string {
@@ -220,15 +233,23 @@ export class ExerciseCategorySectionComponent {
     const defs = exercisesByCategory().get(this.categoryId()) ?? [];
     return defs.map((def) => {
       const matching = entries.filter((e) => e.exerciseId === def.id);
-      // The summary total is exercise-scoped so it represents whatever
-      // unit the catalog assigns: seconds for plank, reps for sit-ups,
-      // future kg/m for strength/cardio. `measurementValueField`
-      // tells us which entry field carries the primary value.
+      // The summary total is exercise-scoped: seconds for plank, reps
+      // for sit-ups, distance + duration for a tracked run.
+      // `measurementValueField` picks the primary field; for composite
+      // measurements (`distance-time`) we also sum the companion field
+      // so the card can show "42.00 km · 3:30:00 (5:00 /km)".
       const valueField = measurementValueField(def.measurement);
+      const companionField = measurementCompanionValueField(def.measurement);
       const totalValue30d = matching.reduce((s, e) => {
         const v = (e[valueField] as number | undefined) ?? 0;
         return s + v;
       }, 0);
+      const totalCompanionValue30d = companionField
+        ? matching.reduce((s, e) => {
+            const v = (e[companionField] as number | undefined) ?? 0;
+            return s + v;
+          }, 0)
+        : undefined;
       // Compare via Date.parse so an offset-bearing timestamp
       // (e.g. `…+02:00`) and a Z-suffixed one sort by their absolute
       // instant — string comparison would order them lexicographically
@@ -240,7 +261,12 @@ export class ExerciseCategorySectionComponent {
               : latest
           )
         : null;
-      return { definition: def, totalValue30d, lastEntry };
+      return {
+        definition: def,
+        totalValue30d,
+        totalCompanionValue30d,
+        lastEntry,
+      };
     });
   });
 

--- a/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
+++ b/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
@@ -121,12 +121,14 @@ interface ExerciseSummary {
                   <div class="exercise-meta">
                     <span i18n="@@exerciseSection.lastEntry">Letzter Eintrag</span>
                     : {{ last.timestamp | date: 'shortDate' }}
-                    — {{ last.reps }}
+                    — {{ formatValue(item.definition, last) }}
                   </div>
                 }
               </div>
               <div class="exercise-stats">
-                <span class="total">{{ item.totalReps30d }}</span>
+                <span class="total">{{
+                  formatTotal(item.definition, item.totalReps30d)
+                }}</span>
                 <span class="label" i18n="@@exerciseSection.last30d"
                   >Letzte 30 Tage</span
                 >
@@ -173,6 +175,29 @@ export class ExerciseCategorySectionComponent {
     return `${this.i18n.addPrefix}: ${this.exerciseName(id)}`;
   }
 
+  /**
+   * Format the per-row "last entry" value. Time-measurement exercises
+   * (plank) carry the value in `durationSec` and render as `m:ss`;
+   * everything else falls back to the raw rep count.
+   */
+  formatValue(def: ExerciseDefinition, entry: ExerciseEntry): string {
+    if (def.measurement === 'time' && entry.durationSec !== undefined) {
+      return formatSeconds(entry.durationSec);
+    }
+    return String(entry.reps ?? 0);
+  }
+
+  /**
+   * Format the section's "30-day total" cell. Same exercise-aware
+   * branch as {@link formatValue}.
+   */
+  formatTotal(def: ExerciseDefinition, total: number): string {
+    if (def.measurement === 'time') {
+      return formatSeconds(total);
+    }
+    return String(total);
+  }
+
   private localizeCategory(id: ExerciseCategoryId): string {
     return this.i18n.categoryNames[id] ?? id;
   }
@@ -201,7 +226,15 @@ export class ExerciseCategorySectionComponent {
     const defs = exercisesByCategory().get(this.categoryId()) ?? [];
     return defs.map((def) => {
       const matching = entries.filter((e) => e.exerciseId === def.id);
-      const totalReps30d = matching.reduce((s, e) => s + (e.reps ?? 0), 0);
+      // Time-measurement exercises (plank) carry the value in
+      // `durationSec`; reps-measurement exercises in `reps`. The
+      // summary total is exercise-scoped so it represents whichever
+      // unit the catalog defines.
+      const totalReps30d = matching.reduce((s, e) => {
+        const v =
+          def.measurement === 'time' ? (e.durationSec ?? 0) : (e.reps ?? 0);
+        return s + v;
+      }, 0);
       // Compare via Date.parse so an offset-bearing timestamp
       // (e.g. `…+02:00`) and a Z-suffixed one sort by their absolute
       // instant — string comparison would order them lexicographically
@@ -239,9 +272,17 @@ export class ExerciseCategorySectionComponent {
         this.exerciseService.createEntry(userId, {
           exerciseId: result.exerciseId,
           timestamp: result.timestamp,
-          reps: result.reps,
+          // Measurement-aware payload shape: time exercises (plank)
+          // ship a `durationSec` and no reps/sets; reps exercises do
+          // the inverse. Mirroring the dialog's measurement
+          // discriminator keeps the validator happy on both paths.
+          ...(result.measurement === 'time'
+            ? { durationSec: result.durationSec ?? 0 }
+            : {
+                reps: result.reps,
+                ...(result.sets.length > 1 ? { sets: result.sets } : {}),
+              }),
           ...(result.variantId ? { variantId: result.variantId } : {}),
-          ...(result.sets.length > 1 ? { sets: result.sets } : {}),
         })
       );
       this.entriesResource.reload();
@@ -261,6 +302,18 @@ export class ExerciseCategorySectionComponent {
       this.snack.open(message, this.i18n.dismissLabel, { duration: 5000 });
     }
   }
+}
+
+/**
+ * Format raw seconds as `m:ss`. Module-level helper (mirrors the one in
+ * StatsTableComponent — Track UI-3 Phase B will move both into a
+ * shared service together with the variant-picker work).
+ */
+function formatSeconds(totalSec: number): string {
+  if (!Number.isFinite(totalSec) || totalSec < 0) return '';
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
 }
 
 function thirtyDaysAgoIso(): string {
@@ -288,10 +341,12 @@ function buildI18n(): I18nBundle {
     pushup: $localize`:@@exercise.category.pushup:Liegestütze`,
     abs: $localize`:@@exercise.category.abs:Bauch`,
     legs: $localize`:@@exercise.category.legs:Beine`,
+    plank: $localize`:@@exercise.category.plank:Plank`,
   };
   const exerciseNames: Record<string, string> = {
     'abs.situps': $localize`:@@exercise.abs.situps.name:Sit-ups`,
     'legs.squats': $localize`:@@exercise.legs.squats.name:Kniebeugen`,
+    'plank.standard': $localize`:@@exercise.plank.standard.name:Plank`,
   };
   return {
     categoryNames,

--- a/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
+++ b/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
@@ -34,7 +34,7 @@ import {
 
 interface ExerciseSummary {
   definition: ExerciseDefinition;
-  totalReps30d: number;
+  totalValue30d: number;
   lastEntry: ExerciseEntry | null;
 }
 
@@ -127,7 +127,7 @@ interface ExerciseSummary {
               </div>
               <div class="exercise-stats">
                 <span class="total">{{
-                  formatTotal(item.definition, item.totalReps30d)
+                  formatTotal(item.definition, item.totalValue30d)
                 }}</span>
                 <span class="label" i18n="@@exerciseSection.last30d"
                   >Letzte 30 Tage</span
@@ -230,7 +230,7 @@ export class ExerciseCategorySectionComponent {
       // `durationSec`; reps-measurement exercises in `reps`. The
       // summary total is exercise-scoped so it represents whichever
       // unit the catalog defines.
-      const totalReps30d = matching.reduce((s, e) => {
+      const totalValue30d = matching.reduce((s, e) => {
         const v =
           def.measurement === 'time' ? (e.durationSec ?? 0) : (e.reps ?? 0);
         return s + v;
@@ -246,7 +246,7 @@ export class ExerciseCategorySectionComponent {
               : latest
           )
         : null;
-      return { definition: def, totalReps30d, lastEntry };
+      return { definition: def, totalValue30d, lastEntry };
     });
   });
 

--- a/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
+++ b/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
@@ -292,16 +292,23 @@ export class ExerciseCategorySectionComponent {
         this.exerciseService.createEntry(userId, {
           exerciseId: result.exerciseId,
           timestamp: result.timestamp,
-          // Measurement-aware payload shape: time exercises (plank)
-          // ship a `durationSec` and no reps/sets; reps exercises do
-          // the inverse. Mirroring the dialog's measurement
-          // discriminator keeps the validator happy on both paths.
+          // Measurement-aware payload shape:
+          //   - 'time' (plank): durationSec only.
+          //   - 'distance-time' (cardio.running): distanceM + durationSec.
+          //   - reps measurements: reps + optional sets.
+          // Mirroring the dialog's measurement discriminator keeps the
+          // validator happy on every path.
           ...(result.measurement === 'time'
             ? { durationSec: result.durationSec ?? 0 }
-            : {
-                reps: result.reps,
-                ...(result.sets.length > 1 ? { sets: result.sets } : {}),
-              }),
+            : result.measurement === 'distance-time'
+              ? {
+                  distanceM: result.distanceM ?? 0,
+                  durationSec: result.durationSec ?? 0,
+                }
+              : {
+                  reps: result.reps,
+                  ...(result.sets.length > 1 ? { sets: result.sets } : {}),
+                }),
           ...(result.variantId ? { variantId: result.variantId } : {}),
         })
       );

--- a/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
+++ b/web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts
@@ -23,6 +23,8 @@ import {
   ExerciseEntry,
   exercisesByCategory,
   findExerciseCategory,
+  formatExerciseValue,
+  measurementValueField,
   toLocalIsoDate,
 } from '@pu-stats/models';
 import { firstValueFrom, of } from 'rxjs';
@@ -176,26 +178,18 @@ export class ExerciseCategorySectionComponent {
   }
 
   /**
-   * Format the per-row "last entry" value. Time-measurement exercises
-   * (plank) carry the value in `durationSec` and render as `m:ss`;
-   * everything else falls back to the raw rep count.
+   * Format the per-row "last entry" value. Reads the right entry field
+   * via the catalog's `measurement` (data flow) and formats according
+   * to `def.unit` (display) — keeps the two concerns separated.
    */
   formatValue(def: ExerciseDefinition, entry: ExerciseEntry): string {
-    if (def.measurement === 'time' && entry.durationSec !== undefined) {
-      return formatSeconds(entry.durationSec);
-    }
-    return String(entry.reps ?? 0);
+    const valueField = measurementValueField(def.measurement);
+    const raw = (entry[valueField] as number | undefined) ?? 0;
+    return formatExerciseValue(raw, def.unit);
   }
 
-  /**
-   * Format the section's "30-day total" cell. Same exercise-aware
-   * branch as {@link formatValue}.
-   */
   formatTotal(def: ExerciseDefinition, total: number): string {
-    if (def.measurement === 'time') {
-      return formatSeconds(total);
-    }
-    return String(total);
+    return formatExerciseValue(total, def.unit);
   }
 
   private localizeCategory(id: ExerciseCategoryId): string {
@@ -226,13 +220,13 @@ export class ExerciseCategorySectionComponent {
     const defs = exercisesByCategory().get(this.categoryId()) ?? [];
     return defs.map((def) => {
       const matching = entries.filter((e) => e.exerciseId === def.id);
-      // Time-measurement exercises (plank) carry the value in
-      // `durationSec`; reps-measurement exercises in `reps`. The
-      // summary total is exercise-scoped so it represents whichever
-      // unit the catalog defines.
+      // The summary total is exercise-scoped so it represents whatever
+      // unit the catalog assigns: seconds for plank, reps for sit-ups,
+      // future kg/m for strength/cardio. `measurementValueField`
+      // tells us which entry field carries the primary value.
+      const valueField = measurementValueField(def.measurement);
       const totalValue30d = matching.reduce((s, e) => {
-        const v =
-          def.measurement === 'time' ? (e.durationSec ?? 0) : (e.reps ?? 0);
+        const v = (e[valueField] as number | undefined) ?? 0;
         return s + v;
       }, 0);
       // Compare via Date.parse so an offset-bearing timestamp
@@ -302,18 +296,6 @@ export class ExerciseCategorySectionComponent {
       this.snack.open(message, this.i18n.dismissLabel, { duration: 5000 });
     }
   }
-}
-
-/**
- * Format raw seconds as `m:ss`. Module-level helper (mirrors the one in
- * StatsTableComponent — Track UI-3 Phase B will move both into a
- * shared service together with the variant-picker work).
- */
-function formatSeconds(totalSec: number): string {
-  if (!Number.isFinite(totalSec) || totalSec < 0) return '';
-  const m = Math.floor(totalSec / 60);
-  const s = totalSec % 60;
-  return `${m}:${String(s).padStart(2, '0')}`;
 }
 
 function thirtyDaysAgoIso(): string {

--- a/web/src/app/stats/components/stats-table/stats-table.component.html
+++ b/web/src/app/stats/components/stats-table/stats-table.component.html
@@ -77,9 +77,13 @@
         >Reps</mat-header-cell
       >
       <mat-cell *matCellDef="let entry">
-        <span>{{ entry.reps }}</span>
-        @if (entry.sets?.length && entry.sets.length !== 1) {
-          <span class="sets-detail">({{ formatSets(entry.sets) }})</span>
+        @if (entry.durationSec !== undefined) {
+          <span>{{ formatDuration(entry.durationSec) }}</span>
+        } @else {
+          <span>{{ entry.reps }}</span>
+          @if (entry.sets?.length && entry.sets.length !== 1) {
+            <span class="sets-detail">({{ formatSets(entry.sets) }})</span>
+          }
         }
       </mat-cell>
     </ng-container>

--- a/web/src/app/stats/components/stats-table/stats-table.component.html
+++ b/web/src/app/stats/components/stats-table/stats-table.component.html
@@ -77,13 +77,9 @@
         >Reps</mat-header-cell
       >
       <mat-cell *matCellDef="let entry">
-        @if (entry.durationSec !== undefined) {
-          <span>{{ formatDuration(entry.durationSec) }}</span>
-        } @else {
-          <span>{{ entry.reps }}</span>
-          @if (entry.sets?.length && entry.sets.length !== 1) {
-            <span class="sets-detail">({{ formatSets(entry.sets) }})</span>
-          }
+        <span>{{ formatEntry(entry) }}</span>
+        @if (entry.kind === 'pushup' && entry.sets?.length && entry.sets.length !== 1) {
+          <span class="sets-detail">({{ formatSets(entry.sets) }})</span>
         }
       </mat-cell>
     </ng-container>

--- a/web/src/app/stats/components/stats-table/stats-table.component.spec.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.spec.ts
@@ -407,6 +407,86 @@ describe('StatsTableComponent', () => {
         expect.objectContaining({ sets: [] })
       );
     });
+
+    it('emits a plank update with durationSec and no reps/sets', () => {
+      const component = fixture.componentInstance;
+      const updateSpy = vitest.fn();
+      component.update.subscribe(updateSpy);
+
+      const editResult: EntryDialogResult = {
+        measurement: 'time' as const,
+        exerciseId: 'plank.standard',
+        timestamp: '2026-02-10T14:00+01:00',
+        reps: 0,
+        sets: [],
+        durationSec: 90,
+      };
+      vitest.spyOn(component.dialog, 'open').mockReturnValue({
+        afterClosed: () => of(editResult),
+      } as never);
+
+      component.openEditDialog({
+        kind: 'exercise',
+        _id: 'pl-1',
+        exerciseId: 'plank.standard',
+        timestamp: '2026-02-10T13:45:00',
+        reps: 0,
+        durationSec: 60,
+        source: 'web',
+      });
+
+      const call = updateSpy.mock.calls[0][0];
+      expect(call).toMatchObject({
+        kind: 'exercise',
+        id: 'pl-1',
+        exerciseId: 'plank.standard',
+        durationSec: 90,
+      });
+      // Measurement-aware shape: time entries do not carry reps/sets.
+      expect('reps' in call).toBe(false);
+      expect('sets' in call).toBe(false);
+    });
+
+    it('emits a cardio.running update with distanceM + durationSec and no reps/sets', () => {
+      const component = fixture.componentInstance;
+      const updateSpy = vitest.fn();
+      component.update.subscribe(updateSpy);
+
+      const editResult: EntryDialogResult = {
+        measurement: 'distance-time' as const,
+        exerciseId: 'cardio.running',
+        timestamp: '2026-02-10T14:00+01:00',
+        reps: 0,
+        sets: [],
+        distanceM: 5250,
+        durationSec: 1500,
+      };
+      vitest.spyOn(component.dialog, 'open').mockReturnValue({
+        afterClosed: () => of(editResult),
+      } as never);
+
+      component.openEditDialog({
+        kind: 'exercise',
+        _id: 'r-1',
+        exerciseId: 'cardio.running',
+        timestamp: '2026-02-10T13:45:00',
+        reps: 0,
+        distanceM: 5000,
+        durationSec: 1450,
+        source: 'web',
+      });
+
+      const call = updateSpy.mock.calls[0][0];
+      expect(call).toMatchObject({
+        kind: 'exercise',
+        id: 'r-1',
+        exerciseId: 'cardio.running',
+        distanceM: 5250,
+        durationSec: 1500,
+      });
+      expect('reps' in call).toBe(false);
+      expect('sets' in call).toBe(false);
+    });
   });
 
   describe('showExerciseColumn distinct-key heuristic', () => {

--- a/web/src/app/stats/components/stats-table/stats-table.component.spec.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.spec.ts
@@ -259,6 +259,7 @@ describe('StatsTableComponent', () => {
       };
 
       const editResult: EntryDialogResult = {
+        measurement: 'reps' as const,
         exerciseId: 'abs.situps',
         timestamp: '2026-02-10T14:00+01:00',
         reps: 35,
@@ -287,6 +288,7 @@ describe('StatsTableComponent', () => {
       component.update.subscribe(updateSpy);
 
       const editResult: EntryDialogResult = {
+        measurement: 'reps' as const,
         exerciseId: 'legs.squats',
         timestamp: '2026-02-10T14:00+01:00',
         reps: 20,
@@ -316,6 +318,7 @@ describe('StatsTableComponent', () => {
       component.update.subscribe(updateSpy);
 
       const editResult: EntryDialogResult = {
+        measurement: 'reps' as const,
         exerciseId: 'abs.situps',
         timestamp: '2026-02-10T14:00+01:00',
         reps: 30,
@@ -346,6 +349,7 @@ describe('StatsTableComponent', () => {
       component.update.subscribe(updateSpy);
 
       const editResult: EntryDialogResult = {
+        measurement: 'reps' as const,
         exerciseId: 'abs.situps',
         timestamp: '2026-02-10T14:00+01:00',
         reps: 30,
@@ -377,6 +381,7 @@ describe('StatsTableComponent', () => {
       component.update.subscribe(updateSpy);
 
       const editResult: EntryDialogResult = {
+        measurement: 'reps' as const,
         exerciseId: 'abs.situps',
         timestamp: '2026-02-10T14:00+01:00',
         reps: 30,

--- a/web/src/app/stats/components/stats-table/stats-table.component.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.ts
@@ -26,6 +26,7 @@ import { UserConfigApiService } from '@pu-stats/data-access';
 import {
   displayPushupType,
   findExerciseDefinition,
+  formatExerciseValue,
   PushupRecord,
   pushupRecordToUnified,
   UnifiedEntry,
@@ -387,15 +388,13 @@ export class StatsTableComponent {
   }
 
   /**
-   * Format raw seconds as `m:ss` for the table cell — keeps the column
-   * compact (a 90 s plank reads "1:30"). Hour-long planks would hit
-   * `90:00` which is fine for the cap of 7200 s.
+   * Format a duration cell. Delegates to the unit-aware
+   * `formatExerciseValue` so the same helper drives the section card,
+   * the dialog cap hint, and this column — keeps display logic in one
+   * place when more units (kg, m) land in later phases.
    */
   formatDuration(totalSec: number): string {
-    if (!Number.isFinite(totalSec) || totalSec < 0) return '';
-    const m = Math.floor(totalSec / 60);
-    const s = totalSec % 60;
-    return `${m}:${String(s).padStart(2, '0')}`;
+    return formatExerciseValue(totalSec, 's');
   }
 
   private async loadShowSourceFromDb(): Promise<void> {

--- a/web/src/app/stats/components/stats-table/stats-table.component.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.ts
@@ -61,6 +61,7 @@ export interface StatsTableUpdate {
   reps?: number;
   sets?: number[];
   durationSec?: number;
+  distanceM?: number;
   source: string;
   type?: string;
   exerciseId?: string;

--- a/web/src/app/stats/components/stats-table/stats-table.component.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.ts
@@ -26,7 +26,9 @@ import { UserConfigApiService } from '@pu-stats/data-access';
 import {
   displayPushupType,
   findExerciseDefinition,
+  formatEntryDisplay,
   formatExerciseValue,
+  measurementValueField,
   PushupRecord,
   pushupRecordToUnified,
   UnifiedEntry,
@@ -195,14 +197,13 @@ export class StatsTableComponent {
   constructor() {
     this.dataSource.sortingDataAccessor = (item, property) => {
       if (property === 'timestamp') return new Date(item.timestamp).getTime();
-      // The "reps" column also renders durationSec for time-measured
-      // entries (plank). For sit-ups/squats `durationSec` is undefined,
-      // for plank `reps` is normalized to 0 — coalescing in this order
-      // keeps both kinds correctly ordered when the column is sorted.
-      if (property === 'reps')
-        return ('durationSec' in item && item.durationSec !== undefined
-          ? item.durationSec
-          : item.reps);
+      // The "reps" column renders measurement-aware values (reps for
+      // sit-ups/squats, durationSec for plank, distanceM for the
+      // composite distance-time cardio.running). Sort by the primary
+      // measurement field so the displayed value drives ordering —
+      // otherwise distance-time rows would tie on duration and plank
+      // rows would tie on the normalized 0 reps.
+      if (property === 'reps') return this.sortValue(item);
       if (property === 'source') return item.source;
       if (property === 'type') return this.typeLabel(item);
       if (property === 'exercise') return this.exerciseLabel(item);
@@ -396,6 +397,35 @@ export class StatsTableComponent {
     if (!sets?.length) return '';
     const allSame = sets.every((s) => s === sets[0]);
     return allSame ? `${sets.length}×${sets[0]}` : sets.join(' + ');
+  }
+
+  /**
+   * Renders the "Reps" column for any measurement type. Pushup rows
+   * fall through to the legacy reps + sets path; for catalog
+   * exercises we route through {@link formatEntryDisplay} which
+   * handles the composite distance-time format and the per-unit
+   * formatting in one place.
+   */
+  formatEntry(entry: UnifiedEntry): string {
+    if (entry.kind === 'pushup') return String(entry.reps);
+    const def = findExerciseDefinition(entry.exerciseId);
+    if (!def) return String(entry.reps);
+    return formatEntryDisplay(entry, def);
+  }
+
+  /**
+   * Sort key for the "Reps" column. Picks the primary measurement
+   * field per definition: distance for cardio.running, duration for
+   * plank, reps for everything else. Falls back to `entry.reps` when
+   * the catalog id is missing — same fallback the table uses for
+   * stale entries.
+   */
+  private sortValue(entry: UnifiedEntry): number {
+    if (entry.kind === 'pushup') return entry.reps;
+    const def = findExerciseDefinition(entry.exerciseId);
+    if (!def) return entry.reps;
+    const field = measurementValueField(def.measurement);
+    return (entry[field] as number | undefined) ?? entry.reps;
   }
 
   /**

--- a/web/src/app/stats/components/stats-table/stats-table.component.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.ts
@@ -49,13 +49,17 @@ import { exerciseDisplayName } from '../../i18n/exercise-display-names';
  * `kind` discriminator so the parent store can dispatch to the right
  * Firestore service. `exerciseId` and `variantId` are only meaningful
  * when `kind === 'exercise'`; `type` only when `kind === 'pushup'`.
+ *
+ * Either `reps` (with optional `sets`) or `durationSec` is set,
+ * depending on the underlying exercise's measurement.
  */
 export interface StatsTableUpdate {
   kind: 'pushup' | 'exercise';
   id: string;
   timestamp: string;
-  reps: number;
+  reps?: number;
   sets?: number[];
+  durationSec?: number;
   source: string;
   type?: string;
   exerciseId?: string;
@@ -298,6 +302,9 @@ export class StatsTableComponent {
               timestamp: entry.timestamp,
               reps: entry.reps,
               sets: entry.sets,
+              ...(entry.durationSec !== undefined
+                ? { durationSec: entry.durationSec }
+                : {}),
               variantId: entry.variantId,
             },
           },
@@ -311,16 +318,24 @@ export class StatsTableComponent {
             id: entry._id,
             exerciseId: entry.exerciseId,
             timestamp: result.timestamp,
-            reps: result.reps,
-            // Same single-set-collapse rule as the pushup branch:
-            // explicit `[]` clears a stale per-set breakdown.
-            sets:
-              result.sets.length > 1
-                ? result.sets
-                : entry.sets !== undefined
-                  ? []
-                  : undefined,
             source: entry.source,
+            // Measurement-aware: time exercises (plank) carry a
+            // durationSec; reps exercises carry reps + optional sets.
+            // The reps branch keeps the explicit-clear sentinel
+            // semantics (sets: [] when collapsing a multi-set entry to
+            // a single set) so a stale per-set breakdown doesn't
+            // survive the update via Firestore field-omit.
+            ...(result.measurement === 'time'
+              ? { durationSec: result.durationSec ?? 0 }
+              : {
+                  reps: result.reps,
+                  sets:
+                    result.sets.length > 1
+                      ? result.sets
+                      : entry.sets !== undefined
+                        ? []
+                        : undefined,
+                }),
             // Forward the dialog's tri-state variantId verbatim:
             // - non-empty string sets the variant
             // - explicit null tells the store to clear it via deleteField()
@@ -362,6 +377,18 @@ export class StatsTableComponent {
     if (!sets?.length) return '';
     const allSame = sets.every((s) => s === sets[0]);
     return allSame ? `${sets.length}×${sets[0]}` : sets.join(' + ');
+  }
+
+  /**
+   * Format raw seconds as `m:ss` for the table cell — keeps the column
+   * compact (a 90 s plank reads "1:30"). Hour-long planks would hit
+   * `90:00` which is fine for the cap of 7200 s.
+   */
+  formatDuration(totalSec: number): string {
+    if (!Number.isFinite(totalSec) || totalSec < 0) return '';
+    const m = Math.floor(totalSec / 60);
+    const s = totalSec % 60;
+    return `${m}:${String(s).padStart(2, '0')}`;
   }
 
   private async loadShowSourceFromDb(): Promise<void> {

--- a/web/src/app/stats/components/stats-table/stats-table.component.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.ts
@@ -313,6 +313,9 @@ export class StatsTableComponent {
               ...(entry.durationSec !== undefined
                 ? { durationSec: entry.durationSec }
                 : {}),
+              ...(entry.distanceM !== undefined
+                ? { distanceM: entry.distanceM }
+                : {}),
               variantId: entry.variantId,
             },
           },
@@ -327,23 +330,30 @@ export class StatsTableComponent {
             exerciseId: entry.exerciseId,
             timestamp: result.timestamp,
             source: entry.source,
-            // Measurement-aware: time exercises (plank) carry a
-            // durationSec; reps exercises carry reps + optional sets.
-            // The reps branch keeps the explicit-clear sentinel
-            // semantics (sets: [] when collapsing a multi-set entry to
-            // a single set) so a stale per-set breakdown doesn't
-            // survive the update via Firestore field-omit.
+            // Measurement-aware:
+            //   - 'time' (plank): durationSec only.
+            //   - 'distance-time' (cardio.running): distanceM + durationSec.
+            //   - reps measurements: reps + optional sets. The sets
+            //     branch keeps the explicit-clear sentinel `[]` when
+            //     collapsing a multi-set entry to a single set so a
+            //     stale per-set breakdown doesn't survive the update
+            //     via Firestore field-omit.
             ...(result.measurement === 'time'
               ? { durationSec: result.durationSec ?? 0 }
-              : {
-                  reps: result.reps,
-                  sets:
-                    result.sets.length > 1
-                      ? result.sets
-                      : entry.sets !== undefined
-                        ? []
-                        : undefined,
-                }),
+              : result.measurement === 'distance-time'
+                ? {
+                    distanceM: result.distanceM ?? 0,
+                    durationSec: result.durationSec ?? 0,
+                  }
+                : {
+                    reps: result.reps,
+                    sets:
+                      result.sets.length > 1
+                        ? result.sets
+                        : entry.sets !== undefined
+                          ? []
+                          : undefined,
+                  }),
             // Forward the dialog's tri-state variantId verbatim:
             // - non-empty string sets the variant
             // - explicit null tells the store to clear it via deleteField()

--- a/web/src/app/stats/components/stats-table/stats-table.component.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.ts
@@ -193,7 +193,14 @@ export class StatsTableComponent {
   constructor() {
     this.dataSource.sortingDataAccessor = (item, property) => {
       if (property === 'timestamp') return new Date(item.timestamp).getTime();
-      if (property === 'reps') return item.reps;
+      // The "reps" column also renders durationSec for time-measured
+      // entries (plank). For sit-ups/squats `durationSec` is undefined,
+      // for plank `reps` is normalized to 0 — coalescing in this order
+      // keeps both kinds correctly ordered when the column is sorted.
+      if (property === 'reps')
+        return ('durationSec' in item && item.durationSec !== undefined
+          ? item.durationSec
+          : item.reps);
       if (property === 'source') return item.source;
       if (property === 'type') return this.typeLabel(item);
       if (property === 'exercise') return this.exerciseLabel(item);

--- a/web/src/app/stats/entries.store.ts
+++ b/web/src/app/stats/entries.store.ts
@@ -261,11 +261,15 @@ export const EntriesStore = signalStore(
         id: string;
         exerciseId?: string;
         timestamp: string;
-        // Reps measurement field; `undefined` for time-measurement
-        // updates (where `durationSec` carries the value instead).
+        // Measurement-specific value fields. Reps/sets for reps
+        // exercises, durationSec for plank, distanceM (+ durationSec
+        // companion) for cardio.running. Each call patches whatever
+        // the dialog produced; the data-access layer enforces that
+        // mutually exclusive fields don't end up on the same doc.
         reps?: number;
         sets?: number[];
         durationSec?: number;
+        distanceM?: number;
         source?: string;
         type?: string;
         // `null` is the "clear this variant" sentinel forwarded from the
@@ -302,6 +306,9 @@ export const EntriesStore = signalStore(
                 ...(payload.reps !== undefined ? { reps: payload.reps } : {}),
                 ...(payload.durationSec !== undefined
                   ? { durationSec: payload.durationSec }
+                  : {}),
+                ...(payload.distanceM !== undefined
+                  ? { distanceM: payload.distanceM }
                   : {}),
                 ...(payload.sets !== undefined ? { sets: payload.sets } : {}),
                 ...(payload.source !== undefined

--- a/web/src/app/stats/entries.store.ts
+++ b/web/src/app/stats/entries.store.ts
@@ -261,8 +261,11 @@ export const EntriesStore = signalStore(
         id: string;
         exerciseId?: string;
         timestamp: string;
-        reps: number;
+        // Reps measurement field; `undefined` for time-measurement
+        // updates (where `durationSec` carries the value instead).
+        reps?: number;
         sets?: number[];
+        durationSec?: number;
         source?: string;
         type?: string;
         // `null` is the "clear this variant" sentinel forwarded from the
@@ -296,7 +299,10 @@ export const EntriesStore = signalStore(
             await firstValueFrom(
               _exerciseService.updateEntry(payload.id, payload.exerciseId, {
                 timestamp: payload.timestamp,
-                reps: payload.reps,
+                ...(payload.reps !== undefined ? { reps: payload.reps } : {}),
+                ...(payload.durationSec !== undefined
+                  ? { durationSec: payload.durationSec }
+                  : {}),
                 ...(payload.sets !== undefined ? { sets: payload.sets } : {}),
                 ...(payload.source !== undefined
                   ? { source: payload.source }

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -7,6 +7,8 @@
 const EXERCISE_DISPLAY_NAMES: Record<string, string> = {
   'abs.situps': $localize`:@@exercise.abs.situps.name:Sit-ups`,
   'legs.squats': $localize`:@@exercise.legs.squats.name:Kniebeugen`,
+  'plank.standard': $localize`:@@exercise.plank.standard.name:Plank`,
+  'cardio.running': $localize`:@@exercise.cardio.running.name:Laufen`,
 };
 
 export function exerciseDisplayName(id: string): string {

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -3822,6 +3822,12 @@
         <target> Αποθήκευση </target>
       </segment>
     </unit>
+    <unit id="entryDialog.distance">
+      <segment state="translated">
+        <source>Distanz (km)</source>
+        <target>Απόσταση (χλμ)</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.duration">
       <segment state="translated">
         <source>Dauer (mm:ss)</source>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -3834,6 +3834,12 @@
         <target>Διάρκεια (mm:ss)</target>
       </segment>
     </unit>
+    <unit id="entryDialog.overCapDuration">
+      <segment state="translated">
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
+        <target>Μέγιστη διάρκεια: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+      </segment>
+    </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -3822,6 +3822,30 @@
         <target> Αποθήκευση </target>
       </segment>
     </unit>
+    <unit id="entryDialog.duration">
+      <segment state="translated">
+        <source>Dauer (mm:ss)</source>
+        <target>Διάρκεια (mm:ss)</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapTime">
+      <segment state="translated">
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
+        <target>Μέγιστο: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.plank">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Πλανκ</target>
+      </segment>
+    </unit>
+    <unit id="exercise.plank.standard.name">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Πλανκ</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -3846,6 +3846,18 @@
         <target>Πλανκ</target>
       </segment>
     </unit>
+    <unit id="exercise.category.cardio">
+      <segment state="translated">
+        <source>Ausdauer</source>
+        <target>Καρδιαγγειακή</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.running.name">
+      <segment state="translated">
+        <source>Laufen</source>
+        <target>Τρέξιμο</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -3227,6 +3227,18 @@ Deine Position: # ·  Reps        </source>
         <target>Plank</target>
       </segment>
     </unit>
+    <unit id="exercise.category.cardio">
+      <segment state="translated">
+        <source>Ausdauer</source>
+        <target>Cardio</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.running.name">
+      <segment state="translated">
+        <source>Laufen</source>
+        <target>Running</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -3215,6 +3215,12 @@ Deine Position: # ·  Reps        </source>
         <target>Duration (mm:ss)</target>
       </segment>
     </unit>
+    <unit id="entryDialog.overCapDuration">
+      <segment state="translated">
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
+        <target>Maximum duration: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+      </segment>
+    </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -3203,6 +3203,30 @@ Deine Position: # ·  Reps        </source>
         <target>Save</target>
       </segment>
     </unit>
+    <unit id="entryDialog.duration">
+      <segment state="translated">
+        <source>Dauer (mm:ss)</source>
+        <target>Duration (mm:ss)</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapTime">
+      <segment state="translated">
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
+        <target>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.plank">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exercise.plank.standard.name">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -3203,6 +3203,12 @@ Deine Position: # ·  Reps        </source>
         <target>Save</target>
       </segment>
     </unit>
+    <unit id="entryDialog.distance">
+      <segment state="translated">
+        <source>Distanz (km)</source>
+        <target>Distance (km)</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.duration">
       <segment state="translated">
         <source>Dauer (mm:ss)</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -3834,6 +3834,12 @@
         <target>Duración (mm:ss)</target>
       </segment>
     </unit>
+    <unit id="entryDialog.overCapDuration">
+      <segment state="translated">
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
+        <target>Duración máxima: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+      </segment>
+    </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -3846,6 +3846,18 @@
         <target>Plancha</target>
       </segment>
     </unit>
+    <unit id="exercise.category.cardio">
+      <segment state="translated">
+        <source>Ausdauer</source>
+        <target>Cardio</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.running.name">
+      <segment state="translated">
+        <source>Laufen</source>
+        <target>Correr</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -3822,6 +3822,12 @@
         <target> Guardar </target>
       </segment>
     </unit>
+    <unit id="entryDialog.distance">
+      <segment state="translated">
+        <source>Distanz (km)</source>
+        <target>Distancia (km)</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.duration">
       <segment state="translated">
         <source>Dauer (mm:ss)</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -3822,6 +3822,30 @@
         <target> Guardar </target>
       </segment>
     </unit>
+    <unit id="entryDialog.duration">
+      <segment state="translated">
+        <source>Dauer (mm:ss)</source>
+        <target>Duración (mm:ss)</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapTime">
+      <segment state="translated">
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
+        <target>Máximo: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.plank">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plancha</target>
+      </segment>
+    </unit>
+    <unit id="exercise.plank.standard.name">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plancha</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3846,6 +3846,18 @@
         <target>Planche</target>
       </segment>
     </unit>
+    <unit id="exercise.category.cardio">
+      <segment state="translated">
+        <source>Ausdauer</source>
+        <target>Cardio</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.running.name">
+      <segment state="translated">
+        <source>Laufen</source>
+        <target>Course à pied</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3834,6 +3834,12 @@
         <target>Durée (mm:ss)</target>
       </segment>
     </unit>
+    <unit id="entryDialog.overCapDuration">
+      <segment state="translated">
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
+        <target>Durée maximale : <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+      </segment>
+    </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3822,6 +3822,30 @@
         <target> Enregistrer </target>
       </segment>
     </unit>
+    <unit id="entryDialog.duration">
+      <segment state="translated">
+        <source>Dauer (mm:ss)</source>
+        <target>Durée (mm:ss)</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapTime">
+      <segment state="translated">
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
+        <target>Maximum : <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.plank">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Planche</target>
+      </segment>
+    </unit>
+    <unit id="exercise.plank.standard.name">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Planche</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3822,6 +3822,12 @@
         <target> Enregistrer </target>
       </segment>
     </unit>
+    <unit id="entryDialog.distance">
+      <segment state="translated">
+        <source>Distanz (km)</source>
+        <target>Distance (km)</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.duration">
       <segment state="translated">
         <source>Dauer (mm:ss)</source>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -3846,6 +3846,18 @@
         <target>Plank</target>
       </segment>
     </unit>
+    <unit id="exercise.category.cardio">
+      <segment state="translated">
+        <source>Ausdauer</source>
+        <target>Cardio</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.running.name">
+      <segment state="translated">
+        <source>Laufen</source>
+        <target>Corsa</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -3834,6 +3834,12 @@
         <target>Durata (mm:ss)</target>
       </segment>
     </unit>
+    <unit id="entryDialog.overCapDuration">
+      <segment state="translated">
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
+        <target>Durata massima: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+      </segment>
+    </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -3822,6 +3822,12 @@
         <target> Salva </target>
       </segment>
     </unit>
+    <unit id="entryDialog.distance">
+      <segment state="translated">
+        <source>Distanz (km)</source>
+        <target>Distanza (km)</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.duration">
       <segment state="translated">
         <source>Dauer (mm:ss)</source>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -3822,6 +3822,30 @@
         <target> Salva </target>
       </segment>
     </unit>
+    <unit id="entryDialog.duration">
+      <segment state="translated">
+        <source>Dauer (mm:ss)</source>
+        <target>Durata (mm:ss)</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapTime">
+      <segment state="translated">
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
+        <target>Massimo: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.plank">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exercise.plank.standard.name">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3822,6 +3822,30 @@
         <target> Servare </target>
       </segment>
     </unit>
+    <unit id="entryDialog.duration">
+      <segment state="translated">
+        <source>Dauer (mm:ss)</source>
+        <target>Duratio (mm:ss)</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapTime">
+      <segment state="translated">
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
+        <target>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.plank">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exercise.plank.standard.name">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3822,6 +3822,12 @@
         <target> Servare </target>
       </segment>
     </unit>
+    <unit id="entryDialog.distance">
+      <segment state="translated">
+        <source>Distanz (km)</source>
+        <target>Spatium (km)</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.duration">
       <segment state="translated">
         <source>Dauer (mm:ss)</source>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3834,6 +3834,12 @@
         <target>Duratio (mm:ss)</target>
       </segment>
     </unit>
+    <unit id="entryDialog.overCapDuration">
+      <segment state="translated">
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
+        <target>Maxima duratio: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+      </segment>
+    </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3855,7 +3855,7 @@
     <unit id="exercise.category.cardio">
       <segment state="translated">
         <source>Ausdauer</source>
-        <target>Cursus</target>
+        <target>Exercitatio</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.running.name">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3846,6 +3846,18 @@
         <target>Plank</target>
       </segment>
     </unit>
+    <unit id="exercise.category.cardio">
+      <segment state="translated">
+        <source>Ausdauer</source>
+        <target>Cursus</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.running.name">
+      <segment state="translated">
+        <source>Laufen</source>
+        <target>Cursus</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3822,6 +3822,30 @@
         <target> Opslaan </target>
       </segment>
     </unit>
+    <unit id="entryDialog.duration">
+      <segment state="translated">
+        <source>Dauer (mm:ss)</source>
+        <target>Duur (mm:ss)</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapTime">
+      <segment state="translated">
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
+        <target>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.plank">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exercise.plank.standard.name">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3822,6 +3822,12 @@
         <target> Opslaan </target>
       </segment>
     </unit>
+    <unit id="entryDialog.distance">
+      <segment state="translated">
+        <source>Distanz (km)</source>
+        <target>Afstand (km)</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.duration">
       <segment state="translated">
         <source>Dauer (mm:ss)</source>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3834,6 +3834,12 @@
         <target>Duur (mm:ss)</target>
       </segment>
     </unit>
+    <unit id="entryDialog.overCapDuration">
+      <segment state="translated">
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
+        <target>Maximale duur: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+      </segment>
+    </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3846,6 +3846,18 @@
         <target>Plank</target>
       </segment>
     </unit>
+    <unit id="exercise.category.cardio">
+      <segment state="translated">
+        <source>Ausdauer</source>
+        <target>Cardio</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.running.name">
+      <segment state="translated">
+        <source>Laufen</source>
+        <target>Hardlopen</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -3243,6 +3243,18 @@ Deine Position: # ·  Reps        </source>
         <target>Planke</target>
       </segment>
     </unit>
+    <unit id="exercise.category.cardio">
+      <segment state="translated">
+        <source>Ausdauer</source>
+        <target>Kondisjon</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.running.name">
+      <segment state="translated">
+        <source>Laufen</source>
+        <target>Løping</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -3219,6 +3219,30 @@ Deine Position: # ·  Reps        </source>
         <target>Lagre</target>
       </segment>
     </unit>
+    <unit id="entryDialog.duration">
+      <segment state="translated">
+        <source>Dauer (mm:ss)</source>
+        <target>Varighet (mm:ss)</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapTime">
+      <segment state="translated">
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
+        <target>Maks: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.plank">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Planke</target>
+      </segment>
+    </unit>
+    <unit id="exercise.plank.standard.name">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Planke</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -3231,6 +3231,12 @@ Deine Position: # ·  Reps        </source>
         <target>Varighet (mm:ss)</target>
       </segment>
     </unit>
+    <unit id="entryDialog.overCapDuration">
+      <segment state="translated">
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
+        <target>Maks varighet: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+      </segment>
+    </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -3219,6 +3219,12 @@ Deine Position: # ·  Reps        </source>
         <target>Lagre</target>
       </segment>
     </unit>
+    <unit id="entryDialog.distance">
+      <segment state="translated">
+        <source>Distanz (km)</source>
+        <target>Distanse (km)</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.duration">
       <segment state="translated">
         <source>Dauer (mm:ss)</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -236,7 +236,7 @@
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:277,278</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:190,191</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:239,240</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
       </notes>
@@ -4282,7 +4282,7 @@
     <unit id="editDialogTitle">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:140,142</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:98,100</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:123,125</note>
       </notes>
       <segment>
         <source>Eintrag bearbeiten</source>
@@ -4299,7 +4299,7 @@
     <unit id="timestampLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:148,150</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:107,109</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:132,134</note>
       </notes>
       <segment>
         <source>Zeitpunkt</source>
@@ -4308,7 +4308,7 @@
     <unit id="setLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:162,163</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:137,138</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:177,178</note>
       </notes>
       <segment>
         <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -4317,7 +4317,7 @@
     <unit id="repsLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:164,165</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:139,140</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:179,180</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -4326,7 +4326,7 @@
     <unit id="removeSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:181,183</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:158,160</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:198,200</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -4335,7 +4335,7 @@
     <unit id="addSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:192,193</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:169,171</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:209,211</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -4352,7 +4352,7 @@
     <unit id="totalReps">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:203,205</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:178,180</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:218,220</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -4401,7 +4401,7 @@
     <unit id="saveEntry">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:285,287</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:199,201</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:248,250</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -4425,7 +4425,7 @@
     </unit>
     <unit id="exerciseEntryDialog.title">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:100,102</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:125,127</note>
       </notes>
       <segment>
         <source>Eintrag hinzufügen</source>
@@ -4433,7 +4433,7 @@
     </unit>
     <unit id="entryDialog.variant">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:119,120</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:144,145</note>
       </notes>
       <segment>
         <source>Variante</source>
@@ -4441,18 +4441,34 @@
     </unit>
     <unit id="entryDialog.variantNone">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:122,124</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:147,149</note>
       </notes>
       <segment>
         <source>—</source>
       </segment>
     </unit>
-    <unit id="entryDialog.overCap">
+    <unit id="entryDialog.duration">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:183,185</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:160,162</note>
       </notes>
       <segment>
-        <source> Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> pro Eintrag </source>
+        <source>Dauer (mm:ss)</source>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapTime">
+      <notes>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:226,227</note>
+      </notes>
+      <segment>
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCap">
+      <notes>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:230,231</note>
+      </notes>
+      <segment>
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> pro Eintrag</source>
       </segment>
     </unit>
     <unit id="exerciseSection.lastEntry">
@@ -4465,7 +4481,7 @@
     </unit>
     <unit id="exerciseSection.last30d">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:131,133</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:133,135</note>
       </notes>
       <segment>
         <source>Letzte 30 Tage</source>
@@ -4473,7 +4489,7 @@
     </unit>
     <unit id="exerciseSection.add">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:141,143</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:143,145</note>
       </notes>
       <segment>
         <source>Hinzufügen</source>
@@ -4481,8 +4497,8 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:289</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:176</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:341</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:187</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:276</note>
       </notes>
       <segment>
@@ -4491,7 +4507,7 @@
     </unit>
     <unit id="exercise.category.abs">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:290</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:342</note>
       </notes>
       <segment>
         <source>Bauch</source>
@@ -4499,16 +4515,24 @@
     </unit>
     <unit id="exercise.category.legs">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:291</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:343</note>
       </notes>
       <segment>
         <source>Beine</source>
       </segment>
     </unit>
+    <unit id="exercise.category.plank">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:344</note>
+      </notes>
+      <segment>
+        <source>Plank</source>
+      </segment>
+    </unit>
     <unit id="exercise.abs.situps.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:294</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:359</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:347</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:397</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:285</note>
       </notes>
       <segment>
@@ -4517,17 +4541,27 @@
     </unit>
     <unit id="exercise.legs.squats.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:295</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:360</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:348</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:399</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:286</note>
       </notes>
       <segment>
         <source>Kniebeugen</source>
       </segment>
     </unit>
+    <unit id="exercise.plank.standard.name">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:349</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:398</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:287</note>
+      </notes>
+      <segment>
+        <source>Plank</source>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:300</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:354</note>
       </notes>
       <segment>
         <source>Eintrag hinzufügen</source>
@@ -4535,7 +4569,7 @@
     </unit>
     <unit id="exerciseSection.savedToast">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:301</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:355</note>
       </notes>
       <segment>
         <source>Eintrag gespeichert</source>
@@ -4543,7 +4577,7 @@
     </unit>
     <unit id="exerciseSection.dismiss">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:302</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:356</note>
       </notes>
       <segment>
         <source>OK</source>
@@ -4551,7 +4585,7 @@
     </unit>
     <unit id="exerciseSection.errorPrefix">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:303</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:357</note>
       </notes>
       <segment>
         <source>Konnte nicht gespeichert werden</source>
@@ -4559,7 +4593,7 @@
     </unit>
     <unit id="exerciseSection.genericError">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:304</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:358</note>
       </notes>
       <segment>
         <source>Etwas ist schiefgelaufen</source>
@@ -5133,7 +5167,7 @@
     </unit>
     <unit id="colType">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:101,102</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:105,106</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -5141,7 +5175,7 @@
     </unit>
     <unit id="colSource">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:110,111</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:114,115</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -5149,7 +5183,7 @@
     </unit>
     <unit id="colActions">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:119,120</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:123,124</note>
       </notes>
       <segment>
         <source>Aktion</source>
@@ -5157,7 +5191,7 @@
     </unit>
     <unit id="editAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:126,127</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:130,131</note>
       </notes>
       <segment>
         <source>Bearbeiten</source>
@@ -5165,7 +5199,7 @@
     </unit>
     <unit id="editTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:128,129</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:132,133</note>
       </notes>
       <segment>
         <source>Bearbeiten</source>
@@ -5173,7 +5207,7 @@
     </unit>
     <unit id="deleteAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:139</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:143</note>
       </notes>
       <segment>
         <source>Löschen</source>
@@ -5181,7 +5215,7 @@
     </unit>
     <unit id="deleteTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:141</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:145</note>
       </notes>
       <segment>
         <source>Löschen</source>
@@ -5189,7 +5223,7 @@
     </unit>
     <unit id="colExercise">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:172</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:183</note>
       </notes>
       <segment>
         <source>Übung</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -236,7 +236,7 @@
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:277,278</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:278,279</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:285,286</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
       </notes>
@@ -4282,7 +4282,7 @@
     <unit id="editDialogTitle">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:140,142</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:133,135</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:134,136</note>
       </notes>
       <segment>
         <source>Eintrag bearbeiten</source>
@@ -4299,7 +4299,7 @@
     <unit id="timestampLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:148,150</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:142,144</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:143,145</note>
       </notes>
       <segment>
         <source>Zeitpunkt</source>
@@ -4308,7 +4308,7 @@
     <unit id="setLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:162,163</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:216,217</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:217,218</note>
       </notes>
       <segment>
         <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -4317,7 +4317,7 @@
     <unit id="repsLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:164,165</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:218,219</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:219,220</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -4326,7 +4326,7 @@
     <unit id="removeSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:181,183</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:237,239</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:238,240</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -4335,7 +4335,7 @@
     <unit id="addSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:192,193</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:248,250</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:249,251</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -4352,7 +4352,7 @@
     <unit id="totalReps">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:203,205</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:257,259</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:258,260</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -4401,7 +4401,7 @@
     <unit id="saveEntry">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:285,287</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:287,289</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:294,296</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -4425,7 +4425,7 @@
     </unit>
     <unit id="exerciseEntryDialog.title">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:135,137</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:136,138</note>
       </notes>
       <segment>
         <source>Eintrag hinzufügen</source>
@@ -4433,7 +4433,7 @@
     </unit>
     <unit id="entryDialog.variant">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:154,155</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:155,156</note>
       </notes>
       <segment>
         <source>Variante</source>
@@ -4441,7 +4441,7 @@
     </unit>
     <unit id="entryDialog.variantNone">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:157,159</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:158,160</note>
       </notes>
       <segment>
         <source>—</source>
@@ -4449,7 +4449,7 @@
     </unit>
     <unit id="entryDialog.distance">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:170,172</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:171,173</note>
       </notes>
       <segment>
         <source>Distanz (km)</source>
@@ -4457,16 +4457,24 @@
     </unit>
     <unit id="entryDialog.duration">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:185,187</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:199,201</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:186,188</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:200,202</note>
       </notes>
       <segment>
         <source>Dauer (mm:ss)</source>
       </segment>
     </unit>
+    <unit id="entryDialog.overCapDuration">
+      <notes>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:266,267</note>
+      </notes>
+      <segment>
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
+      </segment>
+    </unit>
     <unit id="entryDialog.overCapTime">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:265,266</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:272,273</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
@@ -4474,7 +4482,7 @@
     </unit>
     <unit id="entryDialog.overCap">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:269,270</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:276,277</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> pro Eintrag</source>
@@ -4507,8 +4515,8 @@
     <unit id="exercise.category.pushup">
       <notes>
         <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:356</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:188</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:276</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:190</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:277</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -4549,8 +4557,7 @@
     <unit id="exercise.abs.situps.name">
       <notes>
         <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:363</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:413</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:285</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:8</note>
       </notes>
       <segment>
         <source>Sit-ups</source>
@@ -4559,8 +4566,7 @@
     <unit id="exercise.legs.squats.name">
       <notes>
         <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:364</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:415</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:286</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:9</note>
       </notes>
       <segment>
         <source>Kniebeugen</source>
@@ -4569,8 +4575,7 @@
     <unit id="exercise.plank.standard.name">
       <notes>
         <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:365</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:414</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:287</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:10</note>
       </notes>
       <segment>
         <source>Plank</source>
@@ -4579,8 +4584,7 @@
     <unit id="exercise.cardio.running.name">
       <notes>
         <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:366</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:416</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:288</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:11</note>
       </notes>
       <segment>
         <source>Laufen</source>
@@ -5194,7 +5198,7 @@
     </unit>
     <unit id="colType">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:105,106</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:101,102</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -5202,7 +5206,7 @@
     </unit>
     <unit id="colSource">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:114,115</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:110,111</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -5210,7 +5214,7 @@
     </unit>
     <unit id="colActions">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:123,124</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:119,120</note>
       </notes>
       <segment>
         <source>Aktion</source>
@@ -5218,7 +5222,7 @@
     </unit>
     <unit id="editAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:130,131</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:126,127</note>
       </notes>
       <segment>
         <source>Bearbeiten</source>
@@ -5226,7 +5230,7 @@
     </unit>
     <unit id="editTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:132,133</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:128,129</note>
       </notes>
       <segment>
         <source>Bearbeiten</source>
@@ -5234,7 +5238,7 @@
     </unit>
     <unit id="deleteAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:143</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:139</note>
       </notes>
       <segment>
         <source>Löschen</source>
@@ -5242,7 +5246,7 @@
     </unit>
     <unit id="deleteTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:145</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:141</note>
       </notes>
       <segment>
         <source>Löschen</source>
@@ -5250,7 +5254,7 @@
     </unit>
     <unit id="colExercise">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:184</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:186</note>
       </notes>
       <segment>
         <source>Übung</source>
@@ -5258,7 +5262,7 @@
     </unit>
     <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:36,37</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:34,35</note>
       </notes>
       <segment>
         <source>Verteilung der Liegestütz-Typen</source>
@@ -5266,7 +5270,7 @@
     </unit>
     <unit id="pie.avgSetSize">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:92,93</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:72,73</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
@@ -5274,7 +5278,7 @@
     </unit>
     <unit id="pie.other">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:102,103</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:84,85</note>
       </notes>
       <segment>
         <source>Sonstige</source>
@@ -5282,7 +5286,7 @@
     </unit>
     <unit id="pie.noData">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:110,113</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:92,95</note>
       </notes>
       <segment>
         <source>Keine Daten</source>
@@ -5565,7 +5569,7 @@
     </unit>
     <unit id="historyHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:37,38</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:38,39</note>
       </notes>
       <segment>
         <source>Historie</source>
@@ -5573,7 +5577,7 @@
     </unit>
     <unit id="historyHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:39,41</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:40,42</note>
       </notes>
       <segment>
         <source> Durchsuche, filtere und bearbeite deine Trainingseinträge. </source>
@@ -5581,7 +5585,7 @@
     </unit>
     <unit id="entries.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:44,45</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:45,46</note>
       </notes>
       <segment>
         <source>Filter</source>
@@ -5589,7 +5593,7 @@
     </unit>
     <unit id="entries.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:46,47</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:47,48</note>
       </notes>
       <segment>
         <source>Zeitraum und Kriterien</source>
@@ -5597,7 +5601,7 @@
     </unit>
     <unit id="entries.dateFrom">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:53,54</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:54,55</note>
       </notes>
       <segment>
         <source>Datum von</source>
@@ -5605,7 +5609,7 @@
     </unit>
     <unit id="entries.dateTo">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:63,64</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:64,65</note>
       </notes>
       <segment>
         <source>Datum bis</source>
@@ -5613,7 +5617,7 @@
     </unit>
     <unit id="entries.exerciseFilter">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:73,74</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:74,75</note>
       </notes>
       <segment>
         <source>Übung</source>
@@ -5621,7 +5625,7 @@
     </unit>
     <unit id="entries.sourceFilter">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:88,89</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:89,90</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -5629,8 +5633,8 @@
     </unit>
     <unit id="entries.allOption">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:94,96</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:109,111</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:95,97</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:110,112</note>
       </notes>
       <segment>
         <source>Alle</source>
@@ -5638,7 +5642,7 @@
     </unit>
     <unit id="entries.typeFilter">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:103,104</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:104,105</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -5646,7 +5650,7 @@
     </unit>
     <unit id="entries.repsMin">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:120,121</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:121,122</note>
       </notes>
       <segment>
         <source>Reps min</source>
@@ -5654,7 +5658,7 @@
     </unit>
     <unit id="entries.repsMax">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:131,132</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:132,133</note>
       </notes>
       <segment>
         <source>Reps max</source>
@@ -5662,7 +5666,7 @@
     </unit>
     <unit id="entries.empty.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:159,161</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:160,162</note>
       </notes>
       <segment>
         <source>Noch keine Einträge.</source>
@@ -5670,7 +5674,7 @@
     </unit>
     <unit id="entries.empty.body">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:162,164</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:163,165</note>
       </notes>
       <segment>
         <source> Trage deinen ersten Trainingseintrag ein — dann wird hier deine Historie sichtbar. </source>
@@ -5678,7 +5682,7 @@
     </unit>
     <unit id="entries.empty.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:174,176</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:175,177</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc> Eintrag erstellen </source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -236,7 +236,7 @@
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:277,278</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:240,241</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:278,279</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
       </notes>
@@ -4282,7 +4282,7 @@
     <unit id="editDialogTitle">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:140,142</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:124,126</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:133,135</note>
       </notes>
       <segment>
         <source>Eintrag bearbeiten</source>
@@ -4299,7 +4299,7 @@
     <unit id="timestampLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:148,150</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:133,135</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:142,144</note>
       </notes>
       <segment>
         <source>Zeitpunkt</source>
@@ -4308,7 +4308,7 @@
     <unit id="setLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:162,163</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:178,179</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:216,217</note>
       </notes>
       <segment>
         <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -4317,7 +4317,7 @@
     <unit id="repsLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:164,165</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:180,181</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:218,219</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -4326,7 +4326,7 @@
     <unit id="removeSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:181,183</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:199,201</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:237,239</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -4335,7 +4335,7 @@
     <unit id="addSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:192,193</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:210,212</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:248,250</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -4352,7 +4352,7 @@
     <unit id="totalReps">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:203,205</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:219,221</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:257,259</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -4401,7 +4401,7 @@
     <unit id="saveEntry">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:285,287</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:249,251</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:287,289</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -4425,7 +4425,7 @@
     </unit>
     <unit id="exerciseEntryDialog.title">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:126,128</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:135,137</note>
       </notes>
       <segment>
         <source>Eintrag hinzufügen</source>
@@ -4433,7 +4433,7 @@
     </unit>
     <unit id="entryDialog.variant">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:145,146</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:154,155</note>
       </notes>
       <segment>
         <source>Variante</source>
@@ -4441,15 +4441,24 @@
     </unit>
     <unit id="entryDialog.variantNone">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:148,150</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:157,159</note>
       </notes>
       <segment>
         <source>—</source>
       </segment>
     </unit>
+    <unit id="entryDialog.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:170,172</note>
+      </notes>
+      <segment>
+        <source>Distanz (km)</source>
+      </segment>
+    </unit>
     <unit id="entryDialog.duration">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:161,163</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:185,187</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:199,201</note>
       </notes>
       <segment>
         <source>Dauer (mm:ss)</source>
@@ -4457,7 +4466,7 @@
     </unit>
     <unit id="entryDialog.overCapTime">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:227,228</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:265,266</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
@@ -4465,7 +4474,7 @@
     </unit>
     <unit id="entryDialog.overCap">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:231,232</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:269,270</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> pro Eintrag</source>
@@ -4497,7 +4506,7 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:349</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:356</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:188</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:276</note>
       </notes>
@@ -4507,7 +4516,7 @@
     </unit>
     <unit id="exercise.category.abs">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:350</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:357</note>
       </notes>
       <segment>
         <source>Bauch</source>
@@ -4515,7 +4524,7 @@
     </unit>
     <unit id="exercise.category.legs">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:351</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:358</note>
       </notes>
       <segment>
         <source>Beine</source>
@@ -4523,7 +4532,7 @@
     </unit>
     <unit id="exercise.category.plank">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:352</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:359</note>
       </notes>
       <segment>
         <source>Plank</source>
@@ -4531,7 +4540,7 @@
     </unit>
     <unit id="exercise.category.cardio">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:353</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:360</note>
       </notes>
       <segment>
         <source>Ausdauer</source>
@@ -4539,8 +4548,8 @@
     </unit>
     <unit id="exercise.abs.situps.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:356</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:403</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:363</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:413</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:285</note>
       </notes>
       <segment>
@@ -4549,8 +4558,8 @@
     </unit>
     <unit id="exercise.legs.squats.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:357</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:405</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:364</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:415</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:286</note>
       </notes>
       <segment>
@@ -4559,8 +4568,8 @@
     </unit>
     <unit id="exercise.plank.standard.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:358</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:404</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:365</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:414</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:287</note>
       </notes>
       <segment>
@@ -4569,8 +4578,8 @@
     </unit>
     <unit id="exercise.cardio.running.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:359</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:406</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:366</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:416</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:288</note>
       </notes>
       <segment>
@@ -4579,7 +4588,7 @@
     </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:364</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:371</note>
       </notes>
       <segment>
         <source>Eintrag hinzufügen</source>
@@ -4587,7 +4596,7 @@
     </unit>
     <unit id="exerciseSection.savedToast">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:365</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:372</note>
       </notes>
       <segment>
         <source>Eintrag gespeichert</source>
@@ -4595,7 +4604,7 @@
     </unit>
     <unit id="exerciseSection.dismiss">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:366</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:373</note>
       </notes>
       <segment>
         <source>OK</source>
@@ -4603,7 +4612,7 @@
     </unit>
     <unit id="exerciseSection.errorPrefix">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:367</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:374</note>
       </notes>
       <segment>
         <source>Konnte nicht gespeichert werden</source>
@@ -4611,7 +4620,7 @@
     </unit>
     <unit id="exerciseSection.genericError">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:368</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:375</note>
       </notes>
       <segment>
         <source>Etwas ist schiefgelaufen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -236,7 +236,7 @@
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:277,278</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:239,240</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:240,241</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
       </notes>
@@ -4282,7 +4282,7 @@
     <unit id="editDialogTitle">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:140,142</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:123,125</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:124,126</note>
       </notes>
       <segment>
         <source>Eintrag bearbeiten</source>
@@ -4299,7 +4299,7 @@
     <unit id="timestampLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:148,150</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:132,134</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:133,135</note>
       </notes>
       <segment>
         <source>Zeitpunkt</source>
@@ -4308,7 +4308,7 @@
     <unit id="setLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:162,163</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:177,178</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:178,179</note>
       </notes>
       <segment>
         <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -4317,7 +4317,7 @@
     <unit id="repsLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:164,165</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:179,180</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:180,181</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -4326,7 +4326,7 @@
     <unit id="removeSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:181,183</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:198,200</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:199,201</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -4335,7 +4335,7 @@
     <unit id="addSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:192,193</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:209,211</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:210,212</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -4352,7 +4352,7 @@
     <unit id="totalReps">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:203,205</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:218,220</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:219,221</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -4401,7 +4401,7 @@
     <unit id="saveEntry">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:285,287</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:248,250</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:249,251</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -4425,7 +4425,7 @@
     </unit>
     <unit id="exerciseEntryDialog.title">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:125,127</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:126,128</note>
       </notes>
       <segment>
         <source>Eintrag hinzufügen</source>
@@ -4433,7 +4433,7 @@
     </unit>
     <unit id="entryDialog.variant">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:144,145</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:145,146</note>
       </notes>
       <segment>
         <source>Variante</source>
@@ -4441,7 +4441,7 @@
     </unit>
     <unit id="entryDialog.variantNone">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:147,149</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:148,150</note>
       </notes>
       <segment>
         <source>—</source>
@@ -4449,7 +4449,7 @@
     </unit>
     <unit id="entryDialog.duration">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:160,162</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:161,163</note>
       </notes>
       <segment>
         <source>Dauer (mm:ss)</source>
@@ -4457,7 +4457,7 @@
     </unit>
     <unit id="entryDialog.overCapTime">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:226,227</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:227,228</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
@@ -4465,7 +4465,7 @@
     </unit>
     <unit id="entryDialog.overCap">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:230,231</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:231,232</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> pro Eintrag</source>
@@ -4473,7 +4473,7 @@
     </unit>
     <unit id="exerciseSection.lastEntry">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:122,123</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:134,135</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -4481,7 +4481,7 @@
     </unit>
     <unit id="exerciseSection.last30d">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:133,135</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:143,145</note>
       </notes>
       <segment>
         <source>Letzte 30 Tage</source>
@@ -4489,7 +4489,7 @@
     </unit>
     <unit id="exerciseSection.add">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:143,145</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:153,155</note>
       </notes>
       <segment>
         <source>Hinzufügen</source>
@@ -4497,8 +4497,8 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:341</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:187</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:349</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:188</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:276</note>
       </notes>
       <segment>
@@ -4507,7 +4507,7 @@
     </unit>
     <unit id="exercise.category.abs">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:342</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:350</note>
       </notes>
       <segment>
         <source>Bauch</source>
@@ -4515,7 +4515,7 @@
     </unit>
     <unit id="exercise.category.legs">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:343</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:351</note>
       </notes>
       <segment>
         <source>Beine</source>
@@ -4523,16 +4523,24 @@
     </unit>
     <unit id="exercise.category.plank">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:344</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:352</note>
       </notes>
       <segment>
         <source>Plank</source>
       </segment>
     </unit>
+    <unit id="exercise.category.cardio">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:353</note>
+      </notes>
+      <segment>
+        <source>Ausdauer</source>
+      </segment>
+    </unit>
     <unit id="exercise.abs.situps.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:347</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:397</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:356</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:403</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:285</note>
       </notes>
       <segment>
@@ -4541,8 +4549,8 @@
     </unit>
     <unit id="exercise.legs.squats.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:348</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:399</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:357</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:405</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:286</note>
       </notes>
       <segment>
@@ -4551,17 +4559,27 @@
     </unit>
     <unit id="exercise.plank.standard.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:349</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:398</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:358</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:404</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:287</note>
       </notes>
       <segment>
         <source>Plank</source>
       </segment>
     </unit>
+    <unit id="exercise.cardio.running.name">
+      <notes>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:359</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:406</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:288</note>
+      </notes>
+      <segment>
+        <source>Laufen</source>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:354</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:364</note>
       </notes>
       <segment>
         <source>Eintrag hinzufügen</source>
@@ -4569,7 +4587,7 @@
     </unit>
     <unit id="exerciseSection.savedToast">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:355</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:365</note>
       </notes>
       <segment>
         <source>Eintrag gespeichert</source>
@@ -4577,7 +4595,7 @@
     </unit>
     <unit id="exerciseSection.dismiss">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:356</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:366</note>
       </notes>
       <segment>
         <source>OK</source>
@@ -4585,7 +4603,7 @@
     </unit>
     <unit id="exerciseSection.errorPrefix">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:357</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:367</note>
       </notes>
       <segment>
         <source>Konnte nicht gespeichert werden</source>
@@ -4593,7 +4611,7 @@
     </unit>
     <unit id="exerciseSection.genericError">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:358</note>
+        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:368</note>
       </notes>
       <segment>
         <source>Etwas ist schiefgelaufen</source>
@@ -5223,7 +5241,7 @@
     </unit>
     <unit id="colExercise">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:183</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:184</note>
       </notes>
       <segment>
         <source>Übung</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -4438,6 +4438,12 @@
         <source>Anleitung öffnen</source>
       <target>打开指南</target></segment>
     </unit>
+    <unit id="entryDialog.distance">
+      <segment state="translated">
+        <source>Distanz (km)</source>
+        <target>距离 (公里)</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.duration">
       <segment state="translated">
         <source>Dauer (mm:ss)</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -4462,6 +4462,18 @@
         <target>平板支撑</target>
       </segment>
     </unit>
+    <unit id="exercise.category.cardio">
+      <segment state="translated">
+        <source>Ausdauer</source>
+        <target>有氧运动</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.running.name">
+      <segment state="translated">
+        <source>Laufen</source>
+        <target>跑步</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -4438,6 +4438,30 @@
         <source>Anleitung öffnen</source>
       <target>打开指南</target></segment>
     </unit>
+    <unit id="entryDialog.duration">
+      <segment state="translated">
+        <source>Dauer (mm:ss)</source>
+        <target>时长 (mm:ss)</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapTime">
+      <segment state="translated">
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
+        <target>最大: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.plank">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>平板支撑</target>
+      </segment>
+    </unit>
+    <unit id="exercise.plank.standard.name">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>平板支撑</target>
+      </segment>
+    </unit>
     <unit id="entryDialog.variant">
       <segment state="translated">
         <source>Variante</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -4450,6 +4450,12 @@
         <target>时长 (mm:ss)</target>
       </segment>
     </unit>
+    <unit id="entryDialog.overCapDuration">
+      <segment state="translated">
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
+        <target>最长时长：<ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+      </segment>
+    </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>


### PR DESCRIPTION
## Summary

**Phase 1 — Plank** from `plans/multi-exercise-roadmap.md`. Stacked on #293 (`claude/unified-entry-dialog`). Brings the first non-reps measurement live end-to-end. Plank entries land in the same `exerciseEntries` collection but carry their primary value in `durationSec`.

## What changed

**Catalog + Firestore rule**

- New `plank` category and `plank.standard` catalog entry with `measurement: 'time'`, cap 1..7200 seconds.
- Firestore rule branches on `exerciseId`: reps-measured exercises keep their reps validation; `plank.standard` requires `durationSec` int 1..7200 and forbids `reps`/`sets`. The whitelist gained `durationSec`.

**UI**

- `EntryDialogComponent` grows a mm:ss input path. The form switches on `def.measurement`: time entries hide the sets row, parse `mm:ss` into seconds, clamp at `def.max`, and emit `{ measurement: 'time', durationSec }`. The result type gained a `measurement` discriminator so callers don't re-lookup the catalog.
- Section + StatsTable callers route results by measurement: reps payloads keep `reps + sets`, time payloads ship `durationSec`.
- Stats-table reps cell renders `durationSec` entries as `m:ss`; section totals format the 30-day sum in seconds for plank, reps for everything else.

**Cloud Function**

- `updateExerciseStatsOnEntryWrite` reads `durationSec` as a fallback for `reps` so the per-exercise `userStats` doc accumulates total seconds for plank. The aggregation slot stays named `reps` for back-compat with the existing `UserStats` schema; downstream display is exercise-aware.

**Misc**

- `ExerciseEntryUpdate.variantId` widened to `string | null` (with `null` as the `deleteField()` sentinel) so the validator and service stop rejecting variant-clearing patches.
- 4 new i18n keys (`entryDialog.duration`, `entryDialog.overCapTime`, `exercise.category.plank`, `exercise.plank.standard.name`) translated across all 9 locales.
- New `EntryDialog` tests cover the time-measurement path: malformed `mm:ss` input, edit-mode pre-fill, per-cap submit lock.

## Out of scope (deferred to follow-ups)

- Plank variants (Forearm / Side / Hollow Hold) — needs the autocomplete-with-wiki variant picker from UI-3 Phase B.
- Stopwatch UI in the dialog.
- Time-specific charts (Plank seconds on the Y-axis) — covered by Track UI-2 in the roadmap.
- Per-exercise streaks / best-hold metric (Phase 2).

## Test plan

- [x] `pnpm exec nx affected -t=lint,test,build -c=production --base=claude/unified-entry-dialog` — 8 projects green.
- [ ] Manual smoke: from the new Plank section on the dashboard, log a 1:30 entry, confirm it appears with the right `m:ss` formatting in the section total and on `/entries`.
- [ ] Manual smoke: edit that entry to 2:00 and confirm the dialog pre-fills `1:30`, accepts `2:00`, and persists.
- [ ] Manual smoke: try entering `90:00` (over the 2h cap) — confirm submit locks and the over-cap hint shows `120:00` as the limit.

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_019N9E4VxLvSHY4YS92b4sXq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added time-based exercise tracking (plank) with duration input in mm:ss format
  * Added distance-time composite exercise tracking (running) with distance in km and duration in mm:ss
  * Exercise entry dialog now supports measurements beyond reps, with measurement-specific validation
  * Statistics now display totals using appropriate measurement units (reps, duration, distance)

* **Documentation**
  * Added exercise measurement system documentation covering formats, units, and aggregation

* **Tests**
  * Added comprehensive test coverage for new exercise types and formatting utilities

* **Localization**
  * Added translations for new exercise categories and distance/duration fields across all supported languages

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/296)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->