### PR TITLE
feat(analysis): make Zeitraumfilter sticky while scrolling

### DIFF
--- a/web/src/app/app.scss
+++ b/web/src/app/app.scss
@@ -25,8 +25,15 @@ mat-card-content + mat-card-footer {
 }
 
 mat-sidenav-content {
-  // Toolbar height — drives the sticky offset for .desktop-nav so both stay in sync.
+  // Toolbar heights — drive sticky offsets for .desktop-nav and any
+  // page-level sticky element (e.g. the analysis filter bar) so they
+  // stay in sync if the nav layout changes.
   --top-nav-height: 64px;
+  --desktop-nav-height: 0px;
+
+  @media (min-width: 768px) {
+    --desktop-nav-height: 40px;
+  }
 
   height: 100svh;
   overflow: auto;

--- a/web/src/app/app.scss
+++ b/web/src/app/app.scss
@@ -161,6 +161,12 @@ mat-sidenav-content {
   display: none;
   @media (min-width: 768px) {
     display: flex;
+    align-items: center;
+    // Couple the actual rendered height to --desktop-nav-height so the
+    // variable is the single source of truth for sticky offset stacking
+    // (e.g. analysis page filter bar) and won't drift if typography or
+    // padding inside the nav links changes.
+    min-height: var(--desktop-nav-height);
     gap: 8px;
     padding-inline: max(16px, calc((100vw - 1200px) / 2));
     background: var(--mat-toolbar-container-background-color, #1e1e1e);

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -317,11 +317,14 @@ describe('AnalysisPageComponent', () => {
     expect(filterSection).toBeTruthy();
     const computed = window.getComputedStyle(filterSection as Element);
     expect(computed.position).toBe('sticky');
-    // The offset should reference the toolbar variables so the filter
-    // sits below the top nav (and desktop nav on >=768px viewports).
-    const stickyTop = computed.top;
-    expect(stickyTop).not.toBe('');
-    expect(stickyTop).not.toBe('auto');
+    // The sticky offset must derive from --top-nav-height +
+    // --desktop-nav-height so it stays in sync with the toolbar layout.
+    // jsdom returns the raw calc()/var() expression rather than resolving
+    // it to pixels, which is exactly what we want to verify here — a
+    // hardcoded magic number (e.g. `top: 64px`) would silently overlap or
+    // gap relative to the nav once the variables change.
+    expect(computed.top).toMatch(/var\(--top-nav-height/);
+    expect(computed.top).toMatch(/var\(--desktop-nav-height/);
   });
 
   it('includes avgSetsPerEntry in week and month trend', () => {

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -310,6 +310,20 @@ describe('AnalysisPageComponent', () => {
     expect(headerToggle?.tagName.toLowerCase()).toBe('mat-button-toggle-group');
   });
 
+  it('keeps the date range filter sticky so it stays visible while scrolling', () => {
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    const filterSection = host.querySelector('.filter-section');
+    expect(filterSection).toBeTruthy();
+    const computed = window.getComputedStyle(filterSection as Element);
+    expect(computed.position).toBe('sticky');
+    // The offset should reference the toolbar variables so the filter
+    // sits below the top nav (and desktop nav on >=768px viewports).
+    const stickyTop = computed.top;
+    expect(stickyTop).not.toBe('');
+    expect(stickyTop).not.toBe('auto');
+  });
+
   it('includes avgSetsPerEntry in week and month trend', () => {
     const { store } = fixture.componentInstance;
     const week = store.weekTrend();

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -340,7 +340,25 @@ import { PageHeaderComponent } from '../../core/page-header/page-header.componen
     }
 
     .filter-section {
-      margin-bottom: 16px;
+      position: sticky;
+      top: calc(var(--top-nav-height, 64px) + var(--desktop-nav-height, 0px));
+      z-index: 8;
+      margin-inline: -16px;
+      padding: 12px 16px;
+      background: var(--mat-sys-surface, #1e1e1e);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      backdrop-filter: blur(6px);
+    }
+
+    :host-context(html.light-theme) .filter-section {
+      border-bottom-color: rgba(148, 163, 184, 0.3);
+    }
+
+    @media (max-width: 900px) {
+      .filter-section {
+        margin-inline: -12px;
+        padding: 10px 12px;
+      }
     }
 
     .chart-card {

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -345,12 +345,22 @@ import { PageHeaderComponent } from '../../core/page-header/page-header.componen
       z-index: 8;
       margin-inline: -16px;
       padding: 12px 16px;
-      background: var(--mat-sys-surface, #1e1e1e);
+      background: color-mix(
+        in srgb,
+        var(--mat-sys-surface, #1e1e1e) 85%,
+        transparent
+      );
       border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      -webkit-backdrop-filter: blur(6px);
       backdrop-filter: blur(6px);
     }
 
     :host-context(html.light-theme) .filter-section {
+      background: color-mix(
+        in srgb,
+        var(--mat-sys-surface, #ffffff) 85%,
+        transparent
+      );
       border-bottom-color: rgba(148, 163, 184, 0.3);
     }
 


### PR DESCRIPTION
Pin the date range filter on the analysis page so it stays visible as
the user scrolls through the chart, trend tables, and heatmap. The
filter sticks below the top toolbar and (on \u2265768px) the desktop
nav, sourced via the existing --top-nav-height variable plus a new
--desktop-nav-height var so future sticky elements can stack the same
way.

https://claude.ai/code/session_019niQ4RfTRXMsj4usn9dBZd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter section in the analysis view is now sticky, remaining visible while scrolling
  * Enhanced visual styling with themed backgrounds, borders, and blur effects
  * Improved responsive design for mobile and desktop viewports

* **Tests**
  * Added unit tests to verify sticky filter positioning during scrolling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->