### PR TITLE
fix(dashboard): show rest day plan goal prominently in Zielfortschritt card

### DIFF
--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -190,6 +190,22 @@ export const DashboardStore = signalStore(
       () => store._trainingPlan.activeCatalog()?.totalDays ?? 0
     );
 
+    /** True when an active plan prescribes a rest day for today. The
+     *  Zielfortschritt card uses this to swap the X/Y count for a
+     *  highlighted "Ruhetag" badge — the plan goal trumps the user's
+     *  configured daily target on rest days. */
+    const isPlanRestDay = computed(
+      () => planActive() && planTodayKind() === 'rest'
+    );
+
+    /** The user's manually configured daily goal, independent of any
+     *  active plan override. Surfaced separately so the rest-day UI
+     *  can show it as a smaller secondary hint under the prominent
+     *  "Ruhetag" label. */
+    const userConfiguredDailyGoal = computed(() =>
+      store._userConfig.dailyGoal()
+    );
+
     const dailyGoal = computed(
       () => planTodayTarget() || store._userConfig.dailyGoal() || 10
     );
@@ -402,6 +418,8 @@ export const DashboardStore = signalStore(
       planTodayKind,
       planDayIndex,
       planTotalDays,
+      isPlanRestDay,
+      userConfiguredDailyGoal,
     };
   }),
   withMethods((store) => ({

--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -157,7 +157,7 @@
       </mat-card-header>
       <mat-card-content>
         @if (isPlanRestDay()) {
-          <div class="goal-row goal-row--rest">
+          <div class="goal-row">
             <small i18n="@@dashboard.dailyGoalLabel">Tag</small>
             <strong
               class="rest-day-badge"
@@ -286,7 +286,11 @@
           <span i18n="@@dashboard.quickAdd.button">+{{ reps }} Reps</span>
         </button>
       }
-      @if (dailyGoalConfigured() && (remainingToGoal() > 0 || goalReached())) {
+      @if (
+        !isPlanRestDay() &&
+        dailyGoalConfigured() &&
+        (remainingToGoal() > 0 || goalReached())
+      ) {
         <button
           type="button"
           mat-flat-button

--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -156,14 +156,43 @@
         </a>
       </mat-card-header>
       <mat-card-content>
-        <div class="goal-row">
-          <small i18n="@@dashboard.dailyGoalLabel">Tag</small>
-          <span>{{ todayTotal() }} / {{ dailyGoal() }}</span>
-        </div>
-        <mat-progress-bar
-          mode="determinate"
-          [value]="goalProgressPercent()"
-        ></mat-progress-bar>
+        @if (isPlanRestDay()) {
+          <div class="goal-row goal-row--rest">
+            <small i18n="@@dashboard.dailyGoalLabel">Tag</small>
+            <strong
+              class="rest-day-badge"
+              data-testid="dashboard-rest-day-target"
+            >
+              <mat-icon class="rest-day-badge-icon" aria-hidden="true"
+                >self_improvement</mat-icon
+              >
+              <span i18n="@@trainingPlans.kind.rest">Ruhetag</span>
+            </strong>
+          </div>
+          @if (userConfiguredDailyGoal() > 0) {
+            <p
+              class="rest-day-config-hint"
+              data-testid="dashboard-rest-day-config-hint"
+            >
+              <span i18n="@@dashboard.restDay.configuredGoalHint"
+                >Konfiguriertes Tagesziel:</span
+              >
+              <span class="rest-day-config-hint-value"
+                >{{ userConfiguredDailyGoal() }}
+                <span i18n="@@trainingPlans.reps">Wdh.</span></span
+              >
+            </p>
+          }
+        } @else {
+          <div class="goal-row">
+            <small i18n="@@dashboard.dailyGoalLabel">Tag</small>
+            <span>{{ todayTotal() }} / {{ dailyGoal() }}</span>
+          </div>
+          <mat-progress-bar
+            mode="determinate"
+            [value]="goalProgressPercent()"
+          ></mat-progress-bar>
+        }
 
         <div class="goal-row">
           <small i18n="@@dashboard.weeklyGoalLabel">Woche</small>

--- a/web/src/app/stats/shell/stats-dashboard.component.scss
+++ b/web/src/app/stats/shell/stats-dashboard.component.scss
@@ -357,6 +357,37 @@ h1 {
   }
 }
 
+.rest-day-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #b6e8d3;
+  background: rgba(72, 165, 124, 0.18);
+  border: 1px solid rgba(124, 207, 168, 0.4);
+}
+.rest-day-badge-icon {
+  font-size: 1.1rem;
+  width: 1.1rem;
+  height: 1.1rem;
+}
+.rest-day-config-hint {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 4px 0 0;
+  font-size: 0.78rem;
+  color: #9fb3de;
+  font-variant-numeric: tabular-nums;
+}
+.rest-day-config-hint-value {
+  color: #cddcf8;
+  font-weight: 600;
+}
+
 .mid-grid {
   display: grid;
   gap: 18px;
@@ -624,5 +655,17 @@ h1 {
 
   .motivational-quote {
     color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  }
+
+  .rest-day-badge {
+    color: #166534;
+    background: rgba(34, 197, 94, 0.12);
+    border-color: rgba(34, 197, 94, 0.35);
+  }
+  .rest-day-config-hint {
+    color: #475569;
+  }
+  .rest-day-config-hint-value {
+    color: #1e293b;
   }
 }

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -986,6 +986,28 @@ describe('StatsDashboardComponent', () => {
       ).toBeNull();
     });
 
+    it('And the Schnellaktionen "+N bis zum Ziel" CTA is suppressed so it does not contradict the rest-day banner', async () => {
+      // Given an active rest day with a non-zero configured daily goal
+      // (default mock has dailyGoal: 100, todayTotal: 12 → remainingToGoal
+      // would otherwise be 88, rendering the goal-fill CTA).
+      trainingPlanApiMock.getActivePlan.mockReturnValue(of(restDayPlan));
+      TestBed.inject(TrainingPlanStore).reload();
+
+      // When the dashboard renders
+      const freshFixture = TestBed.createComponent(StatsDashboardComponent);
+      await freshFixture.whenStable();
+      freshFixture.detectChanges();
+
+      // Then the goal-fill button is hidden — telling the user "fill
+      // to goal" while the Zielfortschritt card says "Ruhetag" would
+      // be contradictory guidance on the same screen.
+      expect(
+        freshFixture.nativeElement.querySelector(
+          '[data-testid="dashboard-quick-actions-goal-fill"]'
+        )
+      ).toBeNull();
+    });
+
     it('And on a non-rest plan day the Zielfortschritt card keeps the regular X / Y display', async () => {
       // Given today resolves to day 1 (a `main` day in recruit-6w-v1)
       trainingPlanApiMock.getActivePlan.mockReturnValue(

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -7,6 +7,7 @@ import {
   StatsApiService,
   UserConfigApiService,
   UserStatsApiService,
+  UserTrainingPlanApiService,
 } from '@pu-stats/data-access';
 import { AuthStore, UserContextService } from '@pu-auth/auth';
 import { AdsStore } from '@pu-stats/ads';
@@ -17,6 +18,7 @@ import { QuickAddOrchestrationService } from '../../core/quick-add-orchestration
 import { AppDataFacade } from '../../core/app-data.facade';
 import { ShareService } from '../../core/share.service';
 import { UserConfigStore } from '../../core/user-config.store';
+import { TrainingPlanStore } from '../../training-plans/training-plan.store';
 
 describe('StatsDashboardComponent', () => {
   let fixture: ComponentFixture<StatsDashboardComponent>;
@@ -113,6 +115,17 @@ describe('StatsDashboardComponent', () => {
   } as unknown as MatDialogRef<unknown>);
   const dialogMock = { open: dialogOpenSpy } as unknown as MatDialog;
 
+  // Default to "no active plan" — same effective behaviour as the
+  // unmocked service (Firestore is optional → resolves to null). Tests
+  // that exercise the plan-aware UI override `getActivePlan` per case.
+  const trainingPlanApiMock = {
+    getActivePlan: vitest.fn().mockReturnValue(of(null)),
+    setPlan: vitest.fn().mockReturnValue(of(null)),
+    addCompletedDay: vitest.fn().mockReturnValue(of(null)),
+    removeCompletedDay: vitest.fn().mockReturnValue(of(null)),
+    updatePlan: vitest.fn().mockReturnValue(of(null)),
+  };
+
   beforeEach(async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(frozenDate);
@@ -123,6 +136,7 @@ describe('StatsDashboardComponent', () => {
     window.history.replaceState({}, '', '/');
 
     dialogOpenSpy.mockClear();
+    trainingPlanApiMock.getActivePlan.mockReset().mockReturnValue(of(null));
 
     TestBed.configureTestingModule({
       imports: [StatsDashboardComponent],
@@ -171,6 +185,10 @@ describe('StatsDashboardComponent', () => {
         },
         { provide: AppDataFacade, useValue: appDataMock },
         { provide: ShareService, useValue: shareServiceMock },
+        {
+          provide: UserTrainingPlanApiService,
+          useValue: trainingPlanApiMock,
+        },
       ],
     });
 
@@ -886,6 +904,107 @@ describe('StatsDashboardComponent', () => {
         // Then - at minimum 1 day (today)
         expect(streak).toBeGreaterThanOrEqual(1);
       });
+    });
+  });
+
+  describe('Given an active training plan prescribes a rest day for today', () => {
+    // Frozen date is 2025-01-15 (see top of describe). The
+    // `recruit-6w-v1` catalog defines day 2 as a rest day, so
+    // `startDate: '2025-01-14'` puts today on a rest day.
+    const restDayPlan = {
+      userId: 'u1',
+      planId: 'recruit-6w-v1',
+      startDate: '2025-01-14',
+      status: 'active' as const,
+      completedDays: [] as number[],
+    };
+
+    function querySelector(
+      el: HTMLElement,
+      testid: string
+    ): HTMLElement | null {
+      return el.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+    }
+
+    it('Then the Zielfortschritt card shows "Ruhetag" instead of an X / Y count', async () => {
+      // Given an active plan with today as rest day
+      trainingPlanApiMock.getActivePlan.mockReturnValue(of(restDayPlan));
+      TestBed.inject(TrainingPlanStore).reload();
+
+      // When the dashboard renders
+      const freshFixture = TestBed.createComponent(StatsDashboardComponent);
+      await freshFixture.whenStable();
+      freshFixture.detectChanges();
+
+      // Then the rest-day badge is shown and the configured-goal hint
+      // sits below it as a small secondary line.
+      const component = freshFixture.componentInstance;
+      expect(component.isPlanRestDay()).toBe(true);
+
+      const badge = querySelector(
+        freshFixture.nativeElement,
+        'dashboard-rest-day-target'
+      );
+      expect(badge).not.toBeNull();
+      expect(badge!.textContent ?? '').toContain('Ruhetag');
+
+      const hint = querySelector(
+        freshFixture.nativeElement,
+        'dashboard-rest-day-config-hint'
+      );
+      expect(hint).not.toBeNull();
+      // Default mock config has dailyGoal: 100 — the configured goal
+      // must remain visible (smaller, below) so the user knows what
+      // their non-plan baseline is.
+      expect(hint!.textContent ?? '').toContain('100');
+    });
+
+    it('And the configured-goal hint is hidden when the user has no daily goal set', async () => {
+      // Given an active rest day AND a user config with dailyGoal=0
+      trainingPlanApiMock.getActivePlan.mockReturnValue(of(restDayPlan));
+      const configApi = TestBed.inject(UserConfigApiService);
+      (configApi.getConfig as ReturnType<typeof vitest.fn>).mockReturnValue(
+        of({ userId: 'u1', dailyGoal: 0, weeklyGoal: 0, monthlyGoal: 0 })
+      );
+      TestBed.inject(UserConfigStore).reload();
+      TestBed.inject(TrainingPlanStore).reload();
+
+      // When the dashboard renders
+      const freshFixture = TestBed.createComponent(StatsDashboardComponent);
+      await freshFixture.whenStable();
+      freshFixture.detectChanges();
+
+      // Then no stale "Konfiguriertes Tagesziel: 0" line bleeds through
+      expect(
+        querySelector(freshFixture.nativeElement, 'dashboard-rest-day-target')
+      ).not.toBeNull();
+      expect(
+        querySelector(
+          freshFixture.nativeElement,
+          'dashboard-rest-day-config-hint'
+        )
+      ).toBeNull();
+    });
+
+    it('And on a non-rest plan day the Zielfortschritt card keeps the regular X / Y display', async () => {
+      // Given today resolves to day 1 (a `main` day in recruit-6w-v1)
+      trainingPlanApiMock.getActivePlan.mockReturnValue(
+        of({ ...restDayPlan, startDate: '2025-01-15' })
+      );
+      TestBed.inject(TrainingPlanStore).reload();
+
+      // When the dashboard renders
+      const freshFixture = TestBed.createComponent(StatsDashboardComponent);
+      await freshFixture.whenStable();
+      freshFixture.detectChanges();
+
+      // Then the rest-day badge is NOT shown — the regular daily
+      // goal row is rendered instead.
+      const component = freshFixture.componentInstance;
+      expect(component.isPlanRestDay()).toBe(false);
+      expect(
+        querySelector(freshFixture.nativeElement, 'dashboard-rest-day-target')
+      ).toBeNull();
     });
   });
 });

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -113,6 +113,8 @@ export class StatsDashboardComponent {
   readonly planTodayKind = this.store.planTodayKind;
   readonly planDayIndex = this.store.planDayIndex;
   readonly planTotalDays = this.store.planTotalDays;
+  readonly isPlanRestDay = this.store.isPlanRestDay;
+  readonly userConfiguredDailyGoal = this.store.userConfiguredDailyGoal;
   private readonly trainingPlans = inject(TrainingPlanStore);
   /**
    * Only render the "no active plan" banner once the plan resource has

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -5435,6 +5435,12 @@
         <target>ημέρα</target>
       </segment>
     </unit>
+    <unit id="dashboard.restDay.configuredGoalHint">
+      <segment state="translated">
+        <source>Konfiguriertes Tagesziel:</source>
+        <target>Διαμορφωμένος ημερήσιος στόχος:</target>
+      </segment>
+    </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:130,131</note>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1277,6 +1277,12 @@ Active:         </target>
         <target>Day</target>
       </segment>
     </unit>
+    <unit id="dashboard.restDay.configuredGoalHint">
+      <segment state="translated">
+        <source>Konfiguriertes Tagesziel:</source>
+        <target>Your configured daily goal:</target>
+      </segment>
+    </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <segment state="translated">
         <source>Woche</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -5435,6 +5435,12 @@
         <target>día</target>
       </segment>
     </unit>
+    <unit id="dashboard.restDay.configuredGoalHint">
+      <segment state="translated">
+        <source>Konfiguriertes Tagesziel:</source>
+        <target>Objetivo diario configurado:</target>
+      </segment>
+    </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:130,131</note>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -5435,6 +5435,12 @@
         <target>jour</target>
       </segment>
     </unit>
+    <unit id="dashboard.restDay.configuredGoalHint">
+      <segment state="translated">
+        <source>Konfiguriertes Tagesziel:</source>
+        <target>Objectif quotidien configuré :</target>
+      </segment>
+    </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:130,131</note>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -5435,6 +5435,12 @@
         <target>giorno</target>
       </segment>
     </unit>
+    <unit id="dashboard.restDay.configuredGoalHint">
+      <segment state="translated">
+        <source>Konfiguriertes Tagesziel:</source>
+        <target>Obiettivo giornaliero configurato:</target>
+      </segment>
+    </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:130,131</note>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -5435,6 +5435,12 @@
         <target>die</target>
       </segment>
     </unit>
+    <unit id="dashboard.restDay.configuredGoalHint">
+      <segment state="translated">
+        <source>Konfiguriertes Tagesziel:</source>
+        <target>Propositum diei configuratum:</target>
+      </segment>
+    </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:130,131</note>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -5435,6 +5435,12 @@
         <target>dag</target>
       </segment>
     </unit>
+    <unit id="dashboard.restDay.configuredGoalHint">
+      <segment state="translated">
+        <source>Konfiguriertes Tagesziel:</source>
+        <target>Geconfigureerd dagdoel:</target>
+      </segment>
+    </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:130,131</note>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -1275,6 +1275,12 @@ Aktiv:         </target>
         <target>Dag</target>
       </segment>
     </unit>
+    <unit id="dashboard.restDay.configuredGoalHint">
+      <segment state="translated">
+        <source>Konfiguriertes Tagesziel:</source>
+        <target>Konfigurert dagsmål:</target>
+      </segment>
+    </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <segment state="translated">
         <source>Woche</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -182,8 +182,8 @@
     <unit id="auth.onboarding.google.username">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:8,11</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:211,213</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:215,217</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:234,236</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:238,240</note>
       </notes>
       <segment>
         <source>Benutzername</source>
@@ -192,8 +192,8 @@
     <unit id="auth.onboarding.google.goal">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:19,21</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:246,248</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:250,252</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:269,271</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:273,275</note>
       </notes>
       <segment>
         <source>Tagesziel</source>
@@ -202,8 +202,8 @@
     <unit id="auth.onboarding.google.consent.checkbox">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:36,39</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:285,287</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:296,298</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:308,310</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:319,321</note>
       </notes>
       <segment>
         <source>Einwilligung erteilen</source>
@@ -221,10 +221,10 @@
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:62,65</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:81,82</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:130,131</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:201,202</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:239,240</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:276,277</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:153,154</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:224,225</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:262,263</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:299,300</note>
       </notes>
       <segment>
         <source> Weiter </source>
@@ -233,7 +233,7 @@
     <unit id="cancel">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:67,69</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:330,331</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:277,278</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
@@ -304,8 +304,8 @@
     <unit id="auth.password">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:41,42</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:109,111</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:138,139</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:132,134</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:161,162</note>
       </notes>
       <segment>
         <source>Passwort</source>
@@ -330,15 +330,15 @@
     </unit>
     <unit id="auth.google.signin">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.html:88,90</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.html:111,113</note>
       </notes>
       <segment>
-        <source> Mit Google anmelden </source>
+        <source>Mit Google anmelden</source>
       </segment>
     </unit>
     <unit id="auth.register.noAccount">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.html:91,92</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.html:114,115</note>
       </notes>
       <segment>
         <source>Noch kein Account?</source>
@@ -346,7 +346,7 @@
     </unit>
     <unit id="2721806142807617942">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.html:93,94</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.html:116,117</note>
       </notes>
       <segment>
         <source> Registrieren </source>
@@ -454,15 +454,15 @@
     </unit>
     <unit id="auth.google.signup">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:93,94</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:116,118</note>
       </notes>
       <segment>
-        <source> Mit Google registrieren </source>
+        <source>Mit Google registrieren</source>
       </segment>
     </unit>
     <unit id="auth.register.google.skipPassword">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:113,115</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:136,138</note>
       </notes>
       <segment>
         <source> Passwort-Schritt übersprungen (Google Registrierung). </source>
@@ -470,11 +470,11 @@
     </unit>
     <unit id="auth.register.back">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:122,123</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:185,186</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:230,231</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:267,268</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:305,306</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:145,146</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:208,209</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:253,254</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:290,291</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:328,329</note>
       </notes>
       <segment>
         <source> Zurück</source>
@@ -482,7 +482,7 @@
     </unit>
     <unit id="auth.register.password.hint">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:162,164</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:185,187</note>
       </notes>
       <segment>
         <source> Mindestens 8 Zeichen, Groß- und Kleinbuchstaben, Zahl und Sonderzeichen. </source>
@@ -490,7 +490,7 @@
     </unit>
     <unit id="auth.register.password.repeat">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:170,172</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:193,195</note>
       </notes>
       <segment>
         <source>Passwort wiederholen</source>
@@ -498,7 +498,7 @@
     </unit>
     <unit id="auth.onboarding.google.consent.text">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:288,291</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:311,314</note>
       </notes>
       <segment>
         <source> Ich willige in die Datenverarbeitung zum Erheben technisch notwendiger Daten, statistischer Auswertungen und zum Ausspielen gezielter Werbung ein. </source>
@@ -506,7 +506,7 @@
     </unit>
     <unit id="auth.register.submit">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:322,323</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:345,346</note>
       </notes>
       <segment>
         <source> Registrieren </source>
@@ -3518,7 +3518,7 @@
     </unit>
     <unit id="landing.feature.pwa.installed">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:556,558</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:557,559</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">check_circle</pc> Du nutzt bereits die installierte App </source>
@@ -3526,7 +3526,7 @@
     </unit>
     <unit id="landing.feature.pwa.install">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:569,571</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:570,572</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">download</pc> Jetzt als App installieren </source>
@@ -3534,7 +3534,7 @@
     </unit>
     <unit id="landing.feature.pwa.iosHint">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:576,579</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:577,580</note>
       </notes>
       <segment>
         <source> Auf iPhone &amp; iPad: Teilen-Symbol antippen und „Zum Home-Bildschirm“ wählen. </source>
@@ -3542,7 +3542,7 @@
     </unit>
     <unit id="landing.feature.privacy.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:587,589</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:588,590</note>
       </notes>
       <segment>
         <source>Privacy first &amp; 100 % kostenlos</source>
@@ -3550,7 +3550,7 @@
     </unit>
     <unit id="landing.feature.privacy.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:591,595</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:592,596</note>
       </notes>
       <segment>
         <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
@@ -3558,7 +3558,7 @@
     </unit>
     <unit id="ads.landing.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:597</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:598</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -3566,7 +3566,7 @@
     </unit>
     <unit id="landing.preview.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:606,608</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:607,609</note>
       </notes>
       <segment>
         <source> Deine Statistik auf einen Blick </source>
@@ -3574,7 +3574,7 @@
     </unit>
     <unit id="landing.preview.alt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:613,614</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:614,615</note>
       </notes>
       <segment>
         <source>Vorschau der Statistikansicht</source>
@@ -3582,7 +3582,7 @@
     </unit>
     <unit id="landing.discover.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:754,755</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:755,756</note>
       </notes>
       <segment>
         <source>Mehr entdecken</source>
@@ -3590,7 +3590,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:760,762</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:761,763</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3598,7 +3598,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:764,767</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:765,768</note>
       </notes>
       <segment>
         <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
@@ -3606,7 +3606,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:774,777</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:775,778</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -3614,7 +3614,7 @@
     </unit>
     <unit id="landing.discover.blog.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:783,785</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:784,786</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3622,7 +3622,7 @@
     </unit>
     <unit id="landing.discover.blog.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:787,790</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:788,791</note>
       </notes>
       <segment>
         <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
@@ -3630,7 +3630,7 @@
     </unit>
     <unit id="landing.discover.blog.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:797,799</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:798,800</note>
       </notes>
       <segment>
         <source>Zum Blog</source>
@@ -5022,7 +5022,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:434</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:452</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Schau dir mein Profil an:</source>
@@ -5030,7 +5030,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:435</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:453</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
@@ -5038,7 +5038,7 @@
     </unit>
     <unit id="dashboard.share.text.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:439</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:457</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
@@ -5046,7 +5046,7 @@
     </unit>
     <unit id="dashboard.share.text.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:440</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:458</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
@@ -5054,7 +5054,7 @@
     </unit>
     <unit id="dashboard.share.title">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:444</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:462</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -5988,6 +5988,7 @@
     <unit id="trainingPlans.kind.rest">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:77,78</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:169,171</note>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:232,233</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:107,108</note>
       </notes>
@@ -6018,6 +6019,7 @@
     <unit id="trainingPlans.reps">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:85,87</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:182,184</note>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:245,246</note>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:251,252</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:125,127</note>
@@ -6093,15 +6095,24 @@
     </unit>
     <unit id="dashboard.dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:160,161</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:161,163</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:188,189</note>
       </notes>
       <segment>
         <source>Tag</source>
       </segment>
     </unit>
+    <unit id="dashboard.restDay.configuredGoalHint">
+      <notes>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:178,180</note>
+      </notes>
+      <segment>
+        <source>Konfiguriertes Tagesziel:</source>
+      </segment>
+    </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:169,170</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:198,199</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -6109,7 +6120,7 @@
     </unit>
     <unit id="dashboard.monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:178,179</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:207,208</note>
       </notes>
       <segment>
         <source>Monat</source>
@@ -6117,7 +6128,7 @@
     </unit>
     <unit id="dashboard.lastEntryLinkAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:203,204</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:232,233</note>
       </notes>
       <segment>
         <source>Letzten Eintrag in der Historie öffnen</source>
@@ -6125,7 +6136,7 @@
     </unit>
     <unit id="lastEntryTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:207,208</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:236,237</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -6133,7 +6144,7 @@
     </unit>
     <unit id="latEntryReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:212,214</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:241,243</note>
       </notes>
       <segment>
         <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ typeLabel(latest) }}"/> </source>
@@ -6141,7 +6152,7 @@
     </unit>
     <unit id="dashboard.noEntryYet">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:216,218</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:245,247</note>
       </notes>
       <segment>
         <source>Noch kein Eintrag.</source>
@@ -6149,7 +6160,7 @@
     </unit>
     <unit id="quickActionsTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:225,227</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:254,256</note>
       </notes>
       <segment>
         <source>Schnellaktionen</source>
@@ -6157,7 +6168,7 @@
     </unit>
     <unit id="quickActionsSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:228,230</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:257,259</note>
       </notes>
       <segment>
         <source>Schnell eintragen ohne Dialog</source>
@@ -6165,7 +6176,7 @@
     </unit>
     <unit id="quickActions.edit.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:235,236</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:264,265</note>
       </notes>
       <segment>
         <source>Schnellaktionen bearbeiten</source>
@@ -6173,7 +6184,7 @@
     </unit>
     <unit id="dashboard.quickAdd.button">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:257,258</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:286,287</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
@@ -6181,7 +6192,7 @@
     </unit>
     <unit id="dashboard.goalFill.reached">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:271,273</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:300,302</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -6189,7 +6200,7 @@
     </unit>
     <unit id="dashboard.goalFill.fill">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:274,275</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:303,304</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> bis zum Ziel</source>
@@ -6197,7 +6208,7 @@
     </unit>
     <unit id="quickAddNew">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:286,288</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:315,317</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">edit_note</pc> Neu </source>
@@ -6205,7 +6216,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:307,311</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:336,340</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -6213,7 +6224,7 @@
     </unit>
     <unit id="dashboard.latestEntriesLinkAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:318,319</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:347,348</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6221,7 +6232,7 @@
     </unit>
     <unit id="dashboard.latestEntries">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:321,322</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:350,351</note>
       </notes>
       <segment>
         <source>Letzte Einträge</source>
@@ -6229,7 +6240,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:328,329</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:357,358</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6237,7 +6248,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:332,335</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:361,364</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -6245,7 +6256,7 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:338</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:367</note>
       </notes>
       <segment>
         <source>Werbung</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -5987,6 +5987,12 @@
         <source>Tag</source>
       <target>天</target></segment>
     </unit>
+    <unit id="dashboard.restDay.configuredGoalHint">
+      <segment state="translated">
+        <source>Konfiguriertes Tagesziel:</source>
+        <target>已配置的每日目标：</target>
+      </segment>
+    </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:130,131</note>


### PR DESCRIPTION
When an active training plan prescribes a rest day, the daily-goal row
showed `X / configuredGoal` as if today still had a target — visually
identical to a regular training day. Replace the count with a
highlighted "Ruhetag" badge and surface the user's configured daily
goal as a smaller secondary hint below, so the plan's instruction is
the one that pops while the baseline goal stays visible for context.

The hint is hidden when no daily goal is configured (config = 0) so
the row doesn't read "Konfiguriertes Tagesziel: 0".