### PR TITLE
feat(analysis): compact mobile filter, move trends below, pie subset selection

### DIFF
--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -85,40 +85,6 @@ function sortedUniqueDates(rows: PushupRecord[]): string[] {
   );
 }
 
-function expandToWeekRange(
-  from: string,
-  to: string
-): { from: string; to: string } {
-  const fromDate = new Date(`${from}T00:00:00`);
-  const day = fromDate.getDay() || 7;
-  fromDate.setDate(fromDate.getDate() - (day - 1));
-
-  const toDate = new Date(`${to}T00:00:00`);
-  const toDay = toDate.getDay() || 7;
-  toDate.setDate(toDate.getDate() + (7 - toDay));
-
-  return {
-    from: toLocalIsoDate(fromDate),
-    to: toLocalIsoDate(toDate),
-  };
-}
-
-function expandToMonthRange(
-  from: string,
-  to: string
-): { from: string; to: string } {
-  const fromDate = new Date(`${from}T00:00:00`);
-  fromDate.setDate(1);
-
-  const toDate = new Date(`${to}T00:00:00`);
-  toDate.setMonth(toDate.getMonth() + 1, 0);
-
-  return {
-    from: toLocalIsoDate(fromDate),
-    to: toLocalIsoDate(toDate),
-  };
-}
-
 export const AnalysisStore = signalStore(
   withState<AnalysisState>(() => {
     const defaultRange = createWeekRange();
@@ -149,17 +115,32 @@ export const AnalysisStore = signalStore(
 
     const rangeMode = computed(() => inferRangeMode(store.from(), store.to()));
 
+    // Trends always span a fixed window ending today, independent of the
+    // page filter: 8 ISO weeks for weekTrend, 6 calendar months for
+    // monthTrend. This is intentional — users want to read recent
+    // momentum, not a slice of an arbitrary filter range.
     const weekFilter = computed(() => {
-      const from = store.from();
-      const to = store.to();
-      if (!from || !to) return { from, to };
-      return expandToWeekRange(from, to);
+      const today = new Date();
+      const day = today.getDay() || 7;
+      const monday = new Date(today);
+      monday.setDate(today.getDate() - (day - 1));
+      const sunday = new Date(monday);
+      sunday.setDate(monday.getDate() + 6);
+      const from = new Date(monday);
+      from.setDate(monday.getDate() - 7 * 7);
+      return {
+        from: toLocalIsoDate(from),
+        to: toLocalIsoDate(sunday),
+      };
     });
     const monthFilter = computed(() => {
-      const from = store.from();
-      const to = store.to();
-      if (!from || !to) return { from, to };
-      return expandToMonthRange(from, to);
+      const today = new Date();
+      const from = new Date(today.getFullYear(), today.getMonth() - 5, 1);
+      const to = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+      return {
+        from: toLocalIsoDate(from),
+        to: toLocalIsoDate(to),
+      };
     });
 
     return { filter, rangeMode, weekFilter, monthFilter };
@@ -273,7 +254,7 @@ export const AnalysisStore = signalStore(
       }
       return [...byMonth.entries()]
         .sort(([a], [b]) => a.localeCompare(b))
-        .slice(-12)
+        .slice(-6)
         .map(([label, { total, entryCount, setsCount }]) => ({
           label,
           total,
@@ -396,51 +377,6 @@ export const AnalysisStore = signalStore(
       return Math.max(...allSets);
     });
 
-    const weekTrendSubtitle = computed(() => {
-      const { from, to } = store.weekFilter();
-      if (!from || !to) return '';
-      const fromDate = new Date(`${from}T00:00:00`);
-      const toDate = new Date(`${to}T00:00:00`);
-      const sameYear = fromDate.getFullYear() === toDate.getFullYear();
-      const fmtFrom = new Intl.DateTimeFormat(store._locale, {
-        day: 'numeric',
-        month: 'short',
-        ...(sameYear ? {} : { year: 'numeric' }),
-      });
-      const fmtTo = new Intl.DateTimeFormat(store._locale, {
-        day: 'numeric',
-        month: 'short',
-        year: 'numeric',
-      });
-      return `${fmtFrom.format(fromDate)} – ${fmtTo.format(toDate)}`;
-    });
-
-    const monthTrendSubtitle = computed(() => {
-      const { from, to } = store.monthFilter();
-      if (!from || !to) return '';
-      const fromDate = new Date(`${from}T00:00:00`);
-      const toDate = new Date(`${to}T00:00:00`);
-      const sameMonth =
-        fromDate.getMonth() === toDate.getMonth() &&
-        fromDate.getFullYear() === toDate.getFullYear();
-      if (sameMonth) {
-        return new Intl.DateTimeFormat(store._locale, {
-          month: 'long',
-          year: 'numeric',
-        }).format(fromDate);
-      }
-      const sameYear = fromDate.getFullYear() === toDate.getFullYear();
-      const fmtFrom = new Intl.DateTimeFormat(store._locale, {
-        month: 'long',
-        ...(sameYear ? {} : { year: 'numeric' }),
-      });
-      const fmtTo = new Intl.DateTimeFormat(store._locale, {
-        month: 'long',
-        year: 'numeric',
-      });
-      return `${fmtFrom.format(fromDate)} – ${fmtTo.format(toDate)}`;
-    });
-
     return {
       stats,
       chartSeries,
@@ -448,8 +384,6 @@ export const AnalysisStore = signalStore(
       rows,
       weekTrend,
       monthTrend,
-      weekTrendSubtitle,
-      monthTrendSubtitle,
       typeBreakdown,
       bestSingleEntry,
       bestDay,

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -43,6 +43,8 @@ interface TrendPoint {
 }
 
 export interface TypeBreakdownDatum {
+  /** Canonical pushup type id — stable across locales. */
+  id: string;
   label: string;
   value: number;
   avgSetSize: number;
@@ -338,6 +340,7 @@ export const AnalysisStore = signalStore(
       return [...byType.entries()]
         .sort((a, b) => b[1].reps - a[1].reps)
         .map(([key, { reps, allSets }]) => ({
+          id: key,
           label: displayPushupType(key, store._locale),
           value: reps,
           avgSetSize: allSets.length

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -93,6 +93,24 @@ function sortedUniqueDates(rows: PushupRecord[]): string[] {
   );
 }
 
+const TREND_WEEKS = 8;
+const TREND_MONTHS = 6;
+
+/** Monday of the ISO week containing the given date (local time, midnight). */
+function startOfIsoWeek(date: Date): Date {
+  const day = date.getDay() || 7;
+  return new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate() - (day - 1)
+  );
+}
+
+/** First day of the calendar month containing the given date. */
+function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
 export const AnalysisStore = signalStore(
   withState<AnalysisState>(() => {
     const defaultRange = createWeekRange();
@@ -101,7 +119,11 @@ export const AnalysisStore = signalStore(
       to: defaultRange.to,
       dayChartMode: undefined as '24h' | '14h' | undefined,
       clockTick: 0,
-      lastDayKey: '',
+      // Seed with today so the first `tickClock()` after construction is a
+      // no-op; otherwise the 5-minute polling interval would force a
+      // spurious reload of weekEntriesResource/monthEntriesResource on
+      // its first iteration even when the calendar day hasn't changed.
+      lastDayKey: toLocalIsoDate(new Date()),
     };
   }),
   withProps(() => {
@@ -131,33 +153,48 @@ export const AnalysisStore = signalStore(
     // momentum, not a slice of an arbitrary filter range. The
     // `clockTick` signal is read so a session kept open across midnight
     // re-evaluates the window when `tickClock()` fires.
-    const weekFilter = computed(() => {
+    const currentMonday = computed(() => {
       store.clockTick();
-      const today = new Date();
-      const day = today.getDay() || 7;
-      const monday = new Date(today);
-      monday.setDate(today.getDate() - (day - 1));
+      return startOfIsoWeek(new Date());
+    });
+    const currentMonthStart = computed(() => {
+      store.clockTick();
+      return startOfMonth(new Date());
+    });
+
+    const weekFilter = computed(() => {
+      const monday = currentMonday();
       const sunday = new Date(monday);
       sunday.setDate(monday.getDate() + 6);
       const from = new Date(monday);
-      from.setDate(monday.getDate() - 7 * 7);
+      from.setDate(monday.getDate() - 7 * (TREND_WEEKS - 1));
       return {
         from: toLocalIsoDate(from),
         to: toLocalIsoDate(sunday),
       };
     });
     const monthFilter = computed(() => {
-      store.clockTick();
-      const today = new Date();
-      const from = new Date(today.getFullYear(), today.getMonth() - 5, 1);
-      const to = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+      const start = currentMonthStart();
+      const from = new Date(
+        start.getFullYear(),
+        start.getMonth() - (TREND_MONTHS - 1),
+        1
+      );
+      const to = new Date(start.getFullYear(), start.getMonth() + 1, 0);
       return {
         from: toLocalIsoDate(from),
         to: toLocalIsoDate(to),
       };
     });
 
-    return { filter, rangeMode, weekFilter, monthFilter };
+    return {
+      filter,
+      rangeMode,
+      weekFilter,
+      monthFilter,
+      currentMonday,
+      currentMonthStart,
+    };
   }),
   withProps((store) => {
     const statsResource = resource({
@@ -216,22 +253,15 @@ export const AnalysisStore = signalStore(
 
     const weekRows = computed(() => store.weekEntriesResource.value() ?? []);
     const weekTrend = computed<TrendPoint[]>(() => {
-      // Pre-seed the last 8 ISO weeks (oldest → newest) so a sparse
+      // Pre-seed TREND_WEEKS ISO weeks (oldest → newest) so a sparse
       // history still produces a fixed-length trend with explicit zero
       // rows; otherwise users would silently see fewer than 8 buckets.
-      store.clockTick();
-      const today = new Date();
-      const day = today.getDay() || 7;
-      const monday = new Date(
-        today.getFullYear(),
-        today.getMonth(),
-        today.getDate() - (day - 1)
-      );
+      const monday = store.currentMonday();
       const byWeek = new Map<
         string,
         { total: number; entryCount: number; setsCount: number }
       >();
-      for (let i = 7; i >= 0; i--) {
+      for (let i = TREND_WEEKS - 1; i >= 0; i--) {
         const d = new Date(monday);
         d.setDate(monday.getDate() - i * 7);
         const key = `${isoWeekYear(d)}-W${String(isoWeek(d)).padStart(2, '0')}`;
@@ -259,14 +289,17 @@ export const AnalysisStore = signalStore(
 
     const monthRows = computed(() => store.monthEntriesResource.value() ?? []);
     const monthTrend = computed<TrendPoint[]>(() => {
-      store.clockTick();
-      const today = new Date();
+      const monthStart = store.currentMonthStart();
       const byMonth = new Map<
         string,
         { total: number; entryCount: number; setsCount: number }
       >();
-      for (let i = 5; i >= 0; i--) {
-        const d = new Date(today.getFullYear(), today.getMonth() - i, 1);
+      for (let i = TREND_MONTHS - 1; i >= 0; i--) {
+        const d = new Date(
+          monthStart.getFullYear(),
+          monthStart.getMonth() - i,
+          1
+        );
         const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
         byMonth.set(key, { total: 0, entryCount: 0, setsCount: 0 });
       }

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -52,10 +52,14 @@ type AnalysisState = {
   from: string;
   to: string;
   dayChartMode: '24h' | '14h' | undefined;
-  // Reactive dependency for the fixed-window trend filters: bumping
-  // this signal re-evaluates `weekFilter`/`monthFilter` so a session
-  // kept open across midnight doesn't render a stale window.
+  // Reactive dependency for the fixed-window trend filters: bumped only
+  // when the local calendar day actually changes, so a polling interval
+  // can call `tickClock()` aggressively without forcing
+  // `weekFilter`/`monthFilter` to emit new params each minute (which would
+  // otherwise re-trigger the trend resource loaders and flicker the empty
+  // CTA back to false during the reload).
   clockTick: number;
+  lastDayKey: string;
 };
 
 function isoWeek(date: Date): number {
@@ -97,6 +101,7 @@ export const AnalysisStore = signalStore(
       to: defaultRange.to,
       dayChartMode: undefined as '24h' | '14h' | undefined,
       clockTick: 0,
+      lastDayKey: '',
     };
   }),
   withProps(() => {
@@ -247,7 +252,7 @@ export const AnalysisStore = signalStore(
           total,
           avgSetsPerEntry: entryCount
             ? Math.round((setsCount / entryCount) * 10) / 10
-            : 0,
+            : undefined,
         })
       );
     });
@@ -280,7 +285,7 @@ export const AnalysisStore = signalStore(
           total,
           avgSetsPerEntry: entryCount
             ? Math.round((setsCount / entryCount) * 10) / 10
-            : 0,
+            : undefined,
         })
       );
     });
@@ -439,7 +444,12 @@ export const AnalysisStore = signalStore(
       store.monthEntriesResource.reload();
     },
     tickClock(): void {
-      patchState(store, { clockTick: store.clockTick() + 1 });
+      const todayKey = toLocalIsoDate(new Date());
+      if (todayKey === store.lastDayKey()) return;
+      patchState(store, {
+        clockTick: store.clockTick() + 1,
+        lastDayKey: todayKey,
+      });
     },
   }))
 );

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -52,6 +52,10 @@ type AnalysisState = {
   from: string;
   to: string;
   dayChartMode: '24h' | '14h' | undefined;
+  // Reactive dependency for the fixed-window trend filters: bumping
+  // this signal re-evaluates `weekFilter`/`monthFilter` so a session
+  // kept open across midnight doesn't render a stale window.
+  clockTick: number;
 };
 
 function isoWeek(date: Date): number {
@@ -92,6 +96,7 @@ export const AnalysisStore = signalStore(
       from: defaultRange.from,
       to: defaultRange.to,
       dayChartMode: undefined as '24h' | '14h' | undefined,
+      clockTick: 0,
     };
   }),
   withProps(() => {
@@ -118,8 +123,11 @@ export const AnalysisStore = signalStore(
     // Trends always span a fixed window ending today, independent of the
     // page filter: 8 ISO weeks for weekTrend, 6 calendar months for
     // monthTrend. This is intentional — users want to read recent
-    // momentum, not a slice of an arbitrary filter range.
+    // momentum, not a slice of an arbitrary filter range. The
+    // `clockTick` signal is read so a session kept open across midnight
+    // re-evaluates the window when `tickClock()` fires.
     const weekFilter = computed(() => {
+      store.clockTick();
       const today = new Date();
       const day = today.getDay() || 7;
       const monday = new Date(today);
@@ -134,6 +142,7 @@ export const AnalysisStore = signalStore(
       };
     });
     const monthFilter = computed(() => {
+      store.clockTick();
       const today = new Date();
       const from = new Date(today.getFullYear(), today.getMonth() - 5, 1);
       const to = new Date(today.getFullYear(), today.getMonth() + 1, 0);
@@ -202,66 +211,78 @@ export const AnalysisStore = signalStore(
 
     const weekRows = computed(() => store.weekEntriesResource.value() ?? []);
     const weekTrend = computed<TrendPoint[]>(() => {
+      // Pre-seed the last 8 ISO weeks (oldest → newest) so a sparse
+      // history still produces a fixed-length trend with explicit zero
+      // rows; otherwise users would silently see fewer than 8 buckets.
+      store.clockTick();
+      const today = new Date();
+      const day = today.getDay() || 7;
+      const monday = new Date(
+        today.getFullYear(),
+        today.getMonth(),
+        today.getDate() - (day - 1)
+      );
       const byWeek = new Map<
         string,
         { total: number; entryCount: number; setsCount: number }
       >();
+      for (let i = 7; i >= 0; i--) {
+        const d = new Date(monday);
+        d.setDate(monday.getDate() - i * 7);
+        const key = `${isoWeekYear(d)}-W${String(isoWeek(d)).padStart(2, '0')}`;
+        byWeek.set(key, { total: 0, entryCount: 0, setsCount: 0 });
+      }
       for (const row of weekRows()) {
         const date = new Date(row.timestamp);
-        const year = isoWeekYear(date);
-        const week = String(isoWeek(date)).padStart(2, '0');
-        const key = `${year}-W${week}`;
-        const entry = byWeek.get(key) ?? {
-          total: 0,
-          entryCount: 0,
-          setsCount: 0,
-        };
+        const key = `${isoWeekYear(date)}-W${String(isoWeek(date)).padStart(2, '0')}`;
+        const entry = byWeek.get(key);
+        if (!entry) continue;
         entry.total += row.reps;
         entry.entryCount += 1;
         entry.setsCount += row.sets?.length ?? 0;
-        byWeek.set(key, entry);
       }
-      return [...byWeek.entries()]
-        .sort(([a], [b]) => a.localeCompare(b))
-        .slice(-8)
-        .map(([label, { total, entryCount, setsCount }]) => ({
+      return [...byWeek.entries()].map(
+        ([label, { total, entryCount, setsCount }]) => ({
           label,
           total,
           avgSetsPerEntry: entryCount
             ? Math.round((setsCount / entryCount) * 10) / 10
             : 0,
-        }));
+        })
+      );
     });
 
     const monthRows = computed(() => store.monthEntriesResource.value() ?? []);
     const monthTrend = computed<TrendPoint[]>(() => {
+      store.clockTick();
+      const today = new Date();
       const byMonth = new Map<
         string,
         { total: number; entryCount: number; setsCount: number }
       >();
+      for (let i = 5; i >= 0; i--) {
+        const d = new Date(today.getFullYear(), today.getMonth() - i, 1);
+        const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+        byMonth.set(key, { total: 0, entryCount: 0, setsCount: 0 });
+      }
       for (const row of monthRows()) {
         const date = new Date(row.timestamp);
-        const label = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-        const entry = byMonth.get(label) ?? {
-          total: 0,
-          entryCount: 0,
-          setsCount: 0,
-        };
+        const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+        const entry = byMonth.get(key);
+        if (!entry) continue;
         entry.total += row.reps;
         entry.entryCount += 1;
         entry.setsCount += row.sets?.length ?? 0;
-        byMonth.set(label, entry);
       }
-      return [...byMonth.entries()]
-        .sort(([a], [b]) => a.localeCompare(b))
-        .slice(-6)
-        .map(([label, { total, entryCount, setsCount }]) => ({
+      return [...byMonth.entries()].map(
+        ([label, { total, entryCount, setsCount }]) => ({
           label,
           total,
           avgSetsPerEntry: entryCount
             ? Math.round((setsCount / entryCount) * 10) / 10
             : 0,
-        }));
+        })
+      );
     });
 
     const typeBreakdown = computed<TypeBreakdownDatum[]>(() => {
@@ -416,6 +437,9 @@ export const AnalysisStore = signalStore(
       store.userStatsResource.reload();
       store.weekEntriesResource.reload();
       store.monthEntriesResource.reload();
+    },
+    tickClock(): void {
+      patchState(store, { clockTick: store.clockTick() + 1 });
     },
   }))
 );

--- a/web/src/app/stats/components/filter-bar/filter-bar.component.scss
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.scss
@@ -67,7 +67,7 @@ mat-form-field {
     padding: 0;
     margin: -1px;
     overflow: hidden;
-    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
     white-space: nowrap;
     border: 0;
   }

--- a/web/src/app/stats/components/filter-bar/filter-bar.component.scss
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.scss
@@ -1,3 +1,7 @@
+:host {
+  display: block;
+}
+
 .controls {
   display: grid;
   gap: 14px;
@@ -18,8 +22,69 @@
 .step-actions {
   display: flex;
   gap: 8px;
+  align-items: center;
+}
+
+.step-icon-mobile {
+  display: none;
+}
+
+.picker-toggle {
+  display: none;
 }
 
 mat-form-field {
   width: min(560px, 100%);
+}
+
+@media (max-width: 600px) {
+  .heading {
+    display: none;
+  }
+
+  .controls {
+    gap: 8px;
+  }
+
+  .quick-range {
+    gap: 6px;
+    justify-content: space-between;
+  }
+
+  .step-actions {
+    gap: 2px;
+  }
+
+  .step-btn {
+    min-width: 0;
+    padding: 0 8px;
+  }
+
+  .step-btn--today .step-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .step-btn--today .step-icon-mobile {
+    display: inline-block;
+  }
+
+  .picker-toggle {
+    display: inline-flex;
+  }
+
+  .date-picker-field {
+    display: none;
+  }
+
+  :host(.picker-expanded) .date-picker-field {
+    display: block;
+  }
 }

--- a/web/src/app/stats/components/filter-bar/filter-bar.component.scss
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.scss
@@ -3,25 +3,44 @@
 }
 
 .controls {
-  display: grid;
-  gap: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 16px;
+}
+
+// "Zeitraum auswählen" is visually hidden but kept in the DOM so screen
+// readers and existing snapshot/textContent assertions still see it. The
+// surrounding analysis page header already provides visual context, so
+// the heading takes no vertical space on any viewport.
+.heading {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .heading h2 {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 1rem;
 }
 
 .quick-range {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
+  flex: 0 0 auto;
 }
 
 .step-actions {
   display: flex;
-  gap: 8px;
+  gap: 6px;
   align-items: center;
 }
 
@@ -33,22 +52,21 @@
   display: none;
 }
 
-mat-form-field {
-  width: min(560px, 100%);
+.date-picker-field {
+  width: min(320px, 100%);
+  flex: 1 1 240px;
+  margin-left: auto;
 }
 
 @media (max-width: 600px) {
-  .heading {
-    display: none;
-  }
-
   .controls {
-    gap: 8px;
+    gap: 6px;
   }
 
   .quick-range {
     gap: 6px;
     justify-content: space-between;
+    width: 100%;
   }
 
   .step-actions {
@@ -82,6 +100,9 @@ mat-form-field {
 
   .date-picker-field {
     display: none;
+    margin-left: 0;
+    width: 100%;
+    flex: 1 1 auto;
   }
 
   :host(.picker-expanded) .date-picker-field {

--- a/web/src/app/stats/components/filter-bar/filter-bar.component.ts
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.ts
@@ -73,7 +73,7 @@ import {
             class="step-btn"
             [disabled]="mode() === 'custom'"
             (click)="shiftRange(-1)"
-            aria-label="Zurück"
+            aria-label="Vorheriger Zeitraum"
             i18n-aria-label="@@rangeBackAria"
           >
             <mat-icon>chevron_left</mat-icon>
@@ -85,7 +85,7 @@ import {
             class="step-btn step-btn--today"
             [disabled]="mode() === 'custom'"
             (click)="jumpToToday()"
-            aria-label="Heute"
+            aria-label="Zum heutigen Zeitraum springen"
             i18n-aria-label="@@rangeTodayAria"
           >
             <mat-icon class="step-icon-mobile">today</mat-icon>
@@ -97,7 +97,7 @@ import {
             class="step-btn"
             [disabled]="mode() === 'custom'"
             (click)="shiftRange(1)"
-            aria-label="Vor"
+            aria-label="Nächster Zeitraum"
             i18n-aria-label="@@rangeForwardAria"
           >
             <span class="step-label" i18n="@@rangeForward">Vor</span>

--- a/web/src/app/stats/components/filter-bar/filter-bar.component.ts
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.ts
@@ -117,7 +117,11 @@ import {
         </div>
       </section>
 
-      <mat-form-field class="date-picker-field" appearance="outline">
+      <mat-form-field
+        class="date-picker-field"
+        appearance="outline"
+        subscriptSizing="dynamic"
+      >
         <mat-label i18n="@@rangeLabel">Zeitraum</mat-label>
         <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
           <input

--- a/web/src/app/stats/components/filter-bar/filter-bar.component.ts
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.ts
@@ -34,6 +34,9 @@ import {
     MatIconModule,
     ReactiveFormsModule,
   ],
+  host: {
+    '[class.picker-expanded]': 'datePickerExpanded()',
+  },
   template: `
     <section class="controls">
       <div class="heading">
@@ -67,36 +70,54 @@ import {
           <button
             type="button"
             mat-stroked-button
+            class="step-btn"
             [disabled]="mode() === 'custom'"
             (click)="shiftRange(-1)"
-            i18n="@@rangeBack"
+            aria-label="Zurück"
+            i18n-aria-label="@@rangeBackAria"
           >
             <mat-icon>chevron_left</mat-icon>
-            Zurück
+            <span class="step-label" i18n="@@rangeBack">Zurück</span>
           </button>
           <button
             type="button"
             mat-stroked-button
+            class="step-btn step-btn--today"
             [disabled]="mode() === 'custom'"
             (click)="jumpToToday()"
-            i18n="@@rangeToday"
+            aria-label="Heute"
+            i18n-aria-label="@@rangeTodayAria"
           >
-            Heute
+            <mat-icon class="step-icon-mobile">today</mat-icon>
+            <span class="step-label" i18n="@@rangeToday">Heute</span>
           </button>
           <button
             type="button"
             mat-stroked-button
+            class="step-btn"
             [disabled]="mode() === 'custom'"
             (click)="shiftRange(1)"
-            i18n="@@rangeForward"
+            aria-label="Vor"
+            i18n-aria-label="@@rangeForwardAria"
           >
-            Vor
+            <span class="step-label" i18n="@@rangeForward">Vor</span>
             <mat-icon>chevron_right</mat-icon>
+          </button>
+          <button
+            type="button"
+            mat-icon-button
+            class="picker-toggle"
+            (click)="toggleDatePicker()"
+            [attr.aria-expanded]="datePickerExpanded()"
+            aria-label="Eigenen Zeitraum auswählen"
+            i18n-aria-label="@@rangePickerToggleAria"
+          >
+            <mat-icon>date_range</mat-icon>
           </button>
         </div>
       </section>
 
-      <mat-form-field appearance="outline">
+      <mat-form-field class="date-picker-field" appearance="outline">
         <mat-label i18n="@@rangeLabel">Zeitraum</mat-label>
         <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
           <input
@@ -128,6 +149,8 @@ export class FilterBarComponent implements OnChanges {
 
   private readonly hasUserModeOverride = signal(false);
   private readonly inferredModeSource = signal<RangeModes>('week');
+
+  readonly datePickerExpanded = signal(false);
 
   readonly fromChange = output<string>();
   readonly toChange = output<string>();
@@ -224,6 +247,10 @@ export class FilterBarComponent implements OnChanges {
   jumpToToday(): void {
     if (this.mode() === 'custom') return;
     this.applyModeRange(new Date());
+  }
+
+  toggleDatePicker(): void {
+    this.datePickerExpanded.update((value) => !value);
   }
 
   private inferMode(start: Date | null, end: Date | null): RangeModes {

--- a/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
@@ -1,0 +1,95 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TypePieComponent, PieDatum } from './type-pie.component';
+
+describe('TypePieComponent', () => {
+  let fixture: ComponentFixture<TypePieComponent>;
+  let component: TypePieComponent;
+
+  const sevenTypes: PieDatum[] = [
+    { label: 'Standard', value: 100 },
+    { label: 'Diamond', value: 80 },
+    { label: 'Wide', value: 60 },
+    { label: 'Decline', value: 40 },
+    { label: 'Knee', value: 30 },
+    { label: 'Spider', value: 20 },
+    { label: 'Clap', value: 10 },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TypePieComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TypePieComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('data', sevenTypes);
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('defaults to Top 5 mode and selects the five highest-value labels', () => {
+    expect(component.mode()).toBe('top5');
+    const selected = [...component.selectedLabels()];
+    expect(selected).toEqual([
+      'Standard',
+      'Diamond',
+      'Wide',
+      'Decline',
+      'Knee',
+    ]);
+    expect(component.visibleSegments()).toHaveLength(5);
+  });
+
+  it('switches to Alle mode when toggled, selecting every label', () => {
+    component.setMode('all');
+    expect(component.selectedLabels().size).toBe(7);
+    expect(component.visibleSegments()).toHaveLength(7);
+  });
+
+  it('toggling a checkbox switches mode to custom and updates the subset', () => {
+    component.toggle('Diamond');
+
+    expect(component.mode()).toBe('custom');
+    expect(component.isSelected('Diamond')).toBe(false);
+    expect(component.isSelected('Standard')).toBe(true);
+    // Re-toggling re-selects.
+    component.toggle('Diamond');
+    expect(component.isSelected('Diamond')).toBe(true);
+  });
+
+  it('renders one legend row with checkbox per type, regardless of mode', () => {
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    const rows = host.querySelectorAll(
+      '[data-testid="type-pie-legend"] mat-checkbox'
+    );
+    expect(rows).toHaveLength(7);
+  });
+
+  it('exposes toggle hooks per label so the legend can drive subset selection', () => {
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    const standard = host.querySelector(
+      '[data-testid="type-pie-toggle-Standard"]'
+    );
+    expect(standard).toBeTruthy();
+  });
+
+  it('shows the empty placeholder when total is zero', () => {
+    fixture.componentRef.setInput('data', [
+      { label: 'A', value: 0 },
+      { label: 'B', value: 0 },
+    ]);
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.textContent).toContain('Keine Daten');
+  });
+
+  it('keeps stable colors per index sorted by descending value', () => {
+    const segments = component.allSegments();
+    expect(segments[0].label).toBe('Standard');
+    expect(segments[0].color).toBe('#1976d2');
+    expect(segments[1].label).toBe('Diamond');
+    expect(segments[1].color).toBe('#9c27b0');
+  });
+});

--- a/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
@@ -30,26 +30,31 @@ describe('TypePieComponent', () => {
     fixture.detectChanges();
   });
 
-  it('defaults to Top 5 mode and selects the five highest-value labels', () => {
+  it('defaults to Top 5 mode and selects the five highest-value ids', () => {
     // Then
     expect(component.mode()).toBe('top5');
-    expect([...component.selectedLabels()]).toEqual([
+    expect([...component.selectedIds()]).toEqual([
       'Standard',
       'Diamond',
       'Wide',
       'Decline',
       'Knee',
     ]);
-    expect(component.visibleSegments()).toHaveLength(5);
+    // 5 selected + an explicit "Other" arc covering the unselected
+    // remainder so the rendered pie always reads as a complete circle.
+    expect(component.visibleSegments()).toHaveLength(6);
+    expect(component.visibleSegments().at(-1)?.id).toBe('__other__');
+    expect(component.otherPercent()).toBeGreaterThan(0);
   });
 
-  it('switches to Alle mode when toggled, selecting every label', () => {
+  it('switches to Alle mode when toggled, selecting every id and dropping the Other arc', () => {
     // When
     component.setMode('all');
 
     // Then
-    expect(component.selectedLabels().size).toBe(7);
+    expect(component.selectedIds().size).toBe(7);
     expect(component.visibleSegments()).toHaveLength(7);
+    expect(component.otherPercent()).toBe(0);
   });
 
   it('toggling a checkbox switches mode to custom and updates the subset', () => {
@@ -90,16 +95,37 @@ describe('TypePieComponent', () => {
     // When: switching directly from Top 5 to custom
     component.setMode('custom');
 
-    // Then: the top-5 selection is preserved instead of starting empty
+    // Then: the top-5 selection is preserved instead of starting empty,
+    // and the Other arc still completes the circle.
     expect(component.mode()).toBe('custom');
-    expect([...component.selectedLabels()]).toEqual([
+    expect([...component.selectedIds()]).toEqual([
       'Standard',
       'Diamond',
       'Wide',
       'Decline',
       'Knee',
     ]);
-    expect(component.visibleSegments()).toHaveLength(5);
+    expect(component.visibleSegments()).toHaveLength(6);
+    expect(component.visibleSegments().at(-1)?.id).toBe('__other__');
+  });
+
+  it('uses the stable id (not the localized label) for selection and test selectors', () => {
+    // Given: data whose label simulates a localized display name
+    fixture.componentRef.setInput('data', [
+      { id: 'standard', label: 'Standard-Liegestütze', value: 50 },
+      { id: 'diamond', label: 'Diamant-Liegestütze', value: 30 },
+    ]);
+    fixture.detectChanges();
+
+    // Then: selection is keyed by id; data-testids carry the canonical id
+    expect([...component.selectedIds()]).toEqual(['standard', 'diamond']);
+    const host: HTMLElement = fixture.nativeElement;
+    expect(
+      host.querySelector('[data-testid="type-pie-toggle-standard"]')
+    ).toBeTruthy();
+    expect(
+      host.querySelector('[data-testid="type-pie-toggle-diamond"]')
+    ).toBeTruthy();
   });
 
   it('switching from Alle to Auswahl seeds custom selection with every label', () => {
@@ -108,7 +134,7 @@ describe('TypePieComponent', () => {
     component.setMode('custom');
 
     // Then
-    expect(component.selectedLabels().size).toBe(7);
+    expect(component.selectedIds().size).toBe(7);
   });
 
   it('renders one legend row with checkbox per type, regardless of mode', () => {

--- a/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
@@ -1,4 +1,6 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { TypePieComponent, PieDatum } from './type-pie.component';
 
 describe('TypePieComponent', () => {
@@ -16,6 +18,7 @@ describe('TypePieComponent', () => {
   ];
 
   beforeEach(async () => {
+    // Given: a TypePieComponent rendered with 7 types ordered by descending value.
     await TestBed.configureTestingModule({
       imports: [TypePieComponent],
     }).compileComponents();
@@ -28,9 +31,9 @@ describe('TypePieComponent', () => {
   });
 
   it('defaults to Top 5 mode and selects the five highest-value labels', () => {
+    // Then
     expect(component.mode()).toBe('top5');
-    const selected = [...component.selectedLabels()];
-    expect(selected).toEqual([
+    expect([...component.selectedLabels()]).toEqual([
       'Standard',
       'Diamond',
       'Wide',
@@ -41,44 +44,53 @@ describe('TypePieComponent', () => {
   });
 
   it('switches to Alle mode when toggled, selecting every label', () => {
+    // When
     component.setMode('all');
+
+    // Then
     expect(component.selectedLabels().size).toBe(7);
     expect(component.visibleSegments()).toHaveLength(7);
   });
 
   it('toggling a checkbox switches mode to custom and updates the subset', () => {
+    // When: Diamond is toggled
     component.toggle('Diamond');
 
+    // Then: mode flips to custom and Diamond drops out
     expect(component.mode()).toBe('custom');
     expect(component.isSelected('Diamond')).toBe(false);
     expect(component.isSelected('Standard')).toBe(true);
-    // Re-toggling re-selects.
+
+    // When: Diamond is re-toggled
     component.toggle('Diamond');
+
+    // Then: it re-enters the selection
     expect(component.isSelected('Diamond')).toBe(true);
   });
 
-  it('clicking a mat-checkbox in the legend wires through to toggle()', () => {
-    fixture.detectChanges();
-    const host: HTMLElement = fixture.nativeElement;
-    // mat-checkbox renders an inner native input — clicking it fires (change).
-    const diamondInput = host.querySelector<HTMLInputElement>(
-      '[data-testid="type-pie-toggle-Diamond"] input[type="checkbox"]'
+  it('clicking a mat-checkbox in the legend wires through to toggle()', async () => {
+    // Given: a harness loader for the rendered checkboxes
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    const diamondCheckbox = await loader.getHarness(
+      MatCheckboxHarness.with({
+        selector: '[data-testid="type-pie-toggle-Diamond"]',
+      })
     );
-    expect(diamondInput).toBeTruthy();
-    diamondInput?.click();
-    fixture.detectChanges();
 
+    // When: the user toggles the Diamond checkbox via Material's public API
+    await diamondCheckbox.toggle();
+
+    // Then: the component's (change) binding flips mode and selection
     expect(component.mode()).toBe('custom');
     expect(component.isSelected('Diamond')).toBe(false);
     expect(component.isSelected('Standard')).toBe(true);
   });
 
   it('seeds custom selection from the current visible set when entering Auswahl via the toggle', () => {
-    // Switching directly from Top 5 to custom should preserve the top-5
-    // selection so the pie doesn't render empty until the user toggles
-    // anything manually.
+    // When: switching directly from Top 5 to custom
     component.setMode('custom');
 
+    // Then: the top-5 selection is preserved instead of starting empty
     expect(component.mode()).toBe('custom');
     expect([...component.selectedLabels()]).toEqual([
       'Standard',
@@ -91,14 +103,16 @@ describe('TypePieComponent', () => {
   });
 
   it('switching from Alle to Auswahl seeds custom selection with every label', () => {
+    // When
     component.setMode('all');
     component.setMode('custom');
 
+    // Then
     expect(component.selectedLabels().size).toBe(7);
   });
 
   it('renders one legend row with checkbox per type, regardless of mode', () => {
-    fixture.detectChanges();
+    // Then
     const host: HTMLElement = fixture.nativeElement;
     const rows = host.querySelectorAll(
       '[data-testid="type-pie-legend"] mat-checkbox'
@@ -107,25 +121,29 @@ describe('TypePieComponent', () => {
   });
 
   it('exposes toggle hooks per label so the legend can drive subset selection', () => {
-    fixture.detectChanges();
+    // Then
     const host: HTMLElement = fixture.nativeElement;
-    const standard = host.querySelector(
-      '[data-testid="type-pie-toggle-Standard"]'
-    );
-    expect(standard).toBeTruthy();
+    expect(
+      host.querySelector('[data-testid="type-pie-toggle-Standard"]')
+    ).toBeTruthy();
   });
 
   it('shows the empty placeholder when total is zero', () => {
+    // When: every datum has value 0
     fixture.componentRef.setInput('data', [
       { label: 'A', value: 0 },
       { label: 'B', value: 0 },
     ]);
     fixture.detectChanges();
-    const host: HTMLElement = fixture.nativeElement;
-    expect(host.textContent).toContain('Keine Daten');
+
+    // Then
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain(
+      'Keine Daten'
+    );
   });
 
   it('keeps stable colors per index sorted by descending value', () => {
+    // Then
     const segments = component.allSegments();
     expect(segments[0].label).toBe('Standard');
     expect(segments[0].color).toBe('#1976d2');

--- a/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
@@ -57,6 +57,46 @@ describe('TypePieComponent', () => {
     expect(component.isSelected('Diamond')).toBe(true);
   });
 
+  it('clicking a mat-checkbox in the legend wires through to toggle()', () => {
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    // mat-checkbox renders an inner native input — clicking it fires (change).
+    const diamondInput = host.querySelector<HTMLInputElement>(
+      '[data-testid="type-pie-toggle-Diamond"] input[type="checkbox"]'
+    );
+    expect(diamondInput).toBeTruthy();
+    diamondInput?.click();
+    fixture.detectChanges();
+
+    expect(component.mode()).toBe('custom');
+    expect(component.isSelected('Diamond')).toBe(false);
+    expect(component.isSelected('Standard')).toBe(true);
+  });
+
+  it('seeds custom selection from the current visible set when entering Auswahl via the toggle', () => {
+    // Switching directly from Top 5 to custom should preserve the top-5
+    // selection so the pie doesn't render empty until the user toggles
+    // anything manually.
+    component.setMode('custom');
+
+    expect(component.mode()).toBe('custom');
+    expect([...component.selectedLabels()]).toEqual([
+      'Standard',
+      'Diamond',
+      'Wide',
+      'Decline',
+      'Knee',
+    ]);
+    expect(component.visibleSegments()).toHaveLength(5);
+  });
+
+  it('switching from Alle to Auswahl seeds custom selection with every label', () => {
+    component.setMode('all');
+    component.setMode('custom');
+
+    expect(component.selectedLabels().size).toBe(7);
+  });
+
   it('renders one legend row with checkbox per type, regardless of mode', () => {
     fixture.detectChanges();
     const host: HTMLElement = fixture.nativeElement;

--- a/web/src/app/stats/components/type-pie/type-pie.component.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.ts
@@ -1,3 +1,4 @@
+import { DecimalPipe } from '@angular/common';
 import { Component, computed, input, signal } from '@angular/core';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -24,7 +25,7 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
 @Component({
   selector: 'app-type-pie',
   standalone: true,
-  imports: [MatButtonToggleModule, MatCheckboxModule],
+  imports: [DecimalPipe, MatButtonToggleModule, MatCheckboxModule],
   template: `
     @if (total() > 0) {
       <div class="wrap">
@@ -91,7 +92,9 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
                 <span class="set-label" i18n="@@pie.avgSetSize"
                   >&#x2300; Set-Gr&#x00F6;&#x00DF;e</span
                 >
-                <span class="set-value">{{ seg.avgSetSize }}</span>
+                <span class="set-value">{{
+                  seg.avgSetSize | number: '1.0-1'
+                }}</span>
               </div>
             }
           }

--- a/web/src/app/stats/components/type-pie/type-pie.component.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.ts
@@ -3,6 +3,14 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 
 export interface PieDatum {
+  /**
+   * Stable, locale-independent identifier used for selection state and
+   * test selectors. Defaults to `label` when omitted, but production
+   * callers should pass a canonical key (e.g. the canonical pushup
+   * type id) so checkbox state and `data-testid` survive locale
+   * switches and labels with spaces/diacritics.
+   */
+  id?: string;
   label: string;
   value: number;
   avgSetSize?: number;
@@ -11,6 +19,7 @@ export interface PieDatum {
 export type PieSelectionMode = 'top5' | 'all' | 'custom';
 
 const TOP_N = 5;
+const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
 
 @Component({
   selector: 'app-type-pie',
@@ -29,7 +38,7 @@ const TOP_N = 5;
           >
             <circle class="bg" cx="21" cy="21" r="15.915" />
 
-            @for (seg of visibleSegments(); track seg.label) {
+            @for (seg of visibleSegments(); track seg.id) {
               <circle
                 class="seg"
                 cx="21"
@@ -62,13 +71,13 @@ const TOP_N = 5;
         </div>
 
         <div class="legend" data-testid="type-pie-legend">
-          @for (seg of allSegments(); track seg.label) {
+          @for (seg of allSegments(); track seg.id) {
             <div class="row">
               <mat-checkbox
                 color="primary"
-                [checked]="isSelected(seg.label)"
-                (change)="toggle(seg.label)"
-                [attr.data-testid]="'type-pie-toggle-' + seg.label"
+                [checked]="isSelected(seg.id)"
+                (change)="toggle(seg.id)"
+                [attr.data-testid]="'type-pie-toggle-' + seg.id"
               >
                 <span class="row-name">
                   <span class="dot" [style.background]="seg.color"></span>
@@ -85,6 +94,15 @@ const TOP_N = 5;
                 <span class="set-value">{{ seg.avgSetSize }}</span>
               </div>
             }
+          }
+          @if (otherPercent() > 0) {
+            <div class="row other-row" data-testid="type-pie-other-row">
+              <span class="row-name">
+                <span class="dot" [style.background]="otherColor"></span>
+                <span class="name" i18n="@@pie.other">Sonstige</span>
+              </span>
+              <span class="pct">{{ otherPercent() }}%</span>
+            </div>
           }
         </div>
       </div>
@@ -162,6 +180,10 @@ const TOP_N = 5;
       grid-template-columns: 1fr auto;
       padding-left: 36px;
     }
+    .other-row {
+      opacity: 0.75;
+      padding-left: 36px;
+    }
     .set-label {
       overflow: hidden;
       text-overflow: ellipsis;
@@ -190,6 +212,8 @@ export class TypePieComponent {
   readonly mode = signal<PieSelectionMode>('top5');
   private readonly customSelection = signal<ReadonlySet<string>>(new Set());
 
+  readonly otherColor = OTHER_COLOR;
+
   readonly total = computed(() =>
     this.data().reduce((sum, x) => sum + (x.value || 0), 0)
   );
@@ -209,6 +233,7 @@ export class TypePieComponent {
     const total = this.total();
     if (!total)
       return [] as Array<{
+        id: string;
         label: string;
         value: number;
         percent: number;
@@ -221,6 +246,7 @@ export class TypePieComponent {
       .sort((a, b) => (b.value || 0) - (a.value || 0));
 
     return rows.map((row, idx) => ({
+      id: row.id ?? row.label,
       label: row.label,
       value: row.value || 0,
       percent: Math.round(((row.value || 0) / total) * 100),
@@ -229,14 +255,14 @@ export class TypePieComponent {
     }));
   });
 
-  readonly selectedLabels = computed<ReadonlySet<string>>(() => {
+  readonly selectedIds = computed<ReadonlySet<string>>(() => {
     const all = this.allSegments();
     const mode = this.mode();
     if (mode === 'top5') {
-      return new Set(all.slice(0, TOP_N).map((s) => s.label));
+      return new Set(all.slice(0, TOP_N).map((s) => s.id));
     }
     if (mode === 'all') {
-      return new Set(all.map((s) => s.label));
+      return new Set(all.map((s) => s.id));
     }
     return this.customSelection();
   });
@@ -245,6 +271,7 @@ export class TypePieComponent {
     const total = this.total();
     if (!total)
       return [] as Array<{
+        id: string;
         label: string;
         percent: number;
         color: string;
@@ -252,13 +279,14 @@ export class TypePieComponent {
         offset: number;
       }>;
 
-    const selected = this.selectedLabels();
+    const selected = this.selectedIds();
     let acc = 0;
-    return this.allSegments()
-      .filter((s) => selected.has(s.label))
+    const segments = this.allSegments()
+      .filter((s) => selected.has(s.id))
       .map((seg) => {
         const dash = (seg.value / total) * 100;
         const result = {
+          id: seg.id,
           label: seg.label,
           percent: seg.percent,
           color: seg.color,
@@ -268,18 +296,45 @@ export class TypePieComponent {
         acc += dash;
         return result;
       });
+
+    // Cap the cumulative dash so floating-point drift can't push the
+    // remainder negative.
+    const remainder = Math.max(0, 100 - acc);
+    if (remainder > 0.5) {
+      segments.push({
+        id: '__other__',
+        label: 'other',
+        percent: Math.round(remainder),
+        color: OTHER_COLOR,
+        dasharray: `${remainder} ${100 - remainder}`,
+        offset: 25 - acc,
+      });
+    }
+    return segments;
   });
 
-  isSelected(label: string): boolean {
-    return this.selectedLabels().has(label);
+  /** Cumulative percent of types not currently visible — for the legend. */
+  readonly otherPercent = computed(() => {
+    const total = this.total();
+    if (!total) return 0;
+    const selected = this.selectedIds();
+    const hiddenValue = this.allSegments()
+      .filter((s) => !selected.has(s.id))
+      .reduce((sum, s) => sum + s.value, 0);
+    if (hiddenValue <= 0) return 0;
+    return Math.round((hiddenValue / total) * 100);
+  });
+
+  isSelected(id: string): boolean {
+    return this.selectedIds().has(id);
   }
 
-  toggle(label: string): void {
-    const next = new Set(this.selectedLabels());
-    if (next.has(label)) {
-      next.delete(label);
+  toggle(id: string): void {
+    const next = new Set(this.selectedIds());
+    if (next.has(id)) {
+      next.delete(id);
     } else {
-      next.add(label);
+      next.add(id);
     }
     this.customSelection.set(next);
     this.mode.set('custom');
@@ -288,7 +343,7 @@ export class TypePieComponent {
   setMode(value: PieSelectionMode): void {
     if (!value) return;
     if (value === 'custom') {
-      this.customSelection.set(new Set(this.selectedLabels()));
+      this.customSelection.set(new Set(this.selectedIds()));
     }
     this.mode.set(value);
   }

--- a/web/src/app/stats/components/type-pie/type-pie.component.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.ts
@@ -1,4 +1,6 @@
-import { Component, computed, input } from '@angular/core';
+import { Component, computed, input, signal } from '@angular/core';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 
 export interface PieDatum {
   label: string;
@@ -6,43 +8,76 @@ export interface PieDatum {
   avgSetSize?: number;
 }
 
+export type PieSelectionMode = 'top5' | 'all' | 'custom';
+
+const TOP_N = 5;
+
 @Component({
   selector: 'app-type-pie',
   standalone: true,
+  imports: [MatButtonToggleModule, MatCheckboxModule],
   template: `
     @if (total() > 0) {
       <div class="wrap">
-        <svg
-          class="pie"
-          viewBox="0 0 42 42"
-          role="img"
-          aria-label="Type distribution"
-        >
-          <circle class="bg" cx="21" cy="21" r="15.915" />
+        <div class="pie-area">
+          <svg
+            class="pie"
+            viewBox="0 0 42 42"
+            role="img"
+            aria-label="Type distribution"
+          >
+            <circle class="bg" cx="21" cy="21" r="15.915" />
 
-          @for (seg of segments(); track seg.label) {
-            <circle
-              class="seg"
-              cx="21"
-              cy="21"
-              r="15.915"
-              [attr.stroke]="seg.color"
-              [attr.stroke-dasharray]="seg.dasharray"
-              [attr.stroke-dashoffset]="seg.offset"
-            />
-          }
-        </svg>
+            @for (seg of visibleSegments(); track seg.label) {
+              <circle
+                class="seg"
+                cx="21"
+                cy="21"
+                r="15.915"
+                [attr.stroke]="seg.color"
+                [attr.stroke-dasharray]="seg.dasharray"
+                [attr.stroke-dashoffset]="seg.offset"
+              />
+            }
+          </svg>
 
-        <div class="legend">
-          @for (seg of segments(); track seg.label) {
+          <mat-button-toggle-group
+            class="mode-toggle"
+            [value]="mode()"
+            (change)="setMode($event.value)"
+            aria-label="Auswahl"
+            i18n-aria-label="@@pie.modeAria"
+          >
+            <mat-button-toggle value="top5" i18n="@@pie.top5"
+              >Top 5</mat-button-toggle
+            >
+            <mat-button-toggle value="all" i18n="@@pie.all"
+              >Alle</mat-button-toggle
+            >
+            <mat-button-toggle value="custom" i18n="@@pie.custom"
+              >Auswahl</mat-button-toggle
+            >
+          </mat-button-toggle-group>
+        </div>
+
+        <div class="legend" data-testid="type-pie-legend">
+          @for (seg of allSegments(); track seg.label) {
             <div class="row">
-              <span class="dot" [style.background]="seg.color"></span>
-              <span class="name">{{ seg.label }}</span>
+              <mat-checkbox
+                color="primary"
+                [checked]="isSelected(seg.label)"
+                (change)="toggle(seg.label)"
+                [attr.data-testid]="'type-pie-toggle-' + seg.label"
+              >
+                <span class="row-name">
+                  <span class="dot" [style.background]="seg.color"></span>
+                  <span class="name">{{ seg.label }}</span>
+                </span>
+              </mat-checkbox>
               <span class="pct">{{ seg.percent }}%</span>
             </div>
             @if (seg.avgSetSize) {
               <div class="row set-detail">
-                <span></span>
                 <span class="set-label" i18n="@@pie.avgSetSize"
                   >&#x2300; Set-Gr&#x00F6;&#x00DF;e</span
                 >
@@ -59,14 +94,22 @@ export interface PieDatum {
   styles: `
     .wrap {
       display: grid;
-      grid-template-columns: 160px 1fr;
-      align-items: center;
+      grid-template-columns: 200px 1fr;
+      align-items: start;
       gap: 16px;
+    }
+    .pie-area {
+      display: grid;
+      gap: 10px;
+      justify-items: center;
     }
     .pie {
       width: 160px;
       height: 160px;
       transform: rotate(-90deg);
+    }
+    .mode-toggle {
+      font-size: 0.78rem;
     }
     .bg {
       fill: none;
@@ -81,20 +124,27 @@ export interface PieDatum {
 
     .legend {
       display: grid;
-      gap: 8px;
+      gap: 4px;
       min-width: 0;
     }
     .row {
       display: grid;
-      grid-template-columns: 14px 1fr auto;
+      grid-template-columns: 1fr auto;
       gap: 10px;
       align-items: center;
+    }
+    .row-name {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
     }
     .dot {
       width: 10px;
       height: 10px;
       border-radius: 50%;
       display: inline-block;
+      flex: 0 0 auto;
     }
     .name {
       overflow: hidden;
@@ -108,6 +158,8 @@ export interface PieDatum {
     .set-detail {
       opacity: 0.6;
       font-size: 0.8rem;
+      grid-template-columns: 1fr auto;
+      padding-left: 36px;
     }
     .set-label {
       overflow: hidden;
@@ -134,6 +186,9 @@ export interface PieDatum {
 export class TypePieComponent {
   readonly data = input<PieDatum[]>([]);
 
+  readonly mode = signal<PieSelectionMode>('top5');
+  private readonly customSelection = signal<ReadonlySet<string>>(new Set());
+
   readonly total = computed(() =>
     this.data().reduce((sum, x) => sum + (x.value || 0), 0)
   );
@@ -149,7 +204,43 @@ export class TypePieComponent {
     '#455a64', // blue grey
   ];
 
-  readonly segments = computed(() => {
+  readonly allSegments = computed(() => {
+    const total = this.total();
+    if (!total)
+      return [] as Array<{
+        label: string;
+        value: number;
+        percent: number;
+        color: string;
+        avgSetSize: number;
+      }>;
+
+    const rows = [...this.data()]
+      .filter((x) => (x.value || 0) > 0)
+      .sort((a, b) => (b.value || 0) - (a.value || 0));
+
+    return rows.map((row, idx) => ({
+      label: row.label,
+      value: row.value || 0,
+      percent: Math.round(((row.value || 0) / total) * 100),
+      color: this.palette[idx % this.palette.length],
+      avgSetSize: row.avgSetSize ?? 0,
+    }));
+  });
+
+  readonly selectedLabels = computed<ReadonlySet<string>>(() => {
+    const all = this.allSegments();
+    const mode = this.mode();
+    if (mode === 'top5') {
+      return new Set(all.slice(0, TOP_N).map((s) => s.label));
+    }
+    if (mode === 'all') {
+      return new Set(all.map((s) => s.label));
+    }
+    return this.customSelection();
+  });
+
+  readonly visibleSegments = computed(() => {
     const total = this.total();
     if (!total)
       return [] as Array<{
@@ -158,29 +249,43 @@ export class TypePieComponent {
         color: string;
         dasharray: string;
         offset: number;
-        avgSetSize: number;
       }>;
 
-    // Sort descending for stable, readable legend.
-    const rows = [...this.data()]
-      .filter((x) => (x.value || 0) > 0)
-      .sort((a, b) => (b.value || 0) - (a.value || 0));
-
-    // We use a 100-unit circumference convention.
+    const selected = this.selectedLabels();
     let acc = 0;
-    return rows.map((row, idx) => {
-      const percent = Math.round(((row.value || 0) / total) * 100);
-      const dash = (row.value / total) * 100;
-      const seg = {
-        label: row.label,
-        percent,
-        color: this.palette[idx % this.palette.length],
-        dasharray: `${dash} ${100 - dash}`,
-        offset: 25 - acc,
-        avgSetSize: row.avgSetSize ?? 0,
-      };
-      acc += dash;
-      return seg;
-    });
+    return this.allSegments()
+      .filter((s) => selected.has(s.label))
+      .map((seg) => {
+        const dash = (seg.value / total) * 100;
+        const result = {
+          label: seg.label,
+          percent: seg.percent,
+          color: seg.color,
+          dasharray: `${dash} ${100 - dash}`,
+          offset: 25 - acc,
+        };
+        acc += dash;
+        return result;
+      });
   });
+
+  isSelected(label: string): boolean {
+    return this.selectedLabels().has(label);
+  }
+
+  toggle(label: string): void {
+    const next = new Set(this.selectedLabels());
+    if (next.has(label)) {
+      next.delete(label);
+    } else {
+      next.add(label);
+    }
+    this.customSelection.set(next);
+    this.mode.set('custom');
+  }
+
+  setMode(value: PieSelectionMode): void {
+    if (!value) return;
+    this.mode.set(value);
+  }
 }

--- a/web/src/app/stats/components/type-pie/type-pie.component.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.ts
@@ -24,7 +24,8 @@ const TOP_N = 5;
             class="pie"
             viewBox="0 0 42 42"
             role="img"
-            aria-label="Type distribution"
+            aria-label="Verteilung der Liegestütz-Typen"
+            i18n-aria-label="@@pie.distributionAria"
           >
             <circle class="bg" cx="21" cy="21" r="15.915" />
 
@@ -45,7 +46,7 @@ const TOP_N = 5;
             class="mode-toggle"
             [value]="mode()"
             (change)="setMode($event.value)"
-            aria-label="Auswahl"
+            aria-label="Anzeigemodus der Typverteilung"
             i18n-aria-label="@@pie.modeAria"
           >
             <mat-button-toggle value="top5" i18n="@@pie.top5"
@@ -286,6 +287,9 @@ export class TypePieComponent {
 
   setMode(value: PieSelectionMode): void {
     if (!value) return;
+    if (value === 'custom') {
+      this.customSelection.set(new Set(this.selectedLabels()));
+    }
     this.mode.set(value);
   }
 }

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -237,7 +237,13 @@ describe('AnalysisPageComponent', () => {
     expect(trends?.textContent).toContain('Letzte 6 Monate');
   });
 
-  it('positions trend cards below the heatmap so they only render on viewport', () => {
+  // The trend cards are wrapped in `@defer (on viewport)`, but verifying
+  // hydration in jsdom is fragile (it requires mocking IntersectionObserver
+  // and using Angular's still-evolving defer-test helpers). This test
+  // narrowly guards the intentional DOM ordering — heatmap above the
+  // trends — which is the stable structural invariant the lazy load
+  // depends on; the @defer behaviour itself is covered by the framework.
+  it('places the trend section after the heatmap card in the DOM', () => {
     fixture.detectChanges();
     const host: HTMLElement = fixture.nativeElement;
     const heatmap = host.querySelector('.heatmap-full');

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -145,6 +145,14 @@ describe('AnalysisPageComponent', () => {
   };
 
   beforeEach(async () => {
+    // Lock the clock to Sun Feb 15 2026 so the fixed-window trend filters
+    // include the mock entries (Feb 9–15 2026). Real "now" would push the
+    // window months ahead and make every bucket empty.
+    vitest.useFakeTimers({
+      toFake: ['Date'],
+    });
+    vitest.setSystemTime(new Date(2026, 1, 15, 12));
+
     await TestBed.configureTestingModule({
       imports: [AnalysisPageComponent],
       providers: [
@@ -183,6 +191,10 @@ describe('AnalysisPageComponent', () => {
 
     fixture = TestBed.createComponent(AnalysisPageComponent);
     await fixture.whenStable();
+  });
+
+  afterEach(() => {
+    vitest.useRealTimers();
   });
 
   it('builds week and month trend series from expanded ranges', () => {
@@ -453,5 +465,246 @@ describe('AnalysisPageComponent empty-state CTA gating', () => {
     // RouterLink resolves `routerLink="/training-plans"` to `/training-plans`
     // when provideRouter([]) is in scope.
     expect(cta?.getAttribute('href')).toBe('/training-plans');
+  });
+});
+
+describe('AnalysisPageComponent empty-state vs populated trends', () => {
+  // Regression guard: when the page filter has no entries but the fixed
+  // 8-week / 6-month trend windows do, the CTA must stay hidden so the
+  // "Letzte 8 Wochen" cards don't render alongside a contradictory
+  // "noch keine Daten" message.
+  let fixture: ComponentFixture<AnalysisPageComponent>;
+
+  const splitApiMock = {
+    load: vitest.fn().mockReturnValue(
+      of({
+        meta: {
+          from: null,
+          to: null,
+          entries: 0,
+          days: 0,
+          total: 0,
+          granularity: 'daily',
+        },
+        series: [],
+      })
+    ),
+    listPushups: vitest.fn().mockImplementation((params: { from: string }) => {
+      // Filter resource (rows) is empty; week/month resources resolve to
+      // historical entries — exercises the populated-trend gate.
+      const isFiltered = params.from && params.from > '2026-04-01';
+      if (isFiltered) return of([]);
+      const today = new Date();
+      const recent = new Date(today.getFullYear(), today.getMonth(), 1);
+      return of([
+        {
+          _id: 'h1',
+          timestamp: recent.toISOString(),
+          reps: 30,
+          sets: [10, 10, 10],
+          source: 'web',
+          type: 'Standard',
+        },
+      ]);
+    }),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AnalysisPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: StatsApiService, useValue: splitApiMock },
+        { provide: AuthStore, useValue: makeAuthStoreMock() },
+        { provide: UserContextService, useValue: { userIdSafe: () => 'u1' } },
+        {
+          provide: UserStatsApiService,
+          useValue: {
+            getUserStats: vitest.fn().mockReturnValue(of(null)),
+          },
+        },
+      ],
+    })
+      .overrideComponent(AnalysisPageComponent, {
+        remove: {
+          imports: [
+            FilterBarComponent,
+            HeatmapComponent,
+            TypePieComponent,
+            StatsChartComponent,
+            SetsDistributionComponent,
+          ],
+        },
+        add: {
+          imports: [
+            MockFilterBarComponent,
+            MockHeatmapComponent,
+            MockTypePieComponent,
+            MockStatsChartComponent,
+            MockSetsDistributionComponent,
+          ],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AnalysisPageComponent);
+    // Force the page filter to a far-future empty range so only the
+    // fixed-window trends produce data.
+    fixture.componentInstance.store.setRange('2026-12-01', '2026-12-07');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('hides the empty CTA when fixed-window trends have data', () => {
+    expect(fixture.componentInstance.store.rows().length).toBe(0);
+    const week = fixture.componentInstance.store.weekTrend();
+    expect(week.some((w) => w.total > 0)).toBe(true);
+    expect(fixture.componentInstance.showEmptyCta()).toBe(false);
+  });
+});
+
+describe('AnalysisStore fixed-window trend filters', () => {
+  // Direct boundary tests for the fixed-window filter computeds. These
+  // are sensitive to ISO week + month rollovers and to JS Date's
+  // Sunday-as-0 convention; lock the system clock to specific edge dates
+  // and assert the exact ISO output.
+  let fixture: ComponentFixture<AnalysisPageComponent>;
+
+  const apiMock = {
+    load: vitest.fn().mockReturnValue(
+      of({
+        meta: {
+          from: null,
+          to: null,
+          entries: 0,
+          days: 0,
+          total: 0,
+          granularity: 'daily',
+        },
+        series: [],
+      })
+    ),
+    listPushups: vitest.fn().mockReturnValue(of([])),
+  };
+
+  async function createAt(date: Date): Promise<void> {
+    vitest.setSystemTime(date);
+    await TestBed.configureTestingModule({
+      imports: [AnalysisPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: StatsApiService, useValue: apiMock },
+        { provide: AuthStore, useValue: makeAuthStoreMock() },
+        { provide: UserContextService, useValue: { userIdSafe: () => 'u1' } },
+        {
+          provide: UserStatsApiService,
+          useValue: {
+            getUserStats: vitest.fn().mockReturnValue(of(null)),
+          },
+        },
+      ],
+    })
+      .overrideComponent(AnalysisPageComponent, {
+        remove: {
+          imports: [
+            FilterBarComponent,
+            HeatmapComponent,
+            TypePieComponent,
+            StatsChartComponent,
+            SetsDistributionComponent,
+          ],
+        },
+        add: {
+          imports: [
+            MockFilterBarComponent,
+            MockHeatmapComponent,
+            MockTypePieComponent,
+            MockStatsChartComponent,
+            MockSetsDistributionComponent,
+          ],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AnalysisPageComponent);
+  }
+
+  beforeEach(() => {
+    // Only fake Date — leaving setTimeout/setInterval real keeps Angular's
+    // resource() and TestBed.compileComponents() pipelines unblocked.
+    vitest.useFakeTimers({ toFake: ['Date'] });
+  });
+
+  afterEach(() => {
+    vitest.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  it('weekFilter spans 8 ISO weeks Mon–Sun for a mid-week anchor', async () => {
+    await createAt(new Date(2026, 0, 14, 12)); // Wed Jan 14 2026
+    const wf = fixture.componentInstance.store.weekFilter();
+    expect(wf.from).toBe('2025-11-24'); // Monday 7 weeks before this Monday
+    expect(wf.to).toBe('2026-01-18'); // Sunday of current ISO week
+  });
+
+  it('weekFilter handles Sunday correctly (getDay() === 0)', async () => {
+    await createAt(new Date(2026, 0, 18, 23, 30)); // Sun Jan 18 2026 night
+    const wf = fixture.componentInstance.store.weekFilter();
+    // Sunday belongs to the week starting Mon Jan 12, so the window
+    // ends on its Sunday and starts 7 weeks earlier.
+    expect(wf.from).toBe('2025-11-24');
+    expect(wf.to).toBe('2026-01-18');
+  });
+
+  it('weekFilter rolls across the year boundary', async () => {
+    await createAt(new Date(2026, 0, 1, 9)); // Thu Jan 1 2026
+    const wf = fixture.componentInstance.store.weekFilter();
+    // Week of Jan 1 2026 starts Mon Dec 29 2025; 7 weeks earlier is
+    // Mon Nov 10 2025.
+    expect(wf.from).toBe('2025-11-10');
+    expect(wf.to).toBe('2026-01-04');
+  });
+
+  it('monthFilter spans 6 calendar months ending current month', async () => {
+    await createAt(new Date(2026, 0, 14, 12)); // Jan 14 2026
+    const mf = fixture.componentInstance.store.monthFilter();
+    expect(mf.from).toBe('2025-08-01');
+    expect(mf.to).toBe('2026-01-31');
+  });
+
+  it('monthFilter handles February correctly in leap and non-leap years', async () => {
+    await createAt(new Date(2028, 1, 15, 12)); // Feb 15 2028 (leap year)
+    const mf = fixture.componentInstance.store.monthFilter();
+    expect(mf.from).toBe('2027-09-01');
+    expect(mf.to).toBe('2028-02-29');
+  });
+
+  it('weekTrend always emits 8 buckets even with zero entries', async () => {
+    await createAt(new Date(2026, 0, 14, 12));
+    const week = fixture.componentInstance.store.weekTrend();
+    expect(week).toHaveLength(8);
+    expect(week.every((w) => w.total === 0)).toBe(true);
+  });
+
+  it('monthTrend always emits 6 buckets even with zero entries', async () => {
+    await createAt(new Date(2026, 0, 14, 12));
+    const month = fixture.componentInstance.store.monthTrend();
+    expect(month).toHaveLength(6);
+    expect(month.every((m) => m.total === 0)).toBe(true);
+  });
+
+  it('weekFilter re-evaluates after tickClock when the day changes', async () => {
+    await createAt(new Date(2026, 0, 18, 23, 59)); // Sun Jan 18
+    const before = fixture.componentInstance.store.weekFilter();
+    expect(before.to).toBe('2026-01-18');
+
+    // Move clock past midnight into the next ISO week.
+    vitest.setSystemTime(new Date(2026, 0, 19, 0, 5)); // Mon Jan 19
+    fixture.componentInstance.store.tickClock();
+
+    const after = fixture.componentInstance.store.weekFilter();
+    expect(after.from).toBe('2025-12-01');
+    expect(after.to).toBe('2026-01-25');
   });
 });

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -213,12 +213,31 @@ describe('AnalysisPageComponent', () => {
     expect(nextDay.getDate()).toBe(1);
   });
 
-  it('provides subtitle strings for trend cards', () => {
-    const { store } = fixture.componentInstance;
-    expect(store.weekTrendSubtitle()).toBeTruthy();
-    expect(store.monthTrendSubtitle()).toBeTruthy();
-    // Subtitles should contain a date separator
-    expect(store.weekTrendSubtitle()).toContain('–');
+  it('renders fixed-window labels for trend cards', () => {
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    const trends = host.querySelector(
+      '[data-testid="analysis-trends-section"]'
+    );
+    expect(trends?.textContent).toContain('Wochentrend');
+    expect(trends?.textContent).toContain('Letzte 8 Wochen');
+    expect(trends?.textContent).toContain('Monatstrend');
+    expect(trends?.textContent).toContain('Letzte 6 Monate');
+  });
+
+  it('positions trend cards below the heatmap so they only render on viewport', () => {
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    const heatmap = host.querySelector('.heatmap-full');
+    const trends = host.querySelector(
+      '[data-testid="analysis-trends-section"]'
+    );
+    expect(heatmap).toBeTruthy();
+    expect(trends).toBeTruthy();
+    if (!heatmap || !trends) return;
+    expect(
+      heatmap.compareDocumentPosition(trends) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
   });
 
   it('computes type breakdown, treating missing type as Standard', () => {

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -475,6 +475,11 @@ describe('AnalysisPageComponent empty-state vs populated trends', () => {
   // "noch keine Daten" message.
   let fixture: ComponentFixture<AnalysisPageComponent>;
 
+  // Locked clock so the future-dated page filter stays after `today` and
+  // the trend window stays before it, regardless of the real wall clock.
+  const FROZEN_NOW = new Date(2026, 4, 8, 12); // Fri May 8 2026
+  const PAGE_FILTER_FROM = '2026-12-01';
+
   const splitApiMock = {
     load: vitest.fn().mockReturnValue(
       of({
@@ -490,12 +495,16 @@ describe('AnalysisPageComponent empty-state vs populated trends', () => {
       })
     ),
     listPushups: vitest.fn().mockImplementation((params: { from: string }) => {
-      // Filter resource (rows) is empty; week/month resources resolve to
-      // historical entries — exercises the populated-trend gate.
-      const isFiltered = params.from && params.from > '2026-04-01';
-      if (isFiltered) return of([]);
-      const today = new Date();
-      const recent = new Date(today.getFullYear(), today.getMonth(), 1);
+      // The page filter (rows resource) gets the explicit far-future
+      // range; the fixed trend windows always start before the page
+      // filter, so distinguish the two by exact prefix instead of a
+      // wall-clock comparison.
+      if (params.from === PAGE_FILTER_FROM) return of([]);
+      const recent = new Date(
+        FROZEN_NOW.getFullYear(),
+        FROZEN_NOW.getMonth(),
+        1
+      );
       return of([
         {
           _id: 'h1',
@@ -510,6 +519,9 @@ describe('AnalysisPageComponent empty-state vs populated trends', () => {
   };
 
   beforeEach(async () => {
+    vitest.useFakeTimers({ toFake: ['Date'] });
+    vitest.setSystemTime(FROZEN_NOW);
+
     await TestBed.configureTestingModule({
       imports: [AnalysisPageComponent],
       providers: [
@@ -550,10 +562,14 @@ describe('AnalysisPageComponent empty-state vs populated trends', () => {
     fixture = TestBed.createComponent(AnalysisPageComponent);
     // Force the page filter to a far-future empty range so only the
     // fixed-window trends produce data.
-    fixture.componentInstance.store.setRange('2026-12-01', '2026-12-07');
+    fixture.componentInstance.store.setRange(PAGE_FILTER_FROM, '2026-12-07');
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vitest.useRealTimers();
   });
 
   it('hides the empty CTA when fixed-window trends have data', () => {

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -398,6 +398,11 @@ import { PageHeaderComponent } from '../../core/page-header/page-header.componen
       width: 100%;
       min-height: 400px;
     }
+    /* Reserve roughly the rendered table height so revealing the
+       deferred trend block doesn't shift the rest of the page down. */
+    .trend-placeholder {
+      min-height: 320px;
+    }
 
     @media (max-width: 900px) {
       .page-wrap {

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -2,6 +2,7 @@ import { DecimalPipe, DOCUMENT, isPlatformBrowser } from '@angular/common';
 import {
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   PLATFORM_ID,
@@ -490,14 +491,22 @@ export class AnalysisPageComponent {
    * Only reveal the empty-state CTA after the entries resource has resolved.
    * Reading `store.rows()` directly during the initial undefined→[] transition
    * trips Angular's expression-changed-after-checked check in dev mode.
+   * Trends use a fixed window independent of the page filter, so the CTA
+   * must also stay hidden whenever a trend bucket has activity — otherwise
+   * narrowing the filter to an empty range contradicts populated trend cards.
    */
-  readonly showEmptyCta = computed(
-    () =>
-      this.store.entriesResource.status() === 'resolved' &&
-      this.store.rows().length === 0
-  );
+  readonly showEmptyCta = computed(() => {
+    if (this.store.entriesResource.status() !== 'resolved') return false;
+    if (this.store.weekEntriesResource.status() !== 'resolved') return false;
+    if (this.store.monthEntriesResource.status() !== 'resolved') return false;
+    if (this.store.rows().length > 0) return false;
+    if (this.store.weekTrend().some((t) => t.total > 0)) return false;
+    if (this.store.monthTrend().some((t) => t.total > 0)) return false;
+    return true;
+  });
 
   private readonly live = inject(LiveDataStore);
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor() {
     // Resolve initial range from URL query params (SSR-aware)
@@ -511,6 +520,15 @@ export class AnalysisPageComponent {
       if (!tick) return;
       this.store.refreshAll();
     });
+
+    // Bump the store clock every 5 minutes so the fixed-window trend
+    // filters re-evaluate when the calendar day rolls over during a
+    // long-running session. Cleared on component destroy to keep tests
+    // and SSR free of leaking timers.
+    if (isPlatformBrowser(this.platformId)) {
+      const interval = setInterval(() => this.store.tickClock(), 5 * 60 * 1000);
+      this.destroyRef.onDestroy(() => clearInterval(interval));
+    }
 
     // URL history tracking effect (UI side effect, stays in component)
     effect(() => {

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -105,94 +105,6 @@ import { PageHeaderComponent } from '../../core/page-header/page-header.componen
       <section class="grid">
         <mat-card>
           <mat-card-header>
-            <mat-card-title i18n="@@analysis.weekTrendTitle"
-              >Wochentrend</mat-card-title
-            >
-            <mat-card-subtitle>{{
-              store.weekTrendSubtitle()
-            }}</mat-card-subtitle>
-          </mat-card-header>
-          <mat-card-content>
-            <mat-table [dataSource]="store.weekTrend()">
-              <ng-container matColumnDef="label">
-                <mat-header-cell *matHeaderCellDef i18n="@@analysis.weekCol"
-                  >Woche</mat-header-cell
-                >
-                <mat-cell *matCellDef="let row">{{ row.label }}</mat-cell>
-              </ng-container>
-              <ng-container matColumnDef="total">
-                <mat-header-cell *matHeaderCellDef i18n="@@analysis.repsCol"
-                  >Reps</mat-header-cell
-                >
-                <mat-cell *matCellDef="let row">{{ row.total }}</mat-cell>
-              </ng-container>
-              <ng-container matColumnDef="avgSetsPerEntry">
-                <mat-header-cell *matHeaderCellDef i18n="@@analysis.avgSetsCol"
-                  >&#x2300; Sets</mat-header-cell
-                >
-                <mat-cell *matCellDef="let row">{{
-                  row.avgSetsPerEntry !== null &&
-                  row.avgSetsPerEntry !== undefined
-                    ? (row.avgSetsPerEntry | number)
-                    : '—'
-                }}</mat-cell>
-              </ng-container>
-              <mat-header-row
-                *matHeaderRowDef="trendColumnsWithSets"
-              ></mat-header-row>
-              <mat-row
-                *matRowDef="let row; columns: trendColumnsWithSets"
-              ></mat-row>
-            </mat-table>
-          </mat-card-content>
-        </mat-card>
-
-        <mat-card>
-          <mat-card-header>
-            <mat-card-title i18n="@@analysis.monthTrendTitle"
-              >Monatstrend</mat-card-title
-            >
-            <mat-card-subtitle>{{
-              store.monthTrendSubtitle()
-            }}</mat-card-subtitle>
-          </mat-card-header>
-          <mat-card-content>
-            <mat-table [dataSource]="store.monthTrend()">
-              <ng-container matColumnDef="label">
-                <mat-header-cell *matHeaderCellDef i18n="@@analysis.monthCol"
-                  >Monat</mat-header-cell
-                >
-                <mat-cell *matCellDef="let row">{{ row.label }}</mat-cell>
-              </ng-container>
-              <ng-container matColumnDef="total">
-                <mat-header-cell *matHeaderCellDef i18n="@@analysis.repsCol"
-                  >Reps</mat-header-cell
-                >
-                <mat-cell *matCellDef="let row">{{ row.total }}</mat-cell>
-              </ng-container>
-              <ng-container matColumnDef="avgSetsPerEntry">
-                <mat-header-cell *matHeaderCellDef i18n="@@analysis.avgSetsCol"
-                  >&#x2300; Sets</mat-header-cell
-                >
-                <mat-cell *matCellDef="let row">{{
-                  row.avgSetsPerEntry !== null &&
-                  row.avgSetsPerEntry !== undefined
-                    ? (row.avgSetsPerEntry | number)
-                    : '—'
-                }}</mat-cell>
-              </ng-container>
-              <mat-header-row
-                *matHeaderRowDef="trendColumnsWithSets"
-              ></mat-header-row>
-              <mat-row
-                *matRowDef="let row; columns: trendColumnsWithSets"
-              ></mat-row>
-            </mat-table>
-          </mat-card-content>
-        </mat-card>
-
-        <mat-card>
-          <mat-card-header>
             <mat-card-title i18n="@@analysis.bestStreaksTitle"
               >Bestwerte & Streaks</mat-card-title
             >
@@ -310,6 +222,108 @@ import { PageHeaderComponent } from '../../core/page-header/page-header.componen
           }
         </mat-card-content>
       </mat-card>
+
+      <section class="trends-section" data-testid="analysis-trends-section">
+        <mat-card>
+          <mat-card-header>
+            <mat-card-title i18n="@@analysis.weekTrendTitle"
+              >Wochentrend</mat-card-title
+            >
+            <mat-card-subtitle i18n="@@analysis.weekTrendSubtitle"
+              >Letzte 8 Wochen</mat-card-subtitle
+            >
+          </mat-card-header>
+          <mat-card-content>
+            @defer (on viewport) {
+              <mat-table [dataSource]="store.weekTrend()">
+                <ng-container matColumnDef="label">
+                  <mat-header-cell *matHeaderCellDef i18n="@@analysis.weekCol"
+                    >Woche</mat-header-cell
+                  >
+                  <mat-cell *matCellDef="let row">{{ row.label }}</mat-cell>
+                </ng-container>
+                <ng-container matColumnDef="total">
+                  <mat-header-cell *matHeaderCellDef i18n="@@analysis.repsCol"
+                    >Reps</mat-header-cell
+                  >
+                  <mat-cell *matCellDef="let row">{{ row.total }}</mat-cell>
+                </ng-container>
+                <ng-container matColumnDef="avgSetsPerEntry">
+                  <mat-header-cell
+                    *matHeaderCellDef
+                    i18n="@@analysis.avgSetsCol"
+                    >&#x2300; Sets</mat-header-cell
+                  >
+                  <mat-cell *matCellDef="let row">{{
+                    row.avgSetsPerEntry !== null &&
+                    row.avgSetsPerEntry !== undefined
+                      ? (row.avgSetsPerEntry | number)
+                      : '—'
+                  }}</mat-cell>
+                </ng-container>
+                <mat-header-row
+                  *matHeaderRowDef="trendColumnsWithSets"
+                ></mat-header-row>
+                <mat-row
+                  *matRowDef="let row; columns: trendColumnsWithSets"
+                ></mat-row>
+              </mat-table>
+            } @placeholder {
+              <div class="trend-placeholder" aria-hidden="true"></div>
+            }
+          </mat-card-content>
+        </mat-card>
+
+        <mat-card>
+          <mat-card-header>
+            <mat-card-title i18n="@@analysis.monthTrendTitle"
+              >Monatstrend</mat-card-title
+            >
+            <mat-card-subtitle i18n="@@analysis.monthTrendSubtitle"
+              >Letzte 6 Monate</mat-card-subtitle
+            >
+          </mat-card-header>
+          <mat-card-content>
+            @defer (on viewport) {
+              <mat-table [dataSource]="store.monthTrend()">
+                <ng-container matColumnDef="label">
+                  <mat-header-cell *matHeaderCellDef i18n="@@analysis.monthCol"
+                    >Monat</mat-header-cell
+                  >
+                  <mat-cell *matCellDef="let row">{{ row.label }}</mat-cell>
+                </ng-container>
+                <ng-container matColumnDef="total">
+                  <mat-header-cell *matHeaderCellDef i18n="@@analysis.repsCol"
+                    >Reps</mat-header-cell
+                  >
+                  <mat-cell *matCellDef="let row">{{ row.total }}</mat-cell>
+                </ng-container>
+                <ng-container matColumnDef="avgSetsPerEntry">
+                  <mat-header-cell
+                    *matHeaderCellDef
+                    i18n="@@analysis.avgSetsCol"
+                    >&#x2300; Sets</mat-header-cell
+                  >
+                  <mat-cell *matCellDef="let row">{{
+                    row.avgSetsPerEntry !== null &&
+                    row.avgSetsPerEntry !== undefined
+                      ? (row.avgSetsPerEntry | number)
+                      : '—'
+                  }}</mat-cell>
+                </ng-container>
+                <mat-header-row
+                  *matHeaderRowDef="trendColumnsWithSets"
+                ></mat-header-row>
+                <mat-row
+                  *matRowDef="let row; columns: trendColumnsWithSets"
+                ></mat-row>
+              </mat-table>
+            } @placeholder {
+              <div class="trend-placeholder" aria-hidden="true"></div>
+            }
+          </mat-card-content>
+        </mat-card>
+      </section>
     </main>
   `,
   styles: `

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -3878,11 +3878,11 @@
     </unit>
     <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Zurück</source>
-        <target>Πίσω</target>
+        <source>Vorheriger Zeitraum</source>
+        <target>Προηγούμενη περίοδος</target>
       </segment>
     </unit>
     <unit id="rangeBack">
@@ -3896,11 +3896,11 @@
     </unit>
     <unit id="rangeTodayAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Heute</source>
-        <target>Σήμερα</target>
+        <source>Zum heutigen Zeitraum springen</source>
+        <target>Μετάβαση στην τρέχουσα περίοδο</target>
       </segment>
     </unit>
     <unit id="rangeToday">
@@ -3923,11 +3923,11 @@
     </unit>
     <unit id="rangeForwardAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Vor</source>
-        <target>Μπροστά</target>
+        <source>Nächster Zeitraum</source>
+        <target>Επόμενη περίοδος</target>
       </segment>
     </unit>
     <unit id="rangeForward">
@@ -4541,13 +4541,22 @@
         <target>Δεν υπάρχουν δεδομένα</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
+    <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:27,28</note>
       </notes>
       <segment state="translated">
-        <source>Auswahl</source>
-        <target>Επιλογή</target>
+        <source>Verteilung der Liegestütz-Typen</source>
+        <target>Κατανομή τύπων push-up</target>
+      </segment>
+    </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Anzeigemodus der Typverteilung</source>
+        <target>Λειτουργία προβολής κατανομής τύπων</target>
       </segment>
     </unit>
     <unit id="pie.top5">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -4559,6 +4559,15 @@
         <target>Λειτουργία προβολής κατανομής τύπων</target>
       </segment>
     </unit>
+    <unit id="pie.other">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
+      </notes>
+      <segment state="translated">
+        <source>Sonstige</source>
+        <target>Άλλα</target>
+      </segment>
+    </unit>
     <unit id="pie.top5">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -3876,31 +3876,67 @@
         <target>έτος</target>
       </segment>
     </unit>
-    <unit id="rangeBack">
+    <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:65,67</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
       </notes>
       <segment state="translated">
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Zurück </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Πίσω </target>
+        <source>Zurück</source>
+        <target>Πίσω</target>
+      </segment>
+    </unit>
+    <unit id="rangeBack">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:80,81</note>
+      </notes>
+      <segment state="translated">
+        <source>Zurück</source>
+        <target>Πίσω</target>
+      </segment>
+    </unit>
+    <unit id="rangeTodayAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+      </notes>
+      <segment state="translated">
+        <source>Heute</source>
+        <target>Σήμερα</target>
       </segment>
     </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:74,75</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:92,93</note>
       </notes>
       <segment state="translated">
-        <source> Heute </source>
-        <target> Σήμερα </target>
+        <source>Heute</source>
+        <target>Σήμερα</target>
+      </segment>
+    </unit>
+    <unit id="rangePickerToggleAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112,113</note>
+      </notes>
+      <segment state="translated">
+        <source>Eigenen Zeitraum auswählen</source>
+        <target>Επιλέξτε προσαρμοσμένο εύρος</target>
+      </segment>
+    </unit>
+    <unit id="rangeForwardAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+      </notes>
+      <segment state="translated">
+        <source>Vor</source>
+        <target>Μπροστά</target>
       </segment>
     </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:82,85</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:103,104</note>
       </notes>
       <segment state="translated">
-        <source> Vor <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></source>
-        <target> Πριν το <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></target>
+        <source>Vor</source>
+        <target>Μπροστά</target>
       </segment>
     </unit>
     <unit id="rangeLabel">
@@ -4505,6 +4541,42 @@
         <target>Δεν υπάρχουν δεδομένα</target>
       </segment>
     </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Επιλογή</target>
+      </segment>
+    </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
+    <unit id="pie.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle</source>
+        <target>Όλα</target>
+      </segment>
+    </unit>
+    <unit id="pie.custom">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Επιλογή</target>
+      </segment>
+    </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
         <note category="location">web/src/app/stats/dashboard.store.ts:436</note>
@@ -4559,6 +4631,15 @@
         <target>Εβδομαδιαία τάση</target>
       </segment>
     </unit>
+    <unit id="analysis.weekTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 8 Wochen</source>
+        <target>Τελευταίες 8 εβδομάδες</target>
+      </segment>
+    </unit>
     <unit id="analysis.weekCol">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,77</note>
@@ -4595,6 +4676,15 @@
       <segment state="translated">
         <source>Monatstrend</source>
         <target>Μηνιαία τάση</target>
+      </segment>
+    </unit>
+    <unit id="analysis.monthTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:283,285</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 6 Monate</source>
+        <target>Τελευταίοι 6 μήνες</target>
       </segment>
     </unit>
     <unit id="analysis.monthCol">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -348,20 +348,21 @@ Active:         </target>
     <unit id="analysis.monthTrendTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:50,52</note>
-
-        
-            </notes>
+      </notes>
       <segment state="translated">
         <source>Monatstrend</source>
         <target>Monthly trend</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
+      </segment>
+    </unit>
+    <unit id="analysis.monthTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:283,285</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 6 Monate</source>
+        <target>Last 6 months</target>
+      </segment>
+    </unit>
     <unit id="analysis.repsCol">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:37,38</note>
@@ -440,21 +441,22 @@ Active:         </target>
         </unit>
     <unit id="analysis.weekTrendTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:24,26</note>
-
-
-            </notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+      </notes>
       <segment state="translated">
         <source>Wochentrend</source>
         <target>Weekly trend</target>
-
-
-
-            </segment>
-
-
-
-        </unit>
+      </segment>
+    </unit>
+    <unit id="analysis.weekTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 8 Wochen</source>
+        <target>Last 8 weeks</target>
+      </segment>
+    </unit>
     <unit id="analysis.avgSetsCol">
       <segment state="translated">
         <source>&#x2300; Sets</source>
@@ -2767,21 +2769,49 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="pie.noData">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:46,49</note>
-
-        
-            </notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:88,89</note>
+      </notes>
       <segment state="translated">
         <source>Keine Daten</source>
         <target>No data</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
+      </segment>
+    </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Selection</target>
+      </segment>
+    </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
+    <unit id="pie.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle</source>
+        <target>All</target>
+      </segment>
+    </unit>
+    <unit id="pie.custom">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Custom</target>
+      </segment>
+    </unit>
     <unit id="quickActionsSubtitle">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:103,105</note>
@@ -2914,40 +2944,49 @@ Deine Position: # ·  Reps        </source>
       
       
         </unit>
+    <unit id="rangeBackAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+      </notes>
+      <segment state="translated">
+        <source>Zurück</source>
+        <target>Back</target>
+      </segment>
+    </unit>
     <unit id="rangeBack">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:60,62</note>
-
-        
-            </notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:80,81</note>
+      </notes>
       <segment state="translated">
-        <source>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc>
- Zurück         </source>
-        <target>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc>
- Back         </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
+        <source>Zurück</source>
+        <target>Back</target>
+      </segment>
+    </unit>
+    <unit id="rangeTodayAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+      </notes>
+      <segment state="translated">
+        <source>Heute</source>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="rangeForwardAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+      </notes>
+      <segment state="translated">
+        <source>Vor</source>
+        <target>Forward</target>
+      </segment>
+    </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77,80</note>
-
-        
-            </notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:103,104</note>
+      </notes>
       <segment state="translated">
-        <source>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc>
- Vor         </source>
-        <target>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc>
- Forward         </target>
+        <source>Vor</source>
+        <target>Forward</target>
 
         
         
@@ -3069,21 +3108,22 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:69,70</note>
-
-        
-            </notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:92,93</note>
+      </notes>
       <segment state="translated">
-        <source> Heute </source>
-        <target> Today </target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
+        <source>Heute</source>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="rangePickerToggleAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112,113</note>
+      </notes>
+      <segment state="translated">
+        <source>Eigenen Zeitraum auswählen</source>
+        <target>Pick a custom range</target>
+      </segment>
+    </unit>
     <unit id="repsLabel">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:162,163</note>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -2776,13 +2776,22 @@ Deine Position: # ·  Reps        </source>
         <target>No data</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
+    <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:27,28</note>
       </notes>
       <segment state="translated">
-        <source>Auswahl</source>
-        <target>Selection</target>
+        <source>Verteilung der Liegestütz-Typen</source>
+        <target>Pushup type distribution</target>
+      </segment>
+    </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Anzeigemodus der Typverteilung</source>
+        <target>Pie segment filter mode</target>
       </segment>
     </unit>
     <unit id="pie.top5">
@@ -2946,11 +2955,11 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Zurück</source>
-        <target>Back</target>
+        <source>Vorheriger Zeitraum</source>
+        <target>Previous period</target>
       </segment>
     </unit>
     <unit id="rangeBack">
@@ -2964,20 +2973,20 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="rangeTodayAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Heute</source>
-        <target>Today</target>
+        <source>Zum heutigen Zeitraum springen</source>
+        <target>Jump to today's period</target>
       </segment>
     </unit>
     <unit id="rangeForwardAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Vor</source>
-        <target>Forward</target>
+        <source>Nächster Zeitraum</source>
+        <target>Next period</target>
       </segment>
     </unit>
     <unit id="rangeForward">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -2794,6 +2794,15 @@ Deine Position: # ·  Reps        </source>
         <target>Pie segment filter mode</target>
       </segment>
     </unit>
+    <unit id="pie.other">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
+      </notes>
+      <segment state="translated">
+        <source>Sonstige</source>
+        <target>Other</target>
+      </segment>
+    </unit>
     <unit id="pie.top5">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -3876,31 +3876,67 @@
         <target>año</target>
       </segment>
     </unit>
-    <unit id="rangeBack">
+    <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:65,67</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
       </notes>
       <segment state="translated">
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Zurück </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Volver </target>
+        <source>Zurück</source>
+        <target>Atrás</target>
+      </segment>
+    </unit>
+    <unit id="rangeBack">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:80,81</note>
+      </notes>
+      <segment state="translated">
+        <source>Zurück</source>
+        <target>Atrás</target>
+      </segment>
+    </unit>
+    <unit id="rangeTodayAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+      </notes>
+      <segment state="translated">
+        <source>Heute</source>
+        <target>Hoy</target>
       </segment>
     </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:74,75</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:92,93</note>
       </notes>
       <segment state="translated">
-        <source> Heute </source>
-        <target> Hoy </target>
+        <source>Heute</source>
+        <target>Hoy</target>
+      </segment>
+    </unit>
+    <unit id="rangePickerToggleAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112,113</note>
+      </notes>
+      <segment state="translated">
+        <source>Eigenen Zeitraum auswählen</source>
+        <target>Elegir un rango personalizado</target>
+      </segment>
+    </unit>
+    <unit id="rangeForwardAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+      </notes>
+      <segment state="translated">
+        <source>Vor</source>
+        <target>Adelante</target>
       </segment>
     </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:82,85</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:103,104</note>
       </notes>
       <segment state="translated">
-        <source> Vor <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></source>
-        <target> Antes de <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></target>
+        <source>Vor</source>
+        <target>Adelante</target>
       </segment>
     </unit>
     <unit id="rangeLabel">
@@ -4505,6 +4541,42 @@
         <target>Sin datos</target>
       </segment>
     </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Selección</target>
+      </segment>
+    </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
+    <unit id="pie.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle</source>
+        <target>Todos</target>
+      </segment>
+    </unit>
+    <unit id="pie.custom">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Selección</target>
+      </segment>
+    </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
         <note category="location">web/src/app/stats/dashboard.store.ts:436</note>
@@ -4559,6 +4631,15 @@
         <target>Tendencia semanal</target>
       </segment>
     </unit>
+    <unit id="analysis.weekTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 8 Wochen</source>
+        <target>Últimas 8 semanas</target>
+      </segment>
+    </unit>
     <unit id="analysis.weekCol">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,77</note>
@@ -4595,6 +4676,15 @@
       <segment state="translated">
         <source>Monatstrend</source>
         <target>Tendencia mensual</target>
+      </segment>
+    </unit>
+    <unit id="analysis.monthTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:283,285</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 6 Monate</source>
+        <target>Últimos 6 meses</target>
       </segment>
     </unit>
     <unit id="analysis.monthCol">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -3878,11 +3878,11 @@
     </unit>
     <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Zurück</source>
-        <target>Atrás</target>
+        <source>Vorheriger Zeitraum</source>
+        <target>Periodo anterior</target>
       </segment>
     </unit>
     <unit id="rangeBack">
@@ -3896,11 +3896,11 @@
     </unit>
     <unit id="rangeTodayAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Heute</source>
-        <target>Hoy</target>
+        <source>Zum heutigen Zeitraum springen</source>
+        <target>Ir al periodo de hoy</target>
       </segment>
     </unit>
     <unit id="rangeToday">
@@ -3923,11 +3923,11 @@
     </unit>
     <unit id="rangeForwardAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Vor</source>
-        <target>Adelante</target>
+        <source>Nächster Zeitraum</source>
+        <target>Periodo siguiente</target>
       </segment>
     </unit>
     <unit id="rangeForward">
@@ -4541,13 +4541,22 @@
         <target>Sin datos</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
+    <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:27,28</note>
       </notes>
       <segment state="translated">
-        <source>Auswahl</source>
-        <target>Selección</target>
+        <source>Verteilung der Liegestütz-Typen</source>
+        <target>Distribución de tipos de flexiones</target>
+      </segment>
+    </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Anzeigemodus der Typverteilung</source>
+        <target>Modo de visualización de la distribución de tipos</target>
       </segment>
     </unit>
     <unit id="pie.top5">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -4559,6 +4559,15 @@
         <target>Modo de visualización de la distribución de tipos</target>
       </segment>
     </unit>
+    <unit id="pie.other">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
+      </notes>
+      <segment state="translated">
+        <source>Sonstige</source>
+        <target>Otros</target>
+      </segment>
+    </unit>
     <unit id="pie.top5">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3876,31 +3876,67 @@
         <target>année</target>
       </segment>
     </unit>
-    <unit id="rangeBack">
+    <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:65,67</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
       </notes>
       <segment state="translated">
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Zurück </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Retour </target>
+        <source>Zurück</source>
+        <target>Retour</target>
+      </segment>
+    </unit>
+    <unit id="rangeBack">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:80,81</note>
+      </notes>
+      <segment state="translated">
+        <source>Zurück</source>
+        <target>Retour</target>
+      </segment>
+    </unit>
+    <unit id="rangeTodayAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+      </notes>
+      <segment state="translated">
+        <source>Heute</source>
+        <target>Aujourd'hui</target>
       </segment>
     </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:74,75</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:92,93</note>
       </notes>
       <segment state="translated">
-        <source> Heute </source>
-        <target> Aujourd'hui </target>
+        <source>Heute</source>
+        <target>Aujourd'hui</target>
+      </segment>
+    </unit>
+    <unit id="rangePickerToggleAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112,113</note>
+      </notes>
+      <segment state="translated">
+        <source>Eigenen Zeitraum auswählen</source>
+        <target>Choisir une plage personnalisée</target>
+      </segment>
+    </unit>
+    <unit id="rangeForwardAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+      </notes>
+      <segment state="translated">
+        <source>Vor</source>
+        <target>Suivant</target>
       </segment>
     </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:82,85</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:103,104</note>
       </notes>
       <segment state="translated">
-        <source> Vor <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></source>
-        <target> Avant <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></target>
+        <source>Vor</source>
+        <target>Suivant</target>
       </segment>
     </unit>
     <unit id="rangeLabel">
@@ -4505,6 +4541,42 @@
         <target>Aucune donnée</target>
       </segment>
     </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Sélection</target>
+      </segment>
+    </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
+    <unit id="pie.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle</source>
+        <target>Tous</target>
+      </segment>
+    </unit>
+    <unit id="pie.custom">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Sélection</target>
+      </segment>
+    </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
         <note category="location">web/src/app/stats/dashboard.store.ts:436</note>
@@ -4559,6 +4631,15 @@
         <target>Tendance hebdomadaire</target>
       </segment>
     </unit>
+    <unit id="analysis.weekTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 8 Wochen</source>
+        <target>Les 8 dernières semaines</target>
+      </segment>
+    </unit>
     <unit id="analysis.weekCol">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,77</note>
@@ -4595,6 +4676,15 @@
       <segment state="translated">
         <source>Monatstrend</source>
         <target>Tendance mensuelle</target>
+      </segment>
+    </unit>
+    <unit id="analysis.monthTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:283,285</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 6 Monate</source>
+        <target>Les 6 derniers mois</target>
       </segment>
     </unit>
     <unit id="analysis.monthCol">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -4559,6 +4559,15 @@
         <target>Mode d'affichage de la répartition des types</target>
       </segment>
     </unit>
+    <unit id="pie.other">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
+      </notes>
+      <segment state="translated">
+        <source>Sonstige</source>
+        <target>Autres</target>
+      </segment>
+    </unit>
     <unit id="pie.top5">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3878,11 +3878,11 @@
     </unit>
     <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Zurück</source>
-        <target>Retour</target>
+        <source>Vorheriger Zeitraum</source>
+        <target>Période précédente</target>
       </segment>
     </unit>
     <unit id="rangeBack">
@@ -3896,11 +3896,11 @@
     </unit>
     <unit id="rangeTodayAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Heute</source>
-        <target>Aujourd'hui</target>
+        <source>Zum heutigen Zeitraum springen</source>
+        <target>Aller à la période d'aujourd'hui</target>
       </segment>
     </unit>
     <unit id="rangeToday">
@@ -3923,11 +3923,11 @@
     </unit>
     <unit id="rangeForwardAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Vor</source>
-        <target>Suivant</target>
+        <source>Nächster Zeitraum</source>
+        <target>Période suivante</target>
       </segment>
     </unit>
     <unit id="rangeForward">
@@ -4541,13 +4541,22 @@
         <target>Aucune donnée</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
+    <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:27,28</note>
       </notes>
       <segment state="translated">
-        <source>Auswahl</source>
-        <target>Sélection</target>
+        <source>Verteilung der Liegestütz-Typen</source>
+        <target>Répartition des types de pompes</target>
+      </segment>
+    </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Anzeigemodus der Typverteilung</source>
+        <target>Mode d'affichage de la répartition des types</target>
       </segment>
     </unit>
     <unit id="pie.top5">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -4559,6 +4559,15 @@
         <target>Modalità di visualizzazione della distribuzione</target>
       </segment>
     </unit>
+    <unit id="pie.other">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
+      </notes>
+      <segment state="translated">
+        <source>Sonstige</source>
+        <target>Altri</target>
+      </segment>
+    </unit>
     <unit id="pie.top5">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -3878,11 +3878,11 @@
     </unit>
     <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Zurück</source>
-        <target>Indietro</target>
+        <source>Vorheriger Zeitraum</source>
+        <target>Periodo precedente</target>
       </segment>
     </unit>
     <unit id="rangeBack">
@@ -3896,11 +3896,11 @@
     </unit>
     <unit id="rangeTodayAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Heute</source>
-        <target>Oggi</target>
+        <source>Zum heutigen Zeitraum springen</source>
+        <target>Vai al periodo di oggi</target>
       </segment>
     </unit>
     <unit id="rangeToday">
@@ -3923,11 +3923,11 @@
     </unit>
     <unit id="rangeForwardAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Vor</source>
-        <target>Avanti</target>
+        <source>Nächster Zeitraum</source>
+        <target>Periodo successivo</target>
       </segment>
     </unit>
     <unit id="rangeForward">
@@ -4541,13 +4541,22 @@
         <target>Nessun dato</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
+    <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:27,28</note>
       </notes>
       <segment state="translated">
-        <source>Auswahl</source>
-        <target>Selezione</target>
+        <source>Verteilung der Liegestütz-Typen</source>
+        <target>Distribuzione dei tipi di piegamenti</target>
+      </segment>
+    </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Anzeigemodus der Typverteilung</source>
+        <target>Modalità di visualizzazione della distribuzione</target>
       </segment>
     </unit>
     <unit id="pie.top5">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -3876,31 +3876,67 @@
         <target>anno</target>
       </segment>
     </unit>
-    <unit id="rangeBack">
+    <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:65,67</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
       </notes>
       <segment state="translated">
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Zurück </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Indietro </target>
+        <source>Zurück</source>
+        <target>Indietro</target>
+      </segment>
+    </unit>
+    <unit id="rangeBack">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:80,81</note>
+      </notes>
+      <segment state="translated">
+        <source>Zurück</source>
+        <target>Indietro</target>
+      </segment>
+    </unit>
+    <unit id="rangeTodayAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+      </notes>
+      <segment state="translated">
+        <source>Heute</source>
+        <target>Oggi</target>
       </segment>
     </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:74,75</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:92,93</note>
       </notes>
       <segment state="translated">
-        <source> Heute </source>
-        <target> Oggi </target>
+        <source>Heute</source>
+        <target>Oggi</target>
+      </segment>
+    </unit>
+    <unit id="rangePickerToggleAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112,113</note>
+      </notes>
+      <segment state="translated">
+        <source>Eigenen Zeitraum auswählen</source>
+        <target>Scegli un intervallo personalizzato</target>
+      </segment>
+    </unit>
+    <unit id="rangeForwardAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+      </notes>
+      <segment state="translated">
+        <source>Vor</source>
+        <target>Avanti</target>
       </segment>
     </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:82,85</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:103,104</note>
       </notes>
       <segment state="translated">
-        <source> Vor <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></source>
-        <target> Prima di <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></target>
+        <source>Vor</source>
+        <target>Avanti</target>
       </segment>
     </unit>
     <unit id="rangeLabel">
@@ -4505,6 +4541,42 @@
         <target>Nessun dato</target>
       </segment>
     </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Selezione</target>
+      </segment>
+    </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
+    <unit id="pie.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle</source>
+        <target>Tutti</target>
+      </segment>
+    </unit>
+    <unit id="pie.custom">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Selezione</target>
+      </segment>
+    </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
         <note category="location">web/src/app/stats/dashboard.store.ts:436</note>
@@ -4559,6 +4631,15 @@
         <target>Andamento settimanale</target>
       </segment>
     </unit>
+    <unit id="analysis.weekTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 8 Wochen</source>
+        <target>Ultime 8 settimane</target>
+      </segment>
+    </unit>
     <unit id="analysis.weekCol">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,77</note>
@@ -4595,6 +4676,15 @@
       <segment state="translated">
         <source>Monatstrend</source>
         <target>Andamento mensile</target>
+      </segment>
+    </unit>
+    <unit id="analysis.monthTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:283,285</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 6 Monate</source>
+        <target>Ultimi 6 mesi</target>
       </segment>
     </unit>
     <unit id="analysis.monthCol">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -4559,6 +4559,15 @@
         <target>Modus ostensionis distributionis generum</target>
       </segment>
     </unit>
+    <unit id="pie.other">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
+      </notes>
+      <segment state="translated">
+        <source>Sonstige</source>
+        <target>Cetera</target>
+      </segment>
+    </unit>
     <unit id="pie.top5">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3878,11 +3878,11 @@
     </unit>
     <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Zurück</source>
-        <target>Retro</target>
+        <source>Vorheriger Zeitraum</source>
+        <target>Spatium praecedens</target>
       </segment>
     </unit>
     <unit id="rangeBack">
@@ -3896,11 +3896,11 @@
     </unit>
     <unit id="rangeTodayAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Heute</source>
-        <target>Hodie</target>
+        <source>Zum heutigen Zeitraum springen</source>
+        <target>Salire ad spatium hodiernum</target>
       </segment>
     </unit>
     <unit id="rangeToday">
@@ -3923,11 +3923,11 @@
     </unit>
     <unit id="rangeForwardAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Vor</source>
-        <target>Procede</target>
+        <source>Nächster Zeitraum</source>
+        <target>Spatium sequens</target>
       </segment>
     </unit>
     <unit id="rangeForward">
@@ -4541,13 +4541,22 @@
         <target>Non data</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
+    <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:27,28</note>
       </notes>
       <segment state="translated">
-        <source>Auswahl</source>
-        <target>Selectio</target>
+        <source>Verteilung der Liegestütz-Typen</source>
+        <target>Distributio generum exercitiorum</target>
+      </segment>
+    </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Anzeigemodus der Typverteilung</source>
+        <target>Modus ostensionis distributionis generum</target>
       </segment>
     </unit>
     <unit id="pie.top5">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3876,31 +3876,67 @@
         <target>annus</target>
       </segment>
     </unit>
-    <unit id="rangeBack">
+    <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:65,67</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
       </notes>
       <segment state="translated">
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Zurück </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Back </target>
+        <source>Zurück</source>
+        <target>Retro</target>
+      </segment>
+    </unit>
+    <unit id="rangeBack">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:80,81</note>
+      </notes>
+      <segment state="translated">
+        <source>Zurück</source>
+        <target>Retro</target>
+      </segment>
+    </unit>
+    <unit id="rangeTodayAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+      </notes>
+      <segment state="translated">
+        <source>Heute</source>
+        <target>Hodie</target>
       </segment>
     </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:74,75</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:92,93</note>
       </notes>
       <segment state="translated">
-        <source> Heute </source>
-        <target> Hodie </target>
+        <source>Heute</source>
+        <target>Hodie</target>
+      </segment>
+    </unit>
+    <unit id="rangePickerToggleAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112,113</note>
+      </notes>
+      <segment state="translated">
+        <source>Eigenen Zeitraum auswählen</source>
+        <target>Elige spatium proprium</target>
+      </segment>
+    </unit>
+    <unit id="rangeForwardAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+      </notes>
+      <segment state="translated">
+        <source>Vor</source>
+        <target>Procede</target>
       </segment>
     </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:82,85</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:103,104</note>
       </notes>
       <segment state="translated">
-        <source> Vor <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></source>
-        <target> ante <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></target>
+        <source>Vor</source>
+        <target>Procede</target>
       </segment>
     </unit>
     <unit id="rangeLabel">
@@ -4505,6 +4541,42 @@
         <target>Non data</target>
       </segment>
     </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Selectio</target>
+      </segment>
+    </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
+    <unit id="pie.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle</source>
+        <target>Omnes</target>
+      </segment>
+    </unit>
+    <unit id="pie.custom">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Selectio</target>
+      </segment>
+    </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
         <note category="location">web/src/app/stats/dashboard.store.ts:436</note>
@@ -4559,6 +4631,15 @@
         <target>Weekly trend</target>
       </segment>
     </unit>
+    <unit id="analysis.weekTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 8 Wochen</source>
+        <target>Ultimae 8 hebdomades</target>
+      </segment>
+    </unit>
     <unit id="analysis.weekCol">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,77</note>
@@ -4595,6 +4676,15 @@
       <segment state="translated">
         <source>Monatstrend</source>
         <target>Vestibulum trend</target>
+      </segment>
+    </unit>
+    <unit id="analysis.monthTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:283,285</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 6 Monate</source>
+        <target>Ultimi 6 menses</target>
       </segment>
     </unit>
     <unit id="analysis.monthCol">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3878,11 +3878,11 @@
     </unit>
     <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Zurück</source>
-        <target>Terug</target>
+        <source>Vorheriger Zeitraum</source>
+        <target>Vorige periode</target>
       </segment>
     </unit>
     <unit id="rangeBack">
@@ -3896,11 +3896,11 @@
     </unit>
     <unit id="rangeTodayAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Heute</source>
-        <target>Vandaag</target>
+        <source>Zum heutigen Zeitraum springen</source>
+        <target>Naar de periode van vandaag</target>
       </segment>
     </unit>
     <unit id="rangeToday">
@@ -3923,11 +3923,11 @@
     </unit>
     <unit id="rangeForwardAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Vor</source>
-        <target>Vooruit</target>
+        <source>Nächster Zeitraum</source>
+        <target>Volgende periode</target>
       </segment>
     </unit>
     <unit id="rangeForward">
@@ -4541,13 +4541,22 @@
         <target>Geen gegevens</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
+    <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:27,28</note>
       </notes>
       <segment state="translated">
-        <source>Auswahl</source>
-        <target>Selectie</target>
+        <source>Verteilung der Liegestütz-Typen</source>
+        <target>Verdeling van push-uptypen</target>
+      </segment>
+    </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Anzeigemodus der Typverteilung</source>
+        <target>Weergavemodus van de typeverdeling</target>
       </segment>
     </unit>
     <unit id="pie.top5">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3876,31 +3876,67 @@
         <target>jaar</target>
       </segment>
     </unit>
-    <unit id="rangeBack">
+    <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:65,67</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
       </notes>
       <segment state="translated">
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Zurück </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Terug </target>
+        <source>Zurück</source>
+        <target>Terug</target>
+      </segment>
+    </unit>
+    <unit id="rangeBack">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:80,81</note>
+      </notes>
+      <segment state="translated">
+        <source>Zurück</source>
+        <target>Terug</target>
+      </segment>
+    </unit>
+    <unit id="rangeTodayAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+      </notes>
+      <segment state="translated">
+        <source>Heute</source>
+        <target>Vandaag</target>
       </segment>
     </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:74,75</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:92,93</note>
       </notes>
       <segment state="translated">
-        <source> Heute </source>
-        <target> Vandaag </target>
+        <source>Heute</source>
+        <target>Vandaag</target>
+      </segment>
+    </unit>
+    <unit id="rangePickerToggleAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112,113</note>
+      </notes>
+      <segment state="translated">
+        <source>Eigenen Zeitraum auswählen</source>
+        <target>Eigen periode kiezen</target>
+      </segment>
+    </unit>
+    <unit id="rangeForwardAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+      </notes>
+      <segment state="translated">
+        <source>Vor</source>
+        <target>Vooruit</target>
       </segment>
     </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:82,85</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:103,104</note>
       </notes>
       <segment state="translated">
-        <source> Vor <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></source>
-        <target> Vóór <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></target>
+        <source>Vor</source>
+        <target>Vooruit</target>
       </segment>
     </unit>
     <unit id="rangeLabel">
@@ -4505,6 +4541,42 @@
         <target>Geen gegevens</target>
       </segment>
     </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Selectie</target>
+      </segment>
+    </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
+    <unit id="pie.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle</source>
+        <target>Alle</target>
+      </segment>
+    </unit>
+    <unit id="pie.custom">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Selectie</target>
+      </segment>
+    </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
         <note category="location">web/src/app/stats/dashboard.store.ts:436</note>
@@ -4559,6 +4631,15 @@
         <target>Wekelijkse trend</target>
       </segment>
     </unit>
+    <unit id="analysis.weekTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 8 Wochen</source>
+        <target>Laatste 8 weken</target>
+      </segment>
+    </unit>
     <unit id="analysis.weekCol">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,77</note>
@@ -4595,6 +4676,15 @@
       <segment state="translated">
         <source>Monatstrend</source>
         <target>Maandelijkse trend</target>
+      </segment>
+    </unit>
+    <unit id="analysis.monthTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:283,285</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 6 Monate</source>
+        <target>Laatste 6 maanden</target>
       </segment>
     </unit>
     <unit id="analysis.monthCol">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -4559,6 +4559,15 @@
         <target>Weergavemodus van de typeverdeling</target>
       </segment>
     </unit>
+    <unit id="pie.other">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
+      </notes>
+      <segment state="translated">
+        <source>Sonstige</source>
+        <target>Overige</target>
+      </segment>
+    </unit>
     <unit id="pie.top5">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -362,6 +362,15 @@ Aktiv:         </target>
 
 
         </unit>
+    <unit id="analysis.monthTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:283,285</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 6 Monate</source>
+        <target>Siste 6 måneder</target>
+      </segment>
+    </unit>
     <unit id="analysis.repsCol">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:37,38</note>
@@ -453,6 +462,15 @@ Aktiv:         </target>
 
 
         </unit>
+    <unit id="analysis.weekTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 8 Wochen</source>
+        <target>Siste 8 uker</target>
+      </segment>
+    </unit>
     <unit id="analysis.avgSetsCol">
       <segment state="translated">
         <source>&#x2300; Sets</source>
@@ -2780,6 +2798,42 @@ Deine Position: # ·  Reps        </source>
 
 
         </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Utvalg</target>
+      </segment>
+    </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Topp 5</target>
+      </segment>
+    </unit>
+    <unit id="pie.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle</source>
+        <target>Alle</target>
+      </segment>
+    </unit>
+    <unit id="pie.custom">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>Utvalg</target>
+      </segment>
+    </unit>
     <unit id="quickActionsSubtitle">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:103,105</note>
@@ -2912,48 +2966,42 @@ Deine Position: # ·  Reps        </source>
 
 
         </unit>
+    <unit id="rangeBackAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+      </notes>
+      <segment state="translated">
+        <source>Zurück</source>
+        <target>Tilbake</target>
+      </segment>
+    </unit>
     <unit id="rangeBack">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:60,62</note>
-
-
-            </notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:80,81</note>
+      </notes>
       <segment state="translated">
-        <source>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc>
- Zurück         </source>
-        <target>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc>
- Tilbake         </target>
-
-
-
-            </segment>
-
-
-
-        </unit>
+        <source>Zurück</source>
+        <target>Tilbake</target>
+      </segment>
+    </unit>
+    <unit id="rangeForwardAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+      </notes>
+      <segment state="translated">
+        <source>Vor</source>
+        <target>Frem</target>
+      </segment>
+    </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77,80</note>
-
-
-            </notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:103,104</note>
+      </notes>
       <segment state="translated">
-        <source>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc>
- Vor         </source>
-        <target>
-          <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc>
- Framover         </target>
-
-
-
-            </segment>
-
-
-
-        </unit>
+        <source>Vor</source>
+        <target>Frem</target>
+      </segment>
+    </unit>
     <unit id="rangeFrom">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:90</note>
@@ -3065,23 +3113,33 @@ Deine Position: # ·  Reps        </source>
 
 
         </unit>
+    <unit id="rangeTodayAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+      </notes>
+      <segment state="translated">
+        <source>Heute</source>
+        <target>I dag</target>
+      </segment>
+    </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:69,70</note>
-
-
-            </notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:92,93</note>
+      </notes>
       <segment state="translated">
-        <source> Heute </source>
-        <target> I dag </target>
-
-
-
-            </segment>
-
-
-
-        </unit>
+        <source>Heute</source>
+        <target>I dag</target>
+      </segment>
+    </unit>
+    <unit id="rangePickerToggleAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112,113</note>
+      </notes>
+      <segment state="translated">
+        <source>Eigenen Zeitraum auswählen</source>
+        <target>Velg egendefinert periode</target>
+      </segment>
+    </unit>
     <unit id="repsLabel">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:162,163</note>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -2798,13 +2798,22 @@ Deine Position: # ·  Reps        </source>
 
 
         </unit>
-    <unit id="pie.modeAria">
+    <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:27,28</note>
       </notes>
       <segment state="translated">
-        <source>Auswahl</source>
-        <target>Utvalg</target>
+        <source>Verteilung der Liegestütz-Typen</source>
+        <target>Fordeling av push-up-typer</target>
+      </segment>
+    </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Anzeigemodus der Typverteilung</source>
+        <target>Visningsmodus for typefordeling</target>
       </segment>
     </unit>
     <unit id="pie.top5">
@@ -2968,11 +2977,11 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Zurück</source>
-        <target>Tilbake</target>
+        <source>Vorheriger Zeitraum</source>
+        <target>Forrige periode</target>
       </segment>
     </unit>
     <unit id="rangeBack">
@@ -2986,11 +2995,11 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="rangeForwardAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Vor</source>
-        <target>Frem</target>
+        <source>Nächster Zeitraum</source>
+        <target>Neste periode</target>
       </segment>
     </unit>
     <unit id="rangeForward">
@@ -3115,11 +3124,11 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="rangeTodayAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Heute</source>
-        <target>I dag</target>
+        <source>Zum heutigen Zeitraum springen</source>
+        <target>Gå til dagens periode</target>
       </segment>
     </unit>
     <unit id="rangeToday">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -2816,6 +2816,15 @@ Deine Position: # ·  Reps        </source>
         <target>Visningsmodus for typefordeling</target>
       </segment>
     </unit>
+    <unit id="pie.other">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
+      </notes>
+      <segment state="translated">
+        <source>Sonstige</source>
+        <target>Andre</target>
+      </segment>
+    </unit>
     <unit id="pie.top5">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4464,10 +4464,10 @@
     </unit>
     <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:76,77</note>
       </notes>
       <segment>
-        <source>Zurück</source>
+        <source>Vorheriger Zeitraum</source>
       </segment>
     </unit>
     <unit id="rangeBack">
@@ -4480,10 +4480,10 @@
     </unit>
     <unit id="rangeTodayAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:88,89</note>
       </notes>
       <segment>
-        <source>Heute</source>
+        <source>Zum heutigen Zeitraum springen</source>
       </segment>
     </unit>
     <unit id="rangeToday">
@@ -4496,10 +4496,10 @@
     </unit>
     <unit id="rangeForwardAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:100,101</note>
       </notes>
       <segment>
-        <source>Vor</source>
+        <source>Nächster Zeitraum</source>
       </segment>
     </unit>
     <unit id="rangeForward">
@@ -5036,17 +5036,25 @@
         <source>Löschen</source>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
+    <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:27,28</note>
       </notes>
       <segment>
-        <source>Auswahl</source>
+        <source>Verteilung der Liegestütz-Typen</source>
+      </segment>
+    </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49,50</note>
+      </notes>
+      <segment>
+        <source>Anzeigemodus der Typverteilung</source>
       </segment>
     </unit>
     <unit id="pie.top5">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:53,54</note>
       </notes>
       <segment>
         <source>Top 5</source>
@@ -5054,7 +5062,7 @@
     </unit>
     <unit id="pie.all">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:56,57</note>
       </notes>
       <segment>
         <source>Alle</source>
@@ -5062,7 +5070,7 @@
     </unit>
     <unit id="pie.custom">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:59,60</note>
       </notes>
       <segment>
         <source>Auswahl</source>
@@ -5070,7 +5078,7 @@
     </unit>
     <unit id="pie.avgSetSize">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:82,83</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:83,84</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
@@ -5078,7 +5086,7 @@
     </unit>
     <unit id="pie.noData">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:91,94</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:92,95</note>
       </notes>
       <segment>
         <source>Keine Daten</source>
@@ -5126,7 +5134,7 @@
     </unit>
     <unit id="analysisHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:52,53</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:53,54</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -5134,7 +5142,7 @@
     </unit>
     <unit id="analysisHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:54,56</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:55,57</note>
       </notes>
       <segment>
         <source> Trends, Verteilungen und Streaks deines Trainings auf einen Blick. </source>
@@ -5142,7 +5150,7 @@
     </unit>
     <unit id="analysis.empty.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:73,75</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:74,76</note>
       </notes>
       <segment>
         <source>Noch keine Daten zum Analysieren.</source>
@@ -5150,7 +5158,7 @@
     </unit>
     <unit id="analysis.empty.body">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,78</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:77,79</note>
       </notes>
       <segment>
         <source> Starte einen Trainingsplan oder trage deinen ersten Satz ein — dann zeigen wir dir hier Trends und Streaks. </source>
@@ -5158,7 +5166,7 @@
     </unit>
     <unit id="analysis.empty.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:87,89</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:88,90</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Trainingsplan wählen </source>
@@ -5166,7 +5174,7 @@
     </unit>
     <unit id="analysis.bestStreaksTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:109,111</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:110,112</note>
       </notes>
       <segment>
         <source>Bestwerte &amp; Streaks</source>
@@ -5174,7 +5182,7 @@
     </unit>
     <unit id="analysis.bestSingleEntry">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:115,117</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:116,118</note>
       </notes>
       <segment>
         <source>Bestwert Einzel-Eintrag:</source>
@@ -5182,7 +5190,7 @@
     </unit>
     <unit id="analysis.bestDay">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:120,122</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:121,123</note>
       </notes>
       <segment>
         <source>Bester Tag:</source>
@@ -5190,7 +5198,7 @@
     </unit>
     <unit id="analysis.bestSingleSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:129,131</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:130,132</note>
       </notes>
       <segment>
         <source>Bestes Einzel-Set:</source>
@@ -5198,7 +5206,7 @@
     </unit>
     <unit id="analysis.repsUnit">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:133,135</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:134,136</note>
       </notes>
       <segment>
         <source>Wdh.</source>
@@ -5206,7 +5214,7 @@
     </unit>
     <unit id="analysis.currentStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:138,140</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:139,141</note>
       </notes>
       <segment>
         <source>Aktuelle Streak:</source>
@@ -5214,8 +5222,8 @@
     </unit>
     <unit id="analysis.streakDays">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:141,142</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:149,150</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:142,143</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:150,151</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}"/> Tage</source>
@@ -5223,7 +5231,7 @@
     </unit>
     <unit id="analysis.longestStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:146,148</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:147,149</note>
       </notes>
       <segment>
         <source>Längste Streak:</source>
@@ -5231,7 +5239,7 @@
     </unit>
     <unit id="analysis.typesTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:159,161</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:160,162</note>
       </notes>
       <segment>
         <source>Typen (Anteile)</source>
@@ -5239,7 +5247,7 @@
     </unit>
     <unit id="analysis.avgSetSizeTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:173,174</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:174,175</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
@@ -5247,7 +5255,7 @@
     </unit>
     <unit id="analysis.repsPerSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:178,179</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:179,180</note>
       </notes>
       <segment>
         <source>Reps / Set</source>
@@ -5255,7 +5263,7 @@
     </unit>
     <unit id="analysis.setsDistTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:187,189</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:188,190</note>
       </notes>
       <segment>
         <source>Sets-Verteilung</source>
@@ -5263,7 +5271,7 @@
     </unit>
     <unit id="analysis.heatmapTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:202,204</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:203,205</note>
       </notes>
       <segment>
         <source>Heatmap (Wochentag/Uhrzeit)</source>
@@ -5271,7 +5279,7 @@
     </unit>
     <unit id="analysis.heatmapToggleAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:208,209</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:209,210</note>
       </notes>
       <segment>
         <source>Heatmap-Modus auswählen</source>
@@ -5279,7 +5287,7 @@
     </unit>
     <unit id="analysis.heatmapReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:212,214</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:213,215</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5287,7 +5295,7 @@
     </unit>
     <unit id="analysis.heatmapSets">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:215,217</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:216,218</note>
       </notes>
       <segment>
         <source>Sets</source>
@@ -5295,7 +5303,7 @@
     </unit>
     <unit id="analysis.weekTrendTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:230,232</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:231,233</note>
       </notes>
       <segment>
         <source>Wochentrend</source>
@@ -5303,7 +5311,7 @@
     </unit>
     <unit id="analysis.weekTrendSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:234,236</note>
       </notes>
       <segment>
         <source>Letzte 8 Wochen</source>
@@ -5311,7 +5319,7 @@
     </unit>
     <unit id="analysis.weekCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:241,242</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:242,243</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -5319,8 +5327,8 @@
     </unit>
     <unit id="analysis.repsCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:247,248</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:297,298</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:248,249</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:298,299</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5328,8 +5336,8 @@
     </unit>
     <unit id="analysis.avgSetsCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:255,256</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:305,306</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:256,257</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:306,307</note>
       </notes>
       <segment>
         <source>⌀ Sets</source>
@@ -5337,7 +5345,7 @@
     </unit>
     <unit id="analysis.monthTrendTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:280,282</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:281,283</note>
       </notes>
       <segment>
         <source>Monatstrend</source>
@@ -5345,7 +5353,7 @@
     </unit>
     <unit id="analysis.monthTrendSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:283,285</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:284,286</note>
       </notes>
       <segment>
         <source>Letzte 6 Monate</source>
@@ -5353,7 +5361,7 @@
     </unit>
     <unit id="analysis.monthCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:291,292</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:292,293</note>
       </notes>
       <segment>
         <source>Monat</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4416,7 +4416,7 @@
     </unit>
     <unit id="selectRangeTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:40,43</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:43,46</note>
       </notes>
       <segment>
         <source>Zeitraum auswählen</source>
@@ -4424,7 +4424,7 @@
     </unit>
     <unit id="quickRangeAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:45,46</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:48,49</note>
       </notes>
       <segment>
         <source>Schnellwahl Zeitraum</source>
@@ -4432,7 +4432,7 @@
     </unit>
     <unit id="rangeModeDay">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:53,54</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:56,57</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -4440,7 +4440,7 @@
     </unit>
     <unit id="rangeModeWeek">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:56,57</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:59,60</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -4448,7 +4448,7 @@
     </unit>
     <unit id="rangeModeMonth">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:59,60</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:62,63</note>
       </notes>
       <segment>
         <source>Monat</source>
@@ -4456,39 +4456,71 @@
     </unit>
     <unit id="rangeModeYear">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:62,63</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:65,66</note>
       </notes>
       <segment>
         <source>Jahr</source>
       </segment>
     </unit>
-    <unit id="rangeBack">
+    <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:74,76</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
       </notes>
       <segment>
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Zurück </source>
+        <source>Zurück</source>
+      </segment>
+    </unit>
+    <unit id="rangeBack">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:80,81</note>
+      </notes>
+      <segment>
+        <source>Zurück</source>
+      </segment>
+    </unit>
+    <unit id="rangeTodayAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+      </notes>
+      <segment>
+        <source>Heute</source>
       </segment>
     </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:84,85</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:92,93</note>
       </notes>
       <segment>
-        <source> Heute </source>
+        <source>Heute</source>
+      </segment>
+    </unit>
+    <unit id="rangeForwardAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+      </notes>
+      <segment>
+        <source>Vor</source>
       </segment>
     </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:93,96</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:103,104</note>
       </notes>
       <segment>
-        <source> Vor <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></source>
+        <source>Vor</source>
+      </segment>
+    </unit>
+    <unit id="rangePickerToggleAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112,113</note>
+      </notes>
+      <segment>
+        <source>Eigenen Zeitraum auswählen</source>
       </segment>
     </unit>
     <unit id="rangeLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:100,101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:121,122</note>
       </notes>
       <segment>
         <source>Zeitraum</source>
@@ -4496,7 +4528,7 @@
     </unit>
     <unit id="rangeFrom">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:106</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:127</note>
       </notes>
       <segment>
         <source>Von</source>
@@ -4504,7 +4536,7 @@
     </unit>
     <unit id="rangeTo">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:133</note>
       </notes>
       <segment>
         <source>Bis</source>
@@ -5004,9 +5036,41 @@
         <source>Löschen</source>
       </segment>
     </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+      </notes>
+      <segment>
+        <source>Auswahl</source>
+      </segment>
+    </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
+      </notes>
+      <segment>
+        <source>Top 5</source>
+      </segment>
+    </unit>
+    <unit id="pie.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
+      </notes>
+      <segment>
+        <source>Alle</source>
+      </segment>
+    </unit>
+    <unit id="pie.custom">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
+      </notes>
+      <segment>
+        <source>Auswahl</source>
+      </segment>
+    </unit>
     <unit id="pie.avgSetSize">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:47,48</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:82,83</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
@@ -5014,7 +5078,7 @@
     </unit>
     <unit id="pie.noData">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:56,59</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:91,94</note>
       </notes>
       <segment>
         <source>Keine Daten</source>
@@ -5100,59 +5164,9 @@
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Trainingsplan wählen </source>
       </segment>
     </unit>
-    <unit id="analysis.weekTrendTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:109,111</note>
-      </notes>
-      <segment>
-        <source>Wochentrend</source>
-      </segment>
-    </unit>
-    <unit id="analysis.weekCol">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:119,120</note>
-      </notes>
-      <segment>
-        <source>Woche</source>
-      </segment>
-    </unit>
-    <unit id="analysis.repsCol">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:125,126</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:169,170</note>
-      </notes>
-      <segment>
-        <source>Reps</source>
-      </segment>
-    </unit>
-    <unit id="analysis.avgSetsCol">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:131,132</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:175,176</note>
-      </notes>
-      <segment>
-        <source>⌀ Sets</source>
-      </segment>
-    </unit>
-    <unit id="analysis.monthTrendTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:153,155</note>
-      </notes>
-      <segment>
-        <source>Monatstrend</source>
-      </segment>
-    </unit>
-    <unit id="analysis.monthCol">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:163,164</note>
-      </notes>
-      <segment>
-        <source>Monat</source>
-      </segment>
-    </unit>
     <unit id="analysis.bestStreaksTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:197,199</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:109,111</note>
       </notes>
       <segment>
         <source>Bestwerte &amp; Streaks</source>
@@ -5160,7 +5174,7 @@
     </unit>
     <unit id="analysis.bestSingleEntry">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:203,205</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:115,117</note>
       </notes>
       <segment>
         <source>Bestwert Einzel-Eintrag:</source>
@@ -5168,7 +5182,7 @@
     </unit>
     <unit id="analysis.bestDay">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:208,210</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:120,122</note>
       </notes>
       <segment>
         <source>Bester Tag:</source>
@@ -5176,7 +5190,7 @@
     </unit>
     <unit id="analysis.bestSingleSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:217,219</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:129,131</note>
       </notes>
       <segment>
         <source>Bestes Einzel-Set:</source>
@@ -5184,7 +5198,7 @@
     </unit>
     <unit id="analysis.repsUnit">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:221,223</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:133,135</note>
       </notes>
       <segment>
         <source>Wdh.</source>
@@ -5192,7 +5206,7 @@
     </unit>
     <unit id="analysis.currentStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:226,228</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:138,140</note>
       </notes>
       <segment>
         <source>Aktuelle Streak:</source>
@@ -5200,8 +5214,8 @@
     </unit>
     <unit id="analysis.streakDays">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:229,230</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:237,238</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:141,142</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:149,150</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}"/> Tage</source>
@@ -5209,7 +5223,7 @@
     </unit>
     <unit id="analysis.longestStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:234,236</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:146,148</note>
       </notes>
       <segment>
         <source>Längste Streak:</source>
@@ -5217,7 +5231,7 @@
     </unit>
     <unit id="analysis.typesTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:247,249</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:159,161</note>
       </notes>
       <segment>
         <source>Typen (Anteile)</source>
@@ -5225,7 +5239,7 @@
     </unit>
     <unit id="analysis.avgSetSizeTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:261,262</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:173,174</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
@@ -5233,7 +5247,7 @@
     </unit>
     <unit id="analysis.repsPerSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:266,267</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:178,179</note>
       </notes>
       <segment>
         <source>Reps / Set</source>
@@ -5241,7 +5255,7 @@
     </unit>
     <unit id="analysis.setsDistTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:275,277</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:187,189</note>
       </notes>
       <segment>
         <source>Sets-Verteilung</source>
@@ -5249,7 +5263,7 @@
     </unit>
     <unit id="analysis.heatmapTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:290,292</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:202,204</note>
       </notes>
       <segment>
         <source>Heatmap (Wochentag/Uhrzeit)</source>
@@ -5257,7 +5271,7 @@
     </unit>
     <unit id="analysis.heatmapToggleAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:296,297</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:208,209</note>
       </notes>
       <segment>
         <source>Heatmap-Modus auswählen</source>
@@ -5265,7 +5279,7 @@
     </unit>
     <unit id="analysis.heatmapReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:300,302</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:212,214</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5273,10 +5287,76 @@
     </unit>
     <unit id="analysis.heatmapSets">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:303,305</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:215,217</note>
       </notes>
       <segment>
         <source>Sets</source>
+      </segment>
+    </unit>
+    <unit id="analysis.weekTrendTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:230,232</note>
+      </notes>
+      <segment>
+        <source>Wochentrend</source>
+      </segment>
+    </unit>
+    <unit id="analysis.weekTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+      </notes>
+      <segment>
+        <source>Letzte 8 Wochen</source>
+      </segment>
+    </unit>
+    <unit id="analysis.weekCol">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:241,242</note>
+      </notes>
+      <segment>
+        <source>Woche</source>
+      </segment>
+    </unit>
+    <unit id="analysis.repsCol">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:247,248</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:297,298</note>
+      </notes>
+      <segment>
+        <source>Reps</source>
+      </segment>
+    </unit>
+    <unit id="analysis.avgSetsCol">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:255,256</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:305,306</note>
+      </notes>
+      <segment>
+        <source>⌀ Sets</source>
+      </segment>
+    </unit>
+    <unit id="analysis.monthTrendTitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:280,282</note>
+      </notes>
+      <segment>
+        <source>Monatstrend</source>
+      </segment>
+    </unit>
+    <unit id="analysis.monthTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:283,285</note>
+      </notes>
+      <segment>
+        <source>Letzte 6 Monate</source>
+      </segment>
+    </unit>
+    <unit id="analysis.monthCol">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:291,292</note>
+      </notes>
+      <segment>
+        <source>Monat</source>
       </segment>
     </unit>
     <unit id="historyHeaderTitle">
@@ -6192,7 +6272,7 @@
     </unit>
     <unit id="dashboard.goalFill.reached">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:300,302</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:304,306</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -6200,7 +6280,7 @@
     </unit>
     <unit id="dashboard.goalFill.fill">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:303,304</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:307,308</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> bis zum Ziel</source>
@@ -6208,7 +6288,7 @@
     </unit>
     <unit id="quickAddNew">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:315,317</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:319,321</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">edit_note</pc> Neu </source>
@@ -6216,7 +6296,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:336,340</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:340,344</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -6224,7 +6304,7 @@
     </unit>
     <unit id="dashboard.latestEntriesLinkAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:347,348</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:351,352</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6232,7 +6312,7 @@
     </unit>
     <unit id="dashboard.latestEntries">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:350,351</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:354,355</note>
       </notes>
       <segment>
         <source>Letzte Einträge</source>
@@ -6240,7 +6320,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:357,358</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:361,362</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6248,7 +6328,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:361,364</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:365,368</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -6256,7 +6336,7 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:367</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:371</note>
       </notes>
       <segment>
         <source>Werbung</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4520,7 +4520,7 @@
     </unit>
     <unit id="rangeLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:121,122</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:125,126</note>
       </notes>
       <segment>
         <source>Zeitraum</source>
@@ -4528,7 +4528,7 @@
     </unit>
     <unit id="rangeFrom">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:127</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:131</note>
       </notes>
       <segment>
         <source>Von</source>
@@ -4536,7 +4536,7 @@
     </unit>
     <unit id="rangeTo">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:133</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:137</note>
       </notes>
       <segment>
         <source>Bis</source>
@@ -5038,7 +5038,7 @@
     </unit>
     <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:27,28</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:36,37</note>
       </notes>
       <segment>
         <source>Verteilung der Liegestütz-Typen</source>
@@ -5046,7 +5046,7 @@
     </unit>
     <unit id="pie.modeAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49,50</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
       </notes>
       <segment>
         <source>Anzeigemodus der Typverteilung</source>
@@ -5054,7 +5054,7 @@
     </unit>
     <unit id="pie.top5">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:53,54</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,63</note>
       </notes>
       <segment>
         <source>Top 5</source>
@@ -5062,7 +5062,7 @@
     </unit>
     <unit id="pie.all">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:56,57</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:65,66</note>
       </notes>
       <segment>
         <source>Alle</source>
@@ -5070,7 +5070,7 @@
     </unit>
     <unit id="pie.custom">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:59,60</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:68,69</note>
       </notes>
       <segment>
         <source>Auswahl</source>
@@ -5078,15 +5078,23 @@
     </unit>
     <unit id="pie.avgSetSize">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:83,84</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:92,93</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
       </segment>
     </unit>
+    <unit id="pie.other">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:102,103</note>
+      </notes>
+      <segment>
+        <source>Sonstige</source>
+      </segment>
+    </unit>
     <unit id="pie.noData">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:92,95</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:110,113</note>
       </notes>
       <segment>
         <source>Keine Daten</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -4488,11 +4488,11 @@
     </unit>
     <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Zurück</source>
-        <target>上一页</target>
+        <source>Vorheriger Zeitraum</source>
+        <target>上一周期</target>
       </segment>
     </unit>
     <unit id="rangeBack">
@@ -4501,16 +4501,16 @@
       </notes>
       <segment state="translated">
         <source>Zurück</source>
-        <target>上一页</target>
+        <target>上一周期</target>
       </segment>
     </unit>
     <unit id="rangeTodayAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Heute</source>
-        <target>今天</target>
+        <source>Zum heutigen Zeitraum springen</source>
+        <target>跳到今天的周期</target>
       </segment>
     </unit>
     <unit id="rangeToday">
@@ -4533,11 +4533,11 @@
     </unit>
     <unit id="rangeForwardAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Vor</source>
-        <target>下一页</target>
+        <source>Nächster Zeitraum</source>
+        <target>下一周期</target>
       </segment>
     </unit>
     <unit id="rangeForward">
@@ -4546,7 +4546,7 @@
       </notes>
       <segment state="translated">
         <source>Vor</source>
-        <target>下一页</target>
+        <target>下一周期</target>
       </segment>
     </unit>
     <unit id="rangeLabel">
@@ -5083,13 +5083,22 @@
         <source>Keine Daten</source>
       <target>无数据</target></segment>
     </unit>
-    <unit id="pie.modeAria">
+    <unit id="pie.distributionAria">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:27,28</note>
       </notes>
       <segment state="translated">
-        <source>Auswahl</source>
-        <target>选择</target>
+        <source>Verteilung der Liegestütz-Typen</source>
+        <target>俯卧撑类型分布</target>
+      </segment>
+    </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Anzeigemodus der Typverteilung</source>
+        <target>选择饼图显示模式</target>
       </segment>
     </unit>
     <unit id="pie.top5">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -5101,6 +5101,15 @@
         <target>选择饼图显示模式</target>
       </segment>
     </unit>
+    <unit id="pie.other">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
+      </notes>
+      <segment state="translated">
+        <source>Sonstige</source>
+        <target>其他</target>
+      </segment>
+    </unit>
     <unit id="pie.top5">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -4486,31 +4486,68 @@
         <source>Jahr</source>
       <target>年</target></segment>
     </unit>
-    <unit id="rangeBack">
+    <unit id="rangeBackAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:74,76</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:77</note>
       </notes>
       <segment state="translated">
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_left</pc> Zurück </source>
-
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">arrow_back</pc> 返回</target>
+        <source>Zurück</source>
+        <target>上一页</target>
+      </segment>
+    </unit>
+    <unit id="rangeBack">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:80,81</note>
+      </notes>
+      <segment state="translated">
+        <source>Zurück</source>
+        <target>上一页</target>
+      </segment>
+    </unit>
+    <unit id="rangeTodayAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:89</note>
+      </notes>
+      <segment state="translated">
+        <source>Heute</source>
+        <target>今天</target>
       </segment>
     </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:84,85</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:92,93</note>
       </notes>
       <segment state="translated">
-        <source> Heute </source>
-      <target> 今天 </target></segment>
+        <source>Heute</source>
+        <target>今天</target>
+      </segment>
+    </unit>
+    <unit id="rangePickerToggleAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112,113</note>
+      </notes>
+      <segment state="translated">
+        <source>Eigenen Zeitraum auswählen</source>
+        <target>选择自定义范围</target>
+      </segment>
+    </unit>
+    <unit id="rangeForwardAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:101</note>
+      </notes>
+      <segment state="translated">
+        <source>Vor</source>
+        <target>下一页</target>
+      </segment>
     </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:93,96</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:103,104</note>
       </notes>
       <segment state="translated">
-        <source> Vor <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">chevron_right</pc></source>
-      <target> 下一步 <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&amp;lt;mat-icon&amp;gt;" dispEnd="&amp;lt;/mat-icon&amp;gt;">chevron_right</pc></target></segment>
+        <source>Vor</source>
+        <target>下一页</target>
+      </segment>
     </unit>
     <unit id="rangeLabel">
       <notes>
@@ -5046,6 +5083,42 @@
         <source>Keine Daten</source>
       <target>无数据</target></segment>
     </unit>
+    <unit id="pie.modeAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:49</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>选择</target>
+      </segment>
+    </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>前 5</target>
+      </segment>
+    </unit>
+    <unit id="pie.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle</source>
+        <target>全部</target>
+      </segment>
+    </unit>
+    <unit id="pie.custom">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
+      </notes>
+      <segment state="translated">
+        <source>Auswahl</source>
+        <target>选择</target>
+      </segment>
+    </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
         <note category="location">web/src/app/stats/dashboard.store.ts:434</note>
@@ -5094,6 +5167,15 @@
         <source>Wochentrend</source>
       <target>周趋势</target></segment>
     </unit>
+    <unit id="analysis.weekTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:233,235</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 8 Wochen</source>
+        <target>最近 8 周</target>
+      </segment>
+    </unit>
     <unit id="analysis.weekCol">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,77</note>
@@ -5127,6 +5209,15 @@
       <segment state="translated">
         <source>Monatstrend</source>
       <target>月趋势</target></segment>
+    </unit>
+    <unit id="analysis.monthTrendSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:283,285</note>
+      </notes>
+      <segment state="translated">
+        <source>Letzte 6 Monate</source>
+        <target>最近 6 个月</target>
+      </segment>
     </unit>
     <unit id="analysis.monthCol">
       <notes>


### PR DESCRIPTION
- FilterBar: hide the "Zeitraum auswählen" heading (visually-hidden / sr-only on every viewport — the analysis page header above already announces context), collapse the date picker behind a calendar icon toggle on mobile, use compact icon-only Heute button so the sticky bar takes one row instead of three on small screens. On desktop the quick-range and date picker share a flex row.
- Move Wochentrend and Monatstrend below the heatmap and wrap them in `@defer (on viewport)` so they only render when the user scrolls. The placeholder reserves min-height so revealing the table doesn't shift surrounding content.
- Wochentrend always covers the last 8 ISO weeks, Monatstrend the last 6 calendar months — independent of the page filter so users always see recent momentum. Both windows zero-fill missing buckets so they always render fixed-length tables, and the trend filters are reactive to a `clockTick` signal that's bumped only when the local calendar day actually changes.
- TypePieComponent: add Top 5 / Alle / Auswahl mode toggle plus per-row checkboxes; toggling a checkbox switches mode to Auswahl and updates the visible pie segments. The pie always reads as a complete circle thanks to an explicit "Sonstige" arc covering the unselected remainder. Selection and `data-testid` are keyed by a stable canonical id (not the localized label) so screen readers and tests are locale-independent.

## Summary by CodeRabbit

* **New Features**
  * Added interactive pie chart with selection modes: Top 5, All, and Custom selections
  * Mobile-optimized filter bar with toggleable date picker for custom ranges
  * Week and month trend views now display fixed time windows (8 weeks and 6 months respectively)

* **Improvements**
  * Enhanced accessibility throughout with improved ARIA labels for navigation controls
  * Optimized mobile responsiveness for date range navigation and filtering
  * Updated translations across multiple languages for new UI elements
