### PR TITLE
feat(analysis): replace pie mode toggle with scrollable checkbox list

### DIFF
--- a/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
@@ -30,9 +30,8 @@ describe('TypePieComponent', () => {
     fixture.detectChanges();
   });
 
-  it('defaults to Top 5 mode and selects the five highest-value ids', () => {
+  it('preselects the top 5 highest-value ids by default', () => {
     // Then
-    expect(component.mode()).toBe('top5');
     expect([...component.selectedIds()]).toEqual([
       'Standard',
       'Diamond',
@@ -47,22 +46,11 @@ describe('TypePieComponent', () => {
     expect(component.otherPercent()).toBeGreaterThan(0);
   });
 
-  it('switches to Alle mode when toggled, selecting every id and dropping the Other arc', () => {
-    // When
-    component.setMode('all');
-
-    // Then
-    expect(component.selectedIds().size).toBe(7);
-    expect(component.visibleSegments()).toHaveLength(7);
-    expect(component.otherPercent()).toBe(0);
-  });
-
-  it('toggling a checkbox switches mode to custom and updates the subset', () => {
-    // When: Diamond is toggled
+  it('toggling a checkbox removes the type and drops its slice from the pie', () => {
+    // When: Diamond is toggled off
     component.toggle('Diamond');
 
-    // Then: mode flips to custom and Diamond drops out
-    expect(component.mode()).toBe('custom');
+    // Then: Diamond drops out, Standard remains
     expect(component.isSelected('Diamond')).toBe(false);
     expect(component.isSelected('Standard')).toBe(true);
 
@@ -71,6 +59,20 @@ describe('TypePieComponent', () => {
 
     // Then: it re-enters the selection
     expect(component.isSelected('Diamond')).toBe(true);
+  });
+
+  it('toggling a previously-hidden type adds it to the visible set', () => {
+    // Given: Spider is initially hidden (rank 6, not in default top 5)
+    expect(component.isSelected('Spider')).toBe(false);
+
+    // When: the user opts Spider in
+    component.toggle('Spider');
+
+    // Then: Spider is visible and contributes a real slice (not "Other")
+    expect(component.isSelected('Spider')).toBe(true);
+    expect(component.visibleSegments().some((s) => s.id === 'Spider')).toBe(
+      true
+    );
   });
 
   it('clicking a mat-checkbox in the legend wires through to toggle()', async () => {
@@ -85,28 +87,9 @@ describe('TypePieComponent', () => {
     // When: the user toggles the Diamond checkbox via Material's public API
     await diamondCheckbox.toggle();
 
-    // Then: the component's (change) binding flips mode and selection
-    expect(component.mode()).toBe('custom');
+    // Then: the component's (change) binding flips selection
     expect(component.isSelected('Diamond')).toBe(false);
     expect(component.isSelected('Standard')).toBe(true);
-  });
-
-  it('seeds custom selection from the current visible set when entering Auswahl via the toggle', () => {
-    // When: switching directly from Top 5 to custom
-    component.setMode('custom');
-
-    // Then: the top-5 selection is preserved instead of starting empty,
-    // and the Other arc still completes the circle.
-    expect(component.mode()).toBe('custom');
-    expect([...component.selectedIds()]).toEqual([
-      'Standard',
-      'Diamond',
-      'Wide',
-      'Decline',
-      'Knee',
-    ]);
-    expect(component.visibleSegments()).toHaveLength(6);
-    expect(component.visibleSegments().at(-1)?.id).toBe('__other__');
   });
 
   it('uses the stable id (not the localized label) for selection and test selectors', () => {
@@ -128,16 +111,7 @@ describe('TypePieComponent', () => {
     ).toBeTruthy();
   });
 
-  it('switching from Alle to Auswahl seeds custom selection with every label', () => {
-    // When
-    component.setMode('all');
-    component.setMode('custom');
-
-    // Then
-    expect(component.selectedIds().size).toBe(7);
-  });
-
-  it('renders one legend row with checkbox per type, regardless of mode', () => {
+  it('renders one legend row with checkbox per type', () => {
     // Then
     const host: HTMLElement = fixture.nativeElement;
     const rows = host.querySelectorAll(
@@ -146,12 +120,18 @@ describe('TypePieComponent', () => {
     expect(rows).toHaveLength(7);
   });
 
-  it('exposes toggle hooks per label so the legend can drive subset selection', () => {
-    // Then
+  it('legend container caps its height so the list scrolls when many types are present', () => {
+    // Given: the legend element rendered for the 7 types in beforeEach
     const host: HTMLElement = fixture.nativeElement;
-    expect(
-      host.querySelector('[data-testid="type-pie-toggle-Standard"]')
-    ).toBeTruthy();
+    const legend = host.querySelector(
+      '[data-testid="type-pie-legend"]'
+    ) as HTMLElement | null;
+
+    // Then: it has a bounded height with vertical overflow auto so users can scroll
+    expect(legend).toBeTruthy();
+    const styles = getComputedStyle(legend!);
+    expect(styles.overflowY).toBe('auto');
+    expect(styles.maxHeight).not.toBe('none');
   });
 
   it('shows the empty placeholder when total is zero', () => {
@@ -175,5 +155,18 @@ describe('TypePieComponent', () => {
     expect(segments[0].color).toBe('#1976d2');
     expect(segments[1].label).toBe('Diamond');
     expect(segments[1].color).toBe('#9c27b0');
+  });
+
+  it('removing the last selected type empties the pie and treats all data as Other', () => {
+    // When: the user unchecks every default-selected type
+    for (const id of [...component.selectedIds()]) {
+      component.toggle(id);
+    }
+
+    // Then: the visible set is just the synthetic Other arc covering 100%
+    expect(component.selectedIds().size).toBe(0);
+    expect(component.visibleSegments()).toHaveLength(1);
+    expect(component.visibleSegments()[0].id).toBe('__other__');
+    expect(component.otherPercent()).toBe(100);
   });
 });

--- a/web/src/app/stats/components/type-pie/type-pie.component.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.ts
@@ -1,6 +1,5 @@
 import { DecimalPipe } from '@angular/common';
 import { Component, computed, input, signal } from '@angular/core';
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 
 export interface PieDatum {
@@ -17,15 +16,13 @@ export interface PieDatum {
   avgSetSize?: number;
 }
 
-export type PieSelectionMode = 'top5' | 'all' | 'custom';
-
 const TOP_N = 5;
 const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
 
 @Component({
   selector: 'app-type-pie',
   standalone: true,
-  imports: [DecimalPipe, MatButtonToggleModule, MatCheckboxModule],
+  imports: [DecimalPipe, MatCheckboxModule],
   template: `
     @if (total() > 0) {
       <div class="wrap">
@@ -51,24 +48,6 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
               />
             }
           </svg>
-
-          <mat-button-toggle-group
-            class="mode-toggle"
-            [value]="mode()"
-            (change)="setMode($event.value)"
-            aria-label="Anzeigemodus der Typverteilung"
-            i18n-aria-label="@@pie.modeAria"
-          >
-            <mat-button-toggle value="top5" i18n="@@pie.top5"
-              >Top 5</mat-button-toggle
-            >
-            <mat-button-toggle value="all" i18n="@@pie.all"
-              >Alle</mat-button-toggle
-            >
-            <mat-button-toggle value="custom" i18n="@@pie.custom"
-              >Auswahl</mat-button-toggle
-            >
-          </mat-button-toggle-group>
         </div>
 
         <div class="legend" data-testid="type-pie-legend">
@@ -130,9 +109,6 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
       height: 160px;
       transform: rotate(-90deg);
     }
-    .mode-toggle {
-      font-size: 0.78rem;
-    }
     .bg {
       fill: none;
       stroke: rgba(0, 0, 0, 0.08);
@@ -148,6 +124,9 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
       display: grid;
       gap: 4px;
       min-width: 0;
+      max-height: 220px;
+      overflow-y: auto;
+      padding-right: 4px;
     }
     .row {
       display: grid;
@@ -212,8 +191,8 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
 export class TypePieComponent {
   readonly data = input<PieDatum[]>([]);
 
-  readonly mode = signal<PieSelectionMode>('top5');
-  private readonly customSelection = signal<ReadonlySet<string>>(new Set());
+  // null = use top-5 default; concrete Set = explicit user choice (may be empty).
+  private readonly userSelection = signal<ReadonlySet<string> | null>(null);
 
   readonly otherColor = OTHER_COLOR;
 
@@ -259,15 +238,13 @@ export class TypePieComponent {
   });
 
   readonly selectedIds = computed<ReadonlySet<string>>(() => {
-    const all = this.allSegments();
-    const mode = this.mode();
-    if (mode === 'top5') {
-      return new Set(all.slice(0, TOP_N).map((s) => s.id));
-    }
-    if (mode === 'all') {
-      return new Set(all.map((s) => s.id));
-    }
-    return this.customSelection();
+    const explicit = this.userSelection();
+    if (explicit !== null) return explicit;
+    return new Set(
+      this.allSegments()
+        .slice(0, TOP_N)
+        .map((s) => s.id)
+    );
   });
 
   readonly visibleSegments = computed(() => {
@@ -339,15 +316,6 @@ export class TypePieComponent {
     } else {
       next.add(id);
     }
-    this.customSelection.set(next);
-    this.mode.set('custom');
-  }
-
-  setMode(value: PieSelectionMode): void {
-    if (!value) return;
-    if (value === 'custom') {
-      this.customSelection.set(new Set(this.selectedIds()));
-    }
-    this.mode.set(value);
+    this.userSelection.set(next);
   }
 }

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -4634,15 +4634,6 @@
         <target>Κατανομή τύπων push-up</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>Anzeigemodus der Typverteilung</source>
-        <target>Λειτουργία προβολής κατανομής τύπων</target>
-      </segment>
-    </unit>
     <unit id="pie.other">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
@@ -4650,33 +4641,6 @@
       <segment state="translated">
         <source>Sonstige</source>
         <target>Άλλα</target>
-      </segment>
-    </unit>
-    <unit id="pie.top5">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
-      </notes>
-      <segment state="translated">
-        <source>Top 5</source>
-        <target>Top 5</target>
-      </segment>
-    </unit>
-    <unit id="pie.all">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
-      </notes>
-      <segment state="translated">
-        <source>Alle</source>
-        <target>Όλα</target>
-      </segment>
-    </unit>
-    <unit id="pie.custom">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
-      </notes>
-      <segment state="translated">
-        <source>Auswahl</source>
-        <target>Επιλογή</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -2785,15 +2785,6 @@ Deine Position: # ·  Reps        </source>
         <target>Pushup type distribution</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>Anzeigemodus der Typverteilung</source>
-        <target>Pie segment filter mode</target>
-      </segment>
-    </unit>
     <unit id="pie.other">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
@@ -2801,33 +2792,6 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source>Sonstige</source>
         <target>Other</target>
-      </segment>
-    </unit>
-    <unit id="pie.top5">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
-      </notes>
-      <segment state="translated">
-        <source>Top 5</source>
-        <target>Top 5</target>
-      </segment>
-    </unit>
-    <unit id="pie.all">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
-      </notes>
-      <segment state="translated">
-        <source>Alle</source>
-        <target>All</target>
-      </segment>
-    </unit>
-    <unit id="pie.custom">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
-      </notes>
-      <segment state="translated">
-        <source>Auswahl</source>
-        <target>Custom</target>
       </segment>
     </unit>
     <unit id="quickActionsSubtitle">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -4634,15 +4634,6 @@
         <target>Distribución de tipos de flexiones</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>Anzeigemodus der Typverteilung</source>
-        <target>Modo de visualización de la distribución de tipos</target>
-      </segment>
-    </unit>
     <unit id="pie.other">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
@@ -4650,33 +4641,6 @@
       <segment state="translated">
         <source>Sonstige</source>
         <target>Otros</target>
-      </segment>
-    </unit>
-    <unit id="pie.top5">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
-      </notes>
-      <segment state="translated">
-        <source>Top 5</source>
-        <target>Top 5</target>
-      </segment>
-    </unit>
-    <unit id="pie.all">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
-      </notes>
-      <segment state="translated">
-        <source>Alle</source>
-        <target>Todos</target>
-      </segment>
-    </unit>
-    <unit id="pie.custom">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
-      </notes>
-      <segment state="translated">
-        <source>Auswahl</source>
-        <target>Selección</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -4634,15 +4634,6 @@
         <target>Répartition des types de pompes</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>Anzeigemodus der Typverteilung</source>
-        <target>Mode d'affichage de la répartition des types</target>
-      </segment>
-    </unit>
     <unit id="pie.other">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
@@ -4650,33 +4641,6 @@
       <segment state="translated">
         <source>Sonstige</source>
         <target>Autres</target>
-      </segment>
-    </unit>
-    <unit id="pie.top5">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
-      </notes>
-      <segment state="translated">
-        <source>Top 5</source>
-        <target>Top 5</target>
-      </segment>
-    </unit>
-    <unit id="pie.all">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
-      </notes>
-      <segment state="translated">
-        <source>Alle</source>
-        <target>Tous</target>
-      </segment>
-    </unit>
-    <unit id="pie.custom">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
-      </notes>
-      <segment state="translated">
-        <source>Auswahl</source>
-        <target>Sélection</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -4634,15 +4634,6 @@
         <target>Distribuzione dei tipi di piegamenti</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>Anzeigemodus der Typverteilung</source>
-        <target>Modalità di visualizzazione della distribuzione</target>
-      </segment>
-    </unit>
     <unit id="pie.other">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
@@ -4650,33 +4641,6 @@
       <segment state="translated">
         <source>Sonstige</source>
         <target>Altri</target>
-      </segment>
-    </unit>
-    <unit id="pie.top5">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
-      </notes>
-      <segment state="translated">
-        <source>Top 5</source>
-        <target>Top 5</target>
-      </segment>
-    </unit>
-    <unit id="pie.all">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
-      </notes>
-      <segment state="translated">
-        <source>Alle</source>
-        <target>Tutti</target>
-      </segment>
-    </unit>
-    <unit id="pie.custom">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
-      </notes>
-      <segment state="translated">
-        <source>Auswahl</source>
-        <target>Selezione</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -4634,15 +4634,6 @@
         <target>Distributio generum exercitiorum</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>Anzeigemodus der Typverteilung</source>
-        <target>Modus ostensionis distributionis generum</target>
-      </segment>
-    </unit>
     <unit id="pie.other">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
@@ -4650,33 +4641,6 @@
       <segment state="translated">
         <source>Sonstige</source>
         <target>Cetera</target>
-      </segment>
-    </unit>
-    <unit id="pie.top5">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
-      </notes>
-      <segment state="translated">
-        <source>Top 5</source>
-        <target>Top 5</target>
-      </segment>
-    </unit>
-    <unit id="pie.all">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
-      </notes>
-      <segment state="translated">
-        <source>Alle</source>
-        <target>Omnes</target>
-      </segment>
-    </unit>
-    <unit id="pie.custom">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
-      </notes>
-      <segment state="translated">
-        <source>Auswahl</source>
-        <target>Selectio</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -4634,15 +4634,6 @@
         <target>Verdeling van push-uptypen</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>Anzeigemodus der Typverteilung</source>
-        <target>Weergavemodus van de typeverdeling</target>
-      </segment>
-    </unit>
     <unit id="pie.other">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
@@ -4650,33 +4641,6 @@
       <segment state="translated">
         <source>Sonstige</source>
         <target>Overige</target>
-      </segment>
-    </unit>
-    <unit id="pie.top5">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
-      </notes>
-      <segment state="translated">
-        <source>Top 5</source>
-        <target>Top 5</target>
-      </segment>
-    </unit>
-    <unit id="pie.all">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
-      </notes>
-      <segment state="translated">
-        <source>Alle</source>
-        <target>Alle</target>
-      </segment>
-    </unit>
-    <unit id="pie.custom">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
-      </notes>
-      <segment state="translated">
-        <source>Auswahl</source>
-        <target>Selectie</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -2807,15 +2807,6 @@ Deine Position: # ·  Reps        </source>
         <target>Fordeling av push-up-typer</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>Anzeigemodus der Typverteilung</source>
-        <target>Visningsmodus for typefordeling</target>
-      </segment>
-    </unit>
     <unit id="pie.other">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
@@ -2823,33 +2814,6 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source>Sonstige</source>
         <target>Andre</target>
-      </segment>
-    </unit>
-    <unit id="pie.top5">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
-      </notes>
-      <segment state="translated">
-        <source>Top 5</source>
-        <target>Topp 5</target>
-      </segment>
-    </unit>
-    <unit id="pie.all">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
-      </notes>
-      <segment state="translated">
-        <source>Alle</source>
-        <target>Alle</target>
-      </segment>
-    </unit>
-    <unit id="pie.custom">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
-      </notes>
-      <segment state="translated">
-        <source>Auswahl</source>
-        <target>Utvalg</target>
       </segment>
     </unit>
     <unit id="quickActionsSubtitle">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -5164,38 +5164,6 @@
         <source>Verteilung der Liegestütz-Typen</source>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
-      </notes>
-      <segment>
-        <source>Anzeigemodus der Typverteilung</source>
-      </segment>
-    </unit>
-    <unit id="pie.top5">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,63</note>
-      </notes>
-      <segment>
-        <source>Top 5</source>
-      </segment>
-    </unit>
-    <unit id="pie.all">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:65,66</note>
-      </notes>
-      <segment>
-        <source>Alle</source>
-      </segment>
-    </unit>
-    <unit id="pie.custom">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:68,69</note>
-      </notes>
-      <segment>
-        <source>Auswahl</source>
-      </segment>
-    </unit>
     <unit id="pie.avgSetSize">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:92,93</note>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -5176,15 +5176,6 @@
         <target>俯卧撑类型分布</target>
       </segment>
     </unit>
-    <unit id="pie.modeAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>Anzeigemodus der Typverteilung</source>
-        <target>选择饼图显示模式</target>
-      </segment>
-    </unit>
     <unit id="pie.other">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
@@ -5192,33 +5183,6 @@
       <segment state="translated">
         <source>Sonstige</source>
         <target>其他</target>
-      </segment>
-    </unit>
-    <unit id="pie.top5">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:52,53</note>
-      </notes>
-      <segment state="translated">
-        <source>Top 5</source>
-        <target>前 5</target>
-      </segment>
-    </unit>
-    <unit id="pie.all">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:55,56</note>
-      </notes>
-      <segment state="translated">
-        <source>Alle</source>
-        <target>全部</target>
-      </segment>
-    </unit>
-    <unit id="pie.custom">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:58,59</note>
-      </notes>
-      <segment state="translated">
-        <source>Auswahl</source>
-        <target>选择</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">


### PR DESCRIPTION
The Top 5 / Alle / Auswahl button-toggle group on the type pie chart
collapses into a single scrollable legend: top 5 are pre-selected, every
other type is a checkbox the user can flip on or off. The legend caps at
220px with overflow-y: auto so the card stays compact even when many
pushup types are tracked.

Drops the now-unused mode signal, setMode method and PieSelectionMode
type, and removes the obsolete pie.modeAria / pie.top5 / pie.all /
pie.custom XLIFF units across all locale files.