### PR TITLE
fix(reminder): snooze deep-link must never silently log push-ups

### DIFF
--- a/libs/reminders/src/lib/push/push-subscription.store.spec.ts
+++ b/libs/reminders/src/lib/push/push-subscription.store.spec.ts
@@ -509,4 +509,118 @@ describe('PushSubscriptionStore', () => {
       expect(store.status()).toBe('subscribed');
     });
   });
+
+  // Regression: clicking "Snooze" on a push notification must only call the
+  // snoozeReminder Cloud Function — never any entry-creation path. This locks
+  // in that the SW message bridge keeps SNOOZE_REMINDER and QUICK_LOG_PUSHUPS
+  // strictly partitioned, so a snooze click can never silently log push-ups.
+  describe('regression: snooze message never triggers entry creation', () => {
+    function setupMessageBridge(): {
+      messageListeners: Array<(ev: MessageEvent) => void>;
+    } {
+      const messageListeners: Array<(ev: MessageEvent) => void> = [];
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: {
+          addEventListener: jest.fn(
+            (type: string, listener: (ev: MessageEvent) => void) => {
+              if (type === 'message') messageListeners.push(listener);
+            }
+          ),
+        },
+        configurable: true,
+        writable: true,
+      });
+      return { messageListeners };
+    }
+
+    it('SNOOZE_REMINDER from the SW invokes the snoozeReminder callable with the supplied minutes', async () => {
+      const { messageListeners } = setupMessageBridge();
+      const callable = jest
+        .fn()
+        .mockResolvedValue({ data: { ok: true, snoozeUntil: 'x' } });
+      const httpsCallableMock = httpsCallable as jest.Mock;
+      httpsCallableMock.mockReset();
+      httpsCallableMock.mockReturnValue(callable);
+
+      const store = setupStore();
+      store.registerSwListener();
+
+      for (const listener of messageListeners) {
+        listener({
+          data: { type: 'SNOOZE_REMINDER', snoozeMinutes: 45 },
+        } as MessageEvent);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Exactly one callable was created — the snoozeReminder one. No second
+      // call (e.g. createPushup, savePushSubscription) leaked through.
+      expect(httpsCallableMock).toHaveBeenCalledTimes(1);
+      expect(httpsCallableMock).toHaveBeenCalledWith(
+        expect.anything(),
+        'snoozeReminder'
+      );
+      expect(callable).toHaveBeenCalledWith({ snoozeMinutes: 45 });
+    });
+
+    it('SNOOZE_REMINDER without explicit minutes defaults to 30', async () => {
+      const { messageListeners } = setupMessageBridge();
+      const callable = jest
+        .fn()
+        .mockResolvedValue({ data: { ok: true, snoozeUntil: 'x' } });
+      const httpsCallableMock = httpsCallable as jest.Mock;
+      httpsCallableMock.mockReset();
+      httpsCallableMock.mockReturnValue(callable);
+
+      const store = setupStore();
+      store.registerSwListener();
+
+      for (const listener of messageListeners) {
+        listener({ data: { type: 'SNOOZE_REMINDER' } } as MessageEvent);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(callable).toHaveBeenCalledWith({ snoozeMinutes: 30 });
+    });
+
+    it('an unrelated SW message (e.g. QUICK_LOG_PUSHUPS) never reaches the snoozeReminder callable', async () => {
+      const { messageListeners } = setupMessageBridge();
+      const callable = jest.fn();
+      const httpsCallableMock = httpsCallable as jest.Mock;
+      httpsCallableMock.mockReset();
+      httpsCallableMock.mockReturnValue(callable);
+
+      const store = setupStore();
+      store.registerSwListener();
+
+      for (const listener of messageListeners) {
+        listener({
+          data: { type: 'QUICK_LOG_PUSHUPS', reps: 20 },
+        } as MessageEvent);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(httpsCallableMock).not.toHaveBeenCalled();
+      expect(callable).not.toHaveBeenCalled();
+    });
+
+    it('snooze() public method calls the snoozeReminder callable and nothing else', async () => {
+      setupMessageBridge();
+      const callable = jest
+        .fn()
+        .mockResolvedValue({ data: { ok: true, snoozeUntil: 'x' } });
+      const httpsCallableMock = httpsCallable as jest.Mock;
+      httpsCallableMock.mockReset();
+      httpsCallableMock.mockReturnValue(callable);
+
+      const store = setupStore();
+      await store.snooze(15);
+
+      expect(httpsCallableMock).toHaveBeenCalledTimes(1);
+      expect(httpsCallableMock).toHaveBeenCalledWith(
+        expect.anything(),
+        'snoozeReminder'
+      );
+      expect(callable).toHaveBeenCalledWith({ snoozeMinutes: 15 });
+    });
+  });
 });

--- a/libs/sw-push/src/handlers.spec.ts
+++ b/libs/sw-push/src/handlers.spec.ts
@@ -315,6 +315,68 @@ describe('handleNotificationClick', () => {
     expect(openWindow).toHaveBeenCalledWith('/en/app?snooze=30');
   });
 
+  // Regression: a snooze click on a notification that ALSO carries
+  // `quickLogReps` (the configured "Log N" button data) must never produce
+  // a quick-log message — only SNOOZE_REMINDER. Locks in the contract that
+  // the snooze handler ignores `data.quickLogReps` and the message types
+  // stay strictly partitioned, so a snooze click can never silently log
+  // push-ups even on a notification built with the quick-log action.
+  it('snooze action ignores notification.data.quickLogReps and never posts QUICK_LOG_PUSHUPS', async () => {
+    const client: ClientLike = {
+      url: 'https://pushup-stats.com/de/app',
+      focus: jest.fn(),
+      postMessage: jest.fn(),
+    };
+    const { ctx, openWindow } = makeCtx({ matchAllResult: [client] });
+    let waited: Promise<unknown> | undefined;
+    const { event } = makeEvent('snooze', {
+      locale: 'de',
+      quickLogReps: 25,
+    });
+    event.waitUntil = (p) => {
+      waited = p;
+    };
+    handleNotificationClick(event, ctx);
+    await waited;
+
+    // Exactly one message, of type SNOOZE_REMINDER. No QUICK_LOG_PUSHUPS
+    // leaks out, and the snooze count is 30 — not the quickLogReps value.
+    expect(client.postMessage).toHaveBeenCalledTimes(1);
+    expect(client.postMessage).toHaveBeenCalledWith({
+      type: 'SNOOZE_REMINDER',
+      snoozeMinutes: 30,
+    });
+    const allMessageTypes = client.postMessage.mock.calls.map(
+      (call) => (call[0] as { type?: string }).type
+    );
+    expect(allMessageTypes).not.toContain('QUICK_LOG_PUSHUPS');
+    expect(openWindow).not.toHaveBeenCalled();
+  });
+
+  // Regression: when no client is open, the snooze deep-link URL must not
+  // include `quickLog` even if `data.quickLogReps` was set on the
+  // notification. App.ts handles `?snooze=30` by calling the snoozeReminder
+  // Cloud Function — the dashboard must not see a `quickLog` param that
+  // would silently create an entry alongside.
+  it('snooze action without an open client opens ?snooze=30 only — never with quickLog', async () => {
+    const { ctx, openWindow } = makeCtx({ matchAllResult: [] });
+    let waited: Promise<unknown> | undefined;
+    const { event } = makeEvent('snooze', {
+      locale: 'de',
+      quickLogReps: 25,
+    });
+    event.waitUntil = (p) => {
+      waited = p;
+    };
+    handleNotificationClick(event, ctx);
+    await waited;
+    expect(openWindow).toHaveBeenCalledTimes(1);
+    expect(openWindow).toHaveBeenCalledWith('/de/app?snooze=30');
+    const openedUrl = openWindow.mock.calls[0][0] as string;
+    expect(openedUrl).not.toContain('quickLog');
+    expect(openedUrl).not.toContain('log=1');
+  });
+
   it('opens the app with ?log=1 for the log action', async () => {
     const { ctx, openWindow } = makeCtx();
     let waited: Promise<unknown> | undefined;

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -14,7 +14,12 @@ import { AuthStore, UserContextService } from '@pu-auth/auth';
 import { AdsStore } from '@pu-stats/ads';
 import { signal } from '@angular/core';
 import { makeAuthStoreMock } from '@pu-stats/testing';
-import { provideRouter, Router } from '@angular/router';
+import {
+  ActivatedRoute,
+  convertToParamMap,
+  provideRouter,
+  Router,
+} from '@angular/router';
 import { QuickAddOrchestrationService } from '../../core/quick-add-orchestration.service';
 import { AppDataFacade } from '../../core/app-data.facade';
 import { ShareService } from '../../core/share.service';
@@ -458,6 +463,128 @@ describe('StatsDashboardComponent', () => {
           expect.any(Function), // CreateEntryDialogComponent
           expect.objectContaining({ width: 'min(92vw, 420px)' })
         );
+      });
+    });
+  });
+
+  // Regression: snooze deep-link must never silently log push-ups.
+  // The push SW opens `/${locale}/app?snooze=30` when the user clicks the
+  // "30 Min snoozen" notification action and no app tab is open. App.ts
+  // consumes that param and calls the snoozeReminder Cloud Function;
+  // the dashboard's `_handleLogParam` deep-link handler must NOT mistake
+  // that URL for a quick-log / log deep-link and create an entry.
+  describe('Given the dashboard mounts on a snooze deep-link URL', () => {
+    /**
+     * Boots a fresh dashboard fixture with the given query params on the
+     * `ActivatedRoute` snapshot — the only path the dashboard's
+     * `_handleLogParam` reads. Resets the testing module so the override
+     * is allowed (overrideProvider can't run after `createComponent`).
+     */
+    async function createDashboardWithQueryParams(
+      params: Record<string, string>
+    ): Promise<ComponentFixture<StatsDashboardComponent>> {
+      TestBed.resetTestingModule();
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.setSystemTime(frozenDate);
+      window.history.replaceState({}, '', '/');
+      TestBed.configureTestingModule({
+        imports: [StatsDashboardComponent],
+        providers: [
+          provideRouter([]),
+          { provide: StatsApiService, useValue: serviceMock },
+          {
+            provide: UserStatsApiService,
+            useValue: { getUserStats: vitest.fn().mockReturnValue(of(null)) },
+          },
+          { provide: LiveDataStore, useValue: liveMock },
+          { provide: UserContextService, useValue: { userIdSafe: () => 'u1' } },
+          { provide: AdsStore, useValue: adsConfigMock },
+          { provide: AuthStore, useValue: makeAuthStoreMock() },
+          {
+            provide: UserConfigApiService,
+            useValue: {
+              getConfig: vitest.fn().mockReturnValue(
+                of({
+                  userId: 'u1',
+                  dailyGoal: 100,
+                  weeklyGoal: 500,
+                  monthlyGoal: 2000,
+                  ui: { showSourceColumn: false },
+                })
+              ),
+            },
+          },
+          {
+            provide: QuickAddOrchestrationService,
+            useValue: {
+              fillToGoal: vitest.fn(),
+              fillToGoalInFlight: signal(false).asReadonly(),
+            },
+          },
+          { provide: AppDataFacade, useValue: appDataMock },
+          { provide: ShareService, useValue: shareServiceMock },
+          {
+            provide: ExerciseFirestoreService,
+            useValue: { listEntries: () => of([]) },
+          },
+          {
+            provide: UserTrainingPlanApiService,
+            useValue: trainingPlanApiMock,
+          },
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: { queryParamMap: convertToParamMap(params) },
+            },
+          },
+        ],
+      });
+      TestBed.overrideProvider(MatDialog, { useValue: dialogMock });
+      await TestBed.compileComponents();
+      const f = TestBed.createComponent(StatsDashboardComponent);
+      await f.whenStable();
+      return f;
+    }
+
+    describe('When the URL carries only ?snooze=30', () => {
+      it('Then it must NOT call createPushup', async () => {
+        // Given — fresh dashboard mounted with the snooze deep-link URL
+        serviceMock.createPushup.mockClear();
+        await createDashboardWithQueryParams({ snooze: '30' });
+
+        // Then — snooze deep-links don't trigger any entry creation. The
+        // SW's snooze action posts SNOOZE_REMINDER to an open client OR
+        // opens this URL when no client exists; either way, the dashboard
+        // must keep its hands off entry creation.
+        expect(serviceMock.createPushup).not.toHaveBeenCalled();
+      });
+
+      it('Then it must NOT open the create-entry dialog', async () => {
+        // Given
+        dialogOpenSpy.mockClear();
+        await createDashboardWithQueryParams({ snooze: '30' });
+
+        // Then — `?log=1` opens the dialog; `?snooze=30` must not.
+        expect(dialogOpenSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('When the URL carries ?snooze=30&quickLog=20 (defense-in-depth)', () => {
+      // The current SW never produces this combination, but if a future
+      // change ever did, the snooze flow should win — clicking snooze
+      // should never silently log push-ups even with a stale `quickLog`
+      // alongside it. This test pins down the dashboard's contract:
+      // a `snooze` param suppresses the quick-log deep-link.
+      it('Then it must NOT call createPushup', async () => {
+        // Given
+        serviceMock.createPushup.mockClear();
+        await createDashboardWithQueryParams({
+          snooze: '30',
+          quickLog: '20',
+        });
+
+        // Then
+        expect(serviceMock.createPushup).not.toHaveBeenCalled();
       });
     });
   });

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -467,12 +467,11 @@ describe('StatsDashboardComponent', () => {
     });
   });
 
-  // Regression: snooze deep-link must never silently log push-ups.
-  // The push SW opens `/${locale}/app?snooze=30` when the user clicks the
-  // "30 Min snoozen" notification action and no app tab is open. App.ts
-  // consumes that param and calls the snoozeReminder Cloud Function;
-  // the dashboard's `_handleLogParam` deep-link handler must NOT mistake
-  // that URL for a quick-log / log deep-link and create an entry.
+  // Regression: a `?snooze=N` deep-link arrives via the SW snooze action
+  // (or via App.ts before it strips the param). The dashboard's
+  // `_handleLogParam` shares the URL with App.ts's `_handleSnoozeParam`,
+  // so it must defer to it — never mistake a snooze URL for a quick-log
+  // or log deep-link.
   describe('Given the dashboard mounts on a snooze deep-link URL', () => {
     /**
      * Boots a fresh dashboard fixture with the given query params on the
@@ -484,8 +483,6 @@ describe('StatsDashboardComponent', () => {
       params: Record<string, string>
     ): Promise<ComponentFixture<StatsDashboardComponent>> {
       TestBed.resetTestingModule();
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-      vi.setSystemTime(frozenDate);
       window.history.replaceState({}, '', '/');
       TestBed.configureTestingModule({
         imports: [StatsDashboardComponent],

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -225,9 +225,15 @@ export class StatsDashboardComponent {
    * `quickLog` arrives via URL and is therefore untrusted: clamp into the
    * configured `[QUICK_LOG_REPS_MIN, QUICK_LOG_REPS_MAX]` range so a tampered
    * link can't persist absurd entries (CodeRabbit/Copilot/Codex P1, PR #249).
+   *
+   * Snooze always wins: if `?snooze=N` is also present, the user explicitly
+   * snoozed and did NOT want to log push-ups in this navigation. Skip both
+   * deep-links so a combined or stale URL can never silently create an entry
+   * alongside the snooze — App.ts consumes the snooze param separately.
    */
   private readonly _handleLogParam = afterNextRender(() => {
     const params = this.route.snapshot.queryParamMap;
+    if (params.has('snooze')) return;
     const quickLog = params.get('quickLog');
     const quickReps = quickLog != null ? Number(quickLog) : NaN;
     if (Number.isFinite(quickReps) && quickReps >= QUICK_LOG_REPS_MIN) {


### PR DESCRIPTION
## Summary

Reported bug: clicking **Snoozen** on a reminder push notification adds push-ups.

After tracing the snooze pipeline end-to-end (SW → message bridge → `PushSubscriptionStore` → `snoozeReminder` Cloud Function → `app.ts` deep-link → dashboard `_handleLogParam`), no path in current source actively logs push-ups on a snooze click. But the dashboard's `_handleLogParam` was vulnerable in one corner case: a URL combining `?snooze=N` with `?quickLog=N` would silently create an entry. The SW never produces that combination today, but locking it down prevents any future change to the SW or `app.ts` from re-introducing the reported behaviour.

## What changed

**Defensive fix — `web/src/app/stats/shell/stats-dashboard.component.ts`:**
- `_handleLogParam` now returns early when `?snooze=...` is in the URL. Snooze always wins over `quickLog`/`log=1`. App.ts's `_handleSnoozeParam` consumes the `snooze` param and calls the snooze CF separately.

**Regression tests at every layer:**
- `libs/sw-push/src/handlers.spec.ts` (+2): snooze action ignores `data.quickLogReps` and never posts `QUICK_LOG_PUSHUPS`; the fallback URL `?snooze=30` never carries `quickLog`/`log=1`.
- `libs/reminders/src/lib/push/push-subscription.store.spec.ts` (+4): `SNOOZE_REMINDER` from the SW invokes only the `snoozeReminder` callable (with explicit + default minutes); unrelated SW messages never reach it; the public `snooze()` method calls the same callable in isolation.
- `web/src/app/stats/shell/stats-dashboard.component.spec.ts` (+3): `?snooze=30` does not call `createPushup` or open the create-entry dialog; the combined `?snooze=30&quickLog=20` URL also does not call `createPushup` (the new defensive fix makes this guarantee true).

## Test plan

- [x] `pnpm nx affected -t=lint,test --base=origin/main --parallel=3` — green (sw-push 27, pus-reminders 72, web 623).
- [x] `pnpm nx affected -t=build -c=production --parallel=3 --base=origin/main` — green.
- [ ] Manual smoke: receive a push reminder, click "30 Min snoozen", confirm Firestore `reminderDispatchState/{uid}` updates and no new pushup entry appears.

https://claude.ai/code/session_01U9sH7mW1m5D1ryPSz1iqGc

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9sH7mW1m5D1ryPSz1iqGc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification snooze functionality to ensure it is properly isolated from quick-log behavior, preventing unexpected entry creation.
  * Fixed deep-link handling so the snooze parameter takes priority, eliminating unwanted dialog openings when both snooze and quick-log parameters coexist.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/304)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->