### PR TITLE
feat(analysis): add Top 5 preset checkbox at top of pie legend

### DIFF
--- a/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
@@ -111,13 +111,13 @@ describe('TypePieComponent', () => {
     ).toBeTruthy();
   });
 
-  it('renders one legend row with checkbox per type', () => {
-    // Then
+  it('renders one legend row with checkbox per type plus the Top 5 preset', () => {
+    // Then: 7 type rows + 1 preset row
     const host: HTMLElement = fixture.nativeElement;
     const rows = host.querySelectorAll(
       '[data-testid="type-pie-legend"] mat-checkbox'
     );
-    expect(rows).toHaveLength(7);
+    expect(rows).toHaveLength(8);
   });
 
   it('legend container caps its height so the list scrolls when many types are present', () => {
@@ -155,6 +155,69 @@ describe('TypePieComponent', () => {
     expect(segments[0].color).toBe('#1976d2');
     expect(segments[1].label).toBe('Diamond');
     expect(segments[1].color).toBe('#9c27b0');
+  });
+
+  it('renders a Top 5 preset checkbox at the top of the legend, checked by default', () => {
+    // Then: the preset row exists and reflects the default top-5 selection
+    const host: HTMLElement = fixture.nativeElement;
+    const preset = host.querySelector(
+      '[data-testid="type-pie-top5"]'
+    ) as HTMLElement | null;
+    expect(preset).toBeTruthy();
+    expect(component.isTopFiveActive()).toBe(true);
+  });
+
+  it('clicking the Top 5 preset on a custom subset restores exactly the top-5 ids', () => {
+    // Given: user has narrowed selection to a non-top-5 subset
+    fixture.componentRef.setInput('data', sevenTypes);
+    fixture.detectChanges();
+    component.toggle('Spider');
+    component.toggle('Standard');
+    expect(component.isTopFiveActive()).toBe(false);
+
+    // When: the user activates the Top 5 preset
+    component.onTopFiveChange(true);
+
+    // Then: selection collapses back to exactly the 5 highest-value ids
+    expect(component.isTopFiveActive()).toBe(true);
+    expect([...component.selectedIds()].sort()).toEqual(
+      ['Decline', 'Diamond', 'Knee', 'Standard', 'Wide'].sort()
+    );
+  });
+
+  it('unchecking the Top 5 preset expands the selection to all types', () => {
+    // Given: default state (top 5 active)
+    expect(component.isTopFiveActive()).toBe(true);
+
+    // When: user unchecks the preset
+    component.onTopFiveChange(false);
+
+    // Then: every type is selected, no Other arc
+    expect(component.selectedIds().size).toBe(7);
+    expect(component.otherPercent()).toBe(0);
+    expect(component.isTopFiveActive()).toBe(false);
+  });
+
+  it('Top 5 preset checkbox harness toggles selection', async () => {
+    // Given: user narrowed to one type
+    component.toggle('Diamond');
+    component.toggle('Wide');
+    component.toggle('Decline');
+    component.toggle('Knee');
+    expect(component.selectedIds().size).toBe(1);
+
+    // When: the preset checkbox is toggled via Material's harness
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    const top5 = await loader.getHarness(
+      MatCheckboxHarness.with({
+        selector: '[data-testid="type-pie-top5"]',
+      })
+    );
+    await top5.toggle();
+    fixture.detectChanges();
+
+    // Then: selection snaps back to the top 5
+    expect(component.isTopFiveActive()).toBe(true);
   });
 
   it('removing the last selected type empties the pie and treats all data as Other', () => {

--- a/web/src/app/stats/components/type-pie/type-pie.component.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.ts
@@ -51,6 +51,18 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
         </div>
 
         <div class="legend" data-testid="type-pie-legend">
+          <div class="row preset-row">
+            <mat-checkbox
+              color="primary"
+              [checked]="isTopFiveActive()"
+              (change)="onTopFiveChange($event.checked)"
+              data-testid="type-pie-top5"
+            >
+              <span class="row-name">
+                <span class="name preset-name" i18n="@@pie.top5">Top 5</span>
+              </span>
+            </mat-checkbox>
+          </div>
           @for (seg of allSegments(); track seg.id) {
             <div class="row">
               <mat-checkbox
@@ -166,6 +178,17 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
       opacity: 0.75;
       padding-left: 36px;
     }
+    .preset-row {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      padding-bottom: 4px;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+      background: var(--mat-sys-surface, #fff);
+    }
+    .preset-name {
+      font-weight: 600;
+    }
     .set-label {
       overflow: hidden;
       text-overflow: ellipsis;
@@ -237,14 +260,29 @@ export class TypePieComponent {
     }));
   });
 
+  readonly topFiveIds = computed<ReadonlySet<string>>(
+    () =>
+      new Set(
+        this.allSegments()
+          .slice(0, TOP_N)
+          .map((s) => s.id)
+      )
+  );
+
   readonly selectedIds = computed<ReadonlySet<string>>(() => {
     const explicit = this.userSelection();
     if (explicit !== null) return explicit;
-    return new Set(
-      this.allSegments()
-        .slice(0, TOP_N)
-        .map((s) => s.id)
-    );
+    return this.topFiveIds();
+  });
+
+  readonly isTopFiveActive = computed(() => {
+    const selected = this.selectedIds();
+    const top = this.topFiveIds();
+    if (selected.size !== top.size) return false;
+    for (const id of top) {
+      if (!selected.has(id)) return false;
+    }
+    return true;
   });
 
   readonly visibleSegments = computed(() => {
@@ -317,5 +355,13 @@ export class TypePieComponent {
       next.add(id);
     }
     this.userSelection.set(next);
+  }
+
+  onTopFiveChange(checked: boolean): void {
+    if (checked) {
+      this.userSelection.set(new Set(this.topFiveIds()));
+    } else {
+      this.userSelection.set(new Set(this.allSegments().map((s) => s.id)));
+    }
   }
 }

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -4637,6 +4637,15 @@
         <target>Διαγραφή</target>
       </segment>
     </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,64</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
     <unit id="pie.avgSetSize">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:47,48</note>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -529,6 +529,15 @@ Active:         </target>
         <target>No sets data available</target>
       </segment>
     </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,64</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
     <unit id="pie.avgSetSize">
       <segment state="translated">
         <source>&#x2300; Set-Gr&#x00F6;&#x00DF;e</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -4637,6 +4637,15 @@
         <target>Eliminar</target>
       </segment>
     </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,64</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
     <unit id="pie.avgSetSize">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:47,48</note>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -4637,6 +4637,15 @@
         <target>Supprimer</target>
       </segment>
     </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,64</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
     <unit id="pie.avgSetSize">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:47,48</note>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -4637,6 +4637,15 @@
         <target>Elimina</target>
       </segment>
     </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,64</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
     <unit id="pie.avgSetSize">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:47,48</note>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -4637,6 +4637,15 @@
         <target>Delete</target>
       </segment>
     </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,64</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
     <unit id="pie.avgSetSize">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:47,48</note>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -4637,6 +4637,15 @@
         <target>Verwijderen</target>
       </segment>
     </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,64</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
     <unit id="pie.avgSetSize">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:47,48</note>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -543,6 +543,15 @@ Aktiv:         </target>
         <target>Ingen seriedata tilgjengelig</target>
       </segment>
     </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,64</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
     <unit id="pie.avgSetSize">
       <segment state="translated">
         <source>&#x2300; Set-Gr&#x00F6;&#x00DF;e</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -5203,6 +5203,14 @@
         <source>Verteilung der Liegestütz-Typen</source>
       </segment>
     </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,64</note>
+      </notes>
+      <segment>
+        <source>Top 5</source>
+      </segment>
+    </unit>
     <unit id="pie.avgSetSize">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:92,93</note>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -5181,6 +5181,15 @@
         <source>Löschen</source>
       <target>删除</target></segment>
     </unit>
+    <unit id="pie.top5">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,64</note>
+      </notes>
+      <segment state="translated">
+        <source>Top 5</source>
+        <target>Top 5</target>
+      </segment>
+    </unit>
     <unit id="pie.avgSetSize">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:47,48</note>


### PR DESCRIPTION
Sticky checkbox above the per-type list that flips selection between the
five highest-value types and "show everything". Mirrors the previous
toggle-group shortcut without re-introducing a separate control: the
preset is checked iff the current selection equals the canonical top 5,
so it doubles as a hint about the active filter.

Restores the `pie.top5` XLIFF unit (German source + 9 translations) that
was dropped together with the toggle group.

## Test plan
- [x] `pnpm nx test web` — all green
- [x] `pnpm nx lint web` — 0 errors
- [x] `pnpm nx build web -c production` — green
- [ ] Manual: verify Top 5 checkbox toggles between top-5-only and all in `/analysis`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GW5ewszHxHZSVfLGAtCHXh)_