### PR TITLE
feat(entry-dialog): split duration input into minutes + seconds fields

### DIFF
--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.spec.ts
@@ -411,6 +411,64 @@ describe('EntryDialogComponent', () => {
       expect(cmp.canSubmit()).toBe(false);
     });
 
+    it('rejects negative seconds when minutes are valid', () => {
+      const cmp = createComponent({
+        definition: plankDef,
+        exerciseName: 'Plank',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.durationMinutesInput.set('1');
+      cmp.durationSecondsInput.set('-5');
+      expect(cmp.durationSec()).toBeNull();
+      expect(cmp.canSubmit()).toBe(false);
+    });
+
+    it('accepts 59 as the upper boundary for seconds', () => {
+      const cmp = createComponent({
+        definition: plankDef,
+        exerciseName: 'Plank',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.durationMinutesInput.set('1');
+      cmp.durationSecondsInput.set('59');
+      expect(cmp.durationSec()).toBe(119);
+      expect(cmp.canSubmit()).toBe(true);
+    });
+
+    it('rejects fractional values in either field', () => {
+      const cmp = createComponent({
+        definition: plankDef,
+        exerciseName: 'Plank',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.durationMinutesInput.set('1.9');
+      cmp.durationSecondsInput.set('30');
+      // Without the integer check, "1.9" would silently floor to 1 and
+      // save 90 s instead of 114 s — regression guard for that.
+      expect(cmp.durationSec()).toBeNull();
+      expect(cmp.canSubmit()).toBe(false);
+
+      cmp.durationMinutesInput.set('1');
+      cmp.durationSecondsInput.set('30.5');
+      expect(cmp.durationSec()).toBeNull();
+      expect(cmp.canSubmit()).toBe(false);
+    });
+
+    it('disables submit on a zero-duration entry even if def.min permits it', () => {
+      const cmp = createComponent({
+        definition: { ...plankDef, min: 0 },
+        exerciseName: 'Plank',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.durationMinutesInput.set('0');
+      cmp.durationSecondsInput.set('0');
+      // canSubmit() must agree with submit()'s `sec <= 0` early-return so
+      // the Save button can't enable on an entry the dialog would
+      // silently drop.
+      expect(cmp.durationSec()).toBe(0);
+      expect(cmp.canSubmit()).toBe(false);
+    });
+
     it('disables submit when the duration exceeds the per-exercise cap', () => {
       const cmp = createComponent({
         definition: { ...plankDef, max: 60 },

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.spec.ts
@@ -107,8 +107,7 @@ describe('EntryDialogComponent', () => {
       cmp.variantControl.setValue('wide');
       cmp.submit();
 
-      const result = dialogRef.close.mock
-        .calls[0][0] as EntryDialogResult;
+      const result = dialogRef.close.mock.calls[0][0] as EntryDialogResult;
       expect(result.variantId).toBe('wide');
       expect(result.exerciseId).toBe('pushup');
     });
@@ -122,8 +121,7 @@ describe('EntryDialogComponent', () => {
       cmp.updateSet(0, '20');
       cmp.submit();
 
-      const result = dialogRef.close.mock
-        .calls[0][0] as EntryDialogResult;
+      const result = dialogRef.close.mock.calls[0][0] as EntryDialogResult;
       expect('variantId' in result).toBe(false);
     });
 
@@ -142,8 +140,7 @@ describe('EntryDialogComponent', () => {
       cmp.variantControl.setValue('');
       cmp.submit();
 
-      const result = dialogRef.close.mock
-        .calls[0][0] as EntryDialogResult;
+      const result = dialogRef.close.mock.calls[0][0] as EntryDialogResult;
       // Tri-state contract: null = clear (deleteField on update),
       // not omitted (which the store would treat as "no change").
       expect(result.variantId).toBeNull();
@@ -161,8 +158,7 @@ describe('EntryDialogComponent', () => {
       });
       cmp.submit();
 
-      const result = dialogRef.close.mock
-        .calls[0][0] as EntryDialogResult;
+      const result = dialogRef.close.mock.calls[0][0] as EntryDialogResult;
       expect('variantId' in result).toBe(false);
     });
 
@@ -182,8 +178,7 @@ describe('EntryDialogComponent', () => {
       // a concurrent variant change by re-asserting the same string.
       cmp.submit();
 
-      const result = dialogRef.close.mock
-        .calls[0][0] as EntryDialogResult;
+      const result = dialogRef.close.mock.calls[0][0] as EntryDialogResult;
       expect('variantId' in result).toBe(false);
     });
   });
@@ -201,8 +196,7 @@ describe('EntryDialogComponent', () => {
       cmp.submit();
 
       expect(dialogRef.close).toHaveBeenCalledTimes(1);
-      const result = dialogRef.close.mock
-        .calls[0][0] as EntryDialogResult;
+      const result = dialogRef.close.mock.calls[0][0] as EntryDialogResult;
       expect(result.exerciseId).toBe('legs.squats');
       expect(result.reps).toBe(25);
       expect(result.sets).toEqual([25]);
@@ -266,8 +260,7 @@ describe('EntryDialogComponent', () => {
       cmp.timestamp.set('2026-04-15T10:00');
       cmp.submit();
 
-      const result = dialogRef.close.mock
-        .calls[0][0] as EntryDialogResult;
+      const result = dialogRef.close.mock.calls[0][0] as EntryDialogResult;
       expect(result.reps).toBe(45);
       expect(result.sets).toEqual([10, 15, 20]);
     });
@@ -282,8 +275,7 @@ describe('EntryDialogComponent', () => {
       cmp.timestamp.set('2026-04-15T10:00');
       cmp.submit();
 
-      const result = dialogRef.close.mock
-        .calls[0][0] as EntryDialogResult;
+      const result = dialogRef.close.mock.calls[0][0] as EntryDialogResult;
       expect(result.sets).toEqual([10, 20]);
       expect(result.reps).toBe(30);
     });
@@ -324,8 +316,7 @@ describe('EntryDialogComponent', () => {
       });
       cmp.submit();
 
-      const result = dialogRef.close.mock
-        .calls[0][0] as EntryDialogResult;
+      const result = dialogRef.close.mock.calls[0][0] as EntryDialogResult;
       expect(result.timestamp).toBe(original);
     });
   });
@@ -341,30 +332,32 @@ describe('EntryDialogComponent', () => {
   });
 
   describe('Time measurement (plank)', () => {
-    it('marks the form as time-measurement and starts with empty mm:ss', () => {
+    it('marks the form as time-measurement and starts with empty min/sec inputs', () => {
       const cmp = createComponent({
         definition: plankDef,
         exerciseName: 'Plank',
       });
       expect(cmp.isTimeMeasurement()).toBe(true);
-      expect(cmp.durationInput()).toBe('');
+      expect(cmp.durationMinutesInput()).toBe('');
+      expect(cmp.durationSecondsInput()).toBe('');
+      expect(cmp.durationSec()).toBeNull();
       expect(cmp.canSubmit()).toBe(false);
     });
 
-    it('parses mm:ss into seconds and submits durationSec', () => {
+    it('combines the min/sec inputs into seconds and submits durationSec', () => {
       const cmp = createComponent({
         definition: plankDef,
         exerciseName: 'Plank',
       });
       cmp.timestamp.set('2026-04-15T10:00');
-      cmp.durationInput.set('1:30');
+      cmp.durationMinutesInput.set('1');
+      cmp.durationSecondsInput.set('30');
       expect(cmp.durationSec()).toBe(90);
       expect(cmp.canSubmit()).toBe(true);
 
       cmp.submit();
 
-      const result = dialogRef.close.mock
-        .calls[0][0] as EntryDialogResult;
+      const result = dialogRef.close.mock.calls[0][0] as EntryDialogResult;
       expect(result.measurement).toBe('time');
       expect(result.durationSec).toBe(90);
       expect(result.exerciseId).toBe('plank.standard');
@@ -372,13 +365,48 @@ describe('EntryDialogComponent', () => {
       expect(result.sets).toEqual([]);
     });
 
-    it('rejects malformed mm:ss strings', () => {
+    it('treats an empty minutes field as 0 when seconds are filled in', () => {
       const cmp = createComponent({
         definition: plankDef,
         exerciseName: 'Plank',
       });
       cmp.timestamp.set('2026-04-15T10:00');
-      cmp.durationInput.set('not-a-time');
+      cmp.durationSecondsInput.set('45');
+      expect(cmp.durationSec()).toBe(45);
+      expect(cmp.canSubmit()).toBe(true);
+    });
+
+    it('treats an empty seconds field as 0 when minutes are filled in', () => {
+      const cmp = createComponent({
+        definition: plankDef,
+        exerciseName: 'Plank',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.durationMinutesInput.set('2');
+      expect(cmp.durationSec()).toBe(120);
+      expect(cmp.canSubmit()).toBe(true);
+    });
+
+    it('rejects seconds outside the 0-59 range', () => {
+      const cmp = createComponent({
+        definition: plankDef,
+        exerciseName: 'Plank',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.durationMinutesInput.set('1');
+      cmp.durationSecondsInput.set('60');
+      expect(cmp.durationSec()).toBeNull();
+      expect(cmp.canSubmit()).toBe(false);
+    });
+
+    it('rejects negative numbers in either field', () => {
+      const cmp = createComponent({
+        definition: plankDef,
+        exerciseName: 'Plank',
+      });
+      cmp.timestamp.set('2026-04-15T10:00');
+      cmp.durationMinutesInput.set('-1');
+      cmp.durationSecondsInput.set('30');
       expect(cmp.durationSec()).toBeNull();
       expect(cmp.canSubmit()).toBe(false);
     });
@@ -389,12 +417,13 @@ describe('EntryDialogComponent', () => {
         exerciseName: 'Plank',
       });
       cmp.timestamp.set('2026-04-15T10:00');
-      cmp.durationInput.set('5:00');
+      cmp.durationMinutesInput.set('5');
+      cmp.durationSecondsInput.set('0');
       expect(cmp.overCap()).toBe(true);
       expect(cmp.canSubmit()).toBe(false);
     });
 
-    it('pre-fills mm:ss in edit mode from the entry durationSec', () => {
+    it('pre-fills min/sec in edit mode from the entry durationSec', () => {
       const cmp = createComponent({
         definition: plankDef,
         exerciseName: 'Plank',
@@ -404,8 +433,9 @@ describe('EntryDialogComponent', () => {
           durationSec: 95,
         },
       });
-      // 95 s → 1:35
-      expect(cmp.durationInput()).toBe('1:35');
+      // 95 s → 1 min 35 s
+      expect(cmp.durationMinutesInput()).toBe('1');
+      expect(cmp.durationSecondsInput()).toBe('35');
     });
   });
 
@@ -417,7 +447,8 @@ describe('EntryDialogComponent', () => {
       });
       expect(cmp.isDistanceTimeMeasurement()).toBe(true);
       expect(cmp.distanceInput()).toBe('');
-      expect(cmp.durationInput()).toBe('');
+      expect(cmp.durationMinutesInput()).toBe('');
+      expect(cmp.durationSecondsInput()).toBe('');
       expect(cmp.canSubmit()).toBe(false);
     });
 
@@ -464,11 +495,13 @@ describe('EntryDialogComponent', () => {
       cmp.distanceInput.set('5.00');
       expect(cmp.canSubmit()).toBe(false);
 
-      cmp.durationInput.set('25:00');
+      cmp.durationMinutesInput.set('25');
+      cmp.durationSecondsInput.set('0');
       expect(cmp.canSubmit()).toBe(true);
 
-      // Clearing the duration locks submit again.
-      cmp.durationInput.set('');
+      // Clearing both duration fields locks submit again.
+      cmp.durationMinutesInput.set('');
+      cmp.durationSecondsInput.set('');
       expect(cmp.canSubmit()).toBe(false);
     });
 
@@ -478,7 +511,8 @@ describe('EntryDialogComponent', () => {
         exerciseName: 'Laufen',
       });
       cmp.timestamp.set('2026-04-15T10:00');
-      cmp.durationInput.set('25:00');
+      cmp.durationMinutesInput.set('25');
+      cmp.durationSecondsInput.set('0');
 
       cmp.distanceInput.set('0.05');
       expect(cmp.canSubmit()).toBe(false);
@@ -499,8 +533,9 @@ describe('EntryDialogComponent', () => {
       });
       cmp.timestamp.set('2026-04-15T10:00');
       cmp.distanceInput.set('5.00');
-      // 86_400 s is the companion ceiling; 1500:00 = 90_000 s clears it.
-      cmp.durationInput.set('1500:00');
+      // 86_400 s is the companion ceiling; 1500 min = 90_000 s clears it.
+      cmp.durationMinutesInput.set('1500');
+      cmp.durationSecondsInput.set('0');
       expect(cmp.overCap()).toBe(true);
       expect(cmp.canSubmit()).toBe(false);
     });
@@ -512,13 +547,13 @@ describe('EntryDialogComponent', () => {
       });
       cmp.timestamp.set('2026-04-15T10:00');
       cmp.distanceInput.set('5.25');
-      cmp.durationInput.set('25:00');
+      cmp.durationMinutesInput.set('25');
+      cmp.durationSecondsInput.set('0');
       expect(cmp.canSubmit()).toBe(true);
 
       cmp.submit();
 
-      const result = dialogRef.close.mock
-        .calls[0][0] as EntryDialogResult;
+      const result = dialogRef.close.mock.calls[0][0] as EntryDialogResult;
       expect(result.measurement).toBe('distance-time');
       expect(result.exerciseId).toBe('cardio.running');
       expect(result.distanceM).toBe(5250);
@@ -539,7 +574,8 @@ describe('EntryDialogComponent', () => {
         },
       });
       expect(cmp.distanceInput()).toBe('5.25');
-      expect(cmp.durationInput()).toBe('25:30');
+      expect(cmp.durationMinutesInput()).toBe('25');
+      expect(cmp.durationSecondsInput()).toBe('30');
     });
 
     it('exposes minKm/maxKm derived from def.min/def.max', () => {

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
@@ -467,7 +467,12 @@ export class EntryDialogComponent {
     }
     if (this.isTimeMeasurement()) {
       const sec = this.durationSec();
-      return sec !== null && sec >= this.data.definition.min && !this.overCap();
+      return (
+        sec !== null &&
+        sec > 0 &&
+        sec >= this.data.definition.min &&
+        !this.overCap()
+      );
     }
     return this.totalReps() >= this.data.definition.min && !this.overCap();
   });
@@ -618,11 +623,15 @@ function parseDurationFromParts(
 
   const minutes = minTrim === '' ? 0 : Number(minTrim);
   const seconds = secTrim === '' ? 0 : Number(secTrim);
-  if (!Number.isFinite(minutes) || !Number.isFinite(seconds)) return null;
+  // Reject fractional input (e.g. "1.9") so a paste-into-the-number-field
+  // doesn't silently truncate to a shorter saved duration. The native
+  // step="1" attribute only flags constraint validity; it does not stop
+  // the value from reaching this parser.
+  if (!Number.isInteger(minutes) || !Number.isInteger(seconds)) return null;
   if (minutes < 0 || seconds < 0) return null;
   if (seconds > SECONDS_MAX) return null;
 
-  return Math.floor(minutes) * 60 + Math.floor(seconds);
+  return minutes * 60 + seconds;
 }
 
 /**

--- a/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
+++ b/web/src/app/stats/components/entry-dialog/entry-dialog.component.ts
@@ -24,6 +24,8 @@ import {
   MeasurementType,
 } from '@pu-stats/models';
 
+const SECONDS_MAX = 59;
+
 export interface EntryDialogData {
   /** Catalog definition the dialog parameters its form against. */
   definition: ExerciseDefinition;
@@ -121,6 +123,13 @@ export interface EntryDialogResult {
       .set-row mat-form-field {
         flex: 1;
       }
+      .duration-row {
+        display: flex;
+        gap: 8px;
+      }
+      .duration-row mat-form-field {
+        flex: 1;
+      }
       .total-reps {
         font-size: 13px;
         color: var(--mat-sys-on-surface-variant);
@@ -182,33 +191,65 @@ export interface EntryDialogResult {
             required
           />
         </mat-form-field>
-        <mat-form-field appearance="outline">
-          <mat-label i18n="@@entryDialog.duration">Dauer (mm:ss)</mat-label>
-          <input
-            matInput
-            type="text"
-            inputmode="numeric"
-            placeholder="25:00"
-            pattern="^[0-9]+:[0-5][0-9]$"
-            [value]="durationInput()"
-            (input)="durationInput.set(asValue($event))"
-            required
-          />
-        </mat-form-field>
+        <div class="duration-row">
+          <mat-form-field appearance="outline">
+            <mat-label i18n="@@entryDialog.durationMinutes">Minuten</mat-label>
+            <input
+              matInput
+              type="number"
+              inputmode="numeric"
+              placeholder="25"
+              min="0"
+              step="1"
+              [value]="durationMinutesInput()"
+              (input)="durationMinutesInput.set(asValue($event))"
+            />
+          </mat-form-field>
+          <mat-form-field appearance="outline">
+            <mat-label i18n="@@entryDialog.durationSeconds">Sekunden</mat-label>
+            <input
+              matInput
+              type="number"
+              inputmode="numeric"
+              placeholder="0"
+              min="0"
+              [max]="secondsMax"
+              step="1"
+              [value]="durationSecondsInput()"
+              (input)="durationSecondsInput.set(asValue($event))"
+            />
+          </mat-form-field>
+        </div>
       } @else if (isTimeMeasurement()) {
-        <mat-form-field appearance="outline">
-          <mat-label i18n="@@entryDialog.duration">Dauer (mm:ss)</mat-label>
-          <input
-            matInput
-            type="text"
-            inputmode="numeric"
-            placeholder="01:30"
-            pattern="^[0-9]+:[0-5][0-9]$"
-            [value]="durationInput()"
-            (input)="durationInput.set(asValue($event))"
-            required
-          />
-        </mat-form-field>
+        <div class="duration-row">
+          <mat-form-field appearance="outline">
+            <mat-label i18n="@@entryDialog.durationMinutes">Minuten</mat-label>
+            <input
+              matInput
+              type="number"
+              inputmode="numeric"
+              placeholder="1"
+              min="0"
+              step="1"
+              [value]="durationMinutesInput()"
+              (input)="durationMinutesInput.set(asValue($event))"
+            />
+          </mat-form-field>
+          <mat-form-field appearance="outline">
+            <mat-label i18n="@@entryDialog.durationSeconds">Sekunden</mat-label>
+            <input
+              matInput
+              type="number"
+              inputmode="numeric"
+              placeholder="30"
+              min="0"
+              [max]="secondsMax"
+              step="1"
+              [value]="durationSecondsInput()"
+              (input)="durationSecondsInput.set(asValue($event))"
+            />
+          </mat-form-field>
+        </div>
       } @else {
         @for (set of sets(); track $index) {
           <div class="set-row">
@@ -265,9 +306,7 @@ export interface EntryDialogResult {
             <span i18n="@@entryDialog.overCapDuration"
               >Maximum-Dauer: {{ formattedDurationMax() }}</span
             >
-          } @else if (
-            overCapKind() === 'distance' || isTimeMeasurement()
-          ) {
+          } @else if (overCapKind() === 'distance' || isTimeMeasurement()) {
             <span i18n="@@entryDialog.overCapTime"
               >Maximum: {{ formattedMax() }}</span
             >
@@ -325,19 +364,27 @@ export class EntryDialogComponent {
   );
 
   /**
-   * Free-text mm:ss input for time-measurement exercises (plank) and
-   * the duration companion of distance-time exercises (cardio.running).
+   * Split duration input — minutes + seconds — for time-measurement
+   * exercises (plank) and the duration companion of distance-time
+   * exercises (cardio.running). Stored as strings so an empty field is
+   * representable; combined into integer seconds via `durationSec`.
    * Pre-filled from `initial.durationSec` in edit mode.
    */
-  readonly durationInput = signal(
-    this.data.initial?.durationSec !== undefined
-      ? formatExerciseValue(this.data.initial.durationSec, 's')
-      : ''
+  private readonly initialDurationParts = splitDurationParts(
+    this.data.initial?.durationSec
   );
 
+  readonly durationMinutesInput = signal(this.initialDurationParts.minutes);
+  readonly durationSecondsInput = signal(this.initialDurationParts.seconds);
+
   readonly durationSec = computed(() =>
-    parseDurationToSeconds(this.durationInput())
+    parseDurationFromParts(
+      this.durationMinutesInput(),
+      this.durationSecondsInput()
+    )
   );
+
+  readonly secondsMax = SECONDS_MAX;
 
   /**
    * Distance input in km (decimal) for distance-time exercises. Stored
@@ -420,13 +467,9 @@ export class EntryDialogComponent {
     }
     if (this.isTimeMeasurement()) {
       const sec = this.durationSec();
-      return (
-        sec !== null && sec >= this.data.definition.min && !this.overCap()
-      );
+      return sec !== null && sec >= this.data.definition.min && !this.overCap();
     }
-    return (
-      this.totalReps() >= this.data.definition.min && !this.overCap()
-    );
+    return this.totalReps() >= this.data.definition.min && !this.overCap();
   });
 
   readonly showVariantPicker = computed(
@@ -559,22 +602,44 @@ export class EntryDialogComponent {
 const VARIANT_LABELS: Record<string, string> = {};
 
 /**
- * Parse `m+:ss` (single colon, any number of minute digits, exactly two
- * second digits in the 0–59 range) into integer seconds. Returns `null`
- * for malformed input so the caller can disable submit instead of
- * writing `NaN` to Firestore. Hours are out of scope — the plank cap
- * tops out at 7200 s ("120:00") and we want the shortest format that
- * still covers it.
+ * Combine the two number-input parts into total integer seconds.
+ * Returns `null` when both parts are empty or any field is invalid, so
+ * the caller can disable submit instead of writing `NaN`/`0` to
+ * Firestore. Either part empty is treated as 0 — typing only minutes or
+ * only seconds is a valid shortcut.
  */
-function parseDurationToSeconds(input: string): number | null {
-  const trimmed = input.trim();
-  if (!trimmed) return null;
-  const match = /^(\d+):([0-5]\d)$/.exec(trimmed);
-  if (!match) return null;
-  const minutes = Number(match[1]);
-  const seconds = Number(match[2]);
+function parseDurationFromParts(
+  minutesInput: string,
+  secondsInput: string
+): number | null {
+  const minTrim = minutesInput.trim();
+  const secTrim = secondsInput.trim();
+  if (minTrim === '' && secTrim === '') return null;
+
+  const minutes = minTrim === '' ? 0 : Number(minTrim);
+  const seconds = secTrim === '' ? 0 : Number(secTrim);
   if (!Number.isFinite(minutes) || !Number.isFinite(seconds)) return null;
-  return minutes * 60 + seconds;
+  if (minutes < 0 || seconds < 0) return null;
+  if (seconds > SECONDS_MAX) return null;
+
+  return Math.floor(minutes) * 60 + Math.floor(seconds);
+}
+
+/**
+ * Split a stored total-seconds value into the two strings shown in the
+ * minutes / seconds inputs. Empty strings when no initial value, so the
+ * fields render blank in create mode.
+ */
+function splitDurationParts(totalSec: number | undefined): {
+  minutes: string;
+  seconds: string;
+} {
+  if (totalSec === undefined || !Number.isFinite(totalSec) || totalSec <= 0) {
+    return { minutes: '', seconds: '' };
+  }
+  const m = Math.floor(totalSec / 60);
+  const s = Math.floor(totalSec % 60);
+  return { minutes: String(m), seconds: String(s) };
 }
 
 /**

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -3828,10 +3828,16 @@
         <target>Απόσταση (χλμ)</target>
       </segment>
     </unit>
-    <unit id="entryDialog.duration">
+    <unit id="entryDialog.durationMinutes">
       <segment state="translated">
-        <source>Dauer (mm:ss)</source>
-        <target>Διάρκεια (mm:ss)</target>
+        <source>Minuten</source>
+        <target>Λεπτά</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationSeconds">
+      <segment state="translated">
+        <source>Sekunden</source>
+        <target>Δευτερόλεπτα</target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapDuration">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -3218,10 +3218,16 @@ Deine Position: # ·  Reps        </source>
         <target>Distance (km)</target>
       </segment>
     </unit>
-    <unit id="entryDialog.duration">
+    <unit id="entryDialog.durationMinutes">
       <segment state="translated">
-        <source>Dauer (mm:ss)</source>
-        <target>Duration (mm:ss)</target>
+        <source>Minuten</source>
+        <target>Minutes</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationSeconds">
+      <segment state="translated">
+        <source>Sekunden</source>
+        <target>Seconds</target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapDuration">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -3828,10 +3828,16 @@
         <target>Distancia (km)</target>
       </segment>
     </unit>
-    <unit id="entryDialog.duration">
+    <unit id="entryDialog.durationMinutes">
       <segment state="translated">
-        <source>Dauer (mm:ss)</source>
-        <target>Duración (mm:ss)</target>
+        <source>Minuten</source>
+        <target>Minutos</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationSeconds">
+      <segment state="translated">
+        <source>Sekunden</source>
+        <target>Segundos</target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapDuration">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3828,10 +3828,16 @@
         <target>Distance (km)</target>
       </segment>
     </unit>
-    <unit id="entryDialog.duration">
+    <unit id="entryDialog.durationMinutes">
       <segment state="translated">
-        <source>Dauer (mm:ss)</source>
-        <target>Durée (mm:ss)</target>
+        <source>Minuten</source>
+        <target>Minutes</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationSeconds">
+      <segment state="translated">
+        <source>Sekunden</source>
+        <target>Secondes</target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapDuration">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -3828,10 +3828,16 @@
         <target>Distanza (km)</target>
       </segment>
     </unit>
-    <unit id="entryDialog.duration">
+    <unit id="entryDialog.durationMinutes">
       <segment state="translated">
-        <source>Dauer (mm:ss)</source>
-        <target>Durata (mm:ss)</target>
+        <source>Minuten</source>
+        <target>Minuti</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationSeconds">
+      <segment state="translated">
+        <source>Sekunden</source>
+        <target>Secondi</target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapDuration">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3828,10 +3828,16 @@
         <target>Spatium (km)</target>
       </segment>
     </unit>
-    <unit id="entryDialog.duration">
+    <unit id="entryDialog.durationMinutes">
       <segment state="translated">
-        <source>Dauer (mm:ss)</source>
-        <target>Duratio (mm:ss)</target>
+        <source>Minuten</source>
+        <target>Minuta</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationSeconds">
+      <segment state="translated">
+        <source>Sekunden</source>
+        <target>Secunda</target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapDuration">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3828,10 +3828,16 @@
         <target>Afstand (km)</target>
       </segment>
     </unit>
-    <unit id="entryDialog.duration">
+    <unit id="entryDialog.durationMinutes">
       <segment state="translated">
-        <source>Dauer (mm:ss)</source>
-        <target>Duur (mm:ss)</target>
+        <source>Minuten</source>
+        <target>Minuten</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationSeconds">
+      <segment state="translated">
+        <source>Sekunden</source>
+        <target>Seconden</target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapDuration">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -3234,10 +3234,16 @@ Deine Position: # ·  Reps        </source>
         <target>Distanse (km)</target>
       </segment>
     </unit>
-    <unit id="entryDialog.duration">
+    <unit id="entryDialog.durationMinutes">
       <segment state="translated">
-        <source>Dauer (mm:ss)</source>
-        <target>Varighet (mm:ss)</target>
+        <source>Minuten</source>
+        <target>Minutter</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationSeconds">
+      <segment state="translated">
+        <source>Sekunden</source>
+        <target>Sekunder</target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapDuration">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -236,7 +236,7 @@
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:277,278</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:285,286</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:326,327</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
       </notes>
@@ -4282,7 +4282,7 @@
     <unit id="editDialogTitle">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:140,142</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:134,136</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:143,145</note>
       </notes>
       <segment>
         <source>Eintrag bearbeiten</source>
@@ -4299,7 +4299,7 @@
     <unit id="timestampLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:148,150</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:143,145</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:152,154</note>
       </notes>
       <segment>
         <source>Zeitpunkt</source>
@@ -4308,7 +4308,7 @@
     <unit id="setLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:162,163</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:217,218</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:258,259</note>
       </notes>
       <segment>
         <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -4317,7 +4317,7 @@
     <unit id="repsLabel">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:164,165</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:219,220</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:260,261</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -4326,7 +4326,7 @@
     <unit id="removeSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:181,183</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:238,240</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:279,281</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -4335,7 +4335,7 @@
     <unit id="addSetAria">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:192,193</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:249,251</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:290,292</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -4352,7 +4352,7 @@
     <unit id="totalReps">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:203,205</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:258,260</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:299,301</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -4401,7 +4401,7 @@
     <unit id="saveEntry">
       <notes>
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:285,287</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:294,296</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:335,337</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -4425,7 +4425,7 @@
     </unit>
     <unit id="exerciseEntryDialog.title">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:136,138</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:145,147</note>
       </notes>
       <segment>
         <source>Eintrag hinzufügen</source>
@@ -4433,7 +4433,7 @@
     </unit>
     <unit id="entryDialog.variant">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:155,156</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:164,165</note>
       </notes>
       <segment>
         <source>Variante</source>
@@ -4441,7 +4441,7 @@
     </unit>
     <unit id="entryDialog.variantNone">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:158,160</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:167,169</note>
       </notes>
       <segment>
         <source>—</source>
@@ -4449,24 +4449,33 @@
     </unit>
     <unit id="entryDialog.distance">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:171,173</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:180,182</note>
       </notes>
       <segment>
         <source>Distanz (km)</source>
       </segment>
     </unit>
-    <unit id="entryDialog.duration">
+    <unit id="entryDialog.durationMinutes">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:186,188</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:200,202</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:196,198</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:226,228</note>
       </notes>
       <segment>
-        <source>Dauer (mm:ss)</source>
+        <source>Minuten</source>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationSeconds">
+      <notes>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:209,211</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:239,241</note>
+      </notes>
+      <segment>
+        <source>Sekunden</source>
       </segment>
     </unit>
     <unit id="entryDialog.overCapDuration">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:266,267</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:307,308</note>
       </notes>
       <segment>
         <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
@@ -4474,7 +4483,7 @@
     </unit>
     <unit id="entryDialog.overCapTime">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:272,273</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:313,314</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
@@ -4482,7 +4491,7 @@
     </unit>
     <unit id="entryDialog.overCap">
       <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:276,277</note>
+        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:317,318</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> pro Eintrag</source>
@@ -5270,7 +5279,7 @@
     </unit>
     <unit id="pie.top5">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,64</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,63</note>
       </notes>
       <segment>
         <source>Top 5</source>
@@ -5278,7 +5287,7 @@
     </unit>
     <unit id="pie.avgSetSize">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:72,73</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:84,85</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
@@ -5286,7 +5295,7 @@
     </unit>
     <unit id="pie.other">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:84,85</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,97</note>
       </notes>
       <segment>
         <source>Sonstige</source>
@@ -5294,7 +5303,7 @@
     </unit>
     <unit id="pie.noData">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:92,95</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:104,107</note>
       </notes>
       <segment>
         <source>Keine Daten</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -4444,10 +4444,16 @@
         <target>距离 (公里)</target>
       </segment>
     </unit>
-    <unit id="entryDialog.duration">
+    <unit id="entryDialog.durationMinutes">
       <segment state="translated">
-        <source>Dauer (mm:ss)</source>
-        <target>时长 (mm:ss)</target>
+        <source>Minuten</source>
+        <target>分钟</target>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationSeconds">
+      <segment state="translated">
+        <source>Sekunden</source>
+        <target>秒</target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapDuration">


### PR DESCRIPTION
Replace the free-text mm:ss field for time and distance-time
exercises with two number inputs, so users get the native numeric
keyboard on mobile and clear per-field clamping (0-59 for seconds).
Drops the regex-based parser in favour of integer parsing per part.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Improvements**
- Duration input in the entry dialog changed from a single combined mm:ss field to separate numeric fields for minutes and seconds
- Localization updates applied to all 11 supported languages (including English, Spanish, French, Italian, Dutch, Norwegian, German, Greek, Chinese, and Latin)
- Component validation and input-handling logic updated; test suite refined to match the new input method

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/306)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->