### PR TITLE
feat(training-plans): scroll to active day from dashboard banner

### DIFF
--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -89,6 +89,7 @@
           <a
             mat-stroked-button
             [routerLink]="['/training-plans', planSlug()]"
+            [queryParams]="{ day: planDayIndex() }"
             i18n="@@trainingPlans.openDetail"
           >
             Details öffnen

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -1163,5 +1163,29 @@ describe('StatsDashboardComponent', () => {
         querySelector(freshFixture.nativeElement, 'dashboard-rest-day-target')
       ).toBeNull();
     });
+
+    it('And the plan banner "Details öffnen" CTA links to the active day so the detail page scrolls there', async () => {
+      // Given today resolves to day 1 (a `main` day in recruit-6w-v1).
+      trainingPlanApiMock.getActivePlan.mockReturnValue(
+        of({ ...restDayPlan, startDate: '2025-01-15' })
+      );
+      TestBed.inject(TrainingPlanStore).reload();
+
+      const freshFixture = TestBed.createComponent(StatsDashboardComponent);
+      await freshFixture.whenStable();
+      freshFixture.detectChanges();
+
+      // When the dashboard banner CTA is rendered, its href carries
+      // `?day=<currentDayIndex>` so the detail page can scroll the
+      // matching `#day-<N>` row into view on arrival.
+      const link: HTMLAnchorElement | null =
+        freshFixture.nativeElement.querySelector(
+          '.plan-banner a[mat-stroked-button]'
+        );
+      expect(link).not.toBeNull();
+      const href = link!.getAttribute('href') ?? '';
+      expect(href).toContain('/training-plans/recruit-6w');
+      expect(href).toContain('day=1');
+    });
   });
 });

--- a/web/src/app/training-plans/training-plan-detail.component.spec.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.spec.ts
@@ -358,6 +358,82 @@ describe('TrainingPlanDetailComponent', () => {
       }
     });
 
+    it('scrolls the matching day-row into view when ?day=N is set in the URL', async () => {
+      // jsdom does not implement `Element.scrollIntoView` — install a
+      // mock on the prototype so the spy can record calls and we can
+      // assert which element it was invoked on.
+      const original = HTMLElement.prototype.scrollIntoView;
+      const scrollIntoView = vitest.fn();
+      HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      // Given the user lands on the plan detail with `?day=12` (e.g.
+      // navigated via the dashboard banner CTA, which carries the
+      // active day index in its queryParams).
+      const { fixture } = await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          {
+            provide: ActivatedRoute,
+            useValue: makeRouteMock('recruit-6w', { day: '12' }),
+          },
+          { provide: TrainingPlanStore, useValue: makeStoreMock() },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: true,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+
+      // afterRenderEffect runs after the next render — flush.
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      // Then each day-row has a stable `day-<index>` id so the dashboard
+      // banner can deep-link any day, and `scrollIntoView` was called
+      // on the day-12 element specifically (not just any element).
+      const root = fixture.nativeElement as HTMLElement;
+      const day12 = root.querySelector('#day-12') as HTMLElement | null;
+      expect(day12).not.toBeNull();
+      expect(day12!.classList.contains('day-row')).toBe(true);
+      expect(scrollIntoView).toHaveBeenCalled();
+      const wasCalledOnDay12 = scrollIntoView.mock.contexts.some(
+        (ctx) => ctx === day12
+      );
+      expect(wasCalledOnDay12).toBe(true);
+
+      HTMLElement.prototype.scrollIntoView = original;
+    });
+
+    it('does not scroll when ?day is missing', async () => {
+      const original = HTMLElement.prototype.scrollIntoView;
+      const scrollIntoView = vitest.fn();
+      HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      const { fixture } = await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: ActivatedRoute, useValue: makeRouteMock('recruit-6w') },
+          { provide: TrainingPlanStore, useValue: makeStoreMock() },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: true,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      HTMLElement.prototype.scrollIntoView = original;
+    });
+
     it('does NOT auto-start (even with ?autoStart=1) when a different plan is already active', async () => {
       const store = makeStoreMock({
         hasActivePlan: signal(true),

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -1,10 +1,14 @@
+import { isPlatformBrowser } from '@angular/common';
 import {
+  afterRenderEffect,
   ChangeDetectionStrategy,
   Component,
   computed,
   effect,
+  ElementRef,
   inject,
   LOCALE_ID,
+  PLATFORM_ID,
 } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
@@ -206,6 +210,7 @@ interface DayRow {
               @for (row of week.rows; track row.day.dayIndex) {
                 <li
                   class="day-row"
+                  [attr.id]="'day-' + row.day.dayIndex"
                   [class.today]="row.isToday"
                   [class.done]="row.isCompleted"
                   [class.future]="row.isFuture"
@@ -516,6 +521,8 @@ export class TrainingPlanDetailComponent {
   private readonly snackbar = inject(MatSnackBar);
   private readonly locale = inject(LOCALE_ID) as string;
   private readonly authStore = inject(AuthStore);
+  private readonly host: ElementRef<HTMLElement> = inject(ElementRef);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   protected readonly isAuthenticated = this.authStore.isAuthenticated;
   protected readonly authResolved = this.authStore.authResolved;
@@ -552,8 +559,27 @@ export class TrainingPlanDetailComponent {
   });
 
   private autoStartTriggered = false;
+  private lastScrolledDay: string | null = null;
 
   constructor() {
+    // Honour an incoming `?day=<index>` query param so deep-links from
+    // the dashboard's plan banner scroll to the active day after route
+    // hydration. Use `Element.scrollIntoView` (not `ViewportScroller`)
+    // because the app shell wraps content in `<mat-sidenav-content>`,
+    // which owns its own scroll container — `ViewportScroller` only
+    // scrolls `window` and would silently no-op.
+    afterRenderEffect(() => {
+      const raw = this.queryParamsSignal().get('day');
+      if (!raw || !this.isBrowser) return;
+      if (raw === this.lastScrolledDay) return;
+      const id = `day-${raw}`;
+      const target = document.getElementById(id);
+      if (target && this.host.nativeElement.contains(target)) {
+        this.lastScrolledDay = raw;
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+
     effect(() => {
       const p = this.plan();
       const wantsAutoStart = this.queryParamsSignal().get('autoStart') === '1';

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -559,7 +559,6 @@ export class TrainingPlanDetailComponent {
   });
 
   private autoStartTriggered = false;
-  private lastScrolledDay: string | null = null;
 
   constructor() {
     // Honour an incoming `?day=<index>` query param so deep-links from
@@ -568,14 +567,17 @@ export class TrainingPlanDetailComponent {
     // because the app shell wraps content in `<mat-sidenav-content>`,
     // which owns its own scroll container — `ViewportScroller` only
     // scrolls `window` and would silently no-op.
+    //
+    // We intentionally do NOT strip `?day=` after scrolling: keeping it
+    // in the URL makes the deep-link bookmarkable and re-fires the
+    // scroll on Back/Forward navigation, matching the `?type=` pattern
+    // in the wiki pushup-types page.
     afterRenderEffect(() => {
+      if (!this.isBrowser) return;
       const raw = this.queryParamsSignal().get('day');
-      if (!raw || !this.isBrowser) return;
-      if (raw === this.lastScrolledDay) return;
-      const id = `day-${raw}`;
-      const target = document.getElementById(id);
+      if (!raw) return;
+      const target = document.getElementById(`day-${raw}`);
       if (target && this.host.nativeElement.contains(target)) {
-        this.lastScrolledDay = raw;
         target.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }
     });


### PR DESCRIPTION
## Summary

- Dashboard plan banner CTA "Details öffnen" now passes `?day=<currentDayIndex>` to the training plan detail page.
- Each `<li class="day-row">` gets a stable `id="day-<N>"`. An `afterRenderEffect` reads `?day=N` and calls `Element.scrollIntoView({behavior:'smooth', block:'start'})` on the matching row.
- Mirrors the wiki page's pattern (`pushup-types-page.component.ts`) — `ViewportScroller`/anchor-scrolling silently no-ops because the app shell wraps content in `<mat-sidenav-content>`, which owns its own scroll container.
- `?day=N` is intentionally not stripped so the deep-link is bookmarkable and re-fires on Back/Forward (matches `?type=` in the wiki).

## Test plan

- [x] `pnpm nx test web` — 647/647 pass, including 3 new tests:
  - detail: scrolls the matching `#day-<N>` row when `?day=12` is set
  - detail: does not scroll when `?day` is missing
  - dashboard: banner href contains `day=1` on a non-rest day-1 plan
- [x] `pnpm nx lint web` — 0 errors
- [x] `pnpm nx affected -t=lint,test,build -c=production --parallel=3` — production build green


---
_Generated by [Claude Code](https://claude.ai/code/session_01QtT7rVnTyt2zQZTy9ho9rm)_