### PR TITLE
fix(analysis): show "Heute" label instead of icon on mobile filter bar

### DIFF
--- a/web/src/app/stats/components/filter-bar/filter-bar.component.scss
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.scss
@@ -44,10 +44,6 @@
   align-items: center;
 }
 
-.step-icon-mobile {
-  display: none;
-}
-
 .picker-toggle {
   display: none;
 }
@@ -76,22 +72,6 @@
   .step-btn {
     min-width: 0;
     padding: 0 8px;
-  }
-
-  .step-btn--today .step-label {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip-path: inset(50%);
-    white-space: nowrap;
-    border: 0;
-  }
-
-  .step-btn--today .step-icon-mobile {
-    display: inline-block;
   }
 
   .picker-toggle {

--- a/web/src/app/stats/components/filter-bar/filter-bar.component.ts
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.ts
@@ -82,13 +82,12 @@ import {
           <button
             type="button"
             mat-stroked-button
-            class="step-btn step-btn--today"
+            class="step-btn"
             [disabled]="mode() === 'custom'"
             (click)="jumpToToday()"
             aria-label="Zum heutigen Zeitraum springen"
             i18n-aria-label="@@rangeTodayAria"
           >
-            <mat-icon class="step-icon-mobile">today</mat-icon>
             <span class="step-label" i18n="@@rangeToday">Heute</span>
           </button>
           <button


### PR DESCRIPTION
## Summary
- Auf der Analyse-Seite (mobil, ≤600 px) wurde im minimierten Filter das Heute-Icon entfernt — der Text "Heute" bleibt sichtbar, weil das `today`-Material-Icon neben dem `date_range`-Picker-Icon visuell verwirrend war.
- Zugehörige mobile-only SCSS-Regeln (`.step-icon-mobile`, versteckter `.step-label`) entfernt; ungenutzten `step-btn--today` Modifier ebenfalls aufgeräumt.

## Test plan
- [x] `pnpm nx test web --filter "FilterBarComponent"` (18 Tests grün)
- [x] `pnpm nx lint web` (keine neuen Errors)
- [ ] Manuell auf Mobile-Viewport prüfen, dass "Heute" als Text statt als Icon erscheint


---
_Generated by [Claude Code](https://claude.ai/code/session_018LFqumDhwK2MfGNhMQbAyH)_