### PR TITLE
feat(analysis): rescale pie to selected types and surface slice info on click

### DIFF
--- a/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
@@ -125,6 +125,36 @@ describe('TypePieComponent', () => {
     expect(component.focusedSegment()?.id).toBe('Diamond');
   });
 
+  it('focuses a slice via Enter keydown', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    const slice = host.querySelector(
+      '[data-testid="type-pie-slice-Diamond"]'
+    ) as SVGElement | null;
+    expect(slice).toBeTruthy();
+
+    slice!.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    );
+    fixture.detectChanges();
+
+    expect(component.focusedSegment()?.id).toBe('Diamond');
+  });
+
+  it('focuses a slice via Space keydown', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    const slice = host.querySelector(
+      '[data-testid="type-pie-slice-Wide"]'
+    ) as SVGElement | null;
+    expect(slice).toBeTruthy();
+
+    slice!.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ' ', bubbles: true })
+    );
+    fixture.detectChanges();
+
+    expect(component.focusedSegment()?.id).toBe('Wide');
+  });
+
   it('toggling off the focused type clears the focus', () => {
     component.focusSegment('Standard');
     expect(component.focusedSegment()?.id).toBe('Standard');
@@ -132,6 +162,51 @@ describe('TypePieComponent', () => {
     // Standard becomes unselected; the focused detail can no longer apply.
     component.toggle('Standard');
     expect(component.focusedSegment()).toBeNull();
+  });
+
+  it('does not dim slices when the parent swaps data and evicts the focused id', () => {
+    // Given: Standard is focused
+    component.focusSegment('Standard');
+    fixture.detectChanges();
+    expect(component.focusedSegment()?.id).toBe('Standard');
+
+    // When: data swaps to a set that no longer contains Standard
+    fixture.componentRef.setInput('data', [
+      { label: 'Diamond', value: 80 },
+      { label: 'Wide', value: 60 },
+    ]);
+    fixture.detectChanges();
+
+    // Then: effective focusedId reports null and no rendered slice is dimmed
+    expect(component.focusedSegment()).toBeNull();
+    expect(component.focusedId()).toBeNull();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.querySelectorAll('.seg.dimmed')).toHaveLength(0);
+    // Total label is restored too.
+    expect(host.querySelector('[data-testid="type-pie-total"]')).toBeTruthy();
+  });
+
+  it('renders 0% (not raw count) for a selected slice whose share rounds to zero', () => {
+    // Given: a tiny slice that rounds to 0% of the selected total
+    fixture.componentRef.setInput('data', [
+      { label: 'Standard', value: 1000 },
+      { label: 'Spider', value: 2 },
+    ]);
+    fixture.detectChanges();
+
+    // Spider is selected (top-5 default covers both) but rounds to 0%.
+    expect(component.isSelected('Spider')).toBe(true);
+    expect(component.legendPercent('Spider')).toBe(0);
+
+    // The legend pct cell renders "0%" instead of falling into the
+    // unselected/raw-count branch.
+    const host: HTMLElement = fixture.nativeElement;
+    const pct = host
+      .querySelector('[data-testid="type-pie-toggle-Spider"]')
+      ?.closest('.row')
+      ?.querySelector('.pct');
+    expect(pct?.textContent).toContain('0%');
+    expect(pct?.classList.contains('count')).toBe(false);
   });
 
   it('toggling a checkbox removes the type and drops its slice from the pie', () => {

--- a/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.spec.ts
@@ -39,20 +39,110 @@ describe('TypePieComponent', () => {
       'Decline',
       'Knee',
     ]);
-    // 5 selected + an explicit "Other" arc covering the unselected
-    // remainder so the rendered pie always reads as a complete circle.
-    expect(component.visibleSegments()).toHaveLength(6);
-    expect(component.visibleSegments().at(-1)?.id).toBe('__other__');
-    expect(component.otherPercent()).toBeGreaterThan(0);
+    // Selected types fill the pie 100% — no synthetic Other arc.
+    expect(component.visibleSegments()).toHaveLength(5);
+    expect(component.visibleSegments().some((s) => s.id === '__other__')).toBe(
+      false
+    );
+  });
+
+  it('selectedTotal sums only the selected types', () => {
+    // Default top-5: 100+80+60+40+30 = 310, vs. grand total 340.
+    expect(component.selectedTotal()).toBe(310);
+    expect(component.total()).toBe(340);
+  });
+
+  it('renders the selected total in the donut center', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    const total = host.querySelector('[data-testid="type-pie-total"]');
+    expect(total).toBeTruthy();
+    expect(total!.textContent?.replace(/\s+/g, '')).toContain('310');
+  });
+
+  it('selected types fill the pie 100% (sum of dash fractions ≈ 100)', () => {
+    const sumDash = component.visibleSegments().reduce((sum, seg) => {
+      const visible = parseFloat(seg.dasharray.split(' ')[0]);
+      return sum + visible;
+    }, 0);
+    expect(sumDash).toBeCloseTo(100, 5);
+  });
+
+  it('legend percentages for selected types are relative to the selected total', () => {
+    // selected total = 310; Standard contributes 100/310 ≈ 32%.
+    expect(component.legendPercent('Standard')).toBe(
+      Math.round((100 / 310) * 100)
+    );
+    expect(component.legendPercent('Diamond')).toBe(
+      Math.round((80 / 310) * 100)
+    );
+    // Spider is unselected → no percent (legend falls back to raw count).
+    expect(component.legendPercent('Spider')).toBeNull();
+  });
+
+  it('focusing a slice surfaces its info in the donut center', () => {
+    // When: a slice is focused programmatically
+    component.focusSegment('Standard');
+    fixture.detectChanges();
+
+    // Then: focusedSegment exposes the slice payload
+    const focused = component.focusedSegment();
+    expect(focused?.id).toBe('Standard');
+    expect(focused?.value).toBe(100);
+
+    // And the rendered center swaps the total for the slice info
+    const host: HTMLElement = fixture.nativeElement;
+    const value = host.querySelector('[data-testid="type-pie-focused-value"]');
+    const label = host.querySelector('[data-testid="type-pie-focused-label"]');
+    const pct = host.querySelector('[data-testid="type-pie-focused-percent"]');
+    expect(value?.textContent?.replace(/\s+/g, '')).toContain('100');
+    expect(label?.textContent).toContain('Standard');
+    expect(pct?.textContent).toContain('%');
+    // Total label is hidden while a slice is focused.
+    expect(host.querySelector('[data-testid="type-pie-total"]')).toBeNull();
+  });
+
+  it('clicking the same slice twice clears the focus and restores the total', () => {
+    component.focusSegment('Standard');
+    expect(component.focusedSegment()?.id).toBe('Standard');
+
+    component.focusSegment('Standard');
+    expect(component.focusedSegment()).toBeNull();
+
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.querySelector('[data-testid="type-pie-total"]')).toBeTruthy();
+  });
+
+  it('clicking a slice in the SVG focuses it via the (click) handler', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    const slice = host.querySelector(
+      '[data-testid="type-pie-slice-Diamond"]'
+    ) as SVGElement | null;
+    expect(slice).toBeTruthy();
+    slice!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    fixture.detectChanges();
+
+    expect(component.focusedSegment()?.id).toBe('Diamond');
+  });
+
+  it('toggling off the focused type clears the focus', () => {
+    component.focusSegment('Standard');
+    expect(component.focusedSegment()?.id).toBe('Standard');
+
+    // Standard becomes unselected; the focused detail can no longer apply.
+    component.toggle('Standard');
+    expect(component.focusedSegment()).toBeNull();
   });
 
   it('toggling a checkbox removes the type and drops its slice from the pie', () => {
     // When: Diamond is toggled off
     component.toggle('Diamond');
 
-    // Then: Diamond drops out, Standard remains
+    // Then: Diamond drops out and the remaining slices still sum to 100%
     expect(component.isSelected('Diamond')).toBe(false);
-    expect(component.isSelected('Standard')).toBe(true);
+    expect(component.visibleSegments().some((s) => s.id === 'Diamond')).toBe(
+      false
+    );
 
     // When: Diamond is re-toggled
     component.toggle('Diamond');
@@ -68,7 +158,7 @@ describe('TypePieComponent', () => {
     // When: the user opts Spider in
     component.toggle('Spider');
 
-    // Then: Spider is visible and contributes a real slice (not "Other")
+    // Then: Spider is visible and contributes a real slice
     expect(component.isSelected('Spider')).toBe(true);
     expect(component.visibleSegments().some((s) => s.id === 'Spider')).toBe(
       true
@@ -108,6 +198,9 @@ describe('TypePieComponent', () => {
     ).toBeTruthy();
     expect(
       host.querySelector('[data-testid="type-pie-toggle-diamond"]')
+    ).toBeTruthy();
+    expect(
+      host.querySelector('[data-testid="type-pie-slice-standard"]')
     ).toBeTruthy();
   });
 
@@ -185,16 +278,16 @@ describe('TypePieComponent', () => {
     );
   });
 
-  it('unchecking the Top 5 preset expands the selection to all types', () => {
+  it('unchecking the Top 5 preset expands the selection so selectedTotal equals the grand total', () => {
     // Given: default state (top 5 active)
     expect(component.isTopFiveActive()).toBe(true);
 
     // When: user unchecks the preset
     component.onTopFiveChange(false);
 
-    // Then: every type is selected, no Other arc
+    // Then: every type contributes; selected total equals the grand total
     expect(component.selectedIds().size).toBe(7);
-    expect(component.otherPercent()).toBe(0);
+    expect(component.selectedTotal()).toBe(component.total());
     expect(component.isTopFiveActive()).toBe(false);
   });
 
@@ -220,16 +313,20 @@ describe('TypePieComponent', () => {
     expect(component.isTopFiveActive()).toBe(true);
   });
 
-  it('removing the last selected type empties the pie and treats all data as Other', () => {
+  it('removing the last selected type empties the pie and shows the no-selection placeholder', () => {
     // When: the user unchecks every default-selected type
     for (const id of [...component.selectedIds()]) {
       component.toggle(id);
     }
+    fixture.detectChanges();
 
-    // Then: the visible set is just the synthetic Other arc covering 100%
+    // Then: the pie has no slices, the selected total is zero, and the
+    // donut center shows the no-selection placeholder.
     expect(component.selectedIds().size).toBe(0);
-    expect(component.visibleSegments()).toHaveLength(1);
-    expect(component.visibleSegments()[0].id).toBe('__other__');
-    expect(component.otherPercent()).toBe(100);
+    expect(component.visibleSegments()).toHaveLength(0);
+    expect(component.selectedTotal()).toBe(0);
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain(
+      'Keine Auswahl'
+    );
   });
 });

--- a/web/src/app/stats/components/type-pie/type-pie.component.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.ts
@@ -30,7 +30,7 @@ const TOP_N = 5;
             <svg
               class="pie"
               viewBox="0 0 42 42"
-              role="img"
+              role="group"
               aria-label="Verteilung der Liegestütz-Typen"
               i18n-aria-label="@@pie.distributionAria"
             >
@@ -120,8 +120,8 @@ const TOP_N = 5;
                   <span class="name">{{ seg.label }}</span>
                 </span>
               </mat-checkbox>
-              @if (legendPercent(seg.id); as pct) {
-                <span class="pct">{{ pct }}%</span>
+              @if (isSelected(seg.id)) {
+                <span class="pct">{{ legendPercent(seg.id) ?? 0 }}%</span>
               } @else {
                 <span class="pct count">{{ seg.value | number }}</span>
               }
@@ -303,7 +303,13 @@ export class TypePieComponent {
   // null = use top-5 default; concrete Set = explicit user choice (may be empty).
   private readonly userSelection = signal<ReadonlySet<string> | null>(null);
   private readonly _focusedId = signal<string | null>(null);
-  readonly focusedId = this._focusedId.asReadonly();
+  // Effective focused id — `null` whenever the raw focus no longer maps
+  // to a visible segment (e.g. after the parent swaps `data` and evicts
+  // it). The template reads this so dimming/focused styling can't get
+  // stuck on a stale id.
+  readonly focusedId = computed<string | null>(
+    () => this.focusedSegment()?.id ?? null
+  );
 
   readonly total = computed(() =>
     this.data().reduce((sum, x) => sum + (x.value || 0), 0)

--- a/web/src/app/stats/components/type-pie/type-pie.component.ts
+++ b/web/src/app/stats/components/type-pie/type-pie.component.ts
@@ -17,7 +17,6 @@ export interface PieDatum {
 }
 
 const TOP_N = 5;
-const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
 
 @Component({
   selector: 'app-type-pie',
@@ -27,27 +26,72 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
     @if (total() > 0) {
       <div class="wrap">
         <div class="pie-area">
-          <svg
-            class="pie"
-            viewBox="0 0 42 42"
-            role="img"
-            aria-label="Verteilung der Liegestütz-Typen"
-            i18n-aria-label="@@pie.distributionAria"
-          >
-            <circle class="bg" cx="21" cy="21" r="15.915" />
+          <div class="pie-stack">
+            <svg
+              class="pie"
+              viewBox="0 0 42 42"
+              role="img"
+              aria-label="Verteilung der Liegestütz-Typen"
+              i18n-aria-label="@@pie.distributionAria"
+            >
+              <circle class="bg" cx="21" cy="21" r="15.915" />
 
-            @for (seg of visibleSegments(); track seg.id) {
-              <circle
-                class="seg"
-                cx="21"
-                cy="21"
-                r="15.915"
-                [attr.stroke]="seg.color"
-                [attr.stroke-dasharray]="seg.dasharray"
-                [attr.stroke-dashoffset]="seg.offset"
-              />
-            }
-          </svg>
+              @for (seg of visibleSegments(); track seg.id) {
+                <circle
+                  class="seg"
+                  [class.focused]="focusedId() === seg.id"
+                  [class.dimmed]="
+                    focusedId() !== null && focusedId() !== seg.id
+                  "
+                  cx="21"
+                  cy="21"
+                  r="15.915"
+                  [attr.stroke]="seg.color"
+                  [attr.stroke-dasharray]="seg.dasharray"
+                  [attr.stroke-dashoffset]="seg.offset"
+                  tabindex="0"
+                  role="button"
+                  [attr.aria-label]="
+                    seg.label + ': ' + seg.value + ' (' + seg.percent + '%)'
+                  "
+                  [attr.aria-pressed]="focusedId() === seg.id"
+                  [attr.data-testid]="'type-pie-slice-' + seg.id"
+                  (click)="focusSegment(seg.id)"
+                  (keydown.enter)="focusSegment(seg.id)"
+                  (keydown.space)="
+                    focusSegment(seg.id); $event.preventDefault()
+                  "
+                />
+              }
+            </svg>
+
+            <div class="pie-center" data-testid="type-pie-center">
+              @if (selectedTotal() === 0) {
+                <span class="center-label" i18n="@@pie.noSelection"
+                  >Keine Auswahl</span
+                >
+              } @else if (focusedSegment(); as f) {
+                <span
+                  class="center-label"
+                  data-testid="type-pie-focused-label"
+                  >{{ f.label }}</span
+                >
+                <span
+                  class="center-value"
+                  data-testid="type-pie-focused-value"
+                  >{{ f.value | number }}</span
+                >
+                <span class="center-pct" data-testid="type-pie-focused-percent"
+                  >{{ f.percent }}%</span
+                >
+              } @else {
+                <span class="center-label" i18n="@@pie.totalLabel">Gesamt</span>
+                <span class="center-value" data-testid="type-pie-total">{{
+                  selectedTotal() | number
+                }}</span>
+              }
+            </div>
+          </div>
         </div>
 
         <div class="legend" data-testid="type-pie-legend">
@@ -76,7 +120,11 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
                   <span class="name">{{ seg.label }}</span>
                 </span>
               </mat-checkbox>
-              <span class="pct">{{ seg.percent }}%</span>
+              @if (legendPercent(seg.id); as pct) {
+                <span class="pct">{{ pct }}%</span>
+              } @else {
+                <span class="pct count">{{ seg.value | number }}</span>
+              }
             </div>
             @if (seg.avgSetSize) {
               <div class="row set-detail">
@@ -88,15 +136,6 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
                 }}</span>
               </div>
             }
-          }
-          @if (otherPercent() > 0) {
-            <div class="row other-row" data-testid="type-pie-other-row">
-              <span class="row-name">
-                <span class="dot" [style.background]="otherColor"></span>
-                <span class="name" i18n="@@pie.other">Sonstige</span>
-              </span>
-              <span class="pct">{{ otherPercent() }}%</span>
-            </div>
           }
         </div>
       </div>
@@ -116,6 +155,11 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
       gap: 10px;
       justify-items: center;
     }
+    .pie-stack {
+      position: relative;
+      width: 160px;
+      height: 160px;
+    }
     .pie {
       width: 160px;
       height: 160px;
@@ -130,6 +174,49 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
       fill: none;
       stroke-width: 10;
       stroke-linecap: butt;
+      cursor: pointer;
+      transition:
+        stroke-width 0.15s ease,
+        opacity 0.15s ease;
+    }
+    .seg:hover,
+    .seg:focus-visible,
+    .seg.focused {
+      stroke-width: 12;
+      outline: none;
+    }
+    .seg.dimmed {
+      opacity: 0.45;
+    }
+    .pie-center {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      align-content: center;
+      justify-items: center;
+      text-align: center;
+      pointer-events: none;
+      padding: 18%;
+      gap: 2px;
+    }
+    .center-label {
+      font-size: 0.72rem;
+      opacity: 0.75;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .center-value {
+      font-size: 1.25rem;
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+      line-height: 1.1;
+    }
+    .center-pct {
+      font-size: 0.85rem;
+      opacity: 0.85;
+      font-variant-numeric: tabular-nums;
     }
 
     .legend {
@@ -168,14 +255,13 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
       font-variant-numeric: tabular-nums;
       opacity: 0.8;
     }
+    .pct.count {
+      opacity: 0.5;
+    }
     .set-detail {
       opacity: 0.6;
       font-size: 0.8rem;
       grid-template-columns: 1fr auto;
-      padding-left: 36px;
-    }
-    .other-row {
-      opacity: 0.75;
       padding-left: 36px;
     }
     .preset-row {
@@ -205,7 +291,7 @@ const OTHER_COLOR = 'rgba(120, 120, 120, 0.55)';
       .wrap {
         grid-template-columns: 1fr;
       }
-      .pie {
+      .pie-stack {
         margin: 0 auto;
       }
     }
@@ -216,8 +302,8 @@ export class TypePieComponent {
 
   // null = use top-5 default; concrete Set = explicit user choice (may be empty).
   private readonly userSelection = signal<ReadonlySet<string> | null>(null);
-
-  readonly otherColor = OTHER_COLOR;
+  private readonly _focusedId = signal<string | null>(null);
+  readonly focusedId = this._focusedId.asReadonly();
 
   readonly total = computed(() =>
     this.data().reduce((sum, x) => sum + (x.value || 0), 0)
@@ -285,62 +371,57 @@ export class TypePieComponent {
     return true;
   });
 
+  /**
+   * Sum of values across the currently selected types — defines the 100%
+   * reference used by the pie and legend percentages so the rendered pie
+   * has no Other arc when types are excluded.
+   */
+  readonly selectedTotal = computed(() => {
+    const selected = this.selectedIds();
+    return this.allSegments()
+      .filter((s) => selected.has(s.id))
+      .reduce((sum, s) => sum + s.value, 0);
+  });
+
   readonly visibleSegments = computed(() => {
-    const total = this.total();
-    if (!total)
+    const selectedTotal = this.selectedTotal();
+    if (!selectedTotal)
       return [] as Array<{
         id: string;
         label: string;
+        value: number;
         percent: number;
         color: string;
+        avgSetSize: number;
         dasharray: string;
         offset: number;
       }>;
 
     const selected = this.selectedIds();
     let acc = 0;
-    const segments = this.allSegments()
+    return this.allSegments()
       .filter((s) => selected.has(s.id))
       .map((seg) => {
-        const dash = (seg.value / total) * 100;
+        const dash = (seg.value / selectedTotal) * 100;
         const result = {
           id: seg.id,
           label: seg.label,
-          percent: seg.percent,
+          value: seg.value,
+          percent: Math.round((seg.value / selectedTotal) * 100),
           color: seg.color,
+          avgSetSize: seg.avgSetSize,
           dasharray: `${dash} ${100 - dash}`,
           offset: 25 - acc,
         };
         acc += dash;
         return result;
       });
-
-    // Cap the cumulative dash so floating-point drift can't push the
-    // remainder negative.
-    const remainder = Math.max(0, 100 - acc);
-    if (remainder > 0.5) {
-      segments.push({
-        id: '__other__',
-        label: 'other',
-        percent: Math.round(remainder),
-        color: OTHER_COLOR,
-        dasharray: `${remainder} ${100 - remainder}`,
-        offset: 25 - acc,
-      });
-    }
-    return segments;
   });
 
-  /** Cumulative percent of types not currently visible — for the legend. */
-  readonly otherPercent = computed(() => {
-    const total = this.total();
-    if (!total) return 0;
-    const selected = this.selectedIds();
-    const hiddenValue = this.allSegments()
-      .filter((s) => !selected.has(s.id))
-      .reduce((sum, s) => sum + s.value, 0);
-    if (hiddenValue <= 0) return 0;
-    return Math.round((hiddenValue / total) * 100);
+  readonly focusedSegment = computed(() => {
+    const id = this._focusedId();
+    if (!id) return null;
+    return this.visibleSegments().find((s) => s.id === id) ?? null;
   });
 
   isSelected(id: string): boolean {
@@ -351,6 +432,7 @@ export class TypePieComponent {
     const next = new Set(this.selectedIds());
     if (next.has(id)) {
       next.delete(id);
+      if (this._focusedId() === id) this._focusedId.set(null);
     } else {
       next.add(id);
     }
@@ -363,5 +445,21 @@ export class TypePieComponent {
     } else {
       this.userSelection.set(new Set(this.allSegments().map((s) => s.id)));
     }
+    const fid = this._focusedId();
+    if (fid && !this.selectedIds().has(fid)) this._focusedId.set(null);
+  }
+
+  focusSegment(id: string): void {
+    this._focusedId.set(this._focusedId() === id ? null : id);
+  }
+
+  /** Percent of the selected total — `null` for unselected rows. */
+  legendPercent(id: string): number | null {
+    if (!this.selectedIds().has(id)) return null;
+    const total = this.selectedTotal();
+    if (total <= 0) return null;
+    const seg = this.allSegments().find((s) => s.id === id);
+    if (!seg) return null;
+    return Math.round((seg.value / total) * 100);
   }
 }

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -4727,13 +4727,16 @@
         <target>Κατανομή τύπων push-up</target>
       </segment>
     </unit>
-    <unit id="pie.other">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
-      </notes>
+    <unit id="pie.totalLabel">
       <segment state="translated">
-        <source>Sonstige</source>
-        <target>Άλλα</target>
+        <source>Gesamt</source>
+        <target>Σύνολο</target>
+      </segment>
+    </unit>
+    <unit id="pie.noSelection">
+      <segment state="translated">
+        <source>Keine Auswahl</source>
+        <target>Καμία επιλογή</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -2806,13 +2806,16 @@ Deine Position: # ·  Reps        </source>
         <target>Pushup type distribution</target>
       </segment>
     </unit>
-    <unit id="pie.other">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
-      </notes>
+    <unit id="pie.totalLabel">
       <segment state="translated">
-        <source>Sonstige</source>
-        <target>Other</target>
+        <source>Gesamt</source>
+        <target>Total</target>
+      </segment>
+    </unit>
+    <unit id="pie.noSelection">
+      <segment state="translated">
+        <source>Keine Auswahl</source>
+        <target>No selection</target>
       </segment>
     </unit>
     <unit id="quickActionsSubtitle">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -4727,13 +4727,16 @@
         <target>Distribución de tipos de flexiones</target>
       </segment>
     </unit>
-    <unit id="pie.other">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
-      </notes>
+    <unit id="pie.totalLabel">
       <segment state="translated">
-        <source>Sonstige</source>
-        <target>Otros</target>
+        <source>Gesamt</source>
+        <target>Total</target>
+      </segment>
+    </unit>
+    <unit id="pie.noSelection">
+      <segment state="translated">
+        <source>Keine Auswahl</source>
+        <target>Sin selección</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -4727,13 +4727,16 @@
         <target>Répartition des types de pompes</target>
       </segment>
     </unit>
-    <unit id="pie.other">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
-      </notes>
+    <unit id="pie.totalLabel">
       <segment state="translated">
-        <source>Sonstige</source>
-        <target>Autres</target>
+        <source>Gesamt</source>
+        <target>Total</target>
+      </segment>
+    </unit>
+    <unit id="pie.noSelection">
+      <segment state="translated">
+        <source>Keine Auswahl</source>
+        <target>Aucune sélection</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -4727,13 +4727,16 @@
         <target>Distribuzione dei tipi di piegamenti</target>
       </segment>
     </unit>
-    <unit id="pie.other">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
-      </notes>
+    <unit id="pie.totalLabel">
       <segment state="translated">
-        <source>Sonstige</source>
-        <target>Altri</target>
+        <source>Gesamt</source>
+        <target>Totale</target>
+      </segment>
+    </unit>
+    <unit id="pie.noSelection">
+      <segment state="translated">
+        <source>Keine Auswahl</source>
+        <target>Nessuna selezione</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -4727,13 +4727,16 @@
         <target>Distributio generum exercitiorum</target>
       </segment>
     </unit>
-    <unit id="pie.other">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
-      </notes>
+    <unit id="pie.totalLabel">
       <segment state="translated">
-        <source>Sonstige</source>
-        <target>Cetera</target>
+        <source>Gesamt</source>
+        <target>Summa</target>
+      </segment>
+    </unit>
+    <unit id="pie.noSelection">
+      <segment state="translated">
+        <source>Keine Auswahl</source>
+        <target>Nulla electio</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -4727,13 +4727,16 @@
         <target>Verdeling van push-uptypen</target>
       </segment>
     </unit>
-    <unit id="pie.other">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
-      </notes>
+    <unit id="pie.totalLabel">
       <segment state="translated">
-        <source>Sonstige</source>
-        <target>Overige</target>
+        <source>Gesamt</source>
+        <target>Totaal</target>
+      </segment>
+    </unit>
+    <unit id="pie.noSelection">
+      <segment state="translated">
+        <source>Keine Auswahl</source>
+        <target>Geen selectie</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -2828,13 +2828,16 @@ Deine Position: # ·  Reps        </source>
         <target>Fordeling av push-up-typer</target>
       </segment>
     </unit>
-    <unit id="pie.other">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
-      </notes>
+    <unit id="pie.totalLabel">
       <segment state="translated">
-        <source>Sonstige</source>
-        <target>Andre</target>
+        <source>Gesamt</source>
+        <target>Totalt</target>
+      </segment>
+    </unit>
+    <unit id="pie.noSelection">
+      <segment state="translated">
+        <source>Keine Auswahl</source>
+        <target>Ingen valg</target>
       </segment>
     </unit>
     <unit id="quickActionsSubtitle">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -235,9 +235,8 @@
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:67,69</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:277,278</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:326,327</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:546,547</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
       </notes>
       <segment>
@@ -4279,366 +4278,6 @@
         <source>Zur Analyse</source>
       </segment>
     </unit>
-    <unit id="editDialogTitle">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:140,142</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:143,145</note>
-      </notes>
-      <segment>
-        <source>Eintrag bearbeiten</source>
-      </segment>
-    </unit>
-    <unit id="createDialogTitle">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:142,146</note>
-      </notes>
-      <segment>
-        <source>Neuen Eintrag anlegen</source>
-      </segment>
-    </unit>
-    <unit id="timestampLabel">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:148,150</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:152,154</note>
-      </notes>
-      <segment>
-        <source>Zeitpunkt</source>
-      </segment>
-    </unit>
-    <unit id="setLabel">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:162,163</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:258,259</note>
-      </notes>
-      <segment>
-        <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-      </segment>
-    </unit>
-    <unit id="repsLabel">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:164,165</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:260,261</note>
-      </notes>
-      <segment>
-        <source>Reps</source>
-      </segment>
-    </unit>
-    <unit id="removeSetAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:181,183</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:279,281</note>
-      </notes>
-      <segment>
-        <source>Set entfernen</source>
-      </segment>
-    </unit>
-    <unit id="addSetAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:192,193</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:290,292</note>
-      </notes>
-      <segment>
-        <source>Set hinzufügen</source>
-      </segment>
-    </unit>
-    <unit id="addSetTooltip">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:194,196</note>
-      </notes>
-      <segment>
-        <source>Weiteres Set hinzufügen</source>
-      </segment>
-    </unit>
-    <unit id="totalReps">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:203,205</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:299,301</note>
-      </notes>
-      <segment>
-        <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
-      </segment>
-    </unit>
-    <unit id="typeLabel">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:209,210</note>
-      </notes>
-      <segment>
-        <source>Typ</source>
-      </segment>
-    </unit>
-    <unit id="typePlaceholder">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:215,216</note>
-      </notes>
-      <segment>
-        <source>Auswählen oder eintippen</source>
-      </segment>
-    </unit>
-    <unit id="typeWikiLinkAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:251,253</note>
-      </notes>
-      <segment>
-        <source>Anleitung zum Liegestütztyp öffnen</source>
-      </segment>
-    </unit>
-    <unit id="sourceLabel">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:258,259</note>
-      </notes>
-      <segment>
-        <source>Quelle</source>
-      </segment>
-    </unit>
-    <unit id="sourcePlaceholder">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:264,265</note>
-      </notes>
-      <segment>
-        <source>web / whatsapp / eigene Quelle</source>
-      </segment>
-    </unit>
-    <unit id="saveEntry">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:285,287</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:335,337</note>
-      </notes>
-      <segment>
-        <source> Speichern </source>
-      </segment>
-    </unit>
-    <unit id="typeWikiLinkTooltip.generic">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:377</note>
-      </notes>
-      <segment>
-        <source>Anleitung zu Liegestütztypen öffnen</source>
-      </segment>
-    </unit>
-    <unit id="typeWikiLinkTooltip.specific">
-      <notes>
-        <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:383</note>
-      </notes>
-      <segment>
-        <source>Anleitung öffnen</source>
-      </segment>
-    </unit>
-    <unit id="exerciseEntryDialog.title">
-      <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:145,147</note>
-      </notes>
-      <segment>
-        <source>Eintrag hinzufügen</source>
-      </segment>
-    </unit>
-    <unit id="entryDialog.variant">
-      <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:164,165</note>
-      </notes>
-      <segment>
-        <source>Variante</source>
-      </segment>
-    </unit>
-    <unit id="entryDialog.variantNone">
-      <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:167,169</note>
-      </notes>
-      <segment>
-        <source>—</source>
-      </segment>
-    </unit>
-    <unit id="entryDialog.distance">
-      <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:180,182</note>
-      </notes>
-      <segment>
-        <source>Distanz (km)</source>
-      </segment>
-    </unit>
-    <unit id="entryDialog.durationMinutes">
-      <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:196,198</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:226,228</note>
-      </notes>
-      <segment>
-        <source>Minuten</source>
-      </segment>
-    </unit>
-    <unit id="entryDialog.durationSeconds">
-      <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:209,211</note>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:239,241</note>
-      </notes>
-      <segment>
-        <source>Sekunden</source>
-      </segment>
-    </unit>
-    <unit id="entryDialog.overCapDuration">
-      <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:307,308</note>
-      </notes>
-      <segment>
-        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
-      </segment>
-    </unit>
-    <unit id="entryDialog.overCapTime">
-      <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:313,314</note>
-      </notes>
-      <segment>
-        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
-      </segment>
-    </unit>
-    <unit id="entryDialog.overCap">
-      <notes>
-        <note category="location">web/src/app/stats/components/entry-dialog/entry-dialog.component.ts:317,318</note>
-      </notes>
-      <segment>
-        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> pro Eintrag</source>
-      </segment>
-    </unit>
-    <unit id="exerciseSection.lastEntry">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:134,135</note>
-      </notes>
-      <segment>
-        <source>Letzter Eintrag</source>
-      </segment>
-    </unit>
-    <unit id="exerciseSection.last30d">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:143,145</note>
-      </notes>
-      <segment>
-        <source>Letzte 30 Tage</source>
-      </segment>
-    </unit>
-    <unit id="exerciseSection.add">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:153,155</note>
-      </notes>
-      <segment>
-        <source>Hinzufügen</source>
-      </segment>
-    </unit>
-    <unit id="exercise.category.pushup">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:356</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:190</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:277</note>
-      </notes>
-      <segment>
-        <source>Liegestütze</source>
-      </segment>
-    </unit>
-    <unit id="exercise.category.abs">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:357</note>
-      </notes>
-      <segment>
-        <source>Bauch</source>
-      </segment>
-    </unit>
-    <unit id="exercise.category.legs">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:358</note>
-      </notes>
-      <segment>
-        <source>Beine</source>
-      </segment>
-    </unit>
-    <unit id="exercise.category.plank">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:359</note>
-      </notes>
-      <segment>
-        <source>Plank</source>
-      </segment>
-    </unit>
-    <unit id="exercise.category.cardio">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:360</note>
-      </notes>
-      <segment>
-        <source>Ausdauer</source>
-      </segment>
-    </unit>
-    <unit id="exercise.abs.situps.name">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:363</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:8</note>
-      </notes>
-      <segment>
-        <source>Sit-ups</source>
-      </segment>
-    </unit>
-    <unit id="exercise.legs.squats.name">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:364</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:9</note>
-      </notes>
-      <segment>
-        <source>Kniebeugen</source>
-      </segment>
-    </unit>
-    <unit id="exercise.plank.standard.name">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:365</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:10</note>
-      </notes>
-      <segment>
-        <source>Plank</source>
-      </segment>
-    </unit>
-    <unit id="exercise.cardio.running.name">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:366</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:11</note>
-      </notes>
-      <segment>
-        <source>Laufen</source>
-      </segment>
-    </unit>
-    <unit id="exerciseSection.addAriaPrefix">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:371</note>
-      </notes>
-      <segment>
-        <source>Eintrag hinzufügen</source>
-      </segment>
-    </unit>
-    <unit id="exerciseSection.savedToast">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:372</note>
-      </notes>
-      <segment>
-        <source>Eintrag gespeichert</source>
-      </segment>
-    </unit>
-    <unit id="exerciseSection.dismiss">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:373</note>
-      </notes>
-      <segment>
-        <source>OK</source>
-      </segment>
-    </unit>
-    <unit id="exerciseSection.errorPrefix">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:374</note>
-      </notes>
-      <segment>
-        <source>Konnte nicht gespeichert werden</source>
-      </segment>
-    </unit>
-    <unit id="exerciseSection.genericError">
-      <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:375</note>
-      </notes>
-      <segment>
-        <source>Etwas ist schiefgelaufen</source>
-      </segment>
-    </unit>
     <unit id="selectRangeTitle">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:43,46</note>
@@ -4713,7 +4352,7 @@
     </unit>
     <unit id="rangeToday">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:92,93</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:91,92</note>
       </notes>
       <segment>
         <source>Heute</source>
@@ -4721,7 +4360,7 @@
     </unit>
     <unit id="rangeForwardAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:100,101</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:99,100</note>
       </notes>
       <segment>
         <source>Nächster Zeitraum</source>
@@ -4729,7 +4368,7 @@
     </unit>
     <unit id="rangeForward">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:103,104</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:102,103</note>
       </notes>
       <segment>
         <source>Vor</source>
@@ -4737,7 +4376,7 @@
     </unit>
     <unit id="rangePickerToggleAria">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:112,113</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:111,112</note>
       </notes>
       <segment>
         <source>Eigenen Zeitraum auswählen</source>
@@ -4745,7 +4384,7 @@
     </unit>
     <unit id="rangeLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:125,126</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:124,125</note>
       </notes>
       <segment>
         <source>Zeitraum</source>
@@ -4753,7 +4392,7 @@
     </unit>
     <unit id="rangeFrom">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:131</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:130</note>
       </notes>
       <segment>
         <source>Von</source>
@@ -4761,7 +4400,7 @@
     </unit>
     <unit id="rangeTo">
       <notes>
-        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:137</note>
+        <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:136</note>
       </notes>
       <segment>
         <source>Bis</source>
@@ -5263,10 +4902,278 @@
     </unit>
     <unit id="colExercise">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:186</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:196</note>
       </notes>
       <segment>
         <source>Übung</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:200</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1093</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:277</note>
+      </notes>
+      <segment>
+        <source>Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="editDialogTitle">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:261,263</note>
+      </notes>
+      <segment>
+        <source>Eintrag bearbeiten</source>
+      </segment>
+    </unit>
+    <unit id="trainingEntryDialog.title">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:263,267</note>
+      </notes>
+      <segment>
+        <source>Trainingseintrag anlegen</source>
+      </segment>
+    </unit>
+    <unit id="trainingEntryDialog.category">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:269,271</note>
+      </notes>
+      <segment>
+        <source>Kategorie</source>
+      </segment>
+    </unit>
+    <unit id="trainingEntryDialog.exercise">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:284,286</note>
+      </notes>
+      <segment>
+        <source>Übung</source>
+      </segment>
+    </unit>
+    <unit id="timestampLabel">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:299,301</note>
+      </notes>
+      <segment>
+        <source>Zeitpunkt</source>
+      </segment>
+    </unit>
+    <unit id="typeLabel">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:312,313</note>
+      </notes>
+      <segment>
+        <source>Typ</source>
+      </segment>
+    </unit>
+    <unit id="typePlaceholder">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:318,319</note>
+      </notes>
+      <segment>
+        <source>Auswählen oder eintippen</source>
+      </segment>
+    </unit>
+    <unit id="typeWikiLinkAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:357,359</note>
+      </notes>
+      <segment>
+        <source>Anleitung zum Liegestütztyp öffnen</source>
+      </segment>
+    </unit>
+    <unit id="entryDialog.variant">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:364,365</note>
+      </notes>
+      <segment>
+        <source>Variante</source>
+      </segment>
+    </unit>
+    <unit id="entryDialog.variantNone">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:367,369</note>
+      </notes>
+      <segment>
+        <source>—</source>
+      </segment>
+    </unit>
+    <unit id="entryDialog.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:380,382</note>
+      </notes>
+      <segment>
+        <source>Distanz (km)</source>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationMinutes">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:396,398</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:426,428</note>
+      </notes>
+      <segment>
+        <source>Minuten</source>
+      </segment>
+    </unit>
+    <unit id="entryDialog.durationSeconds">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:409,411</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:439,441</note>
+      </notes>
+      <segment>
+        <source>Sekunden</source>
+      </segment>
+    </unit>
+    <unit id="setLabel">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:458,459</note>
+      </notes>
+      <segment>
+        <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
+      </segment>
+    </unit>
+    <unit id="repsLabel">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:460,461</note>
+      </notes>
+      <segment>
+        <source>Reps</source>
+      </segment>
+    </unit>
+    <unit id="removeSetAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:479,481</note>
+      </notes>
+      <segment>
+        <source>Set entfernen</source>
+      </segment>
+    </unit>
+    <unit id="addSetAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:490,491</note>
+      </notes>
+      <segment>
+        <source>Set hinzufügen</source>
+      </segment>
+    </unit>
+    <unit id="addSetTooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:492,494</note>
+      </notes>
+      <segment>
+        <source>Weiteres Set hinzufügen</source>
+      </segment>
+    </unit>
+    <unit id="totalReps">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:501,503</note>
+      </notes>
+      <segment>
+        <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapDuration">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:510,511</note>
+      </notes>
+      <segment>
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCapTime">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:514,515</note>
+      </notes>
+      <segment>
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
+      </segment>
+    </unit>
+    <unit id="entryDialog.overCap">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:518,519</note>
+      </notes>
+      <segment>
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ repsMax() }}"/> pro Eintrag</source>
+      </segment>
+    </unit>
+    <unit id="sourceLabel">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:526,527</note>
+      </notes>
+      <segment>
+        <source>Quelle</source>
+      </segment>
+    </unit>
+    <unit id="sourcePlaceholder">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:532,533</note>
+      </notes>
+      <segment>
+        <source>web / whatsapp / eigene Quelle</source>
+      </segment>
+    </unit>
+    <unit id="saveEntry">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:556,558</note>
+      </notes>
+      <segment>
+        <source> Speichern </source>
+      </segment>
+    </unit>
+    <unit id="trainingEntryDialog.pushup.exercise">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:608</note>
+      </notes>
+      <segment>
+        <source>Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="typeWikiLinkTooltip.generic">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:770</note>
+      </notes>
+      <segment>
+        <source>Anleitung zu Liegestütztypen öffnen</source>
+      </segment>
+    </unit>
+    <unit id="typeWikiLinkTooltip.specific">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:772</note>
+      </notes>
+      <segment>
+        <source>Anleitung öffnen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.abs">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1094</note>
+      </notes>
+      <segment>
+        <source>Bauch</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.legs">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1095</note>
+      </notes>
+      <segment>
+        <source>Beine</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.plank">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1096</note>
+      </notes>
+      <segment>
+        <source>Plank</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.cardio">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1097</note>
+      </notes>
+      <segment>
+        <source>Ausdauer</source>
       </segment>
     </unit>
     <unit id="pie.distributionAria">
@@ -5277,9 +5184,25 @@
         <source>Verteilung der Liegestütz-Typen</source>
       </segment>
     </unit>
+    <unit id="pie.noSelection">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:71,73</note>
+      </notes>
+      <segment>
+        <source>Keine Auswahl</source>
+      </segment>
+    </unit>
+    <unit id="pie.totalLabel">
+      <notes>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:86,87</note>
+      </notes>
+      <segment>
+        <source>Gesamt</source>
+      </segment>
+    </unit>
     <unit id="pie.top5">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:62,63</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:104,105</note>
       </notes>
       <segment>
         <source>Top 5</source>
@@ -5287,23 +5210,15 @@
     </unit>
     <unit id="pie.avgSetSize">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:84,85</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:130,131</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
       </segment>
     </unit>
-    <unit id="pie.other">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,97</note>
-      </notes>
-      <segment>
-        <source>Sonstige</source>
-      </segment>
-    </unit>
     <unit id="pie.noData">
       <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:104,107</note>
+        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:141,144</note>
       </notes>
       <segment>
         <source>Keine Daten</source>
@@ -5347,6 +5262,38 @@
       </notes>
       <segment>
         <source>Pushup Tracker</source>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.situps.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:8</note>
+      </notes>
+      <segment>
+        <source>Sit-ups</source>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:9</note>
+      </notes>
+      <segment>
+        <source>Kniebeugen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.plank.standard.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:10</note>
+      </notes>
+      <segment>
+        <source>Plank</source>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.running.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:11</note>
+      </notes>
+      <segment>
+        <source>Laufen</source>
       </segment>
     </unit>
     <unit id="analysisHeaderTitle">
@@ -6301,8 +6248,8 @@
     <unit id="trainingPlans.kind.rest">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:77,78</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:169,171</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:232,233</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:170,172</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:237,238</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:107,108</note>
       </notes>
       <segment>
@@ -6312,7 +6259,7 @@
     <unit id="trainingPlans.kind.light">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:80,81</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:239,241</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:244,246</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:110,111</note>
       </notes>
       <segment>
@@ -6322,7 +6269,7 @@
     <unit id="trainingPlans.kind.test">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:82,84</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:235,237</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:240,242</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:113,115</note>
       </notes>
       <segment>
@@ -6332,9 +6279,9 @@
     <unit id="trainingPlans.reps">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:85,87</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:182,184</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:245,246</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:251,252</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:183,185</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:250,251</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:256,257</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:125,127</note>
       </notes>
       <segment>
@@ -6343,7 +6290,7 @@
     </unit>
     <unit id="trainingPlans.openDetail">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:94,96</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:95,97</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:165,167</note>
       </notes>
       <segment>
@@ -6352,7 +6299,7 @@
     </unit>
     <unit id="dashboard.noPlanTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:106,108</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:107,109</note>
       </notes>
       <segment>
         <source>Noch kein aktiver Trainingsplan</source>
@@ -6360,7 +6307,7 @@
     </unit>
     <unit id="dashboard.noPlanSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:109,111</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:110,112</note>
       </notes>
       <segment>
         <source> Wähle einen Plan, um dein Tagesziel automatisch setzen zu lassen. </source>
@@ -6368,7 +6315,7 @@
     </unit>
     <unit id="dashboard.noPlanCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:118,120</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:119,121</note>
       </notes>
       <segment>
         <source> Plan wählen </source>
@@ -6376,7 +6323,7 @@
     </unit>
     <unit id="todayFocusAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:127,128</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:128,129</note>
       </notes>
       <segment>
         <source>Tagesfokus</source>
@@ -6384,7 +6331,7 @@
     </unit>
     <unit id="dashboard.todayTotal">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:133,135</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:134,136</note>
       </notes>
       <segment>
         <source>Heute Gesamt</source>
@@ -6392,7 +6339,7 @@
     </unit>
     <unit id="goalProgressTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:144,146</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:145,147</note>
       </notes>
       <segment>
         <source>Zielfortschritt</source>
@@ -6400,7 +6347,7 @@
     </unit>
     <unit id="dashboard.goalEditAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:152,153</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:153,154</note>
       </notes>
       <segment>
         <source>Tagesziel in Einstellungen öffnen</source>
@@ -6408,8 +6355,8 @@
     </unit>
     <unit id="dashboard.dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:161,163</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:188,189</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:162,164</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:189,190</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -6417,7 +6364,7 @@
     </unit>
     <unit id="dashboard.restDay.configuredGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:178,180</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:179,181</note>
       </notes>
       <segment>
         <source>Konfiguriertes Tagesziel:</source>
@@ -6425,7 +6372,7 @@
     </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:198,199</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:199,200</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -6433,7 +6380,7 @@
     </unit>
     <unit id="dashboard.monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:207,208</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
       </notes>
       <segment>
         <source>Monat</source>
@@ -6441,7 +6388,7 @@
     </unit>
     <unit id="dashboard.lastEntryLinkAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:232,233</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:233,234</note>
       </notes>
       <segment>
         <source>Letzten Eintrag in der Historie öffnen</source>
@@ -6449,7 +6396,7 @@
     </unit>
     <unit id="lastEntryTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:236,237</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:237,238</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -6457,7 +6404,7 @@
     </unit>
     <unit id="latEntryReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:241,243</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:242,244</note>
       </notes>
       <segment>
         <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ typeLabel(latest) }}"/> </source>
@@ -6465,7 +6412,7 @@
     </unit>
     <unit id="dashboard.noEntryYet">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:245,247</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:246,248</note>
       </notes>
       <segment>
         <source>Noch kein Eintrag.</source>
@@ -6473,7 +6420,7 @@
     </unit>
     <unit id="quickActionsTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:254,256</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:255,257</note>
       </notes>
       <segment>
         <source>Schnellaktionen</source>
@@ -6481,7 +6428,7 @@
     </unit>
     <unit id="quickActionsSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:257,259</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:258,260</note>
       </notes>
       <segment>
         <source>Schnell eintragen ohne Dialog</source>
@@ -6489,7 +6436,7 @@
     </unit>
     <unit id="quickActions.edit.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:264,265</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:265,266</note>
       </notes>
       <segment>
         <source>Schnellaktionen bearbeiten</source>
@@ -6497,7 +6444,7 @@
     </unit>
     <unit id="dashboard.quickAdd.button">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:286,287</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:287,288</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
@@ -6505,7 +6452,7 @@
     </unit>
     <unit id="dashboard.goalFill.reached">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:304,306</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:305,307</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -6513,7 +6460,7 @@
     </unit>
     <unit id="dashboard.goalFill.fill">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:307,308</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:308,309</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> bis zum Ziel</source>
@@ -6521,7 +6468,7 @@
     </unit>
     <unit id="quickAddNew">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:319,321</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:320,322</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">edit_note</pc> Neu </source>
@@ -6529,7 +6476,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:340,344</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:341,345</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -6537,7 +6484,7 @@
     </unit>
     <unit id="dashboard.latestEntriesLinkAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:351,352</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:352,353</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6545,7 +6492,7 @@
     </unit>
     <unit id="dashboard.latestEntries">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:354,355</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:355,356</note>
       </notes>
       <segment>
         <source>Letzte Einträge</source>
@@ -6553,7 +6500,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:361,362</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:362,363</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6561,7 +6508,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:365,368</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:366,369</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -6569,7 +6516,7 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:371</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:372</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -6577,7 +6524,7 @@
     </unit>
     <unit id="dashboard.share.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:80</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:85</note>
       </notes>
       <segment>
         <source>Tagesleistung teilen</source>
@@ -6585,7 +6532,7 @@
     </unit>
     <unit id="dashboard.share">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:81</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:86</note>
       </notes>
       <segment>
         <source>Teilen</source>
@@ -6593,8 +6540,8 @@
     </unit>
     <unit id="trainingPlans.back">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:70</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:329,331</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:74</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:334,336</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -6602,7 +6549,7 @@
     </unit>
     <unit id="trainingPlans.daysSuffix">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:79,81</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:83,85</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:180,182</note>
       </notes>
       <segment>
@@ -6611,7 +6558,7 @@
     </unit>
     <unit id="trainingPlans.level.beginner">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:83,84</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:87,88</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:185,187</note>
       </notes>
       <segment>
@@ -6620,7 +6567,7 @@
     </unit>
     <unit id="trainingPlans.level.intermediate">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:85,87</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:89,91</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:189,191</note>
       </notes>
       <segment>
@@ -6629,7 +6576,7 @@
     </unit>
     <unit id="trainingPlans.level.advanced">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:87,89</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:91,93</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:193,195</note>
       </notes>
       <segment>
@@ -6638,7 +6585,7 @@
     </unit>
     <unit id="trainingPlans.progress">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:96,97</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:100,101</note>
       </notes>
       <segment>
         <source>Fortschritt</source>
@@ -6646,7 +6593,7 @@
     </unit>
     <unit id="trainingPlans.currentDay">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:105,106</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:109,110</note>
       </notes>
       <segment>
         <source>Aktueller Tag:</source>
@@ -6654,7 +6601,7 @@
     </unit>
     <unit id="trainingPlans.goalOverrideHint">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:112,114</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:116,118</note>
       </notes>
       <segment>
         <source> Tagesziel wird vom Plan gesetzt. </source>
@@ -6662,7 +6609,7 @@
     </unit>
     <unit id="trainingPlans.goalOverrideHint.cta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:118,121</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:122,125</note>
       </notes>
       <segment>
         <source>Manuelle Ziele anpassen</source>
@@ -6670,7 +6617,7 @@
     </unit>
     <unit id="trainingPlans.abandon">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:129,131</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:133,135</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:140,142</note>
       </notes>
       <segment>
@@ -6679,7 +6626,7 @@
     </unit>
     <unit id="trainingPlans.startCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:139,141</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:143,145</note>
       </notes>
       <segment>
         <source> Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt. </source>
@@ -6687,7 +6634,7 @@
     </unit>
     <unit id="trainingPlans.signupCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:144,146</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:148,150</note>
       </notes>
       <segment>
         <source> Erstelle ein kostenloses Konto, um diesen Plan zu starten. Wir tracken deinen Fortschritt automatisch und setzen dein Tagesziel passend zum Plan. </source>
@@ -6695,7 +6642,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.tracking">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:150,152</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:154,156</note>
       </notes>
       <segment>
         <source> Automatische Fortschrittsverfolgung </source>
@@ -6703,7 +6650,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.goal">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:153,155</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:157,159</note>
       </notes>
       <segment>
         <source> Tagesziel passt sich täglich an deinen Plan an </source>
@@ -6711,7 +6658,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.streak">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:156,158</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:160,162</note>
       </notes>
       <segment>
         <source> Streaks, Statistiken und Bestenliste </source>
@@ -6719,7 +6666,7 @@
     </unit>
     <unit id="trainingPlans.replaceWarn">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:168,169</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:172,173</note>
       </notes>
       <segment>
         <source> Achtung: Dies ersetzt den aktuell aktiven Plan. </source>
@@ -6727,7 +6674,7 @@
     </unit>
     <unit id="trainingPlans.start">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:173,175</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:177,179</note>
       </notes>
       <segment>
         <source>Plan starten</source>
@@ -6735,7 +6682,7 @@
     </unit>
     <unit id="trainingPlans.signupAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:184,186</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:188,190</note>
       </notes>
       <segment>
         <source>Konto erstellen &amp; Plan starten</source>
@@ -6743,7 +6690,7 @@
     </unit>
     <unit id="trainingPlans.loginAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:192,195</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:196,199</note>
       </notes>
       <segment>
         <source>Schon Konto? Einloggen</source>
@@ -6751,7 +6698,7 @@
     </unit>
     <unit id="trainingPlans.week">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:202,203</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:206,207</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -6759,7 +6706,7 @@
     </unit>
     <unit id="trainingPlans.unmarkAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:290,291</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:295,296</note>
       </notes>
       <segment>
         <source>Als nicht erledigt markieren</source>
@@ -6767,7 +6714,7 @@
     </unit>
     <unit id="trainingPlans.logAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:301,302</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:306,307</note>
       </notes>
       <segment>
         <source>Plan-Sätze eintragen und als erledigt markieren</source>
@@ -6775,7 +6722,7 @@
     </unit>
     <unit id="trainingPlans.markAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:310,311</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:315,316</note>
       </notes>
       <segment>
         <source>Nur als erledigt markieren (ohne Eintrag)</source>
@@ -6783,7 +6730,7 @@
     </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:326,327</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:331,332</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -6791,7 +6738,7 @@
     </unit>
     <unit id="trainingPlans.autoStartFailed">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:588</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:616</note>
       </notes>
       <segment>
         <source>Plan-Start fehlgeschlagen — bitte erneut versuchen.</source>
@@ -6799,7 +6746,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:667</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:695</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -6807,7 +6754,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:684</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:712</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
@@ -6815,7 +6762,7 @@
     </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:710</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:738</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:348</note>
       </notes>
       <segment>
@@ -6824,7 +6771,7 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:712</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:740</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:350</note>
       </notes>
       <segment>
@@ -6833,7 +6780,7 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:714</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:742</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:352</note>
       </notes>
       <segment>
@@ -7043,38 +6990,6 @@
       </notes>
       <segment>
         <source>Detailseite öffnen</source>
-      </segment>
-    </unit>
-    <unit id="trainingEntryDialog.title">
-      <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts</note>
-      </notes>
-      <segment>
-        <source>Trainingseintrag anlegen</source>
-      </segment>
-    </unit>
-    <unit id="trainingEntryDialog.category">
-      <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts</note>
-      </notes>
-      <segment>
-        <source>Kategorie</source>
-      </segment>
-    </unit>
-    <unit id="trainingEntryDialog.exercise">
-      <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts</note>
-      </notes>
-      <segment>
-        <source>Übung</source>
-      </segment>
-    </unit>
-    <unit id="trainingEntryDialog.pushup.exercise">
-      <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts</note>
-      </notes>
-      <segment>
-        <source>Liegestütze</source>
       </segment>
     </unit>
   </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -5269,13 +5269,16 @@
         <target>俯卧撑类型分布</target>
       </segment>
     </unit>
-    <unit id="pie.other">
-      <notes>
-        <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:96,98</note>
-      </notes>
+    <unit id="pie.totalLabel">
       <segment state="translated">
-        <source>Sonstige</source>
-        <target>其他</target>
+        <source>Gesamt</source>
+        <target>总计</target>
+      </segment>
+    </unit>
+    <unit id="pie.noSelection">
+      <segment state="translated">
+        <source>Keine Auswahl</source>
+        <target>未选择</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">


### PR DESCRIPTION
Selected types now define 100% so the pie has no Other arc, the donut
center shows the total of the selected types (Gesamt), and clicking a
slice swaps that total for the slice's label, value, and share.

https://claude.ai/code/session_01K5QhBtWZf3ejUjgFscCaK1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pie chart segments are now interactive—click or focus a segment to display its individual value and percentage.
  * Selection-based percentages now calculate relative to selected types only.
  * "No selection" placeholder appears when no types are selected, replacing previous behavior.

* **Localization**
  * Updated translation strings across all supported languages for pie chart labels.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/310)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->