### PR TITLE
update landing page copy and SEO for multi-exercise support

### DIFF
--- a/web/src/app/app.routes.ts
+++ b/web/src/app/app.routes.ts
@@ -12,8 +12,8 @@ export const appRoutes: Routes = [
     path: '',
     pathMatch: 'full',
     data: {
-      seoTitle: $localize`:@@seo.landing.title:Liegestütze Tracker: Trainingsplan, Streaks & Bestenliste`,
-      seoDescription: $localize`:@@seo.landing.description:Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.`,
+      seoTitle: $localize`:@@seo.landing.title:Fitness-Tracker für Liegestütze, Sit-ups, Kniebeugen, Plank & Laufen`,
+      seoDescription: $localize`:@@seo.landing.description:Tracke Liegestütze (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank-Halten und Laufstrecken – kostenlos. Trainingspläne, Tagesziele, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.`,
     },
     loadComponent: () =>
       import('./marketing/shell/landing-page.component').then(

--- a/web/src/app/app.routes.ts
+++ b/web/src/app/app.routes.ts
@@ -12,8 +12,8 @@ export const appRoutes: Routes = [
     path: '',
     pathMatch: 'full',
     data: {
-      seoTitle: $localize`:@@seo.landing.title:Fitness-Tracker für Liegestütze, Sit-ups, Kniebeugen, Plank & Laufen`,
-      seoDescription: $localize`:@@seo.landing.description:Tracke Liegestütze (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank-Halten und Laufstrecken – kostenlos. Trainingspläne, Tagesziele, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.`,
+      seoTitle: $localize`:@@seo.landing.title:Liegestütze Tracker: Trainingsplan, Streaks & Bestenliste`,
+      seoDescription: $localize`:@@seo.landing.description:Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.`,
     },
     loadComponent: () =>
       import('./marketing/shell/landing-page.component').then(

--- a/web/src/app/marketing/shell/landing-page.component.html
+++ b/web/src/app/marketing/shell/landing-page.component.html
@@ -352,7 +352,7 @@
       <mat-card-header class="key-features-header">
         <mat-icon aria-hidden="true">insights</mat-icon>
         <mat-card-title i18n="@@landing.feature.analytics.title"
-          >Charts, Trends & alle Übungen</mat-card-title
+          >Charts, Trends &amp; alle Übungen</mat-card-title
         >
       </mat-card-header>
       <mat-card-content i18n="@@landing.feature.analytics.body"

--- a/web/src/app/marketing/shell/landing-page.component.html
+++ b/web/src/app/marketing/shell/landing-page.component.html
@@ -14,8 +14,8 @@
       <span class="free-badge" i18n="@@landing.free.badge">kostenlos</span>
       <h1 i18n="@@landing.title">Dein Training. Klar visualisiert.</h1>
       <p class="subtitle" i18n="@@landing.subtitle">
-        Kostenlos tracken: Reps, Trends und Streaks in Sekunden – mobil, schnell
-        und mit Live-Updates.
+        Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen – alles in einer App
+        tracken. Reps, Zeit und Distanz mit Trends, Streaks und Live-Sync.
       </p>
 
       <div class="cta-row">
@@ -352,12 +352,13 @@
       <mat-card-header class="key-features-header">
         <mat-icon aria-hidden="true">insights</mat-icon>
         <mat-card-title i18n="@@landing.feature.analytics.title"
-          >Charts, Trends & Pushup-Typen</mat-card-title
+          >Charts, Trends & alle Übungen</mat-card-title
         >
       </mat-card-header>
       <mat-card-content i18n="@@landing.feature.analytics.body"
-        >Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder
-        Diamond – mit frei wählbarem Zeitraum.</mat-card-content
+        >Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten
+        (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit
+        frei wählbarem Zeitraum.</mat-card-content
       >
     </mat-card>
 

--- a/web/src/app/marketing/shell/landing-page.component.html
+++ b/web/src/app/marketing/shell/landing-page.component.html
@@ -14,8 +14,8 @@
       <span class="free-badge" i18n="@@landing.free.badge">kostenlos</span>
       <h1 i18n="@@landing.title">Dein Training. Klar visualisiert.</h1>
       <p class="subtitle" i18n="@@landing.subtitle">
-        Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen – alles in einer App
-        tracken. Reps, Zeit und Distanz mit Trends, Streaks und Live-Sync.
+        Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync.
+        Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst.
       </p>
 
       <div class="cta-row">

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Tracke Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen in Sekunden – mit Trends, Tagesziel, Streaks und Live-Sync."
+      content="Liegestütze tracken in Sekunden – mit Trends, Tagesziel, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen."
     />
     <meta name="google-adsense-account" content="ca-pub-6346271540341424" />
     <meta property="og:type" content="website" />
@@ -15,7 +15,7 @@
     <meta property="og:title" content="Pushup Tracker" />
     <meta
       property="og:description"
-      content="Multi-Exercise-Tracker: Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen – mit Trainingsplänen, Tagesziel, Streaks und Bestenliste."
+      content="Pushup Tracker für tägliches Training, Ziele und Auswertungen – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen."
     />
     <meta property="og:locale" content="de_DE" />
     <meta
@@ -30,7 +30,7 @@
     <meta name="twitter:title" content="Pushup Tracker" />
     <meta
       name="twitter:description"
-      content="Multi-Exercise-Tracker: Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen – mit Trainingsplänen, Tagesziel, Streaks und Bestenliste."
+      content="Pushup Tracker für tägliches Training, Ziele und Auswertungen – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen."
     />
     <meta
       name="twitter:image"

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Tracke Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live-Updates."
+      content="Tracke Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen in Sekunden – mit Trends, Tagesziel, Streaks und Live-Sync."
     />
     <meta name="google-adsense-account" content="ca-pub-6346271540341424" />
     <meta property="og:type" content="website" />
@@ -15,7 +15,7 @@
     <meta property="og:title" content="Pushup Tracker" />
     <meta
       property="og:description"
-      content="Pushup Tracker für tägliches Training, Ziele und Auswertungen."
+      content="Multi-Exercise-Tracker: Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen – mit Trainingsplänen, Tagesziel, Streaks und Bestenliste."
     />
     <meta property="og:locale" content="de_DE" />
     <meta
@@ -30,7 +30,7 @@
     <meta name="twitter:title" content="Pushup Tracker" />
     <meta
       name="twitter:description"
-      content="Pushup Tracker für tägliches Training, Ziele und Auswertungen."
+      content="Multi-Exercise-Tracker: Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen – mit Trainingsplänen, Tagesziel, Streaks und Bestenliste."
     />
     <meta
       name="twitter:image"

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -2701,7 +2701,7 @@
       </notes>
       <segment state="translated">
         <source>Charts, Trends &amp; alle Übungen</source>
-        <target>Γραφήματα, τάσεις και κάθε άσκηση</target>
+        <target>Γραφήματα, τάσεις και όλες οι ασκήσεις</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -1498,7 +1498,7 @@
       </notes>
       <segment state="translated">
         <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
-        <target>Push-up tracker: προγράμματα, σερί &amp; κατάταξη</target>
+        <target>Tracker κάμψεων: προγράμματα προπόνησης, σερί &amp; πίνακας κατάταξης</target>
       </segment>
     </unit>
     <unit id="seo.landing.description">
@@ -1506,8 +1506,8 @@
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
       <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
-        <target>Παρακολούθησε push-ups με δωρεάν web app: προγράμματα προπόνησης, πρόκληση 30 ημερών, καθημερινός στόχος, σερί και παγκόσμια κατάταξη – κινητό, offline, ζωντανός συγχρονισμός.</target>
+        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+        <target>Κατέγραψε τις κάμψεις με δωρεάν web-app: προγράμματα προπόνησης, πρόκληση 30 ημερών, ημερήσιος στόχος, σερί και πίνακας κατάταξης — τώρα και με sit-ups, καθίσματα, plank και τρέξιμο. Mobile, χωρίς δίκτυο, με live συγχρονισμό.</target>
       </segment>
     </unit>
     <unit id="seo.dashboard.title">
@@ -2499,8 +2499,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
       <segment state="translated">
-        <source> Kostenlos tracken: Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live-Updates. </source>
-        <target> Παρακολούθηση δωρεάν: Επαναλήψεις, τάσεις και σειρές σε δευτερόλεπτα – κινητό, γρήγορο και με ζωντανές ενημερώσεις. </target>
+        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+        <target> Κατέγραψε τις κάμψεις σου σε δευτερόλεπτα — με τάσεις, σερί και live συγχρονισμό. Επιπλέον sit-ups, καθίσματα, plank και τρέξιμο όταν θέλεις περισσότερα. </target>
       </segment>
     </unit>
     <unit id="landing.cta.dashboard">
@@ -2700,8 +2700,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:353,355</note>
       </notes>
       <segment state="translated">
-        <source>Charts, Trends &amp; Pushup-Typen</source>
-        <target>Διαγράμματα, τάσεις και τύποι pushup</target>
+        <source>Charts, Trends &amp; alle Übungen</source>
+        <target>Γραφήματα, τάσεις και κάθε άσκηση</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">
@@ -2709,8 +2709,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
       <segment state="translated">
-        <source>Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder Diamond – mit frei wählbarem Zeitraum.</source>
-        <target>Διαγράμματα προόδου, χάρτες KPI, διανομή σύμφωνα με το πρότυπο, φαρδύ ή διαμάντι – με ελεύθερα επιλέξιμη περίοδο.</target>
+        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+        <target>Γραφήματα τάσεων και κάρτες KPI για κάθε άσκηση: παραλλαγές κάμψεων (Standard, Wide, Diamond), sit-ups, καθίσματα, plank και τρέξιμο — με ελεύθερα επιλέξιμη περίοδο.</target>
       </segment>
     </unit>
     <unit id="landing.feature.goals.title">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1867,7 +1867,7 @@ Active:         </target>
             </notes>
       <segment state="translated">
         <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
-        <target>Trend charts and KPI cards for every exercise: push-up variants (Standard, Wide, Diamond), sit-ups, squats, planks and runs – with a freely selectable time range.</target>
+        <target>Trend charts and KPI cards for every exercise: push-up variants (Standard, Wide, Diamond), sit-ups, squats, planks and running – with a freely selectable time range.</target>
             </segment>
         </unit>
     <unit id="landing.feature.analytics.title">
@@ -2309,7 +2309,7 @@ Deine Position: # ·  Reps        </source>
             </notes>
       <segment state="translated">
         <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
-        <target> Track push-ups in seconds — with trends, streaks and live sync. Plus sit-ups, squats, planks and runs when you want more. </target>
+        <target> Track push-ups in seconds — with trends, streaks and live sync. Plus sit-ups, squats, planks and running when you want more. </target>
 
 
 

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1876,7 +1876,7 @@ Active:         </target>
             </notes>
       <segment state="translated">
         <source>Charts, Trends &amp; alle Übungen</source>
-        <target>Charts, trends &amp; every exercise</target>
+        <target>Charts, trends &amp; all exercises</target>
             </segment>
         </unit>
     <unit id="landing.feature.multiset.title">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1866,8 +1866,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder Diamond – mit frei wählbarem Zeitraum.</source>
-        <target>Trend charts, KPI cards, breakdown by Standard, Wide or Diamond – with a freely selectable time range.</target>
+        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+        <target>Trend charts and KPI cards for every exercise: push-up variants (Standard, Wide, Diamond), sit-ups, squats, planks and runs – with a freely selectable time range.</target>
             </segment>
         </unit>
     <unit id="landing.feature.analytics.title">
@@ -1875,8 +1875,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Charts, Trends &amp; Pushup-Typen</source>
-        <target>Charts, trends &amp; pushup types</target>
+        <source>Charts, Trends &amp; alle Übungen</source>
+        <target>Charts, trends &amp; every exercise</target>
             </segment>
         </unit>
     <unit id="landing.feature.multiset.title">
@@ -2305,18 +2305,18 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
-        
+
             </notes>
       <segment state="translated">
-        <source> Tracke Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live- Updates. </source>
-        <target> Track reps, trends, and streaks in seconds — mobile, fast, and live-updated. </target>
+        <source> Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen – alles in einer App tracken. Reps, Zeit und Distanz mit Trends, Streaks und Live-Sync. </source>
+        <target> Push-ups, sit-ups, squats, planks and runs — track them all in one app. Reps, time and distance with trends, streaks and live sync. </target>
 
-        
-        
+
+
             </segment>
 
-      
-      
+
+
         </unit>
     <unit id="landing.title">
       <notes>
@@ -3475,25 +3475,25 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="seo.landing.description">
       <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
-        <target>Track push-ups with a free web app: training plans, 30-day challenge, daily goal, streaks and global leaderboard – mobile, offline-capable, live-synced.</target>
+        <source>Tracke Liegestütze (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank-Halten und Laufstrecken – kostenlos. Trainingspläne, Tagesziele, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
+        <target>Track push-ups (Standard, Wide, Diamond), sit-ups, squats, plank holds and runs – free. Training plans, daily goals, streaks and a global leaderboard – mobile, offline-capable, live-synced.</target>
 
-        
-        
+
+
             </segment>
 
-      
+
         </unit>
     <unit id="seo.landing.title">
       <segment state="translated">
-        <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
-        <target>Push-Up Tracker: Training Plans, Streaks &amp; Leaderboard</target>
+        <source>Fitness-Tracker für Liegestütze, Sit-ups, Kniebeugen, Plank &amp; Laufen</source>
+        <target>Fitness Tracker for Push-Ups, Sit-Ups, Squats, Planks &amp; Running</target>
 
-        
-        
+
+
             </segment>
 
-      
+
         </unit>
     <unit id="seo.leaderboard.description">
       <segment state="translated">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -2308,8 +2308,8 @@ Deine Position: # ·  Reps        </source>
 
             </notes>
       <segment state="translated">
-        <source> Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen – alles in einer App tracken. Reps, Zeit und Distanz mit Trends, Streaks und Live-Sync. </source>
-        <target> Push-ups, sit-ups, squats, planks and runs — track them all in one app. Reps, time and distance with trends, streaks and live sync. </target>
+        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+        <target> Track push-ups in seconds — with trends, streaks and live sync. Plus sit-ups, squats, planks and runs when you want more. </target>
 
 
 
@@ -3475,8 +3475,8 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="seo.landing.description">
       <segment state="translated">
-        <source>Tracke Liegestütze (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank-Halten und Laufstrecken – kostenlos. Trainingspläne, Tagesziele, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
-        <target>Track push-ups (Standard, Wide, Diamond), sit-ups, squats, plank holds and runs – free. Training plans, daily goals, streaks and a global leaderboard – mobile, offline-capable, live-synced.</target>
+        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+        <target>Track push-ups with a free web app: training plans, 30-day challenge, daily goal, streaks and global leaderboard – now also with sit-ups, squats, planks and running. Mobile, offline-capable, live-synced.</target>
 
 
 
@@ -3486,8 +3486,8 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="seo.landing.title">
       <segment state="translated">
-        <source>Fitness-Tracker für Liegestütze, Sit-ups, Kniebeugen, Plank &amp; Laufen</source>
-        <target>Fitness Tracker for Push-Ups, Sit-Ups, Squats, Planks &amp; Running</target>
+        <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
+        <target>Push-Up Tracker: Training Plans, Streaks &amp; Leaderboard</target>
 
 
 

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -2701,7 +2701,7 @@
       </notes>
       <segment state="translated">
         <source>Charts, Trends &amp; alle Übungen</source>
-        <target>Gráficos, tendencias y cada ejercicio</target>
+        <target>Gráficos, tendencias y todos los ejercicios</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -1498,7 +1498,7 @@
       </notes>
       <segment state="translated">
         <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
-        <target>Rastreador de flexiones: planes, rachas y clasificación</target>
+        <target>Tracker de flexiones: planes de entrenamiento, rachas y clasificación</target>
       </segment>
     </unit>
     <unit id="seo.landing.description">
@@ -1506,8 +1506,8 @@
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
       <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
-        <target>Registra flexiones con web app gratuita: planes de entrenamiento, reto de 30 días, objetivo diario, rachas y clasificación global – móvil, offline, sync en vivo.</target>
+        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+        <target>Registra tus flexiones con una web-app gratuita: planes de entrenamiento, reto de 30 días, objetivo diario, rachas y clasificación — ahora también con abdominales, sentadillas, plancha y carrera. Móvil, sin conexión, sincronización en vivo.</target>
       </segment>
     </unit>
     <unit id="seo.dashboard.title">
@@ -2499,8 +2499,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
       <segment state="translated">
-        <source> Kostenlos tracken: Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live-Updates. </source>
-        <target> Realice un seguimiento gratuito: repeticiones, tendencias y rachas en segundos: móvil, rápido y con actualizaciones en vivo. </target>
+        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+        <target> Registra tus flexiones en segundos — con tendencias, rachas y sincronización en vivo. Además abdominales, sentadillas, plancha y carrera cuando quieras más. </target>
       </segment>
     </unit>
     <unit id="landing.cta.dashboard">
@@ -2700,8 +2700,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:353,355</note>
       </notes>
       <segment state="translated">
-        <source>Charts, Trends &amp; Pushup-Typen</source>
-        <target>Gráficos, tendencias y tipos de flexiones</target>
+        <source>Charts, Trends &amp; alle Übungen</source>
+        <target>Gráficos, tendencias y cada ejercicio</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">
@@ -2709,8 +2709,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
       <segment state="translated">
-        <source>Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder Diamond – mit frei wählbarem Zeitraum.</source>
-        <target>Gráficos de progreso, mapas de KPI, distribución según estándar, ancho o diamante, con un período de libre elección.</target>
+        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+        <target>Gráficos de tendencia y tarjetas KPI para cada ejercicio: variantes de flexión (Standard, Wide, Diamond), abdominales, sentadillas, plancha y carrera — con un periodo libremente seleccionable.</target>
       </segment>
     </unit>
     <unit id="landing.feature.goals.title">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -2500,7 +2500,7 @@
       </notes>
       <segment state="translated">
         <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
-        <target> Tracke tes pompes en quelques secondes — avec tendances, séries et synchronisation en direct. Plus des abdos, squats, gainage et course quand tu en veux plus. </target>
+        <target> Suis tes pompes en quelques secondes — avec tendances, séries et synchronisation en direct. Plus des abdos, squats, gainage et course quand tu en veux plus. </target>
       </segment>
     </unit>
     <unit id="landing.cta.dashboard">
@@ -2701,7 +2701,7 @@
       </notes>
       <segment state="translated">
         <source>Charts, Trends &amp; alle Übungen</source>
-        <target>Graphiques, tendances &amp; chaque exercice</target>
+        <target>Graphiques, tendances &amp; tous les exercices</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -1498,7 +1498,7 @@
       </notes>
       <segment state="translated">
         <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
-        <target>Suivi des pompes : plans d'entraînement, séries &amp; classement</target>
+        <target>Tracker de pompes : plans d'entraînement, séries &amp; classement</target>
       </segment>
     </unit>
     <unit id="seo.landing.description">
@@ -1506,8 +1506,8 @@
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
       <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
-        <target>Suivez vos pompes avec une web app gratuite : plans d'entraînement, défi 30 jours, objectif quotidien, séries et classement mondial – mobile, hors-ligne, sync en direct.</target>
+        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+        <target>Suivez vos pompes avec une web-app gratuite : plans d'entraînement, défi 30 jours, objectif quotidien, séries et classement mondial — désormais aussi avec abdos, squats, gainage et course. Mobile, hors-ligne, sync en direct.</target>
       </segment>
     </unit>
     <unit id="seo.dashboard.title">
@@ -2499,8 +2499,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
       <segment state="translated">
-        <source> Kostenlos tracken: Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live-Updates. </source>
-        <target> Suivez gratuitement: les répétitions, les tendances et les séquences en quelques secondes - mobile, rapide et avec des mises à jour en direct. </target>
+        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+        <target> Tracke tes pompes en quelques secondes — avec tendances, séries et synchronisation en direct. Plus des abdos, squats, gainage et course quand tu en veux plus. </target>
       </segment>
     </unit>
     <unit id="landing.cta.dashboard">
@@ -2700,8 +2700,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:353,355</note>
       </notes>
       <segment state="translated">
-        <source>Charts, Trends &amp; Pushup-Typen</source>
-        <target>Graphiques, tendances et types de pompes</target>
+        <source>Charts, Trends &amp; alle Übungen</source>
+        <target>Graphiques, tendances &amp; chaque exercice</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">
@@ -2709,8 +2709,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
       <segment state="translated">
-        <source>Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder Diamond – mit frei wählbarem Zeitraum.</source>
-        <target>Graphiques de progression, cartes KPI, répartition selon standard, large ou losange – avec une période librement sélectionnable.</target>
+        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+        <target>Graphiques de tendance et cartes KPI pour chaque exercice : variantes de pompes (Standard, Wide, Diamond), abdos, squats, gainage et course — avec une période librement sélectionnable.</target>
       </segment>
     </unit>
     <unit id="landing.feature.goals.title">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -1498,7 +1498,7 @@
       </notes>
       <segment state="translated">
         <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
-        <target>Tracker push-up: programmi, serie &amp; classifica</target>
+        <target>Tracker piegamenti: piani di allenamento, streak e classifica</target>
       </segment>
     </unit>
     <unit id="seo.landing.description">
@@ -1506,8 +1506,8 @@
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
       <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
-        <target>Traccia le flessioni con una web app gratuita: programmi di allenamento, sfida 30 giorni, obiettivo quotidiano, serie e classifica globale – mobile, offline, live sync.</target>
+        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+        <target>Traccia i piegamenti con una web-app gratuita: piani di allenamento, sfida di 30 giorni, obiettivo giornaliero, streak e classifica — ora anche con sit-up, squat, plank e corsa. Mobile, offline, sincronizzazione live.</target>
       </segment>
     </unit>
     <unit id="seo.dashboard.title">
@@ -2499,8 +2499,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
       <segment state="translated">
-        <source> Kostenlos tracken: Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live-Updates. </source>
-        <target> Tieni traccia gratuitamente: ripetizioni, tendenze e serie in pochi secondi: mobile, veloce e con aggiornamenti in tempo reale. </target>
+        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+        <target> Traccia i piegamenti in pochi secondi — con tendenze, streak e sincronizzazione live. Più sit-up, squat, plank e corsa quando vuoi di più. </target>
       </segment>
     </unit>
     <unit id="landing.cta.dashboard">
@@ -2700,8 +2700,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:353,355</note>
       </notes>
       <segment state="translated">
-        <source>Charts, Trends &amp; Pushup-Typen</source>
-        <target>Grafici, tendenze e tipi di pushup</target>
+        <source>Charts, Trends &amp; alle Übungen</source>
+        <target>Grafici, trend e ogni esercizio</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">
@@ -2709,8 +2709,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
       <segment state="translated">
-        <source>Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder Diamond – mit frei wählbarem Zeitraum.</source>
-        <target>Grafici di avanzamento, mappe KPI, distribuzione secondo standard, largo o diamante – con periodo liberamente selezionabile.</target>
+        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+        <target>Grafici di tendenza e schede KPI per ogni esercizio: varianti di piegamento (Standard, Wide, Diamond), sit-up, squat, plank e corsa — con periodo a scelta.</target>
       </segment>
     </unit>
     <unit id="landing.feature.goals.title">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -2701,7 +2701,7 @@
       </notes>
       <segment state="translated">
         <source>Charts, Trends &amp; alle Übungen</source>
-        <target>Grafici, trend e ogni esercizio</target>
+        <target>Grafici, trend e tutti gli esercizi</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -1498,7 +1498,7 @@
       </notes>
       <segment state="translated">
         <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
-        <target>Push-ups Tracker: programmata, series &amp; tabula victorum</target>
+        <target>Pressionum Cursor: rationes exercitii, series &amp; tabula primorum</target>
       </segment>
     </unit>
     <unit id="seo.landing.description">
@@ -1506,8 +1506,8 @@
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
       <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
-        <target>Persequere push-ups cum web app gratuita: programmata exercitii, certamen XXX dierum, meta cotidiana, series et tabula victorum – mobile, sine rete, synchronizatio viva.</target>
+        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+        <target>Pressiones cum gratuita applicatione interretiali metiri: rationes exercitii, certamen XXX dierum, propositum cotidianum, series et tabula primorum — nunc etiam cum sedationibus, genuflexionibus, planca et cursu. Mobile, sine rete, cum synchronia viva.</target>
       </segment>
     </unit>
     <unit id="seo.dashboard.title">
@@ -2499,8 +2499,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
       <segment state="translated">
-        <source> Kostenlos tracken: Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live-Updates. </source>
-        <target> Vestigium gratis: Reps, trends et stricturae in secundis - mobilibus, celeriter et cum updates vivunt. </target>
+        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+        <target> Pressiones in secundis metiri – cum tendentiis, seriebus et synchronia viva. Praeterea sedationes, genuflexiones, planca et cursus, cum plura velis. </target>
       </segment>
     </unit>
     <unit id="landing.cta.dashboard">
@@ -2700,8 +2700,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:353,355</note>
       </notes>
       <segment state="translated">
-        <source>Charts, Trends &amp; Pushup-Typen</source>
-        <target>Charts, trends &amp; pushup types</target>
+        <source>Charts, Trends &amp; alle Übungen</source>
+        <target>Diagrammata, tendentiae &amp; omnis exercitatio</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">
@@ -2709,8 +2709,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
       <segment state="translated">
-        <source>Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder Diamond – mit frei wählbarem Zeitraum.</source>
-        <target>Progress charts, KPI maps, distribution according to standard, wide or diamond – with a freely selectable period.</target>
+        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+        <target>Diagrammata tendentiarum et tabellae KPI pro omni exercitatione: varietates pressionum (Standard, Wide, Diamond), sedationes, genuflexiones, planca et cursus — cum tempore libere eligendo.</target>
       </segment>
     </unit>
     <unit id="landing.feature.goals.title">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -2701,7 +2701,7 @@
       </notes>
       <segment state="translated">
         <source>Charts, Trends &amp; alle Übungen</source>
-        <target>Diagrammata, tendentiae &amp; omnis exercitatio</target>
+        <target>Diagrammata, tendentiae &amp; omnes exercitationes</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -2701,7 +2701,7 @@
       </notes>
       <segment state="translated">
         <source>Charts, Trends &amp; alle Übungen</source>
-        <target>Grafieken, trends en elke oefening</target>
+        <target>Grafieken, trends en alle oefeningen</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -1498,7 +1498,7 @@
       </notes>
       <segment state="translated">
         <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
-        <target>Push-up tracker: trainingsplannen, streaks &amp; ranglijst</target>
+        <target>Push-Up Tracker: trainingsplannen, streaks &amp; ranglijst</target>
       </segment>
     </unit>
     <unit id="seo.landing.description">
@@ -1506,8 +1506,8 @@
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
       <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
-        <target>Houd push-ups bij met een gratis webapp: trainingsplannen, 30-daagse challenge, dagelijks doel, streaks en wereldwijde ranglijst – mobiel, offline, live-sync.</target>
+        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+        <target>Volg je push-ups met een gratis web-app: trainingsplannen, 30-daagse uitdaging, dagdoel, streaks en ranglijst — nu ook met sit-ups, squats, plank en hardlopen. Mobiel, offline en met live-sync.</target>
       </segment>
     </unit>
     <unit id="seo.dashboard.title">
@@ -2499,8 +2499,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
       <segment state="translated">
-        <source> Kostenlos tracken: Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live-Updates. </source>
-        <target> Gratis volgen: herhalingen, trends en streaks in seconden – mobiel, snel en met live updates. </target>
+        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+        <target> Volg je push-ups in seconden — met trends, streaks en live-sync. Plus sit-ups, squats, plank en hardlopen wanneer je meer wilt. </target>
       </segment>
     </unit>
     <unit id="landing.cta.dashboard">
@@ -2700,8 +2700,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:353,355</note>
       </notes>
       <segment state="translated">
-        <source>Charts, Trends &amp; Pushup-Typen</source>
-        <target>Grafieken, trends en push-ups</target>
+        <source>Charts, Trends &amp; alle Übungen</source>
+        <target>Grafieken, trends en elke oefening</target>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">
@@ -2709,8 +2709,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
       <segment state="translated">
-        <source>Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder Diamond – mit frei wählbarem Zeitraum.</source>
-        <target>Voortgangsgrafieken, KPI-kaarten, verdeling volgens standaard, breed of ruit – met een vrij te kiezen periode.</target>
+        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+        <target>Trendgrafieken en KPI-kaarten voor elke oefening: push-up-varianten (Standard, Wide, Diamond), sit-ups, squats, plank en hardlopen — met vrij te kiezen periode.</target>
       </segment>
     </unit>
     <unit id="landing.feature.goals.title">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -1880,8 +1880,8 @@ Aktiv:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder Diamond – mit frei wählbarem Zeitraum.</source>
-        <target>Trenddiagrammer, KPI-kort, fordeling etter Standard, Wide eller Diamond – med fritt valgt tidsperiode.</target>
+        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+        <target>Trenddiagrammer og KPI-kort for hver øvelse: push-up-varianter (Standard, Wide, Diamond), sit-ups, knebøy, plank og løping — med fritt valgt tidsrom.</target>
             </segment>
         </unit>
     <unit id="landing.feature.analytics.title">
@@ -1889,8 +1889,8 @@ Aktiv:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Charts, Trends &amp; Pushup-Typen</source>
-        <target>Diagrammer, trender &amp; armhevingstyper</target>
+        <source>Charts, Trends &amp; alle Übungen</source>
+        <target>Diagrammer, trender og hver øvelse</target>
             </segment>
         </unit>
     <unit id="landing.feature.multiset.title">
@@ -2322,8 +2322,8 @@ Deine Position: # ·  Reps        </source>
 
             </notes>
       <segment state="translated">
-        <source> Tracke Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live- Updates. </source>
-        <target> Spor armhevninger, trender og streaker på sekunder — mobil, rask og sanntids oppdatert. </target>
+        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+        <target> Spor push-ups på sekunder — med trender, streaks og live-sync. Pluss sit-ups, knebøy, plank og løping når du vil ha mer. </target>
 
 
 
@@ -3491,8 +3491,8 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="seo.landing.description">
       <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
-        <target>Spor armhevninger med en gratis web-app: treningsplaner, 30-dagers utfordring, daglig mål, streaks og global ledertavle – mobil, offline, live-synk.</target>
+        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+        <target>Spor push-ups med en gratis nettapp: treningsplaner, 30-dagers utfordring, daglig mål, streaks og topplister — nå også med sit-ups, knebøy, plank og løping. Mobil, offline, live-sync.</target>
 
 
 
@@ -3503,7 +3503,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="seo.landing.title">
       <segment state="translated">
         <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
-        <target>Push-up-sporer: treningsplaner, streaks &amp; ledertavle</target>
+        <target>Push-up-tracker: treningsplaner, streaks &amp; topplister</target>
 
 
 

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -1890,7 +1890,7 @@ Aktiv:         </target>
             </notes>
       <segment state="translated">
         <source>Charts, Trends &amp; alle Übungen</source>
-        <target>Diagrammer, trender og hver øvelse</target>
+        <target>Diagrammer, trender og alle øvelser</target>
             </segment>
         </unit>
     <unit id="landing.feature.multiset.title">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2298,7 +2298,7 @@
         <note category="location">web/src/app/app.routes.ts:15</note>
       </notes>
       <segment>
-        <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
+        <source>Fitness-Tracker für Liegestütze, Sit-ups, Kniebeugen, Plank &amp; Laufen</source>
       </segment>
     </unit>
     <unit id="seo.landing.description">
@@ -2306,7 +2306,7 @@
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
       <segment>
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
+        <source>Tracke Liegestütze (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank-Halten und Laufstrecken – kostenlos. Trainingspläne, Tagesziele, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
       </segment>
     </unit>
     <unit id="seo.dashboard.title">
@@ -3247,7 +3247,7 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:17,21</note>
       </notes>
       <segment>
-        <source> Kostenlos tracken: Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live-Updates. </source>
+        <source> Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen – alles in einer App tracken. Reps, Zeit und Distanz mit Trends, Streaks und Live-Sync. </source>
       </segment>
     </unit>
     <unit id="landing.cta.dashboard">
@@ -3426,7 +3426,7 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:355,357</note>
       </notes>
       <segment>
-        <source>Charts, Trends &amp; Pushup-Typen</source>
+        <source>Charts, Trends &amp; alle Übungen</source>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.body">
@@ -3434,7 +3434,7 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:359,362</note>
       </notes>
       <segment>
-        <source>Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder Diamond – mit frei wählbarem Zeitraum.</source>
+        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
       </segment>
     </unit>
     <unit id="landing.feature.goals.title">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2298,7 +2298,7 @@
         <note category="location">web/src/app/app.routes.ts:15</note>
       </notes>
       <segment>
-        <source>Fitness-Tracker für Liegestütze, Sit-ups, Kniebeugen, Plank &amp; Laufen</source>
+        <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
       </segment>
     </unit>
     <unit id="seo.landing.description">
@@ -2306,7 +2306,7 @@
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
       <segment>
-        <source>Tracke Liegestütze (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank-Halten und Laufstrecken – kostenlos. Trainingspläne, Tagesziele, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
+        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
       </segment>
     </unit>
     <unit id="seo.dashboard.title">
@@ -3247,7 +3247,7 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:17,21</note>
       </notes>
       <segment>
-        <source> Liegestütze, Sit-ups, Kniebeugen, Plank und Laufen – alles in einer App tracken. Reps, Zeit und Distanz mit Trends, Streaks und Live-Sync. </source>
+        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
       </segment>
     </unit>
     <unit id="landing.cta.dashboard">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -2297,15 +2297,15 @@
       </notes>
       <segment state="translated">
         <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
-      <target>俯卧撑追踪器：训练计划、连续纪录和排行榜</target></segment>
+      <target>俯卧撑追踪器：训练计划、连续天数与排行榜</target></segment>
     </unit>
     <unit id="seo.landing.description">
       <notes>
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
       <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – mobil, offline-fähig, mit Live-Sync.</source>
-      <target>用免费网络应用追踪俯卧撑：训练计划、30天挑战、每日目标、连续纪录和全球排行榜 — 移动端、可离线、实时同步。</target></segment>
+        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+      <target>用免费网页应用追踪俯卧撑：训练计划、30 天挑战、每日目标、连续天数与排行榜 — 现在也支持仰卧起坐、深蹲、平板支撑与跑步。手机端、离线可用、实时同步。</target></segment>
     </unit>
     <unit id="seo.dashboard.title">
       <notes>
@@ -3207,8 +3207,8 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
       <segment state="translated">
-        <source> Kostenlos tracken: Reps, Trends und Streaks in Sekunden – mobil, schnell und mit Live-Updates. </source>
-      <target> 免费追踪：几秒内掌握次数、趋势和连续纪录 – 移动端、快速、实时更新。 </target></segment>
+        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+      <target> 几秒钟记录俯卧撑 — 提供趋势、连续天数与实时同步。需要更多时还可记录仰卧起坐、深蹲、平板支撑和跑步。</target></segment>
     </unit>
     <unit id="landing.cta.dashboard">
       <notes>
@@ -3386,16 +3386,16 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,359</note>
       </notes>
       <segment state="translated">
-        <source>Charts, Trends &amp; Pushup-Typen</source>
-      <target>图表、趋势和俯卧撑类型分析</target></segment>
+        <source>Charts, Trends &amp; alle Übungen</source>
+      <target>图表、趋势与每项练习</target></segment>
     </unit>
     <unit id="landing.feature.analytics.body">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:361,364</note>
       </notes>
       <segment state="translated">
-        <source>Verlaufsdiagramme, KPI-Karten, Verteilung nach Standard, Wide oder Diamond – mit frei wählbarem Zeitraum.</source>
-      <target>趋势图表、关键指标卡、按标准、宽距或菱形分类 — 支持自定义时间段。</target></segment>
+        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+      <target>为每项练习提供趋势图与 KPI 卡片：俯卧撑变体(Standard、Wide、Diamond)、仰卧起坐、深蹲、平板支撑与跑步 — 可自由选择时间范围。</target></segment>
     </unit>
     <unit id="landing.feature.goals.title">
       <notes>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -3387,7 +3387,7 @@
       </notes>
       <segment state="translated">
         <source>Charts, Trends &amp; alle Übungen</source>
-      <target>图表、趋势与每项练习</target></segment>
+      <target>图表、趋势与全部练习</target></segment>
     </unit>
     <unit id="landing.feature.analytics.body">
       <notes>


### PR DESCRIPTION
Re-pitches the landing copy and SEO so push-ups stay the headline while the newly tracked exercises (sit-ups, squats, plank, running) are surfaced as a clear "plus".

## What changed
- **Hero subtitle** rewritten as push-up-led: "Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst."
- **Analytics feature card** retitled "Charts, Trends & alle Übungen" with a body that lists push-up variants (Standard, Wide, Diamond) plus the new exercises.
- **`seo.landing.title`** kept as "Liegestütze Tracker: Trainingsplan, Streaks & Bestenliste" — push-ups remain the SEO headline.
- **`seo.landing.description`** keeps the original push-up pitch and appends "jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen."
- **`index.html`** meta description / og:description / twitter:description match the same push-up-first framing.
- **All 10 locales updated** (de source + en/fr/es/it/nl/el/la/no/zh) for the four changed landing keys and the two SEO keys, including a CodeRabbit-flagged fix for "Tracke" leaking into French and a singular→plural correction for the analytics title across every locale (German source is "alle Übungen").

## Test plan
- [x] `pnpm nx lint web` (0 errors)
- [x] `pnpm nx test web --filter=landing-page` (LandingPageComponent specs green)
- [x] `pnpm nx build web --configuration=production-preview` localizes all 10 locales without `i18nMissingTranslation` errors (the only failure is a pre-existing landing-page.scss budget overflow unrelated to this PR)

## Summary by CodeRabbit

* **Documentation**
  * Updated SEO descriptions and page metadata to reflect the expanded exercise tracking capabilities while keeping push-ups as the primary pitch.
  * Refreshed landing page marketing messaging to surface tracking of multiple exercise types alongside trends, streaks, and live synchronization.
  * Synchronized all marketing copy updates across every supported language.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/311)
