### PR TITLE
fix(analysis): place forward arrow after "Vor" label on filter bar

### DIFF
--- a/web/src/app/stats/components/filter-bar/filter-bar.component.ts
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.ts
@@ -100,7 +100,7 @@ import {
             i18n-aria-label="@@rangeForwardAria"
           >
             <span class="step-label" i18n="@@rangeForward">Vor</span>
-            <mat-icon>chevron_right</mat-icon>
+            <mat-icon iconPositionEnd>chevron_right</mat-icon>
           </button>
           <button
             type="button"


### PR DESCRIPTION
Angular Material projects mat-icon before button text by default.
Add iconPositionEnd so the chevron renders after the label, matching
the natural reading order ("Vor →") and pairing visually with the
back button (← Zurück).