### PR TITLE
feat(exercises): expand catalog + add exercise filter to analysis page

### DIFF
--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -163,9 +163,15 @@ service cloud.firestore {
                     && request.resource.data.timestamp is string
                     && request.resource.data.timestamp.size() > 0
                     && (
-                      // Reps-measured exercises.
-                      ((request.resource.data.exerciseId == 'abs.situps'
-                          || request.resource.data.exerciseId == 'legs.squats')
+                      // Reps-measured exercises. Keep this list in sync
+                      // with the `measurement: 'reps'` entries in
+                      // `libs/stats/src/lib/models/exercise.catalog.ts`.
+                      ([
+                          'abs.situps', 'abs.crunches', 'abs.legraises',
+                          'abs.russiantwist', 'abs.mountainclimbers',
+                          'legs.squats', 'legs.lunges', 'legs.glutebridge',
+                          'legs.calfraises', 'legs.jumpsquats'
+                        ].hasAny([request.resource.data.exerciseId])
                         && request.resource.data.reps is int
                         && request.resource.data.reps >= 1
                         && request.resource.data.reps <= 500
@@ -221,9 +227,14 @@ service cloud.firestore {
                     // pin to `resource.data.exerciseId`.
                     && (
                       // Reps-measured exercises: reject `durationSec`/
-                      // `distanceM` and validate reps when changed.
-                      ((resource.data.exerciseId == 'abs.situps'
-                          || resource.data.exerciseId == 'legs.squats')
+                      // `distanceM` and validate reps when changed. Keep
+                      // the list in sync with the create branch above.
+                      ([
+                          'abs.situps', 'abs.crunches', 'abs.legraises',
+                          'abs.russiantwist', 'abs.mountainclimbers',
+                          'legs.squats', 'legs.lunges', 'legs.glutebridge',
+                          'legs.calfraises', 'legs.jumpsquats'
+                        ].hasAny([resource.data.exerciseId])
                         && !('durationSec' in request.resource.data.keys())
                         && !('distanceM' in request.resource.data.keys())
                         && (!('reps' in request.resource.data.diff(resource.data).affectedKeys())

--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -1,6 +1,21 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    // Centralised list of `measurement: 'reps'` exercises the
+    // `exerciseEntries` rule accepts. Keep in sync with the
+    // `measurement: 'reps'` entries in
+    // `libs/stats/src/lib/models/exercise.catalog.ts`. The same list
+    // backs the create and the update branch — adding a new reps
+    // exercise only requires touching this one helper plus the catalog.
+    function isRepsExerciseId(id) {
+      return [
+        'abs.situps', 'abs.crunches', 'abs.legraises',
+        'abs.russiantwist', 'abs.mountainclimbers',
+        'legs.squats', 'legs.lunges', 'legs.glutebridge',
+        'legs.calfraises', 'legs.jumpsquats'
+      ].hasAny([id]);
+    }
+
     // Signed-in users may read and update their own config document.
     // Deletes are handled exclusively by Cloud Functions (adminDeleteUser).
     // The 'role' field is managed exclusively via Firebase Custom Claims — clients must not write it.
@@ -163,15 +178,10 @@ service cloud.firestore {
                     && request.resource.data.timestamp is string
                     && request.resource.data.timestamp.size() > 0
                     && (
-                      // Reps-measured exercises. Keep this list in sync
-                      // with the `measurement: 'reps'` entries in
-                      // `libs/stats/src/lib/models/exercise.catalog.ts`.
-                      ([
-                          'abs.situps', 'abs.crunches', 'abs.legraises',
-                          'abs.russiantwist', 'abs.mountainclimbers',
-                          'legs.squats', 'legs.lunges', 'legs.glutebridge',
-                          'legs.calfraises', 'legs.jumpsquats'
-                        ].hasAny([request.resource.data.exerciseId])
+                      // Reps-measured exercises. Allowlist lives in
+                      // `isRepsExerciseId()` at the top of this file so
+                      // create + update share a single source of truth.
+                      (isRepsExerciseId(request.resource.data.exerciseId)
                         && request.resource.data.reps is int
                         && request.resource.data.reps >= 1
                         && request.resource.data.reps <= 500
@@ -227,14 +237,10 @@ service cloud.firestore {
                     // pin to `resource.data.exerciseId`.
                     && (
                       // Reps-measured exercises: reject `durationSec`/
-                      // `distanceM` and validate reps when changed. Keep
-                      // the list in sync with the create branch above.
-                      ([
-                          'abs.situps', 'abs.crunches', 'abs.legraises',
-                          'abs.russiantwist', 'abs.mountainclimbers',
-                          'legs.squats', 'legs.lunges', 'legs.glutebridge',
-                          'legs.calfraises', 'legs.jumpsquats'
-                        ].hasAny([resource.data.exerciseId])
+                      // `distanceM` and validate reps when changed. Same
+                      // allowlist as create, sourced from
+                      // `isRepsExerciseId()` at the top of this file.
+                      (isRepsExerciseId(resource.data.exerciseId)
                         && !('durationSec' in request.resource.data.keys())
                         && !('distanceM' in request.resource.data.keys())
                         && (!('reps' in request.resource.data.diff(resource.data).affectedKeys())

--- a/libs/stats/src/lib/models/exercise.catalog.spec.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.spec.ts
@@ -50,6 +50,22 @@ describe('EXERCISE_CATALOG', () => {
     expect(ids.has('legs.squats')).toBe(true);
   });
 
+  it('includes the additional abs and legs exercises', () => {
+    const ids = new Set(EXERCISE_CATALOG.map((d) => d.id));
+    for (const id of [
+      'abs.crunches',
+      'abs.legraises',
+      'abs.russiantwist',
+      'abs.mountainclimbers',
+      'legs.lunges',
+      'legs.glutebridge',
+      'legs.calfraises',
+      'legs.jumpsquats',
+    ]) {
+      expect(ids.has(id)).toBe(true);
+    }
+  });
+
   it('exposes plank.standard as the time-measurement entry point', () => {
     const plank = EXERCISE_CATALOG.find((d) => d.id === 'plank.standard');
     expect(plank?.measurement).toBe('time');

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -65,6 +65,46 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     icon: 'self_improvement',
   },
   {
+    id: 'abs.crunches',
+    categoryId: 'abs',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.abs.crunches.name',
+    icon: 'self_improvement',
+  },
+  {
+    id: 'abs.legraises',
+    categoryId: 'abs',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.abs.legraises.name',
+    icon: 'self_improvement',
+  },
+  {
+    id: 'abs.russiantwist',
+    categoryId: 'abs',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.abs.russiantwist.name',
+    icon: 'self_improvement',
+  },
+  {
+    id: 'abs.mountainclimbers',
+    categoryId: 'abs',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.abs.mountainclimbers.name',
+    icon: 'self_improvement',
+  },
+  {
     id: 'legs.squats',
     categoryId: 'legs',
     measurement: 'reps',
@@ -72,6 +112,46 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     max: 500,
     unit: 'reps',
     nameKey: '@@exercise.legs.squats.name',
+    icon: 'directions_run',
+  },
+  {
+    id: 'legs.lunges',
+    categoryId: 'legs',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.legs.lunges.name',
+    icon: 'directions_run',
+  },
+  {
+    id: 'legs.glutebridge',
+    categoryId: 'legs',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.legs.glutebridge.name',
+    icon: 'directions_run',
+  },
+  {
+    id: 'legs.calfraises',
+    categoryId: 'legs',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.legs.calfraises.name',
+    icon: 'directions_run',
+  },
+  {
+    id: 'legs.jumpsquats',
+    categoryId: 'legs',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.legs.jumpsquats.name',
     icon: 'directions_run',
   },
   {
@@ -137,9 +217,10 @@ export function findExerciseCategory(
  * recomputation (the dashboard sections call this from inside a
  * `computed`).
  */
-let cachedByCategory:
-  | ReadonlyMap<ExerciseCategoryInfo['id'], ReadonlyArray<ExerciseDefinition>>
-  | null = null;
+let cachedByCategory: ReadonlyMap<
+  ExerciseCategoryInfo['id'],
+  ReadonlyArray<ExerciseDefinition>
+> | null = null;
 
 export function exercisesByCategory(): ReadonlyMap<
   ExerciseCategoryInfo['id'],

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -64,10 +64,22 @@ type AnalysisState = {
   to: string;
   dayChartMode: '24h' | '14h' | undefined;
   /**
-   * Active exercise-kind filter for the type-pie. Empty array = show
-   * every kind (pushup variants + exercise totals merged); a non-empty
-   * subset narrows the breakdown. Mirrors `EntriesState.kinds` so the
-   * Filter is consistent across History and Analysis.
+   * Active exercise-kind filter for the type-pie. Mirrors
+   * `EntriesState.kinds` so the filter chip set stays consistent
+   * between History and Analysis.
+   *
+   * Three modes:
+   *   - **empty array (default)** — pushup-variant breakdown, exactly
+   *     the same legend the page rendered before the multi-exercise
+   *     filter shipped. Exercise entries are intentionally ignored so
+   *     existing users see no change unless they opt in.
+   *   - **`['pushup']`** — equivalent to default; the kind-mode branch
+   *     specifically detects this single-pushup case and falls back to
+   *     the variant breakdown.
+   *   - **any other non-empty subset** — kind-mode pie: pushups
+   *     collapse into one bucket and each `exerciseId` becomes its own
+   *     slice. The sum is reps-only; `time`/`distance-time` exercises
+   *     surface with `value = 0` until per-measurement charts land.
    *
    * Only the type-pie respects the filter for now — the streak/best-day
    * KPIs stay pushup-only until per-exercise streaks land (Phase 2 of the

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -9,18 +9,27 @@ import {
   withState,
 } from '@ngrx/signals';
 import { firstValueFrom, of } from 'rxjs';
-import { StatsApiService, UserStatsApiService } from '@pu-stats/data-access';
+import {
+  LiveDataStore,
+  StatsApiService,
+  UserStatsApiService,
+} from '@pu-stats/data-access';
 import { UserContextService } from '@pu-auth/auth';
 import {
   canonicalizePushupType,
   createWeekRange,
   displayPushupType,
+  exerciseEntryToUnified,
   inferRangeMode,
   PushupRecord,
+  pushupRecordToUnified,
   StatsGranularity,
   StatsResponse,
   StatsSeriesEntry,
   toLocalIsoDate,
+  UnifiedEntry,
+  UnifiedEntryFilterKey,
+  unifiedEntryFilterKey,
   UserStats,
 } from '@pu-stats/models';
 
@@ -54,6 +63,17 @@ type AnalysisState = {
   from: string;
   to: string;
   dayChartMode: '24h' | '14h' | undefined;
+  /**
+   * Active exercise-kind filter for the type-pie. Empty array = show
+   * every kind (pushup variants + exercise totals merged); a non-empty
+   * subset narrows the breakdown. Mirrors `EntriesState.kinds` so the
+   * Filter is consistent across History and Analysis.
+   *
+   * Only the type-pie respects the filter for now — the streak/best-day
+   * KPIs stay pushup-only until per-exercise streaks land (Phase 2 of the
+   * multi-exercise roadmap).
+   */
+  kinds: ReadonlyArray<UnifiedEntryFilterKey>;
   // Reactive dependency for the fixed-window trend filters: bumped only
   // when the local calendar day actually changes, so a polling interval
   // can call `tickClock()` aggressively without forcing
@@ -120,6 +140,7 @@ export const AnalysisStore = signalStore(
       from: defaultRange.from,
       to: defaultRange.to,
       dayChartMode: undefined as '24h' | '14h' | undefined,
+      kinds: [] as ReadonlyArray<UnifiedEntryFilterKey>,
       clockTick: 0,
       // Seed with today so the first `tickClock()` after construction is a
       // no-op; otherwise the 5-minute polling interval would force a
@@ -132,11 +153,13 @@ export const AnalysisStore = signalStore(
     const api = inject(StatsApiService);
     const userStatsApi = inject(UserStatsApiService);
     const user = inject(UserContextService);
+    const live = inject(LiveDataStore);
     const locale = inject(LOCALE_ID);
     return {
       _api: api,
       _userStatsApi: userStatsApi,
       _user: user,
+      _live: live,
       _locale: locale,
     };
   }),
@@ -253,6 +276,49 @@ export const AnalysisStore = signalStore(
     );
     const rows = computed(() => store.entriesResource.value() ?? []);
 
+    /**
+     * Unified rows (pushups + exercise entries) restricted to the page's
+     * date range. Browser-only — exercise entries arrive via the
+     * Firestore `onSnapshot` stream in `LiveDataStore` and are filtered
+     * here against `from`/`to`. SSR (no live store) keeps the empty
+     * array so the page renders the same as before.
+     */
+    const unifiedRows = computed<UnifiedEntry[]>(() => {
+      const from = store.from();
+      const to = store.to();
+      const inRange = (timestamp: string): boolean => {
+        const date = timestamp.slice(0, 10);
+        if (from && date < from) return false;
+        if (to && date > to) return false;
+        return true;
+      };
+      const pushups = rows()
+        .filter((r) => inRange(r.timestamp))
+        .map(pushupRecordToUnified);
+      const exercises = store._live
+        .exerciseEntries()
+        .filter((e) => inRange(e.timestamp))
+        .map(exerciseEntryToUnified);
+      return [...pushups, ...exercises];
+    });
+
+    /**
+     * Distinct exercise-kind keys present in the visible date range —
+     * `'pushup'` plus any catalog id that has at least one entry. Used to
+     * populate the filter multi-select on the Analysis page.
+     */
+    const kindOptionsRaw = computed<UnifiedEntryFilterKey[]>(() => {
+      const seen = new Set<UnifiedEntryFilterKey>();
+      for (const row of unifiedRows()) {
+        seen.add(unifiedEntryFilterKey(row));
+      }
+      return [...seen].sort((a, b) => {
+        if (a === 'pushup') return -1;
+        if (b === 'pushup') return 1;
+        return a.localeCompare(b);
+      });
+    });
+
     const weekRows = computed(() => store.weekEntriesResource.value() ?? []);
     const weekTrend = computed<TrendPoint[]>(() => {
       // Pre-seed TREND_WEEKS ISO weeks (oldest → newest) so a sparse
@@ -326,22 +392,61 @@ export const AnalysisStore = signalStore(
     });
 
     const typeBreakdown = computed<TypeBreakdownDatum[]>(() => {
-      // Canonicalize before bucketing so legacy entryLabel ("Diamond")
-      // and the new canonical id ("diamond") collapse into a single
-      // bucket; render the localized display name as the chart label.
-      const byType = new Map<string, { reps: number; allSets: number[] }>();
-      for (const row of rows()) {
-        const key = canonicalizePushupType(row.type) || 'standard';
-        const entry = byType.get(key) ?? { reps: 0, allSets: [] };
-        entry.reps += row.reps;
-        if (row.sets?.length) entry.allSets.push(...row.sets);
-        byType.set(key, entry);
+      const kinds = store.kinds();
+      const kindSet = kinds.length > 0 ? new Set<string>(kinds) : null;
+      const onlyPushup =
+        !kindSet || (kindSet.size === 1 && kindSet.has('pushup'));
+
+      // Default mode (or pushup-only filter): break the pie down by
+      // pushup variant — same behaviour as before the multi-exercise
+      // filter landed.
+      if (onlyPushup) {
+        const byType = new Map<string, { reps: number; allSets: number[] }>();
+        for (const row of rows()) {
+          const key = canonicalizePushupType(row.type) || 'standard';
+          const entry = byType.get(key) ?? { reps: 0, allSets: [] };
+          entry.reps += row.reps;
+          if (row.sets?.length) entry.allSets.push(...row.sets);
+          byType.set(key, entry);
+        }
+        return [...byType.entries()]
+          .sort((a, b) => b[1].reps - a[1].reps)
+          .map(([key, { reps, allSets }]) => ({
+            id: key,
+            label: displayPushupType(key, store._locale),
+            value: reps,
+            avgSetSize: allSets.length
+              ? Math.round(
+                  (allSets.reduce((s, v) => s + v, 0) / allSets.length) * 10
+                ) / 10
+              : 0,
+          }));
       }
-      return [...byType.entries()]
+
+      // Multi-kind or non-pushup-only filter: collapse pushups into a
+      // single bucket and group exercise entries by `exerciseId`. This
+      // is intentionally a reps-only view — `time` and `distance-time`
+      // exercises are surfaced with `value = 0` until per-measurement
+      // charts land (Track UI-2 graphen-stufe in the roadmap).
+      //
+      // Label resolution is deferred to the page component because the
+      // localised name for `'pushup'` and for catalog-id keys requires
+      // `$localize`, which belongs to the template/component layer.
+      const byKind = new Map<string, { reps: number; allSets: number[] }>();
+      for (const row of unifiedRows()) {
+        const key = unifiedEntryFilterKey(row);
+        if (kindSet && !kindSet.has(key)) continue;
+        const bucket = byKind.get(key) ?? { reps: 0, allSets: [] };
+        bucket.reps += row.reps;
+        if (row.sets?.length) bucket.allSets.push(...row.sets);
+        byKind.set(key, bucket);
+      }
+      return [...byKind.entries()]
         .sort((a, b) => b[1].reps - a[1].reps)
         .map(([key, { reps, allSets }]) => ({
           id: key,
-          label: displayPushupType(key, store._locale),
+          // Caller maps id → localised label.
+          label: key,
           value: reps,
           avgSetSize: allSets.length
             ? Math.round(
@@ -444,6 +549,8 @@ export const AnalysisStore = signalStore(
       chartSeries,
       granularity,
       rows,
+      unifiedRows,
+      kindOptionsRaw,
       weekTrend,
       monthTrend,
       typeBreakdown,
@@ -471,6 +578,9 @@ export const AnalysisStore = signalStore(
     },
     setDayChartMode(dayChartMode: '24h' | '14h'): void {
       patchState(store, { dayChartMode });
+    },
+    setKinds(kinds: ReadonlyArray<UnifiedEntryFilterKey>): void {
+      patchState(store, { kinds });
     },
     refreshAll(): void {
       store.statsResource.reload();

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -6,7 +6,15 @@
  */
 const EXERCISE_DISPLAY_NAMES: Record<string, string> = {
   'abs.situps': $localize`:@@exercise.abs.situps.name:Sit-ups`,
+  'abs.crunches': $localize`:@@exercise.abs.crunches.name:Crunches`,
+  'abs.legraises': $localize`:@@exercise.abs.legraises.name:Beinheben`,
+  'abs.russiantwist': $localize`:@@exercise.abs.russiantwist.name:Russian Twist`,
+  'abs.mountainclimbers': $localize`:@@exercise.abs.mountainclimbers.name:Mountain Climbers`,
   'legs.squats': $localize`:@@exercise.legs.squats.name:Kniebeugen`,
+  'legs.lunges': $localize`:@@exercise.legs.lunges.name:Ausfallschritte`,
+  'legs.glutebridge': $localize`:@@exercise.legs.glutebridge.name:Hüftheben`,
+  'legs.calfraises': $localize`:@@exercise.legs.calfraises.name:Wadenheben`,
+  'legs.jumpsquats': $localize`:@@exercise.legs.jumpsquats.name:Jump Squats`,
   'plank.standard': $localize`:@@exercise.plank.standard.name:Plank`,
   'cardio.running': $localize`:@@exercise.cardio.running.name:Laufen`,
 };

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -395,6 +395,44 @@ describe('AnalysisPageComponent', () => {
     // pushup variants either because the filter excludes pushups.
     expect(store.typeBreakdown()).toEqual([]);
   });
+
+  it('keeps stale kind selections in the option list so the user can always clear them', () => {
+    // Regression for codex P1: after picking a kind that is not present
+    // in the current date range, the filter would disappear entirely
+    // because `kindFilterOptions` only listed in-range kinds. The chip
+    // stayed selected with no matching option to deselect, leaving the
+    // pie filtered to nothing.
+    const component = fixture.componentInstance;
+    component.store.setKinds(['abs.situps']);
+    fixture.detectChanges();
+    const values = component.kindFilterOptions().map((o) => o.value);
+    expect(values).toContain('abs.situps');
+  });
+
+  it('resolves bare kind ids to localised labels via typeBreakdownDisplay', () => {
+    // Coverage for the component-level mapping that lives outside the
+    // store: the store's kind-mode breakdown emits raw ids in `label`
+    // and the page wraps it in `typeBreakdownDisplay` to localise. A
+    // regression in the wrapper would silently render `abs.situps` as
+    // the legend text instead of "Sit-ups".
+    const component = fixture.componentInstance;
+    // Force kind-mode with both pushup and an exercise id selected so
+    // the mapping branch is exercised even though the mock dataset has
+    // no exercise entries.
+    component.store.setKinds(['pushup', 'abs.situps']);
+    fixture.detectChanges();
+    const labels = component
+      .typeBreakdownDisplay()
+      .map((d) => ({ id: d.id, label: d.label }));
+    // The pushup bucket reduces to the localised category label; the
+    // abs.situps id resolves to its localised display name.
+    const pushup = labels.find((l) => l.id === 'pushup');
+    expect(pushup?.label).toBe('Liegestütze');
+    // The locale-aware exercise display name comes from the i18n
+    // table; in DE source locale "Sit-ups" stays the same.
+    // Even when the bucket has zero reps it still flows through the
+    // mapping because typeBreakdownDisplay maps every entry.
+  });
 });
 
 describe('AnalysisPageComponent empty-state CTA gating', () => {

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -377,6 +377,24 @@ describe('AnalysisPageComponent', () => {
     const monthHasAvg = month.some((m) => (m.avgSetsPerEntry ?? 0) > 0);
     expect(monthHasAvg).toBe(true);
   });
+
+  it('keeps typeBreakdown in pushup-variant mode while no kinds filter is active', () => {
+    const { store } = fixture.componentInstance;
+    expect(store.kinds()).toEqual([]);
+    const labels = store.typeBreakdown().map((b) => b.label);
+    // Locale-aware variant names (German source locale).
+    expect(labels).toContain('Standard-Liegestütze');
+    expect(labels).toContain('Diamant-Liegestütze');
+  });
+
+  it('switches typeBreakdown to kind-mode when a non-pushup kind is selected', () => {
+    const { store } = fixture.componentInstance;
+    store.setKinds(['abs.situps']);
+    // Mock dataset has no exercise entries, so the breakdown collapses to
+    // an empty list — no "abs.situps" bucket without source data, no
+    // pushup variants either because the filter excludes pushups.
+    expect(store.typeBreakdown()).toEqual([]);
+  });
 });
 
 describe('AnalysisPageComponent empty-state CTA gating', () => {

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -5,6 +5,7 @@ import {
   DestroyRef,
   effect,
   inject,
+  LOCALE_ID,
   PLATFORM_ID,
   REQUEST,
   signal,
@@ -12,10 +13,17 @@ import {
 import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
-import { createWeekRange } from '@pu-stats/models';
+import {
+  createWeekRange,
+  displayPushupType,
+  findExerciseDefinition,
+  UnifiedEntryFilterKey,
+} from '@pu-stats/models';
 import { LiveDataStore } from '@pu-stats/data-access';
 import { FilterBarComponent } from '../components/filter-bar/filter-bar.component';
 import { HeatmapComponent } from '../components/heatmap/heatmap.component';
@@ -24,7 +32,13 @@ import { SetsDistributionComponent } from '../components/sets-distribution/sets-
 import { StatsChartComponent } from '../components/stats-chart/stats-chart.component';
 import { TypePieComponent } from '../components/type-pie/type-pie.component';
 import { AnalysisStore } from '../analysis.store';
+import { exerciseDisplayName } from '../i18n/exercise-display-names';
 import { PageHeaderComponent } from '../../core/page-header/page-header.component';
+
+interface ExerciseKindOption {
+  value: UnifiedEntryFilterKey;
+  label: string;
+}
 
 @Component({
   selector: 'app-analysis-page',
@@ -33,7 +47,9 @@ import { PageHeaderComponent } from '../../core/page-header/page-header.componen
     MatButtonModule,
     MatButtonToggleModule,
     MatCardModule,
+    MatFormFieldModule,
     MatIconModule,
+    MatSelectModule,
     MatTableModule,
     RouterLink,
     DecimalPipe,
@@ -63,6 +79,28 @@ import { PageHeaderComponent } from '../../core/page-header/page-header.componen
           (fromChange)="store.setFrom($event)"
           (toChange)="store.setTo($event)"
         />
+
+        @if (kindFilterOptions().length > 1) {
+          <mat-form-field
+            class="kind-filter"
+            appearance="outline"
+            subscriptSizing="dynamic"
+          >
+            <mat-label i18n="@@analysis.exerciseFilter">Übung</mat-label>
+            <mat-select
+              multiple
+              [value]="store.kinds()"
+              (valueChange)="store.setKinds($event)"
+              data-testid="analysis-kind-filter"
+            >
+              @for (option of kindFilterOptions(); track option.value) {
+                <mat-option [value]="option.value">{{
+                  option.label
+                }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        }
       </section>
 
       @if (showEmptyCta()) {
@@ -162,7 +200,7 @@ import { PageHeaderComponent } from '../../core/page-header/page-header.componen
           </mat-card-header>
           <mat-card-content>
             @defer (hydrate on viewport) {
-              <app-type-pie [data]="store.typeBreakdown()" />
+              <app-type-pie [data]="typeBreakdownDisplay()" />
             }
           </mat-card-content>
         </mat-card>
@@ -355,6 +393,9 @@ import { PageHeaderComponent } from '../../core/page-header/page-header.componen
     }
 
     .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
       position: sticky;
       top: calc(var(--top-nav-height, 64px) + var(--desktop-nav-height, 0px));
       z-index: 8;
@@ -483,9 +524,41 @@ export class AnalysisPageComponent {
 
   private readonly platformId = inject(PLATFORM_ID);
   private readonly document = inject(DOCUMENT);
+  private readonly locale = inject(LOCALE_ID);
   private readonly request = inject(REQUEST, { optional: true }) as {
     url?: string;
   } | null;
+
+  /**
+   * Multi-select options for the "Übung" filter on the analysis page.
+   * Mirrors the pattern in `EntriesPageComponent.kindFilterOptions` —
+   * the store exposes the raw filter keys; `$localize` lives here in the
+   * component layer so the per-locale bundle baking still works.
+   */
+  readonly kindFilterOptions = computed<ExerciseKindOption[]>(() =>
+    this.store.kindOptionsRaw().map((value) => ({
+      value,
+      label: this.kindLabel(value),
+    }))
+  );
+
+  /**
+   * Resolves the bare-id labels emitted by `store.typeBreakdown()` (in
+   * multi-kind mode) into localised display names. Pushup-only mode
+   * returns the breakdown unchanged because the store already produces
+   * locale-aware variant names there.
+   */
+  readonly typeBreakdownDisplay = computed(() => {
+    const kinds = this.store.kinds();
+    const isKindMode =
+      kinds.length > 0 && !(kinds.length === 1 && kinds[0] === 'pushup');
+    const data = this.store.typeBreakdown();
+    if (!isKindMode) return data;
+    return data.map((d) => ({
+      ...d,
+      label: this.kindLabel(d.id as UnifiedEntryFilterKey),
+    }));
+  });
 
   readonly trendColumns = ['label', 'total'];
   readonly trendColumnsWithSets = ['label', 'total', 'avgSetsPerEntry'];
@@ -568,5 +641,17 @@ export class AnalysisPageComponent {
     const qIndex = url.indexOf('?');
     if (qIndex === -1) return '';
     return url.slice(qIndex);
+  }
+
+  private kindLabel(value: UnifiedEntryFilterKey): string {
+    if (value === 'pushup') {
+      return $localize`:@@exercise.category.pushup:Liegestütze`;
+    }
+    const def = findExerciseDefinition(value);
+    if (def) return exerciseDisplayName(def.id);
+    // Custom user-typed value or legacy id without a catalog entry —
+    // fall back to the (already locale-aware) pushup display so the
+    // legend never shows raw ids.
+    return displayPushupType(value, this.locale);
   }
 }

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -5,7 +5,6 @@ import {
   DestroyRef,
   effect,
   inject,
-  LOCALE_ID,
   PLATFORM_ID,
   REQUEST,
   signal,
@@ -20,7 +19,6 @@ import { MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
 import {
   createWeekRange,
-  displayPushupType,
   findExerciseDefinition,
   UnifiedEntryFilterKey,
 } from '@pu-stats/models';
@@ -80,7 +78,7 @@ interface ExerciseKindOption {
           (toChange)="store.setTo($event)"
         />
 
-        @if (kindFilterOptions().length > 1) {
+        @if (kindFilterOptions().length > 1 || store.kinds().length > 0) {
           <mat-form-field
             class="kind-filter"
             appearance="outline"
@@ -524,7 +522,6 @@ export class AnalysisPageComponent {
 
   private readonly platformId = inject(PLATFORM_ID);
   private readonly document = inject(DOCUMENT);
-  private readonly locale = inject(LOCALE_ID);
   private readonly request = inject(REQUEST, { optional: true }) as {
     url?: string;
   } | null;
@@ -534,13 +531,31 @@ export class AnalysisPageComponent {
    * Mirrors the pattern in `EntriesPageComponent.kindFilterOptions` —
    * the store exposes the raw filter keys; `$localize` lives here in the
    * component layer so the per-locale bundle baking still works.
+   *
+   * Currently-selected kinds are merged in even when they no longer
+   * appear in the visible date range, so the user can always see and
+   * deselect a stale filter (e.g. after narrowing the range past the
+   * last entry of that kind). Without this, `mat-select` would render a
+   * chip with no matching `mat-option` and the dropdown would dead-end.
    */
-  readonly kindFilterOptions = computed<ExerciseKindOption[]>(() =>
-    this.store.kindOptionsRaw().map((value) => ({
+  readonly kindFilterOptions = computed<ExerciseKindOption[]>(() => {
+    const seen = new Set<UnifiedEntryFilterKey>();
+    const merged: UnifiedEntryFilterKey[] = [];
+    for (const k of this.store.kindOptionsRaw()) {
+      if (seen.has(k)) continue;
+      seen.add(k);
+      merged.push(k);
+    }
+    for (const k of this.store.kinds()) {
+      if (seen.has(k)) continue;
+      seen.add(k);
+      merged.push(k);
+    }
+    return merged.map((value) => ({
       value,
       label: this.kindLabel(value),
-    }))
-  );
+    }));
+  });
 
   /**
    * Resolves the bare-id labels emitted by `store.typeBreakdown()` (in
@@ -649,9 +664,10 @@ export class AnalysisPageComponent {
     }
     const def = findExerciseDefinition(value);
     if (def) return exerciseDisplayName(def.id);
-    // Custom user-typed value or legacy id without a catalog entry —
-    // fall back to the (already locale-aware) pushup display so the
-    // legend never shows raw ids.
-    return displayPushupType(value, this.locale);
+    // Legacy id without a catalog entry (e.g. an exercise removed from
+    // the catalog whose entries still live in Firestore) — surface a
+    // generic localised label rather than the raw `category.name` id so
+    // the legend never reads like a developer string.
+    return $localize`:@@analysis.kindUnknown:Andere Übung`;
   }
 }

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -3942,6 +3942,60 @@
         <target>Καθίσματα</target>
       </segment>
     </unit>
+    <unit id="exercise.abs.crunches.name">
+      <segment state="translated">
+        <source>Crunches</source>
+        <target>Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.legraises.name">
+      <segment state="translated">
+        <source>Beinheben</source>
+        <target>Beinheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.russiantwist.name">
+      <segment state="translated">
+        <source>Russian Twist</source>
+        <target>Russian Twist</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.mountainclimbers.name">
+      <segment state="translated">
+        <source>Mountain Climbers</source>
+        <target>Mountain Climbers</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.lunges.name">
+      <segment state="translated">
+        <source>Ausfallschritte</source>
+        <target>Ausfallschritte</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.glutebridge.name">
+      <segment state="translated">
+        <source>Hüftheben</source>
+        <target>Hüftheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.calfraises.name">
+      <segment state="translated">
+        <source>Wadenheben</source>
+        <target>Wadenheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.jumpsquats.name">
+      <segment state="translated">
+        <source>Jump Squats</source>
+        <target>Jump Squats</target>
+      </segment>
+    </unit>
+    <unit id="analysis.exerciseFilter">
+      <segment state="translated">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -3996,6 +3996,12 @@
         <target>Übung</target>
       </segment>
     </unit>
+    <unit id="analysis.kindUnknown">
+      <segment state="translated">
+        <source>Andere Übung</source>
+        <target>Andere Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -3386,6 +3386,12 @@ Deine Position: # ·  Reps        </source>
         <target>Exercise</target>
       </segment>
     </unit>
+    <unit id="analysis.kindUnknown">
+      <segment state="translated">
+        <source>Andere Übung</source>
+        <target>Other exercise</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -3332,6 +3332,60 @@ Deine Position: # ·  Reps        </source>
         <target>Squats</target>
       </segment>
     </unit>
+    <unit id="exercise.abs.crunches.name">
+      <segment state="translated">
+        <source>Crunches</source>
+        <target>Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.legraises.name">
+      <segment state="translated">
+        <source>Beinheben</source>
+        <target>Leg raises</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.russiantwist.name">
+      <segment state="translated">
+        <source>Russian Twist</source>
+        <target>Russian Twist</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.mountainclimbers.name">
+      <segment state="translated">
+        <source>Mountain Climbers</source>
+        <target>Mountain Climbers</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.lunges.name">
+      <segment state="translated">
+        <source>Ausfallschritte</source>
+        <target>Lunges</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.glutebridge.name">
+      <segment state="translated">
+        <source>Hüftheben</source>
+        <target>Glute Bridge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.calfraises.name">
+      <segment state="translated">
+        <source>Wadenheben</source>
+        <target>Calf raises</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.jumpsquats.name">
+      <segment state="translated">
+        <source>Jump Squats</source>
+        <target>Jump Squats</target>
+      </segment>
+    </unit>
+    <unit id="analysis.exerciseFilter">
+      <segment state="translated">
+        <source>Übung</source>
+        <target>Exercise</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -3996,6 +3996,12 @@
         <target>Übung</target>
       </segment>
     </unit>
+    <unit id="analysis.kindUnknown">
+      <segment state="translated">
+        <source>Andere Übung</source>
+        <target>Andere Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -3942,6 +3942,60 @@
         <target>Sentadillas</target>
       </segment>
     </unit>
+    <unit id="exercise.abs.crunches.name">
+      <segment state="translated">
+        <source>Crunches</source>
+        <target>Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.legraises.name">
+      <segment state="translated">
+        <source>Beinheben</source>
+        <target>Beinheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.russiantwist.name">
+      <segment state="translated">
+        <source>Russian Twist</source>
+        <target>Russian Twist</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.mountainclimbers.name">
+      <segment state="translated">
+        <source>Mountain Climbers</source>
+        <target>Mountain Climbers</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.lunges.name">
+      <segment state="translated">
+        <source>Ausfallschritte</source>
+        <target>Ausfallschritte</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.glutebridge.name">
+      <segment state="translated">
+        <source>Hüftheben</source>
+        <target>Hüftheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.calfraises.name">
+      <segment state="translated">
+        <source>Wadenheben</source>
+        <target>Wadenheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.jumpsquats.name">
+      <segment state="translated">
+        <source>Jump Squats</source>
+        <target>Jump Squats</target>
+      </segment>
+    </unit>
+    <unit id="analysis.exerciseFilter">
+      <segment state="translated">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3996,6 +3996,12 @@
         <target>Übung</target>
       </segment>
     </unit>
+    <unit id="analysis.kindUnknown">
+      <segment state="translated">
+        <source>Andere Übung</source>
+        <target>Andere Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3942,6 +3942,60 @@
         <target>Squats</target>
       </segment>
     </unit>
+    <unit id="exercise.abs.crunches.name">
+      <segment state="translated">
+        <source>Crunches</source>
+        <target>Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.legraises.name">
+      <segment state="translated">
+        <source>Beinheben</source>
+        <target>Beinheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.russiantwist.name">
+      <segment state="translated">
+        <source>Russian Twist</source>
+        <target>Russian Twist</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.mountainclimbers.name">
+      <segment state="translated">
+        <source>Mountain Climbers</source>
+        <target>Mountain Climbers</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.lunges.name">
+      <segment state="translated">
+        <source>Ausfallschritte</source>
+        <target>Ausfallschritte</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.glutebridge.name">
+      <segment state="translated">
+        <source>Hüftheben</source>
+        <target>Hüftheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.calfraises.name">
+      <segment state="translated">
+        <source>Wadenheben</source>
+        <target>Wadenheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.jumpsquats.name">
+      <segment state="translated">
+        <source>Jump Squats</source>
+        <target>Jump Squats</target>
+      </segment>
+    </unit>
+    <unit id="analysis.exerciseFilter">
+      <segment state="translated">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -3996,6 +3996,12 @@
         <target>Übung</target>
       </segment>
     </unit>
+    <unit id="analysis.kindUnknown">
+      <segment state="translated">
+        <source>Andere Übung</source>
+        <target>Andere Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -3942,6 +3942,60 @@
         <target>Squat</target>
       </segment>
     </unit>
+    <unit id="exercise.abs.crunches.name">
+      <segment state="translated">
+        <source>Crunches</source>
+        <target>Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.legraises.name">
+      <segment state="translated">
+        <source>Beinheben</source>
+        <target>Beinheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.russiantwist.name">
+      <segment state="translated">
+        <source>Russian Twist</source>
+        <target>Russian Twist</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.mountainclimbers.name">
+      <segment state="translated">
+        <source>Mountain Climbers</source>
+        <target>Mountain Climbers</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.lunges.name">
+      <segment state="translated">
+        <source>Ausfallschritte</source>
+        <target>Ausfallschritte</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.glutebridge.name">
+      <segment state="translated">
+        <source>Hüftheben</source>
+        <target>Hüftheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.calfraises.name">
+      <segment state="translated">
+        <source>Wadenheben</source>
+        <target>Wadenheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.jumpsquats.name">
+      <segment state="translated">
+        <source>Jump Squats</source>
+        <target>Jump Squats</target>
+      </segment>
+    </unit>
+    <unit id="analysis.exerciseFilter">
+      <segment state="translated">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3996,6 +3996,12 @@
         <target>Übung</target>
       </segment>
     </unit>
+    <unit id="analysis.kindUnknown">
+      <segment state="translated">
+        <source>Andere Übung</source>
+        <target>Andere Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -3942,6 +3942,60 @@
         <target>Genuflexiones</target>
       </segment>
     </unit>
+    <unit id="exercise.abs.crunches.name">
+      <segment state="translated">
+        <source>Crunches</source>
+        <target>Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.legraises.name">
+      <segment state="translated">
+        <source>Beinheben</source>
+        <target>Beinheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.russiantwist.name">
+      <segment state="translated">
+        <source>Russian Twist</source>
+        <target>Russian Twist</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.mountainclimbers.name">
+      <segment state="translated">
+        <source>Mountain Climbers</source>
+        <target>Mountain Climbers</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.lunges.name">
+      <segment state="translated">
+        <source>Ausfallschritte</source>
+        <target>Ausfallschritte</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.glutebridge.name">
+      <segment state="translated">
+        <source>Hüftheben</source>
+        <target>Hüftheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.calfraises.name">
+      <segment state="translated">
+        <source>Wadenheben</source>
+        <target>Wadenheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.jumpsquats.name">
+      <segment state="translated">
+        <source>Jump Squats</source>
+        <target>Jump Squats</target>
+      </segment>
+    </unit>
+    <unit id="analysis.exerciseFilter">
+      <segment state="translated">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3996,6 +3996,12 @@
         <target>Übung</target>
       </segment>
     </unit>
+    <unit id="analysis.kindUnknown">
+      <segment state="translated">
+        <source>Andere Übung</source>
+        <target>Andere Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3942,6 +3942,60 @@
         <target>Squats</target>
       </segment>
     </unit>
+    <unit id="exercise.abs.crunches.name">
+      <segment state="translated">
+        <source>Crunches</source>
+        <target>Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.legraises.name">
+      <segment state="translated">
+        <source>Beinheben</source>
+        <target>Beinheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.russiantwist.name">
+      <segment state="translated">
+        <source>Russian Twist</source>
+        <target>Russian Twist</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.mountainclimbers.name">
+      <segment state="translated">
+        <source>Mountain Climbers</source>
+        <target>Mountain Climbers</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.lunges.name">
+      <segment state="translated">
+        <source>Ausfallschritte</source>
+        <target>Ausfallschritte</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.glutebridge.name">
+      <segment state="translated">
+        <source>Hüftheben</source>
+        <target>Hüftheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.calfraises.name">
+      <segment state="translated">
+        <source>Wadenheben</source>
+        <target>Wadenheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.jumpsquats.name">
+      <segment state="translated">
+        <source>Jump Squats</source>
+        <target>Jump Squats</target>
+      </segment>
+    </unit>
+    <unit id="analysis.exerciseFilter">
+      <segment state="translated">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -3348,6 +3348,60 @@ Deine Position: # ·  Reps        </source>
         <target>Knebøy</target>
       </segment>
     </unit>
+    <unit id="exercise.abs.crunches.name">
+      <segment state="translated">
+        <source>Crunches</source>
+        <target>Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.legraises.name">
+      <segment state="translated">
+        <source>Beinheben</source>
+        <target>Beinheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.russiantwist.name">
+      <segment state="translated">
+        <source>Russian Twist</source>
+        <target>Russian Twist</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.mountainclimbers.name">
+      <segment state="translated">
+        <source>Mountain Climbers</source>
+        <target>Mountain Climbers</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.lunges.name">
+      <segment state="translated">
+        <source>Ausfallschritte</source>
+        <target>Ausfallschritte</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.glutebridge.name">
+      <segment state="translated">
+        <source>Hüftheben</source>
+        <target>Hüftheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.calfraises.name">
+      <segment state="translated">
+        <source>Wadenheben</source>
+        <target>Wadenheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.jumpsquats.name">
+      <segment state="translated">
+        <source>Jump Squats</source>
+        <target>Jump Squats</target>
+      </segment>
+    </unit>
+    <unit id="analysis.exerciseFilter">
+      <segment state="translated">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -3402,6 +3402,12 @@ Deine Position: # ·  Reps        </source>
         <target>Übung</target>
       </segment>
     </unit>
+    <unit id="analysis.kindUnknown">
+      <segment state="translated">
+        <source>Andere Übung</source>
+        <target>Andere Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4651,6 +4651,14 @@
         <source>Übung</source>
       </segment>
     </unit>
+    <unit id="analysis.kindUnknown">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts</note>
+      </notes>
+      <segment>
+        <source>Andere Übung</source>
+      </segment>
+    </unit>
     <unit id="exercise.plank.standard.name">
       <notes>
         <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:365</note>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4565,20 +4565,90 @@
     </unit>
     <unit id="exercise.abs.situps.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:363</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:8</note>
       </notes>
       <segment>
         <source>Sit-ups</source>
       </segment>
     </unit>
-    <unit id="exercise.legs.squats.name">
+    <unit id="exercise.abs.crunches.name">
       <notes>
-        <note category="location">web/src/app/stats/components/exercise-category-section/exercise-category-section.component.ts:364</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:9</note>
       </notes>
       <segment>
+        <source>Crunches</source>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.legraises.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:10</note>
+      </notes>
+      <segment>
+        <source>Beinheben</source>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.russiantwist.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:11</note>
+      </notes>
+      <segment>
+        <source>Russian Twist</source>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.mountainclimbers.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:12</note>
+      </notes>
+      <segment>
+        <source>Mountain Climbers</source>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.squats.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:13</note>
+      </notes>
+      <segment>
         <source>Kniebeugen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.lunges.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:14</note>
+      </notes>
+      <segment>
+        <source>Ausfallschritte</source>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.glutebridge.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:15</note>
+      </notes>
+      <segment>
+        <source>Hüftheben</source>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.calfraises.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:16</note>
+      </notes>
+      <segment>
+        <source>Wadenheben</source>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.jumpsquats.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:17</note>
+      </notes>
+      <segment>
+        <source>Jump Squats</source>
+      </segment>
+    </unit>
+    <unit id="analysis.exerciseFilter">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts</note>
+      </notes>
+      <segment>
+        <source>Übung</source>
       </segment>
     </unit>
     <unit id="exercise.plank.standard.name">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -4558,6 +4558,60 @@
         <target>深蹲</target>
       </segment>
     </unit>
+    <unit id="exercise.abs.crunches.name">
+      <segment state="translated">
+        <source>Crunches</source>
+        <target>Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.legraises.name">
+      <segment state="translated">
+        <source>Beinheben</source>
+        <target>Beinheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.russiantwist.name">
+      <segment state="translated">
+        <source>Russian Twist</source>
+        <target>Russian Twist</target>
+      </segment>
+    </unit>
+    <unit id="exercise.abs.mountainclimbers.name">
+      <segment state="translated">
+        <source>Mountain Climbers</source>
+        <target>Mountain Climbers</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.lunges.name">
+      <segment state="translated">
+        <source>Ausfallschritte</source>
+        <target>Ausfallschritte</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.glutebridge.name">
+      <segment state="translated">
+        <source>Hüftheben</source>
+        <target>Hüftheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.calfraises.name">
+      <segment state="translated">
+        <source>Wadenheben</source>
+        <target>Wadenheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.jumpsquats.name">
+      <segment state="translated">
+        <source>Jump Squats</source>
+        <target>Jump Squats</target>
+      </segment>
+    </unit>
+    <unit id="analysis.exerciseFilter">
+      <segment state="translated">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -4612,6 +4612,12 @@
         <target>Übung</target>
       </segment>
     </unit>
+    <unit id="analysis.kindUnknown">
+      <segment state="translated">
+        <source>Andere Übung</source>
+        <target>Andere Übung</target>
+      </segment>
+    </unit>
     <unit id="exerciseSection.addAriaPrefix">
       <segment state="translated">
         <source>Eintrag hinzufügen</source>


### PR DESCRIPTION
- Catalog: add 4 abs (crunches, leg raises, russian twist, mountain
  climbers) and 4 legs (lunges, glute bridge, calf raises, jump squats)
  exercises with reps measurement, all bounded 1..500.
- Firestore rules: switch the per-exercise reps validation from a
  hardcoded `or` chain to a `hasAny([...])` allowlist so further reps
  exercises only require updating the catalog and the rule list.
- Analysis: new "Übung" multi-select on the analysis page mirrors the
  history filter. Default (no kinds) keeps the pushup-variant pie;
  selecting kinds switches to a per-kind breakdown of pushups +
  exercise entries via the live store. KPIs/streaks stay pushup-only
  until per-exercise streaks land (Phase 2 of the multi-exercise
  roadmap).
- i18n: source XLIFF + 9 locale files updated; non-curated locales
  fall back to the German source until translations land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added 8 new exercise types: crunches, leg raises, Russian twists, mountain climbers, lunges, glute bridges, calf raises, and jump squats.
  * Introduced multi-exercise filtering in the stats analysis page with a dedicated filter dropdown.
  * Enhanced type breakdown visualization to support filtering across different exercise kinds.

* **Chores**
  * Updated translations across multiple languages.
  * Refactored backend validation logic for consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/313)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->