### PR TITLE
fix(analysis): post-merge review fixups for #313

### DIFF
--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -64,26 +64,12 @@ type AnalysisState = {
   to: string;
   dayChartMode: '24h' | '14h' | undefined;
   /**
-   * Active exercise-kind filter for the type-pie. Mirrors
-   * `EntriesState.kinds` so the filter chip set stays consistent
-   * between History and Analysis.
-   *
-   * Three modes:
-   *   - **empty array (default)** — pushup-variant breakdown, exactly
-   *     the same legend the page rendered before the multi-exercise
-   *     filter shipped. Exercise entries are intentionally ignored so
-   *     existing users see no change unless they opt in.
-   *   - **`['pushup']`** — equivalent to default; the kind-mode branch
-   *     specifically detects this single-pushup case and falls back to
-   *     the variant breakdown.
-   *   - **any other non-empty subset** — kind-mode pie: pushups
-   *     collapse into one bucket and each `exerciseId` becomes its own
-   *     slice. The sum is reps-only; `time`/`distance-time` exercises
-   *     surface with `value = 0` until per-measurement charts land.
-   *
-   * Only the type-pie respects the filter for now — the streak/best-day
-   * KPIs stay pushup-only until per-exercise streaks land (Phase 2 of the
-   * multi-exercise roadmap).
+   * Active exercise-kind filter for the type-pie. Empty array and
+   * `['pushup']` both render the pushup-variant breakdown (default);
+   * any other non-empty subset switches the pie into kind-mode where
+   * pushups collapse into one bucket and each `exerciseId` becomes a
+   * slice. Streaks/best-day KPIs stay pushup-only — per-exercise
+   * versions land with Phase 2 of the multi-exercise roadmap.
    */
   kinds: ReadonlyArray<UnifiedEntryFilterKey>;
   // Reactive dependency for the fixed-window trend filters: bumped only
@@ -289,11 +275,9 @@ export const AnalysisStore = signalStore(
     const rows = computed(() => store.entriesResource.value() ?? []);
 
     /**
-     * Unified rows (pushups + exercise entries) restricted to the page's
-     * date range. Browser-only — exercise entries arrive via the
-     * Firestore `onSnapshot` stream in `LiveDataStore` and are filtered
-     * here against `from`/`to`. SSR (no live store) keeps the empty
-     * array so the page renders the same as before.
+     * Browser-only: exercise entries come from the live Firestore
+     * snapshot and are filtered to the page's date range. SSR has no
+     * live store and keeps the array empty.
      */
     const unifiedRows = computed<UnifiedEntry[]>(() => {
       const from = store.from();
@@ -314,11 +298,7 @@ export const AnalysisStore = signalStore(
       return [...pushups, ...exercises];
     });
 
-    /**
-     * Distinct exercise-kind keys present in the visible date range —
-     * `'pushup'` plus any catalog id that has at least one entry. Used to
-     * populate the filter multi-select on the Analysis page.
-     */
+    /** Distinct kind keys with at least one entry in the visible range. */
     const kindOptionsRaw = computed<UnifiedEntryFilterKey[]>(() => {
       const seen = new Set<UnifiedEntryFilterKey>();
       for (const row of unifiedRows()) {
@@ -409,9 +389,6 @@ export const AnalysisStore = signalStore(
       const onlyPushup =
         !kindSet || (kindSet.size === 1 && kindSet.has('pushup'));
 
-      // Default mode (or pushup-only filter): break the pie down by
-      // pushup variant — same behaviour as before the multi-exercise
-      // filter landed.
       if (onlyPushup) {
         const byType = new Map<string, { reps: number; allSets: number[] }>();
         for (const row of rows()) {
@@ -435,15 +412,10 @@ export const AnalysisStore = signalStore(
           }));
       }
 
-      // Multi-kind or non-pushup-only filter: collapse pushups into a
-      // single bucket and group exercise entries by `exerciseId`. This
-      // is intentionally a reps-only view — `time` and `distance-time`
-      // exercises are surfaced with `value = 0` until per-measurement
-      // charts land (Track UI-2 graphen-stufe in the roadmap).
-      //
-      // Label resolution is deferred to the page component because the
-      // localised name for `'pushup'` and for catalog-id keys requires
-      // `$localize`, which belongs to the template/component layer.
+      // Reps-only view: `time` and `distance-time` exercises surface
+      // with `value = 0` until per-measurement charts land. Label is
+      // emitted as the bare key — `$localize` for kind names lives in
+      // the page component.
       const byKind = new Map<string, { reps: number; allSets: number[] }>();
       for (const row of unifiedRows()) {
         const key = unifiedEntryFilterKey(row);

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -396,6 +396,29 @@ describe('AnalysisPageComponent', () => {
     expect(store.typeBreakdown()).toEqual([]);
   });
 
+  it('hides the kind filter for pushup-only ranges to keep the default page minimal', () => {
+    // Mock dataset has only pushup entries; the filter would just show
+    // a single "Pushup" option which is redundant with the variant pie.
+    const component = fixture.componentInstance;
+    expect(component.kindFilterOptions().map((o) => o.value)).toEqual([
+      'pushup',
+    ]);
+    expect(component.showKindFilter()).toBe(false);
+  });
+
+  it('shows the kind filter when a non-pushup kind is selected even on a pushup-only range', () => {
+    // Regression for Copilot finding: a user with only sit-up entries
+    // would never see the filter, and the default pushup-variant pie
+    // would render empty. Setting a non-pushup kind via the store —
+    // which the page also does when handling URL params or stale
+    // selections — must immediately surface the filter so the user
+    // can adjust it.
+    const component = fixture.componentInstance;
+    component.store.setKinds(['abs.situps']);
+    fixture.detectChanges();
+    expect(component.showKindFilter()).toBe(true);
+  });
+
   it('keeps stale kind selections in the option list so the user can always clear them', () => {
     // Regression for codex P1: after picking a kind that is not present
     // in the current date range, the filter would disappear entirely
@@ -416,22 +439,23 @@ describe('AnalysisPageComponent', () => {
     // regression in the wrapper would silently render `abs.situps` as
     // the legend text instead of "Sit-ups".
     const component = fixture.componentInstance;
-    // Force kind-mode with both pushup and an exercise id selected so
-    // the mapping branch is exercised even though the mock dataset has
-    // no exercise entries.
     component.store.setKinds(['pushup', 'abs.situps']);
     fixture.detectChanges();
-    const labels = component
+    const breakdown = component
       .typeBreakdownDisplay()
       .map((d) => ({ id: d.id, label: d.label }));
-    // The pushup bucket reduces to the localised category label; the
-    // abs.situps id resolves to its localised display name.
-    const pushup = labels.find((l) => l.id === 'pushup');
+    const pushup = breakdown.find((l) => l.id === 'pushup');
     expect(pushup?.label).toBe('Liegestütze');
-    // The locale-aware exercise display name comes from the i18n
-    // table; in DE source locale "Sit-ups" stays the same.
-    // Even when the bucket has zero reps it still flows through the
-    // mapping because typeBreakdownDisplay maps every entry.
+
+    // The mock dataset has no abs.situps entries so the breakdown
+    // bucket itself is missing; `kindFilterOptions` calls the same
+    // `kindLabel` mapping for both selected and in-range kinds, so it
+    // proves the catalog lookup → localised name path also works for
+    // catalog ids — without needing fixture data we don't have.
+    const situpsOption = component
+      .kindFilterOptions()
+      .find((o) => o.value === 'abs.situps');
+    expect(situpsOption?.label).toBe('Sit-ups');
   });
 });
 

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -78,7 +78,7 @@ interface ExerciseKindOption {
           (toChange)="store.setTo($event)"
         />
 
-        @if (kindFilterOptions().length > 1 || store.kinds().length > 0) {
+        @if (showKindFilter()) {
           <mat-form-field
             class="kind-filter"
             appearance="outline"
@@ -555,6 +555,20 @@ export class AnalysisPageComponent {
       value,
       label: this.kindLabel(value),
     }));
+  });
+
+  /**
+   * The filter is meaningful whenever the user has any choice to make:
+   *   - any non-pushup kind is present in the range (a pushups-only
+   *     range still fully describes itself via the variant pie), OR
+   *   - a kind is already selected (so the user can always clear it,
+   *     even after narrowing the range past its last entry).
+   * Hiding it for a pure-pushup range keeps the page minimal for the
+   * default user.
+   */
+  readonly showKindFilter = computed(() => {
+    if (this.store.kinds().length > 0) return true;
+    return this.kindFilterOptions().some((o) => o.value !== 'pushup');
   });
 
   /**

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -3945,61 +3945,61 @@
     <unit id="exercise.abs.crunches.name">
       <segment state="translated">
         <source>Crunches</source>
-        <target>Crunches</target>
+        <target>Κοιλιακοί (crunches)</target>
       </segment>
     </unit>
     <unit id="exercise.abs.legraises.name">
       <segment state="translated">
         <source>Beinheben</source>
-        <target>Beinheben</target>
+        <target>Άρσεις ποδιών</target>
       </segment>
     </unit>
     <unit id="exercise.abs.russiantwist.name">
       <segment state="translated">
         <source>Russian Twist</source>
-        <target>Russian Twist</target>
+        <target>Ρωσικές στροφές</target>
       </segment>
     </unit>
     <unit id="exercise.abs.mountainclimbers.name">
       <segment state="translated">
         <source>Mountain Climbers</source>
-        <target>Mountain Climbers</target>
+        <target>Ορειβάτες</target>
       </segment>
     </unit>
     <unit id="exercise.legs.lunges.name">
       <segment state="translated">
         <source>Ausfallschritte</source>
-        <target>Ausfallschritte</target>
+        <target>Προβολές</target>
       </segment>
     </unit>
     <unit id="exercise.legs.glutebridge.name">
       <segment state="translated">
         <source>Hüftheben</source>
-        <target>Hüftheben</target>
+        <target>Γέφυρα γλουτών</target>
       </segment>
     </unit>
     <unit id="exercise.legs.calfraises.name">
       <segment state="translated">
         <source>Wadenheben</source>
-        <target>Wadenheben</target>
+        <target>Άρσεις γαμπών</target>
       </segment>
     </unit>
     <unit id="exercise.legs.jumpsquats.name">
       <segment state="translated">
         <source>Jump Squats</source>
-        <target>Jump Squats</target>
+        <target>Καθίσματα με άλμα</target>
       </segment>
     </unit>
     <unit id="analysis.exerciseFilter">
       <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Άσκηση</target>
       </segment>
     </unit>
     <unit id="analysis.kindUnknown">
       <segment state="translated">
         <source>Andere Übung</source>
-        <target>Andere Übung</target>
+        <target>Άλλη άσκηση</target>
       </segment>
     </unit>
     <unit id="exerciseSection.addAriaPrefix">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -3951,55 +3951,55 @@
     <unit id="exercise.abs.legraises.name">
       <segment state="translated">
         <source>Beinheben</source>
-        <target>Beinheben</target>
+        <target>Elevaciones de piernas</target>
       </segment>
     </unit>
     <unit id="exercise.abs.russiantwist.name">
       <segment state="translated">
         <source>Russian Twist</source>
-        <target>Russian Twist</target>
+        <target>Giro ruso</target>
       </segment>
     </unit>
     <unit id="exercise.abs.mountainclimbers.name">
       <segment state="translated">
         <source>Mountain Climbers</source>
-        <target>Mountain Climbers</target>
+        <target>Escaladores</target>
       </segment>
     </unit>
     <unit id="exercise.legs.lunges.name">
       <segment state="translated">
         <source>Ausfallschritte</source>
-        <target>Ausfallschritte</target>
+        <target>Zancadas</target>
       </segment>
     </unit>
     <unit id="exercise.legs.glutebridge.name">
       <segment state="translated">
         <source>Hüftheben</source>
-        <target>Hüftheben</target>
+        <target>Puente de glúteos</target>
       </segment>
     </unit>
     <unit id="exercise.legs.calfraises.name">
       <segment state="translated">
         <source>Wadenheben</source>
-        <target>Wadenheben</target>
+        <target>Elevaciones de talones</target>
       </segment>
     </unit>
     <unit id="exercise.legs.jumpsquats.name">
       <segment state="translated">
         <source>Jump Squats</source>
-        <target>Jump Squats</target>
+        <target>Sentadillas con salto</target>
       </segment>
     </unit>
     <unit id="analysis.exerciseFilter">
       <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Ejercicio</target>
       </segment>
     </unit>
     <unit id="analysis.kindUnknown">
       <segment state="translated">
         <source>Andere Übung</source>
-        <target>Andere Übung</target>
+        <target>Otro ejercicio</target>
       </segment>
     </unit>
     <unit id="exerciseSection.addAriaPrefix">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3951,7 +3951,7 @@
     <unit id="exercise.abs.legraises.name">
       <segment state="translated">
         <source>Beinheben</source>
-        <target>Beinheben</target>
+        <target>Relevés de jambes</target>
       </segment>
     </unit>
     <unit id="exercise.abs.russiantwist.name">
@@ -3969,19 +3969,19 @@
     <unit id="exercise.legs.lunges.name">
       <segment state="translated">
         <source>Ausfallschritte</source>
-        <target>Ausfallschritte</target>
+        <target>Fentes</target>
       </segment>
     </unit>
     <unit id="exercise.legs.glutebridge.name">
       <segment state="translated">
         <source>Hüftheben</source>
-        <target>Hüftheben</target>
+        <target>Pont fessier</target>
       </segment>
     </unit>
     <unit id="exercise.legs.calfraises.name">
       <segment state="translated">
         <source>Wadenheben</source>
-        <target>Wadenheben</target>
+        <target>Extensions mollets</target>
       </segment>
     </unit>
     <unit id="exercise.legs.jumpsquats.name">
@@ -3993,13 +3993,13 @@
     <unit id="analysis.exerciseFilter">
       <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Exercice</target>
       </segment>
     </unit>
     <unit id="analysis.kindUnknown">
       <segment state="translated">
         <source>Andere Übung</source>
-        <target>Andere Übung</target>
+        <target>Autre exercice</target>
       </segment>
     </unit>
     <unit id="exerciseSection.addAriaPrefix">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -3951,7 +3951,7 @@
     <unit id="exercise.abs.legraises.name">
       <segment state="translated">
         <source>Beinheben</source>
-        <target>Beinheben</target>
+        <target>Sollevamenti gambe</target>
       </segment>
     </unit>
     <unit id="exercise.abs.russiantwist.name">
@@ -3969,13 +3969,13 @@
     <unit id="exercise.legs.lunges.name">
       <segment state="translated">
         <source>Ausfallschritte</source>
-        <target>Ausfallschritte</target>
+        <target>Affondi</target>
       </segment>
     </unit>
     <unit id="exercise.legs.glutebridge.name">
       <segment state="translated">
         <source>Hüftheben</source>
-        <target>Hüftheben</target>
+        <target>Ponte glutei</target>
       </segment>
     </unit>
     <unit id="exercise.legs.calfraises.name">
@@ -3993,13 +3993,13 @@
     <unit id="analysis.exerciseFilter">
       <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Esercizio</target>
       </segment>
     </unit>
     <unit id="analysis.kindUnknown">
       <segment state="translated">
         <source>Andere Übung</source>
-        <target>Andere Übung</target>
+        <target>Altro esercizio</target>
       </segment>
     </unit>
     <unit id="exerciseSection.addAriaPrefix">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -3951,7 +3951,7 @@
     <unit id="exercise.abs.legraises.name">
       <segment state="translated">
         <source>Beinheben</source>
-        <target>Beinheben</target>
+        <target>Beenheffen</target>
       </segment>
     </unit>
     <unit id="exercise.abs.russiantwist.name">
@@ -3969,19 +3969,19 @@
     <unit id="exercise.legs.lunges.name">
       <segment state="translated">
         <source>Ausfallschritte</source>
-        <target>Ausfallschritte</target>
+        <target>Uitvalspassen</target>
       </segment>
     </unit>
     <unit id="exercise.legs.glutebridge.name">
       <segment state="translated">
         <source>Hüftheben</source>
-        <target>Hüftheben</target>
+        <target>Heupbrug</target>
       </segment>
     </unit>
     <unit id="exercise.legs.calfraises.name">
       <segment state="translated">
         <source>Wadenheben</source>
-        <target>Wadenheben</target>
+        <target>Kuitheffen</target>
       </segment>
     </unit>
     <unit id="exercise.legs.jumpsquats.name">
@@ -3993,13 +3993,13 @@
     <unit id="analysis.exerciseFilter">
       <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Oefening</target>
       </segment>
     </unit>
     <unit id="analysis.kindUnknown">
       <segment state="translated">
         <source>Andere Übung</source>
-        <target>Andere Übung</target>
+        <target>Andere oefening</target>
       </segment>
     </unit>
     <unit id="exerciseSection.addAriaPrefix">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -3360,7 +3360,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="exercise.abs.legraises.name">
       <segment state="translated">
         <source>Beinheben</source>
-        <target>Beinheben</target>
+        <target>Benhev</target>
       </segment>
     </unit>
     <unit id="exercise.abs.russiantwist.name">
@@ -3378,19 +3378,19 @@ Deine Position: # ·  Reps        </source>
     <unit id="exercise.legs.lunges.name">
       <segment state="translated">
         <source>Ausfallschritte</source>
-        <target>Ausfallschritte</target>
+        <target>Utfall</target>
       </segment>
     </unit>
     <unit id="exercise.legs.glutebridge.name">
       <segment state="translated">
         <source>Hüftheben</source>
-        <target>Hüftheben</target>
+        <target>Seteløft</target>
       </segment>
     </unit>
     <unit id="exercise.legs.calfraises.name">
       <segment state="translated">
         <source>Wadenheben</source>
-        <target>Wadenheben</target>
+        <target>Tåhev</target>
       </segment>
     </unit>
     <unit id="exercise.legs.jumpsquats.name">
@@ -3402,13 +3402,13 @@ Deine Position: # ·  Reps        </source>
     <unit id="analysis.exerciseFilter">
       <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Øvelse</target>
       </segment>
     </unit>
     <unit id="analysis.kindUnknown">
       <segment state="translated">
         <source>Andere Übung</source>
-        <target>Andere Übung</target>
+        <target>Annen øvelse</target>
       </segment>
     </unit>
     <unit id="exerciseSection.addAriaPrefix">


### PR DESCRIPTION
Address late review feedback that landed after the squash-merge of #313.

## Summary

- **Filter visibility for non-pushup-only ranges (Copilot finding)**: surface the "Übung" multi-select whenever any non-pushup kind exists in the range OR a kind is selected. Previously a user with only sit-up entries (or who narrowed past all pushups) saw no filter and an empty pie. Adds two regression tests.
- **`abs.situps` localised label assertion (Copilot + CodeRabbit)**: extend the `typeBreakdownDisplay` test to also assert via `kindFilterOptions` that catalog ids resolve to localised names — covers the kindLabel mapping path that the bucket-only path could not reach without seeded exercise data.
- **Verbose comment trim (CodeRabbit, AGENTS.md style)**: shrink the `kinds` state docstring + a couple of "what" comments in `analysis.store.ts` so the file follows the repo's "default to no comments" rule.
- **Locale targets (CodeRabbit)**: replace the German fallback for the new exercise catalog strings + analysis filter labels with curated translations in **el / es / fr / it / nl / no**, sourced from the CodeRabbit review suggestions on #313. **la** and **zh** stay on the German fallback pending a translator's pass.

## Test plan

- [x] `pnpm nx affected -t lint,test --base=main --parallel=3` (web: 622 tests passing)
- [x] `pnpm nx run web:build -c production` (succeeds, no missing-translation errors)
- [ ] Spot-check the analysis page in the browser:
  - Range with only pushup entries → filter hidden (default)
  - Range with abs/legs entries → filter visible, can deselect to clear
  - Each non-source locale renders the new exercise names + "Übung" label in the native language

Refs: #313


---
_Generated by [Claude Code](https://claude.ai/code/session_013YH5V3jwXERYntWb8gvTSW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved how the exercise filter displays based on available exercise types.

* **Documentation**
  * Updated internal documentation for the analysis store.

* **Tests**
  * Enhanced test coverage for filter visibility behavior.

* **Localization**
  * Updated translations for exercise names and filter labels across Greek, Spanish, French, Italian, Dutch, and Norwegian.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/314)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->