### PR TITLE
feat(training-plans): skip days and jump to a different plan day

### DIFF
--- a/libs/data-access/src/lib/api/user-training-plan-api.service.spec.ts
+++ b/libs/data-access/src/lib/api/user-training-plan-api.service.spec.ts
@@ -17,6 +17,7 @@ jest.mock('@angular/fire/firestore', () => ({
   docData: jest.fn(),
   setDoc: jest.fn(() => Promise.resolve()),
   updateDoc: jest.fn(() => Promise.resolve()),
+  runTransaction: jest.fn(),
   arrayUnion: jest.fn((...values: unknown[]) => ({
     __type: 'arrayUnion',
     values,
@@ -256,6 +257,66 @@ describe('UserTrainingPlanApiService', () => {
         completedDays: expect.objectContaining({ __type: 'arrayRemove' }),
       })
     );
+  });
+
+  it('jumpToDay reads completedDays/skippedDays inside a transaction and rewrites both fields atomically', async () => {
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
+
+    // Capture the transaction body so we can run it against a fake
+    // snapshot and inspect the resulting tx.update payload.
+    let capturedUpdate: Record<string, unknown> | null = null;
+    (firestoreFns.runTransaction as jest.Mock).mockImplementation(
+      async (_fs: unknown, body: (tx: unknown) => Promise<void>) => {
+        const tx = {
+          get: async () => ({
+            // Fresh server state: a concurrent skip(7) landed before the
+            // transaction reads, plus prior completion of day 10.
+            data: () => ({
+              completedDays: [10],
+              skippedDays: [7],
+            }),
+          }),
+          update: (_ref: unknown, payload: Record<string, unknown>) => {
+            capturedUpdate = payload;
+          },
+        };
+        await body(tx);
+      }
+    );
+
+    const { fixture } = await render('', {
+      providers: [
+        UserTrainingPlanApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'u' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(
+      UserTrainingPlanApiService
+    );
+    // Jump to day 8 in a 30-day plan; non-rest days < 8 are 1..6 (7 is
+    // a rest day, omitted by caller).
+    await new Promise<void>((resolve, reject) =>
+      service
+        .jumpToDay('u', {
+          newStartDate: '2026-04-15',
+          targetDayIndex: 8,
+          nonRestDaysBeforeTarget: [1, 2, 3, 4, 5, 6],
+        })
+        .subscribe({ next: () => resolve(), error: reject })
+    );
+
+    expect(firestoreFns.runTransaction).toHaveBeenCalled();
+    expect(capturedUpdate).not.toBeNull();
+    const payload = capturedUpdate as Record<string, unknown>;
+    expect(payload['startDate']).toBe('2026-04-15');
+    // Day 10 stays completed (preserved server-side); day 7 was the
+    // concurrent skip — it's NOT in nonRestDaysBeforeTarget but IS in
+    // priorSkipped, so it should be preserved as well. Days 1..6 sans
+    // 10 are bulk-skipped.
+    expect(payload['skippedDays']).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
   it('removeSkippedDay uses arrayRemove on skippedDays', async () => {

--- a/libs/data-access/src/lib/api/user-training-plan-api.service.spec.ts
+++ b/libs/data-access/src/lib/api/user-training-plan-api.service.spec.ts
@@ -200,6 +200,91 @@ describe('UserTrainingPlanApiService', () => {
     );
   });
 
+  it('addCompletedDay also clears the same day from skippedDays atomically', async () => {
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
+
+    const { fixture } = await render('', {
+      providers: [
+        UserTrainingPlanApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'u' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(
+      UserTrainingPlanApiService
+    );
+    service.addCompletedDay('u', 5).subscribe();
+
+    await Promise.resolve();
+    expect(firestoreFns.arrayUnion).toHaveBeenCalledWith(5);
+    expect(firestoreFns.arrayRemove).toHaveBeenCalledWith(5);
+    expect(firestoreFns.updateDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        completedDays: expect.objectContaining({ __type: 'arrayUnion' }),
+        skippedDays: expect.objectContaining({ __type: 'arrayRemove' }),
+      })
+    );
+  });
+
+  it('addSkippedDay adds to skippedDays and removes from completedDays atomically', async () => {
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
+
+    const { fixture } = await render('', {
+      providers: [
+        UserTrainingPlanApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'u' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(
+      UserTrainingPlanApiService
+    );
+    service.addSkippedDay('u', 7).subscribe();
+
+    await Promise.resolve();
+    expect(firestoreFns.arrayUnion).toHaveBeenCalledWith(7);
+    expect(firestoreFns.arrayRemove).toHaveBeenCalledWith(7);
+    expect(firestoreFns.updateDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        skippedDays: expect.objectContaining({ __type: 'arrayUnion' }),
+        completedDays: expect.objectContaining({ __type: 'arrayRemove' }),
+      })
+    );
+  });
+
+  it('removeSkippedDay uses arrayRemove on skippedDays', async () => {
+    (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
+
+    const { fixture } = await render('', {
+      providers: [
+        UserTrainingPlanApiService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Firestore, useValue: {} },
+        { provide: Auth, useValue: { currentUser: { uid: 'u' } } },
+      ],
+    });
+
+    const service = fixture.debugElement.injector.get(
+      UserTrainingPlanApiService
+    );
+    service.removeSkippedDay('u', 3).subscribe();
+
+    await Promise.resolve();
+    expect(firestoreFns.arrayRemove).toHaveBeenCalledWith(3);
+    expect(firestoreFns.updateDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        skippedDays: expect.objectContaining({ __type: 'arrayRemove' }),
+      })
+    );
+  });
+
   it('uses arrayRemove for removeCompletedDay', async () => {
     (firestoreFns.doc as jest.Mock).mockReturnValue({ id: 'u' });
 

--- a/libs/data-access/src/lib/api/user-training-plan-api.service.ts
+++ b/libs/data-access/src/lib/api/user-training-plan-api.service.ts
@@ -7,6 +7,7 @@ import {
   docData,
   DocumentReference,
   Firestore,
+  runTransaction,
   setDoc,
   updateDoc,
 } from '@angular/fire/firestore';
@@ -134,6 +135,59 @@ export class UserTrainingPlanApiService {
         skippedDays: arrayUnion(dayIndex),
         completedDays: arrayRemove(dayIndex),
         updatedAt: new Date().toISOString(),
+      })
+    ).pipe(map(() => void 0));
+  }
+
+  /**
+   * Atomic re-anchor: write `startDate` and a recomputed `skippedDays`
+   * inside a Firestore transaction so concurrent `arrayUnion` /
+   * `arrayRemove` writes from another tab can't be silently
+   * overwritten by the bulk-array replacement that this operation
+   * needs to perform.
+   *
+   * `nonRestDaysBeforeTarget` is the set of plan-day indexes
+   * `< targetDayIndex` whose `kind !== 'rest'`. The transaction reads
+   * the current `completedDays` from server state and:
+   * - keeps prior skips that still sit before the new cursor and
+   *   aren't completed,
+   * - bulk-skips every non-rest predecessor that isn't completed.
+   *
+   * Days already in `completedDays` are preserved as-is (even if they
+   * end up in the future relative to the new `startDate`).
+   */
+  jumpToDay(
+    userId: string,
+    args: {
+      newStartDate: string;
+      targetDayIndex: number;
+      nonRestDaysBeforeTarget: ReadonlyArray<number>;
+    }
+  ): Observable<void> {
+    const effectiveUserId = this.resolveUserId(userId);
+    if (!effectiveUserId || !this.firestore) return of(void 0);
+    const ref = this.docRef(effectiveUserId);
+    const firestore = this.firestore;
+    return from(
+      runTransaction(firestore, async (tx) => {
+        const snap = await tx.get(ref);
+        const data = (snap.data() as UserTrainingPlan | undefined) ?? null;
+        const completed = new Set<number>(data?.completedDays ?? []);
+        const priorSkipped: ReadonlyArray<number> = data?.skippedDays ?? [];
+        const preservedPriorSkips = priorSkipped.filter(
+          (idx) => idx < args.targetDayIndex && !completed.has(idx)
+        );
+        const newlySkipped = args.nonRestDaysBeforeTarget.filter(
+          (idx) => !completed.has(idx)
+        );
+        const skippedDays = Array.from(
+          new Set([...preservedPriorSkips, ...newlySkipped])
+        ).sort((x, y) => x - y);
+        tx.update(ref, {
+          startDate: args.newStartDate,
+          skippedDays,
+          updatedAt: new Date().toISOString(),
+        });
       })
     ).pipe(map(() => void 0));
   }

--- a/libs/data-access/src/lib/api/user-training-plan-api.service.ts
+++ b/libs/data-access/src/lib/api/user-training-plan-api.service.ts
@@ -94,9 +94,14 @@ export class UserTrainingPlanApiService {
     const effectiveUserId = this.resolveUserId(userId);
     if (!effectiveUserId || !this.firestore) return of(void 0);
     const ref = this.docRef(effectiveUserId);
+    // Marking done implicitly unskips: a day must be in at most one
+    // of `completedDays` / `skippedDays`. The arrayRemove on a value
+    // that isn't in the array is a no-op, so this is safe even when
+    // the day was never skipped.
     return from(
       updateDoc(ref, {
         completedDays: arrayUnion(dayIndex),
+        skippedDays: arrayRemove(dayIndex),
         updatedAt: new Date().toISOString(),
       })
     ).pipe(map(() => void 0));
@@ -109,6 +114,37 @@ export class UserTrainingPlanApiService {
     return from(
       updateDoc(ref, {
         completedDays: arrayRemove(dayIndex),
+        updatedAt: new Date().toISOString(),
+      })
+    ).pipe(map(() => void 0));
+  }
+
+  /**
+   * Atomic skip: add to `skippedDays` and remove from `completedDays`
+   * in one write so a day index can never appear in both arrays.
+   * Mixing `arrayUnion` and `arrayRemove` across two fields in a
+   * single `updateDoc` is supported by Firestore.
+   */
+  addSkippedDay(userId: string, dayIndex: number): Observable<void> {
+    const effectiveUserId = this.resolveUserId(userId);
+    if (!effectiveUserId || !this.firestore) return of(void 0);
+    const ref = this.docRef(effectiveUserId);
+    return from(
+      updateDoc(ref, {
+        skippedDays: arrayUnion(dayIndex),
+        completedDays: arrayRemove(dayIndex),
+        updatedAt: new Date().toISOString(),
+      })
+    ).pipe(map(() => void 0));
+  }
+
+  removeSkippedDay(userId: string, dayIndex: number): Observable<void> {
+    const effectiveUserId = this.resolveUserId(userId);
+    if (!effectiveUserId || !this.firestore) return of(void 0);
+    const ref = this.docRef(effectiveUserId);
+    return from(
+      updateDoc(ref, {
+        skippedDays: arrayRemove(dayIndex),
         updatedAt: new Date().toISOString(),
       })
     ).pipe(map(() => void 0));

--- a/libs/stats/src/lib/models/training-plan.models.spec.ts
+++ b/libs/stats/src/lib/models/training-plan.models.spec.ts
@@ -2,6 +2,7 @@ import {
   currentPlanDayIndex,
   isPlanCompleted,
   planDayByIndex,
+  startDateForTargetDay,
   TrainingPlan,
 } from './training-plan.models';
 import { findPlanById, TRAINING_PLANS } from './training-plan.catalog';
@@ -96,6 +97,45 @@ describe('training-plan models', () => {
     it('is false while any non-rest day is missing', () => {
       expect(isPlanCompleted(plan, [1, 4])).toBe(false);
       expect(isPlanCompleted(plan, [])).toBe(false);
+    });
+
+    it('treats skipped non-rest days as not required', () => {
+      // Day 3 skipped → only 1 and 4 are required.
+      expect(isPlanCompleted(plan, [1, 4], [3])).toBe(true);
+    });
+
+    it('returns false when every working day is skipped (nothing to finish)', () => {
+      expect(isPlanCompleted(plan, [], [1, 3, 4])).toBe(false);
+    });
+  });
+
+  describe('startDateForTargetDay', () => {
+    it('returns today for targetDay === 1', () => {
+      expect(startDateForTargetDay(30, 1, '2026-04-15')).toBe('2026-04-15');
+    });
+
+    it('returns today minus (target-1) days for later targets', () => {
+      expect(startDateForTargetDay(30, 8, '2026-04-15')).toBe('2026-04-08');
+    });
+
+    it('crosses month boundaries', () => {
+      // 2026-05-02 - 5 days = 2026-04-27
+      expect(startDateForTargetDay(30, 6, '2026-05-02')).toBe('2026-04-27');
+    });
+
+    it('crosses year boundaries', () => {
+      // 2026-01-02 - 5 days = 2025-12-28
+      expect(startDateForTargetDay(30, 6, '2026-01-02')).toBe('2025-12-28');
+    });
+
+    it('returns null for out-of-range targets', () => {
+      expect(startDateForTargetDay(30, 0, '2026-04-15')).toBeNull();
+      expect(startDateForTargetDay(30, 31, '2026-04-15')).toBeNull();
+      expect(startDateForTargetDay(30, -1, '2026-04-15')).toBeNull();
+    });
+
+    it('returns null on malformed today', () => {
+      expect(startDateForTargetDay(30, 1, 'nope')).toBeNull();
     });
   });
 

--- a/libs/stats/src/lib/models/training-plan.models.ts
+++ b/libs/stats/src/lib/models/training-plan.models.ts
@@ -85,12 +85,24 @@ export interface UserTrainingPlan {
    * skipped days.
    */
   completedDays: number[];
+  /**
+   * Day indexes the user has chosen to skip (e.g. via `jumpToDay` or
+   * an explicit per-day skip action). Skipped days are excluded from
+   * both the completion percent denominator and the `isPlanCompleted`
+   * required-set, so the user can still finish a plan after missing
+   * days. Mutually exclusive with `completedDays` — a day index is in
+   * at most one of the two arrays.
+   */
+  skippedDays?: number[];
   createdAt?: string;
   updatedAt?: string;
 }
 
 export type UserTrainingPlanUpdate = Partial<
-  Pick<UserTrainingPlan, 'planId' | 'startDate' | 'status' | 'completedDays'>
+  Pick<
+    UserTrainingPlan,
+    'planId' | 'startDate' | 'status' | 'completedDays' | 'skippedDays'
+  >
 >;
 
 /**
@@ -123,16 +135,48 @@ export function planDayByIndex(
   return plan.days.find((d) => d.dayIndex === dayIndex) ?? null;
 }
 
-/** Returns true once every non-rest day is in `completedDays`. */
+/**
+ * Returns true once every non-rest, non-skipped day is in
+ * `completedDays`. A plan with every working day skipped is NOT
+ * considered completed — that would mark "did nothing" as a finished
+ * plan, which is not the contract `isPlanCompleted` is meant to
+ * satisfy (used for the dashboard "Plan abgeschlossen" badge).
+ */
 export function isPlanCompleted(
   plan: Pick<TrainingPlan, 'days'>,
-  completedDays: ReadonlyArray<number>
+  completedDays: ReadonlyArray<number>,
+  skippedDays: ReadonlyArray<number> = []
 ): boolean {
+  const skipped = new Set(skippedDays);
   const required = plan.days
-    .filter((d) => d.kind !== 'rest')
+    .filter((d) => d.kind !== 'rest' && !skipped.has(d.dayIndex))
     .map((d) => d.dayIndex);
   if (required.length === 0) return false;
   return required.every((idx) => completedDays.includes(idx));
+}
+
+/**
+ * 1-based day index that `jumpToDay` should re-anchor `startDate` to
+ * for a given target day and "today". Returns the ISO date the
+ * `UserTrainingPlan.startDate` field should be set to so that
+ * `currentPlanDayIndex(plan, result, today) === targetDayIndex`.
+ *
+ * Returns `null` for an out-of-range target. Does not mutate.
+ */
+export function startDateForTargetDay(
+  totalDays: number,
+  targetDayIndex: number,
+  today: string
+): string | null {
+  if (targetDayIndex < 1 || targetDayIndex > totalDays) return null;
+  const now = parseIsoDate(today);
+  if (!now) return null;
+  const start = new Date(now);
+  start.setDate(now.getDate() - (targetDayIndex - 1));
+  const y = start.getFullYear();
+  const m = String(start.getMonth() + 1).padStart(2, '0');
+  const d = String(start.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
 function parseIsoDate(value: string): Date | null {

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -289,68 +289,70 @@ interface DayRow {
                     }
                   </div>
                   <div class="day-actions">
-                    @if (isThisPlanActive() && row.day.kind !== 'rest') {
-                      @if (row.isCompleted) {
-                        <button
-                          mat-icon-button
-                          (click)="unmark(row.day.dayIndex)"
-                          aria-label="Als nicht erledigt markieren"
-                          i18n-aria-label="@@trainingPlans.unmarkAria"
-                        >
-                          <mat-icon>check_circle</mat-icon>
-                        </button>
-                      } @else if (row.isSkipped) {
-                        <button
-                          mat-icon-button
-                          (click)="unskip(row.day.dayIndex)"
-                          aria-label="Übersprungen rückgängig"
-                          i18n-aria-label="@@trainingPlans.unskipAria"
-                          matTooltip="Übersprungen rückgängig"
-                          i18n-matTooltip="@@trainingPlans.unskipTooltip"
-                        >
-                          <mat-icon>redo</mat-icon>
-                        </button>
-                      } @else {
-                        @if (row.day.targetReps > 0) {
+                    @if (isThisPlanActive()) {
+                      @if (row.day.kind !== 'rest') {
+                        @if (row.isCompleted) {
                           <button
                             mat-icon-button
-                            color="primary"
-                            (click)="logPlanDay(row.day.dayIndex)"
-                            aria-label="Plan-Sätze eintragen und als erledigt markieren"
-                            i18n-aria-label="@@trainingPlans.logAria"
+                            (click)="unmark(row.day.dayIndex)"
+                            aria-label="Als nicht erledigt markieren"
+                            i18n-aria-label="@@trainingPlans.unmarkAria"
                           >
-                            <mat-icon>play_circle</mat-icon>
+                            <mat-icon>check_circle</mat-icon>
                           </button>
-                        }
-                        <button
-                          mat-icon-button
-                          (click)="mark(row.day.dayIndex)"
-                          aria-label="Nur als erledigt markieren (ohne Eintrag)"
-                          i18n-aria-label="@@trainingPlans.markAria"
-                        >
-                          <mat-icon>radio_button_unchecked</mat-icon>
-                        </button>
-                        @if (!row.isToday) {
+                        } @else if (row.isSkipped) {
                           <button
                             mat-icon-button
-                            (click)="jumpToDay(row.day.dayIndex)"
-                            aria-label="Zu diesem Tag springen"
-                            i18n-aria-label="@@trainingPlans.jumpAria"
-                            matTooltip="Zu diesem Tag springen"
-                            i18n-matTooltip="@@trainingPlans.jumpTooltip"
+                            (click)="unskip(row.day.dayIndex)"
+                            aria-label="Überspringen rückgängig machen"
+                            i18n-aria-label="@@trainingPlans.unskipAria"
+                            matTooltip="Überspringen rückgängig machen"
+                            i18n-matTooltip="@@trainingPlans.unskipTooltip"
                           >
-                            <mat-icon>fast_forward</mat-icon>
+                            <mat-icon>redo</mat-icon>
+                          </button>
+                        } @else {
+                          @if (row.day.targetReps > 0) {
+                            <button
+                              mat-icon-button
+                              color="primary"
+                              (click)="logPlanDay(row.day.dayIndex)"
+                              aria-label="Plan-Sätze eintragen und als erledigt markieren"
+                              i18n-aria-label="@@trainingPlans.logAria"
+                            >
+                              <mat-icon>play_circle</mat-icon>
+                            </button>
+                          }
+                          <button
+                            mat-icon-button
+                            (click)="mark(row.day.dayIndex)"
+                            aria-label="Nur als erledigt markieren (ohne Eintrag)"
+                            i18n-aria-label="@@trainingPlans.markAria"
+                          >
+                            <mat-icon>radio_button_unchecked</mat-icon>
+                          </button>
+                          <button
+                            mat-icon-button
+                            (click)="skip(row.day.dayIndex)"
+                            aria-label="Tag überspringen"
+                            i18n-aria-label="@@trainingPlans.skipAria"
+                            matTooltip="Tag überspringen"
+                            i18n-matTooltip="@@trainingPlans.skipTooltip"
+                          >
+                            <mat-icon>skip_next</mat-icon>
                           </button>
                         }
+                      }
+                      @if (!row.isToday) {
                         <button
                           mat-icon-button
-                          (click)="skip(row.day.dayIndex)"
-                          aria-label="Tag überspringen"
-                          i18n-aria-label="@@trainingPlans.skipAria"
-                          matTooltip="Tag überspringen"
-                          i18n-matTooltip="@@trainingPlans.skipTooltip"
+                          (click)="jumpToDay(row.day.dayIndex)"
+                          aria-label="Zu diesem Tag springen"
+                          i18n-aria-label="@@trainingPlans.jumpAria"
+                          matTooltip="Zu diesem Tag springen"
+                          i18n-matTooltip="@@trainingPlans.jumpTooltip"
                         >
-                          <mat-icon>skip_next</mat-icon>
+                          <mat-icon>fast_forward</mat-icon>
                         </button>
                       }
                     }

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -42,6 +42,7 @@ interface DayRow {
   weekIndex: number;
   isToday: boolean;
   isCompleted: boolean;
+  isSkipped: boolean;
   isFuture: boolean;
   pushupTypes: ReadonlyArray<PushupTypeChip>;
 }
@@ -213,6 +214,7 @@ interface DayRow {
                   [attr.id]="'day-' + row.day.dayIndex"
                   [class.today]="row.isToday"
                   [class.done]="row.isCompleted"
+                  [class.skipped]="row.isSkipped"
                   [class.future]="row.isFuture"
                 >
                   <div class="day-num">
@@ -297,6 +299,17 @@ interface DayRow {
                         >
                           <mat-icon>check_circle</mat-icon>
                         </button>
+                      } @else if (row.isSkipped) {
+                        <button
+                          mat-icon-button
+                          (click)="unskip(row.day.dayIndex)"
+                          aria-label="Übersprungen rückgängig"
+                          i18n-aria-label="@@trainingPlans.unskipAria"
+                          matTooltip="Übersprungen rückgängig"
+                          i18n-matTooltip="@@trainingPlans.unskipTooltip"
+                        >
+                          <mat-icon>redo</mat-icon>
+                        </button>
                       } @else {
                         @if (row.day.targetReps > 0) {
                           <button
@@ -316,6 +329,28 @@ interface DayRow {
                           i18n-aria-label="@@trainingPlans.markAria"
                         >
                           <mat-icon>radio_button_unchecked</mat-icon>
+                        </button>
+                        @if (!row.isToday) {
+                          <button
+                            mat-icon-button
+                            (click)="jumpToDay(row.day.dayIndex)"
+                            aria-label="Zu diesem Tag springen"
+                            i18n-aria-label="@@trainingPlans.jumpAria"
+                            matTooltip="Zu diesem Tag springen"
+                            i18n-matTooltip="@@trainingPlans.jumpTooltip"
+                          >
+                            <mat-icon>fast_forward</mat-icon>
+                          </button>
+                        }
+                        <button
+                          mat-icon-button
+                          (click)="skip(row.day.dayIndex)"
+                          aria-label="Tag überspringen"
+                          i18n-aria-label="@@trainingPlans.skipAria"
+                          matTooltip="Tag überspringen"
+                          i18n-matTooltip="@@trainingPlans.skipTooltip"
+                        >
+                          <mat-icon>skip_next</mat-icon>
                         </button>
                       }
                     }
@@ -442,6 +477,14 @@ interface DayRow {
       }
       .day-row.future {
         opacity: 0.85;
+      }
+      .day-row.skipped {
+        opacity: 0.55;
+      }
+      .day-row.skipped .day-num,
+      .day-row.skipped .day-title,
+      .day-row.skipped .day-desc {
+        text-decoration: line-through;
       }
       .day-num {
         text-align: center;
@@ -637,6 +680,9 @@ export class TrainingPlanDetailComponent {
     const completed = this.isThisPlanActive()
       ? new Set(this.store.activePlan()?.completedDays ?? [])
       : new Set<number>();
+    const skipped = this.isThisPlanActive()
+      ? new Set(this.store.activePlan()?.skippedDays ?? [])
+      : new Set<number>();
 
     const grouped = new Map<number, DayRow[]>();
     for (const day of plan.days) {
@@ -647,6 +693,7 @@ export class TrainingPlanDetailComponent {
         weekIndex,
         isToday,
         isCompleted: completed.has(day.dayIndex),
+        isSkipped: skipped.has(day.dayIndex),
         isFuture: currentDay !== null && day.dayIndex > currentDay,
         pushupTypes: this.pushupTypeChipsForDay(day),
       };
@@ -722,6 +769,28 @@ export class TrainingPlanDetailComponent {
 
   async unmark(dayIndex: number): Promise<void> {
     await this.store.unmarkDayDone(dayIndex);
+  }
+
+  async skip(dayIndex: number): Promise<void> {
+    await this.store.skipDay(dayIndex);
+    this.snackbar.open(
+      $localize`:@@trainingPlans.skipped:Tag übersprungen.`,
+      undefined,
+      { duration: 2000 }
+    );
+  }
+
+  async unskip(dayIndex: number): Promise<void> {
+    await this.store.unskipDay(dayIndex);
+  }
+
+  async jumpToDay(dayIndex: number): Promise<void> {
+    await this.store.jumpToDay(dayIndex);
+    this.snackbar.open(
+      $localize`:@@trainingPlans.jumped:Auf Tag ${dayIndex}:INTERPOLATION: gesprungen.`,
+      undefined,
+      { duration: 2500 }
+    );
   }
 
   async logPlanDay(dayIndex: number): Promise<void> {

--- a/web/src/app/training-plans/training-plan.store.spec.ts
+++ b/web/src/app/training-plans/training-plan.store.spec.ts
@@ -29,6 +29,7 @@ interface Mocks {
     removeCompletedDay: ReturnType<typeof vitest.fn>;
     addSkippedDay: ReturnType<typeof vitest.fn>;
     removeSkippedDay: ReturnType<typeof vitest.fn>;
+    jumpToDay: ReturnType<typeof vitest.fn>;
   };
   statsApiMock: {
     createPushup: ReturnType<typeof vitest.fn>;
@@ -132,6 +133,39 @@ describe('TrainingPlanStore', () => {
           }
           return of(void 0);
         }),
+        // Mirrors the production transaction: reads the current
+        // completedDays/skippedDays and rewrites both startDate and
+        // skippedDays in one write. Tests rely on this matching the
+        // documented invariants.
+        jumpToDay: vitest.fn(
+          (
+            _uid: string,
+            args: {
+              newStartDate: string;
+              targetDayIndex: number;
+              nonRestDaysBeforeTarget: ReadonlyArray<number>;
+            }
+          ) => {
+            const cur = mocks.current as UserTrainingPlan;
+            const completed = new Set(cur.completedDays);
+            const preservedPriorSkips = (cur.skippedDays ?? []).filter(
+              (idx) => idx < args.targetDayIndex && !completed.has(idx)
+            );
+            const newlySkipped = args.nonRestDaysBeforeTarget.filter(
+              (idx) => !completed.has(idx)
+            );
+            const skippedDays = Array.from(
+              new Set([...preservedPriorSkips, ...newlySkipped])
+            ).sort((x, y) => x - y);
+            mocks.current = {
+              ...cur,
+              startDate: args.newStartDate,
+              skippedDays,
+            };
+            stream.next(mocks.current);
+            return of(void 0);
+          }
+        ),
       },
       statsApiMock: {
         createPushup: vitest.fn((payload: PushupCreate) =>
@@ -817,7 +851,7 @@ describe('TrainingPlanStore', () => {
       await store.jumpToDay(8);
       await flush();
 
-      expect(mocks.apiMock.updatePlan).toHaveBeenCalled();
+      expect(mocks.apiMock.jumpToDay).toHaveBeenCalled();
       // The new startDate should make currentDayIndex return 8.
       expect(store.currentDayIndex()).toBe(8);
     });
@@ -857,17 +891,20 @@ describe('TrainingPlanStore', () => {
       }
     });
 
-    it('drops prior skips that are now in the future after a backward jump', async () => {
+    it('drops prior skips that are now in the future after a backward jump and preserves future-completed days', async () => {
       // Start the plan so today is plan-day 12, with day 5 previously
-      // skipped. Jump back to day 3 → day 5 is now in the future and
-      // should be removed from skippedDays so the user can re-do it.
+      // skipped and day 10 previously completed. Jump back to day 3:
+      // - day 5 is now in the future → should be removed from
+      //   skippedDays so the user can re-do it,
+      // - day 10 stays completed even though it's now in the future
+      //   (jumpToDay never strips completedDays).
       const startDate = toBerlinIsoDate(new Date(Date.now() - 11 * 86_400_000));
       const { store } = setup({
         userId: 'u1',
         planId: PLAN.id,
         startDate,
         status: 'active',
-        completedDays: [],
+        completedDays: [10],
         skippedDays: [5],
       });
       await flush();
@@ -878,6 +915,8 @@ describe('TrainingPlanStore', () => {
 
       const skipped = new Set(store.activePlan()?.skippedDays ?? []);
       expect(skipped.has(5)).toBe(false);
+      // Completed days that are now in the future stay completed.
+      expect(store.activePlan()?.completedDays).toContain(10);
       expect(store.currentDayIndex()).toBe(3);
     });
 
@@ -896,7 +935,7 @@ describe('TrainingPlanStore', () => {
       await store.jumpToDay(PLAN.totalDays + 1);
       await flush();
 
-      expect(mocks.apiMock.updatePlan).not.toHaveBeenCalled();
+      expect(mocks.apiMock.jumpToDay).not.toHaveBeenCalled();
     });
   });
 

--- a/web/src/app/training-plans/training-plan.store.spec.ts
+++ b/web/src/app/training-plans/training-plan.store.spec.ts
@@ -27,6 +27,8 @@ interface Mocks {
     updatePlan: ReturnType<typeof vitest.fn>;
     addCompletedDay: ReturnType<typeof vitest.fn>;
     removeCompletedDay: ReturnType<typeof vitest.fn>;
+    addSkippedDay: ReturnType<typeof vitest.fn>;
+    removeSkippedDay: ReturnType<typeof vitest.fn>;
   };
   statsApiMock: {
     createPushup: ReturnType<typeof vitest.fn>;
@@ -74,11 +76,16 @@ describe('TrainingPlanStore', () => {
         ),
         addCompletedDay: vitest.fn((_uid: string, dayIndex: number) => {
           const cur = mocks.current as UserTrainingPlan;
-          if (!cur.completedDays.includes(dayIndex)) {
+          const completedHas = cur.completedDays.includes(dayIndex);
+          const skippedHas = (cur.skippedDays ?? []).includes(dayIndex);
+          if (!completedHas || skippedHas) {
             mocks.current = {
               ...cur,
-              completedDays: [...cur.completedDays, dayIndex].sort(
-                (x, y) => x - y
+              completedDays: completedHas
+                ? cur.completedDays
+                : [...cur.completedDays, dayIndex].sort((x, y) => x - y),
+              skippedDays: (cur.skippedDays ?? []).filter(
+                (d) => d !== dayIndex
               ),
             };
             stream.next(mocks.current);
@@ -91,6 +98,35 @@ describe('TrainingPlanStore', () => {
             mocks.current = {
               ...cur,
               completedDays: cur.completedDays.filter((d) => d !== dayIndex),
+            };
+            stream.next(mocks.current);
+          }
+          return of(void 0);
+        }),
+        addSkippedDay: vitest.fn((_uid: string, dayIndex: number) => {
+          const cur = mocks.current as UserTrainingPlan;
+          const skippedHas = (cur.skippedDays ?? []).includes(dayIndex);
+          const completedHas = cur.completedDays.includes(dayIndex);
+          if (!skippedHas || completedHas) {
+            mocks.current = {
+              ...cur,
+              completedDays: cur.completedDays.filter((d) => d !== dayIndex),
+              skippedDays: skippedHas
+                ? (cur.skippedDays ?? [])
+                : [...(cur.skippedDays ?? []), dayIndex].sort((x, y) => x - y),
+            };
+            stream.next(mocks.current);
+          }
+          return of(void 0);
+        }),
+        removeSkippedDay: vitest.fn((_uid: string, dayIndex: number) => {
+          const cur = mocks.current as UserTrainingPlan;
+          if ((cur.skippedDays ?? []).includes(dayIndex)) {
+            mocks.current = {
+              ...cur,
+              skippedDays: (cur.skippedDays ?? []).filter(
+                (d) => d !== dayIndex
+              ),
             };
             stream.next(mocks.current);
           }
@@ -638,6 +674,229 @@ describe('TrainingPlanStore', () => {
 
       // Tear down the implicit setInterval started by withHooks.
       TestBed.resetTestingModule();
+    });
+  });
+
+  describe('skipDay / unskipDay', () => {
+    it('skipDay records the index in skippedDays', async () => {
+      const today = toBerlinIsoDate(new Date());
+      const { store, mocks } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate: today,
+        status: 'active',
+        completedDays: [],
+      });
+      await flush();
+
+      // Day 2 is a non-rest day in challenge-30d.
+      await store.skipDay(2);
+      await flush();
+
+      expect(mocks.apiMock.addSkippedDay).toHaveBeenCalledWith('u1', 2);
+      expect(store.activePlan()?.skippedDays).toContain(2);
+    });
+
+    it('skipDay removes the index from completedDays so a day is in at most one array', async () => {
+      const today = toBerlinIsoDate(new Date());
+      const { store } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate: today,
+        status: 'active',
+        completedDays: [2, 3],
+      });
+      await flush();
+
+      await store.skipDay(2);
+      await flush();
+
+      expect(store.activePlan()?.completedDays).not.toContain(2);
+      expect(store.activePlan()?.skippedDays).toContain(2);
+    });
+
+    it('skipDay is a no-op for rest days', async () => {
+      const today = toBerlinIsoDate(new Date());
+      const { store, mocks } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate: today,
+        status: 'active',
+        completedDays: [],
+      });
+      await flush();
+
+      const restDay = PLAN.days.find((d) => d.kind === 'rest');
+      if (!restDay) throw new Error('catalog invariant: rest day exists');
+
+      await store.skipDay(restDay.dayIndex);
+      await flush();
+
+      expect(mocks.apiMock.addSkippedDay).not.toHaveBeenCalled();
+    });
+
+    it('unskipDay removes the index from skippedDays', async () => {
+      const today = toBerlinIsoDate(new Date());
+      const { store, mocks } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate: today,
+        status: 'active',
+        completedDays: [],
+        skippedDays: [2, 3],
+      });
+      await flush();
+
+      await store.unskipDay(2);
+      await flush();
+
+      expect(mocks.apiMock.removeSkippedDay).toHaveBeenCalledWith('u1', 2);
+      expect(store.activePlan()?.skippedDays).toEqual([3]);
+    });
+
+    it('marking a previously-skipped day done auto-unskips it', async () => {
+      const today = toBerlinIsoDate(new Date());
+      const { store } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate: today,
+        status: 'active',
+        completedDays: [],
+        skippedDays: [2],
+      });
+      await flush();
+
+      await store.markDayDone(2);
+      await flush();
+
+      // The mock for addCompletedDay mirrors the API: it strips the
+      // index from skippedDays so the invariant holds.
+      expect(store.activePlan()?.skippedDays).not.toContain(2);
+      expect(store.activePlan()?.completedDays).toContain(2);
+    });
+  });
+
+  describe('completionPercent with skippedDays', () => {
+    it('excludes skipped days from the denominator', async () => {
+      const today = toBerlinIsoDate(new Date());
+      const allNonRest = PLAN.days
+        .filter((d) => d.kind !== 'rest')
+        .map((d) => d.dayIndex);
+      const skipIdx = allNonRest[0];
+      const completedRest = allNonRest.slice(1);
+
+      const { store } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate: today,
+        status: 'active',
+        completedDays: completedRest,
+        skippedDays: [skipIdx],
+      });
+      await flush();
+
+      // All remaining required days completed → 100%.
+      expect(store.completionPercent()).toBe(100);
+    });
+  });
+
+  describe('jumpToDay', () => {
+    it('re-anchors startDate so today maps to the target day', async () => {
+      // Start a 30-day plan today, then jump to day 8.
+      const today = toBerlinIsoDate(new Date());
+      const { store, mocks } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate: today,
+        status: 'active',
+        completedDays: [],
+      });
+      await flush();
+      expect(store.currentDayIndex()).toBe(1);
+
+      await store.jumpToDay(8);
+      await flush();
+
+      expect(mocks.apiMock.updatePlan).toHaveBeenCalled();
+      // The new startDate should make currentDayIndex return 8.
+      expect(store.currentDayIndex()).toBe(8);
+    });
+
+    it('marks intervening non-rest, non-completed days as skipped', async () => {
+      const today = toBerlinIsoDate(new Date());
+      const { store } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate: today,
+        status: 'active',
+        // Day 2 already done — should NOT end up skipped.
+        completedDays: [2],
+      });
+      await flush();
+
+      await store.jumpToDay(8);
+      await flush();
+
+      const skipped = new Set(store.activePlan()?.skippedDays ?? []);
+      // Day 2 stays completed.
+      expect(skipped.has(2)).toBe(false);
+      expect(store.activePlan()?.completedDays).toContain(2);
+      // Every other non-rest day in 1..7 should be skipped.
+      for (const day of PLAN.days) {
+        if (day.dayIndex >= 8) break;
+        if (day.kind === 'rest') continue;
+        if (day.dayIndex === 2) continue;
+        expect(skipped.has(day.dayIndex)).toBe(true);
+      }
+      // Rest days never end up in skippedDays.
+      const restIndexesBefore8 = PLAN.days
+        .filter((d) => d.dayIndex < 8 && d.kind === 'rest')
+        .map((d) => d.dayIndex);
+      for (const restIdx of restIndexesBefore8) {
+        expect(skipped.has(restIdx)).toBe(false);
+      }
+    });
+
+    it('drops prior skips that are now in the future after a backward jump', async () => {
+      // Start the plan so today is plan-day 12, with day 5 previously
+      // skipped. Jump back to day 3 → day 5 is now in the future and
+      // should be removed from skippedDays so the user can re-do it.
+      const startDate = toBerlinIsoDate(new Date(Date.now() - 11 * 86_400_000));
+      const { store } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate,
+        status: 'active',
+        completedDays: [],
+        skippedDays: [5],
+      });
+      await flush();
+      expect(store.currentDayIndex()).toBe(12);
+
+      await store.jumpToDay(3);
+      await flush();
+
+      const skipped = new Set(store.activePlan()?.skippedDays ?? []);
+      expect(skipped.has(5)).toBe(false);
+      expect(store.currentDayIndex()).toBe(3);
+    });
+
+    it('rejects out-of-range targets', async () => {
+      const today = toBerlinIsoDate(new Date());
+      const { store, mocks } = setup({
+        userId: 'u1',
+        planId: PLAN.id,
+        startDate: today,
+        status: 'active',
+        completedDays: [],
+      });
+      await flush();
+
+      await store.jumpToDay(0);
+      await store.jumpToDay(PLAN.totalDays + 1);
+      await flush();
+
+      expect(mocks.apiMock.updatePlan).not.toHaveBeenCalled();
     });
   });
 

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -482,9 +482,11 @@ export const TrainingPlanStore = signalStore(
      * - Days that were previously skipped but are now `>= targetDay`
      *   are removed from `skippedDays` so re-doing them is possible.
      *
-     * Writes via `updatePlan` so `startDate` and `skippedDays` change
-     * in a single doc write — partial state (new startDate without
-     * the skip backfill) would mis-render the progress bar.
+     * Delegates to `_api.jumpToDay`, which runs a Firestore
+     * transaction. Recomputing `skippedDays` from the local snapshot
+     * and writing it via `setDoc({merge:true})` would silently drop
+     * concurrent `arrayUnion`/`arrayRemove` skip writes from another
+     * tab/device, since `merge: true` does not field-merge arrays.
      */
     async jumpToDay(targetDayIndex: number): Promise<void> {
       const a = store.activePlan();
@@ -500,31 +502,16 @@ export const TrainingPlanStore = signalStore(
       );
       if (!newStartDate) return;
 
-      const completed = new Set(a.completedDays);
-      // Days strictly before `targetDayIndex` that the user hasn't
-      // completed and aren't rest get marked skipped. Existing skips
-      // that still sit before the cursor stay skipped.
-      const newlySkipped = c.days
-        .filter(
-          (d) =>
-            d.dayIndex < targetDayIndex &&
-            d.kind !== 'rest' &&
-            !completed.has(d.dayIndex)
-        )
+      const nonRestDaysBeforeTarget = c.days
+        .filter((d) => d.dayIndex < targetDayIndex && d.kind !== 'rest')
         .map((d) => d.dayIndex);
-      // Drop any prior skips that are now in the future (>= target).
-      const preservedPriorSkips = (a.skippedDays ?? []).filter(
-        (idx) => idx < targetDayIndex && !completed.has(idx)
-      );
-      const skippedDays = Array.from(
-        new Set([...preservedPriorSkips, ...newlySkipped])
-      ).sort((x, y) => x - y);
 
       const userId = store._user.userIdSafe();
       await firstValueFrom(
-        store._api.updatePlan(userId, {
-          startDate: newStartDate,
-          skippedDays,
+        store._api.jumpToDay(userId, {
+          newStartDate,
+          targetDayIndex,
+          nonRestDaysBeforeTarget,
         })
       );
       store.activeResource.reload();

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -27,6 +27,7 @@ import {
   findPlanById,
   isPlanCompleted,
   planDayByIndex,
+  startDateForTargetDay,
   toBerlinIsoDate,
   toLocalIsoDate,
   TrainingPlan,
@@ -135,23 +136,33 @@ export const TrainingPlanStore = signalStore(
       return a.completedDays.includes(idx);
     });
 
+    const todaySkipped = computed(() => {
+      const idx = currentDayIndex();
+      const a = activePlan();
+      if (!a || idx === null) return false;
+      return (a.skippedDays ?? []).includes(idx);
+    });
+
     const completionPercent = computed(() => {
       const a = activePlan();
       const c = activeCatalog();
       if (!a || !c) return 0;
-      const nonRestDayIndexes = new Set(
-        c.days.filter((d) => d.kind !== 'rest').map((d) => d.dayIndex)
+      const skipped = new Set(a.skippedDays ?? []);
+      const requiredDayIndexes = new Set(
+        c.days
+          .filter((d) => d.kind !== 'rest' && !skipped.has(d.dayIndex))
+          .map((d) => d.dayIndex)
       );
-      if (nonRestDayIndexes.size === 0) return 0;
-      // Filter `completedDays` to only count non-rest days. Rest-day
-      // entries can otherwise leak progress > 100% (e.g. via direct
-      // API writes or future UI changes that mark rest days done).
-      const completedNonRest = a.completedDays.filter((idx) =>
-        nonRestDayIndexes.has(idx)
+      if (requiredDayIndexes.size === 0) return 0;
+      // Only count non-rest, non-skipped days. Rest-day or skipped-day
+      // entries leaking into `completedDays` would otherwise skew
+      // progress > 100%.
+      const completedRequired = a.completedDays.filter((idx) =>
+        requiredDayIndexes.has(idx)
       ).length;
       return Math.min(
         100,
-        Math.round((completedNonRest / nonRestDayIndexes.size) * 100)
+        Math.round((completedRequired / requiredDayIndexes.size) * 100)
       );
     });
 
@@ -159,7 +170,7 @@ export const TrainingPlanStore = signalStore(
       const a = activePlan();
       const c = activeCatalog();
       if (!a || !c) return false;
-      return isPlanCompleted(c, a.completedDays);
+      return isPlanCompleted(c, a.completedDays, a.skippedDays ?? []);
     });
 
     /**
@@ -197,6 +208,7 @@ export const TrainingPlanStore = signalStore(
       todayDay,
       todayTarget,
       todayDone,
+      todaySkipped,
       completionPercent,
       isCompleted,
       hasActivePlan,
@@ -284,6 +296,7 @@ export const TrainingPlanStore = signalStore(
           startDate: toBerlinIsoDate(new Date()),
           status: 'active',
           completedDays: [],
+          skippedDays: [],
         })
       );
       store.activeResource.reload();
@@ -419,6 +432,101 @@ export const TrainingPlanStore = signalStore(
       if (!a.completedDays.includes(dayIndex)) return;
       const userId = store._user.userIdSafe();
       await firstValueFrom(store._api.removeCompletedDay(userId, dayIndex));
+      store.activeResource.reload();
+    },
+
+    /**
+     * Mark a plan day as skipped (user chose not to do it). Skipped
+     * days are excluded from the completion percent denominator and
+     * the `isPlanCompleted` required-set.
+     *
+     * Idempotent on the skip side. Mutually exclusive with
+     * `completedDays`: the API atomically removes the same index from
+     * `completedDays` so a day can never be in both arrays.
+     *
+     * No-op for rest days (already excluded from progress) and for
+     * out-of-range indexes.
+     */
+    async skipDay(dayIndex: number): Promise<void> {
+      const a = store.activePlan();
+      const c = store.activeCatalog();
+      if (!a || !c) return;
+      const day = planDayByIndex(c, dayIndex);
+      if (!day || day.kind === 'rest') return;
+      if ((a.skippedDays ?? []).includes(dayIndex)) return;
+      const userId = store._user.userIdSafe();
+      await firstValueFrom(store._api.addSkippedDay(userId, dayIndex));
+      store.activeResource.reload();
+    },
+
+    /** Undo a skip. */
+    async unskipDay(dayIndex: number): Promise<void> {
+      const a = store.activePlan();
+      if (!a) return;
+      if (!(a.skippedDays ?? []).includes(dayIndex)) return;
+      const userId = store._user.userIdSafe();
+      await firstValueFrom(store._api.removeSkippedDay(userId, dayIndex));
+      store.activeResource.reload();
+    },
+
+    /**
+     * Re-anchor the plan so today maps to `targetDayIndex`. Adjusts
+     * `startDate` accordingly and bulk-marks all earlier non-rest,
+     * non-completed days as skipped so progress reflects "I jumped
+     * over these" rather than counting them as still-pending.
+     *
+     * - `targetDayIndex` must be in `[1, totalDays]` — otherwise
+     *   no-op.
+     * - Days already in `completedDays` stay completed even if they're
+     *   now in the future relative to the new `startDate`.
+     * - Days that were previously skipped but are now `>= targetDay`
+     *   are removed from `skippedDays` so re-doing them is possible.
+     *
+     * Writes via `updatePlan` so `startDate` and `skippedDays` change
+     * in a single doc write — partial state (new startDate without
+     * the skip backfill) would mis-render the progress bar.
+     */
+    async jumpToDay(targetDayIndex: number): Promise<void> {
+      const a = store.activePlan();
+      const c = store.activeCatalog();
+      if (!a || !c || a.status !== 'active') return;
+      if (targetDayIndex < 1 || targetDayIndex > c.totalDays) return;
+
+      const today = toBerlinIsoDate(new Date());
+      const newStartDate = startDateForTargetDay(
+        c.totalDays,
+        targetDayIndex,
+        today
+      );
+      if (!newStartDate) return;
+
+      const completed = new Set(a.completedDays);
+      // Days strictly before `targetDayIndex` that the user hasn't
+      // completed and aren't rest get marked skipped. Existing skips
+      // that still sit before the cursor stay skipped.
+      const newlySkipped = c.days
+        .filter(
+          (d) =>
+            d.dayIndex < targetDayIndex &&
+            d.kind !== 'rest' &&
+            !completed.has(d.dayIndex)
+        )
+        .map((d) => d.dayIndex);
+      // Drop any prior skips that are now in the future (>= target).
+      const preservedPriorSkips = (a.skippedDays ?? []).filter(
+        (idx) => idx < targetDayIndex && !completed.has(idx)
+      );
+      const skippedDays = Array.from(
+        new Set([...preservedPriorSkips, ...newlySkipped])
+      ).sort((x, y) => x - y);
+
+      const userId = store._user.userIdSafe();
+      await firstValueFrom(
+        store._api.updatePlan(userId, {
+          startDate: newStartDate,
+          skippedDays,
+        })
+      );
       store.activeResource.reload();
     },
 

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -6124,13 +6124,13 @@
     </unit>
     <unit id="trainingPlans.unskipAria">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Αναίρεση παράλειψης</target>
       </segment>
     </unit>
     <unit id="trainingPlans.unskipTooltip">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Αναίρεση παράλειψης</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -6110,6 +6110,54 @@
         <target>Επισήμανση ως μη ολοκληρωμένη</target>
       </segment>
     </unit>
+    <unit id="trainingPlans.skipAria">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Παράλειψη ημέρας</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipTooltip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Παράλειψη ημέρας</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipAria">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Αναίρεση παράλειψης</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipTooltip">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Αναίρεση παράλειψης</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpAria">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Μετάβαση σε αυτή την ημέρα</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpTooltip">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Μετάβαση σε αυτή την ημέρα</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipped">
+      <segment state="translated">
+        <source>Tag übersprungen.</source>
+        <target>Η ημέρα παραλείφθηκε.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumped">
+      <segment state="translated">
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
+        <target>Μετάβαση στην ημέρα <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
+      </segment>
+    </unit>
     <unit id="trainingPlans.logAria">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -6297,13 +6297,13 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="trainingPlans.unskipAria">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Undo skip</target>
       </segment>
     </unit>
     <unit id="trainingPlans.unskipTooltip">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Undo skip</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -6283,6 +6283,54 @@ Deine Position: # ·  Reps        </source>
         <target>Mark as not done</target>
       </segment>
     </unit>
+    <unit id="trainingPlans.skipAria">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Skip day</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipTooltip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Skip day</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipAria">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Undo skip</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipTooltip">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Undo skip</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpAria">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Jump to this day</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpTooltip">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Jump to this day</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipped">
+      <segment state="translated">
+        <source>Tag übersprungen.</source>
+        <target>Day skipped.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumped">
+      <segment state="translated">
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
+        <target>Jumped to day <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
+      </segment>
+    </unit>
     <unit id="trainingPlans.back">
       <segment state="translated">
         <source>Zurück</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -6124,13 +6124,13 @@
     </unit>
     <unit id="trainingPlans.unskipAria">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Deshacer salto</target>
       </segment>
     </unit>
     <unit id="trainingPlans.unskipTooltip">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Deshacer salto</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -6110,6 +6110,54 @@
         <target>Marcar como no completado</target>
       </segment>
     </unit>
+    <unit id="trainingPlans.skipAria">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Saltar día</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipTooltip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Saltar día</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipAria">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Deshacer salto</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipTooltip">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Deshacer salto</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpAria">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Ir a este día</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpTooltip">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Ir a este día</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipped">
+      <segment state="translated">
+        <source>Tag übersprungen.</source>
+        <target>Día omitido.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumped">
+      <segment state="translated">
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
+        <target>Saltado al día <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
+      </segment>
+    </unit>
     <unit id="trainingPlans.logAria">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -6124,13 +6124,13 @@
     </unit>
     <unit id="trainingPlans.unskipAria">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Annuler le saut</target>
       </segment>
     </unit>
     <unit id="trainingPlans.unskipTooltip">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Annuler le saut</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -6110,6 +6110,54 @@
         <target>Marquer comme non terminé</target>
       </segment>
     </unit>
+    <unit id="trainingPlans.skipAria">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Passer le jour</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipTooltip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Passer le jour</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipAria">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Annuler le saut</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipTooltip">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Annuler le saut</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpAria">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Aller à ce jour</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpTooltip">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Aller à ce jour</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipped">
+      <segment state="translated">
+        <source>Tag übersprungen.</source>
+        <target>Jour passé.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumped">
+      <segment state="translated">
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
+        <target>Saut au jour <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
+      </segment>
+    </unit>
     <unit id="trainingPlans.logAria">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -6110,6 +6110,54 @@
         <target>Contrassegna come non completato</target>
       </segment>
     </unit>
+    <unit id="trainingPlans.skipAria">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Salta giorno</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipTooltip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Salta giorno</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipAria">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Annulla salto</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipTooltip">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Annulla salto</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpAria">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Vai a questo giorno</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpTooltip">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Vai a questo giorno</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipped">
+      <segment state="translated">
+        <source>Tag übersprungen.</source>
+        <target>Giorno saltato.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumped">
+      <segment state="translated">
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
+        <target>Saltato al giorno <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
+      </segment>
+    </unit>
     <unit id="trainingPlans.logAria">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -6124,13 +6124,13 @@
     </unit>
     <unit id="trainingPlans.unskipAria">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Annulla salto</target>
       </segment>
     </unit>
     <unit id="trainingPlans.unskipTooltip">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Annulla salto</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -6124,13 +6124,13 @@
     </unit>
     <unit id="trainingPlans.unskipAria">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Praeteritum revoca</target>
       </segment>
     </unit>
     <unit id="trainingPlans.unskipTooltip">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Praeteritum revoca</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -6110,6 +6110,54 @@
         <target>Mark non perficitur</target>
       </segment>
     </unit>
+    <unit id="trainingPlans.skipAria">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Diem praeteri</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipTooltip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Diem praeteri</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipAria">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Praeteritum revoca</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipTooltip">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Praeteritum revoca</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpAria">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Ad hunc diem salta</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpTooltip">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Ad hunc diem salta</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipped">
+      <segment state="translated">
+        <source>Tag übersprungen.</source>
+        <target>Dies praeteritus.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumped">
+      <segment state="translated">
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
+        <target>Saltatum ad diem <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
+      </segment>
+    </unit>
     <unit id="trainingPlans.logAria">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -6110,6 +6110,54 @@
         <target>Markeer als niet voltooid</target>
       </segment>
     </unit>
+    <unit id="trainingPlans.skipAria">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Dag overslaan</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipTooltip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Dag overslaan</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipAria">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Overslaan ongedaan maken</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipTooltip">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Overslaan ongedaan maken</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpAria">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Naar deze dag springen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpTooltip">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Naar deze dag springen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipped">
+      <segment state="translated">
+        <source>Tag übersprungen.</source>
+        <target>Dag overgeslagen.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumped">
+      <segment state="translated">
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
+        <target>Gesprongen naar dag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
+      </segment>
+    </unit>
     <unit id="trainingPlans.logAria">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -6124,13 +6124,13 @@
     </unit>
     <unit id="trainingPlans.unskipAria">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Overslaan ongedaan maken</target>
       </segment>
     </unit>
     <unit id="trainingPlans.unskipTooltip">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Overslaan ongedaan maken</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -6329,13 +6329,13 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="trainingPlans.unskipAria">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Angre hopp</target>
       </segment>
     </unit>
     <unit id="trainingPlans.unskipTooltip">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>Angre hopp</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -6315,6 +6315,54 @@ Deine Position: # ·  Reps        </source>
         <target>Marker som ikke gjort</target>
       </segment>
     </unit>
+    <unit id="trainingPlans.skipAria">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Hopp over dag</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipTooltip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Hopp over dag</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipAria">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Angre hopp</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipTooltip">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>Angre hopp</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpAria">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Hopp til denne dagen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpTooltip">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Hopp til denne dagen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipped">
+      <segment state="translated">
+        <source>Tag übersprungen.</source>
+        <target>Dag hoppet over.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumped">
+      <segment state="translated">
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
+        <target>Hoppet til dag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
+      </segment>
+    </unit>
     <unit id="trainingPlans.back">
       <segment state="translated">
         <source>Zurück</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -6622,7 +6622,7 @@
     <unit id="trainingPlans.back">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:75</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:369,371</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:371,373</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -6787,7 +6787,7 @@
     </unit>
     <unit id="trainingPlans.unmarkAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:297,298</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:298,299</note>
       </notes>
       <segment>
         <source>Als nicht erledigt markieren</source>
@@ -6795,23 +6795,23 @@
     </unit>
     <unit id="trainingPlans.unskipAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:306,307</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:307,308</note>
       </notes>
       <segment>
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
       </segment>
     </unit>
     <unit id="trainingPlans.unskipTooltip">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:308,309</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:309,310</note>
       </notes>
       <segment>
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
       </segment>
     </unit>
     <unit id="trainingPlans.logAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:319,320</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:320,321</note>
       </notes>
       <segment>
         <source>Plan-Sätze eintragen und als erledigt markieren</source>
@@ -6819,31 +6819,15 @@
     </unit>
     <unit id="trainingPlans.markAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:328,329</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:329,330</note>
       </notes>
       <segment>
         <source>Nur als erledigt markieren (ohne Eintrag)</source>
       </segment>
     </unit>
-    <unit id="trainingPlans.jumpAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:337,338</note>
-      </notes>
-      <segment>
-        <source>Zu diesem Tag springen</source>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpTooltip">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:339,340</note>
-      </notes>
-      <segment>
-        <source>Zu diesem Tag springen</source>
-      </segment>
-    </unit>
     <unit id="trainingPlans.skipAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:348,349</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:337,338</note>
       </notes>
       <segment>
         <source>Tag überspringen</source>
@@ -6851,15 +6835,31 @@
     </unit>
     <unit id="trainingPlans.skipTooltip">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:350,351</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:339,340</note>
       </notes>
       <segment>
         <source>Tag überspringen</source>
       </segment>
     </unit>
+    <unit id="trainingPlans.jumpAria">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:350,351</note>
+      </notes>
+      <segment>
+        <source>Zu diesem Tag springen</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpTooltip">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:352,353</note>
+      </notes>
+      <segment>
+        <source>Zu diesem Tag springen</source>
+      </segment>
+    </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:366,367</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:368,369</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -6867,7 +6867,7 @@
     </unit>
     <unit id="trainingPlans.autoStartFailed">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:659</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:661</note>
       </notes>
       <segment>
         <source>Plan-Start fehlgeschlagen — bitte erneut versuchen.</source>
@@ -6875,7 +6875,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:742</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:744</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -6883,7 +6883,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:759</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:761</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
@@ -6891,7 +6891,7 @@
     </unit>
     <unit id="trainingPlans.skipped">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:777</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:779</note>
       </notes>
       <segment>
         <source>Tag übersprungen.</source>
@@ -6899,7 +6899,7 @@
     </unit>
     <unit id="trainingPlans.jumped">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:790</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:792</note>
       </notes>
       <segment>
         <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
@@ -6907,7 +6907,7 @@
     </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:807</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:809</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:348</note>
       </notes>
       <segment>
@@ -6916,7 +6916,7 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:809</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:811</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:350</note>
       </notes>
       <segment>
@@ -6925,7 +6925,7 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:811</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:813</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:352</note>
       </notes>
       <segment>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -3430,7 +3430,7 @@
     </unit>
     <unit id="landing.feature.analytics.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:359,362</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:359,363</note>
       </notes>
       <segment>
         <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
@@ -3438,7 +3438,7 @@
     </unit>
     <unit id="landing.feature.goals.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:456,458</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:457,459</note>
       </notes>
       <segment>
         <source>Tages-, Wochen- &amp; Monatsziele</source>
@@ -3446,7 +3446,7 @@
     </unit>
     <unit id="landing.feature.goals.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:460,463</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:461,464</note>
       </notes>
       <segment>
         <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
@@ -3454,7 +3454,7 @@
     </unit>
     <unit id="landing.feature.heatmap.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:504,506</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:505,507</note>
       </notes>
       <segment>
         <source>Heatmap-Kalender</source>
@@ -3462,7 +3462,7 @@
     </unit>
     <unit id="landing.feature.heatmap.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:508,512</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:509,513</note>
       </notes>
       <segment>
         <source>Sieh auf einen Blick, an welchen Tagen du wie hart trainiert hast. Lücken werden sichtbar – Konsistenz wird zur Gewohnheit.</source>
@@ -3470,7 +3470,7 @@
     </unit>
     <unit id="landing.feature.quick.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:518,520</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:519,521</note>
       </notes>
       <segment>
         <source>Quick Logging mit FAB</source>
@@ -3478,7 +3478,7 @@
     </unit>
     <unit id="landing.feature.quick.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:522,525</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:523,526</note>
       </notes>
       <segment>
         <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
@@ -3486,7 +3486,7 @@
     </unit>
     <unit id="landing.feature.adaptive.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:532,534</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:533,535</note>
       </notes>
       <segment>
         <source>Adaptive Vorschläge</source>
@@ -3494,7 +3494,7 @@
     </unit>
     <unit id="landing.feature.adaptive.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:536,540</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:537,541</note>
       </notes>
       <segment>
         <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
@@ -3502,7 +3502,7 @@
     </unit>
     <unit id="landing.feature.pwa.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:546,548</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:547,549</note>
       </notes>
       <segment>
         <source>App-Installation, Live-Sync &amp; Teilen</source>
@@ -3510,7 +3510,7 @@
     </unit>
     <unit id="landing.feature.pwa.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:550,553</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:551,554</note>
       </notes>
       <segment>
         <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
@@ -3518,7 +3518,7 @@
     </unit>
     <unit id="landing.feature.pwa.installed">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:557,559</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:558,560</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">check_circle</pc> Du nutzt bereits die installierte App </source>
@@ -3526,7 +3526,7 @@
     </unit>
     <unit id="landing.feature.pwa.install">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:570,572</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:571,573</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">download</pc> Jetzt als App installieren </source>
@@ -3534,7 +3534,7 @@
     </unit>
     <unit id="landing.feature.pwa.iosHint">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:577,580</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:578,581</note>
       </notes>
       <segment>
         <source> Auf iPhone &amp; iPad: Teilen-Symbol antippen und „Zum Home-Bildschirm“ wählen. </source>
@@ -3542,7 +3542,7 @@
     </unit>
     <unit id="landing.feature.privacy.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:588,590</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:589,591</note>
       </notes>
       <segment>
         <source>Privacy first &amp; 100 % kostenlos</source>
@@ -3550,7 +3550,7 @@
     </unit>
     <unit id="landing.feature.privacy.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:592,596</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:593,597</note>
       </notes>
       <segment>
         <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
@@ -3558,7 +3558,7 @@
     </unit>
     <unit id="ads.landing.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:598</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:599</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -3566,7 +3566,7 @@
     </unit>
     <unit id="landing.preview.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:607,609</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:608,610</note>
       </notes>
       <segment>
         <source> Deine Statistik auf einen Blick </source>
@@ -3574,7 +3574,7 @@
     </unit>
     <unit id="landing.preview.alt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:614,615</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:615,616</note>
       </notes>
       <segment>
         <source>Vorschau der Statistikansicht</source>
@@ -3582,7 +3582,7 @@
     </unit>
     <unit id="landing.discover.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:755,756</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:756,757</note>
       </notes>
       <segment>
         <source>Mehr entdecken</source>
@@ -3590,7 +3590,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:761,763</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:762,764</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3598,7 +3598,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:765,768</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:766,769</note>
       </notes>
       <segment>
         <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
@@ -3606,7 +3606,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:775,778</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:776,779</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -3614,7 +3614,7 @@
     </unit>
     <unit id="landing.discover.blog.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:784,786</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:785,787</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3622,7 +3622,7 @@
     </unit>
     <unit id="landing.discover.blog.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:788,791</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:789,792</note>
       </notes>
       <segment>
         <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
@@ -3630,7 +3630,7 @@
     </unit>
     <unit id="landing.discover.blog.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:798,800</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:799,801</note>
       </notes>
       <segment>
         <source>Zum Blog</source>
@@ -4912,7 +4912,7 @@
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:200</note>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1093</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:663</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:677</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:277</note>
       </notes>
       <segment>
@@ -5606,7 +5606,7 @@
     </unit>
     <unit id="analysis.kindUnknown">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:671</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:685</note>
       </notes>
       <segment>
         <source>Andere Übung</source>
@@ -6330,7 +6330,7 @@
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:77,78</note>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:170,172</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:237,238</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:239,240</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:107,108</note>
       </notes>
       <segment>
@@ -6340,7 +6340,7 @@
     <unit id="trainingPlans.kind.light">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:80,81</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:244,246</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:246,248</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:110,111</note>
       </notes>
       <segment>
@@ -6350,7 +6350,7 @@
     <unit id="trainingPlans.kind.test">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:82,84</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:240,242</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:242,244</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:113,115</note>
       </notes>
       <segment>
@@ -6361,8 +6361,8 @@
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:85,87</note>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:183,185</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:250,251</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:256,257</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:252,253</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:258,259</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:125,127</note>
       </notes>
       <segment>
@@ -6621,8 +6621,8 @@
     </unit>
     <unit id="trainingPlans.back">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:74</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:334,336</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:75</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:369,371</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -6630,7 +6630,7 @@
     </unit>
     <unit id="trainingPlans.daysSuffix">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:83,85</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:84,86</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:180,182</note>
       </notes>
       <segment>
@@ -6639,7 +6639,7 @@
     </unit>
     <unit id="trainingPlans.level.beginner">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:87,88</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:88,89</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:185,187</note>
       </notes>
       <segment>
@@ -6648,7 +6648,7 @@
     </unit>
     <unit id="trainingPlans.level.intermediate">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:89,91</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:90,92</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:189,191</note>
       </notes>
       <segment>
@@ -6657,7 +6657,7 @@
     </unit>
     <unit id="trainingPlans.level.advanced">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:91,93</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:92,94</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:193,195</note>
       </notes>
       <segment>
@@ -6666,7 +6666,7 @@
     </unit>
     <unit id="trainingPlans.progress">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:100,101</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:101,102</note>
       </notes>
       <segment>
         <source>Fortschritt</source>
@@ -6674,7 +6674,7 @@
     </unit>
     <unit id="trainingPlans.currentDay">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:109,110</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:110,111</note>
       </notes>
       <segment>
         <source>Aktueller Tag:</source>
@@ -6682,7 +6682,7 @@
     </unit>
     <unit id="trainingPlans.goalOverrideHint">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:116,118</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:117,119</note>
       </notes>
       <segment>
         <source> Tagesziel wird vom Plan gesetzt. </source>
@@ -6690,7 +6690,7 @@
     </unit>
     <unit id="trainingPlans.goalOverrideHint.cta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:122,125</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:123,126</note>
       </notes>
       <segment>
         <source>Manuelle Ziele anpassen</source>
@@ -6698,7 +6698,7 @@
     </unit>
     <unit id="trainingPlans.abandon">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:133,135</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:134,136</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:140,142</note>
       </notes>
       <segment>
@@ -6707,7 +6707,7 @@
     </unit>
     <unit id="trainingPlans.startCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:143,145</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:144,146</note>
       </notes>
       <segment>
         <source> Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt. </source>
@@ -6715,7 +6715,7 @@
     </unit>
     <unit id="trainingPlans.signupCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:148,150</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:149,151</note>
       </notes>
       <segment>
         <source> Erstelle ein kostenloses Konto, um diesen Plan zu starten. Wir tracken deinen Fortschritt automatisch und setzen dein Tagesziel passend zum Plan. </source>
@@ -6723,7 +6723,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.tracking">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:154,156</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:155,157</note>
       </notes>
       <segment>
         <source> Automatische Fortschrittsverfolgung </source>
@@ -6731,7 +6731,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.goal">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:157,159</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:158,160</note>
       </notes>
       <segment>
         <source> Tagesziel passt sich täglich an deinen Plan an </source>
@@ -6739,7 +6739,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.streak">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:160,162</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:161,163</note>
       </notes>
       <segment>
         <source> Streaks, Statistiken und Bestenliste </source>
@@ -6747,7 +6747,7 @@
     </unit>
     <unit id="trainingPlans.replaceWarn">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:172,173</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:173,174</note>
       </notes>
       <segment>
         <source> Achtung: Dies ersetzt den aktuell aktiven Plan. </source>
@@ -6755,7 +6755,7 @@
     </unit>
     <unit id="trainingPlans.start">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:177,179</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:178,180</note>
       </notes>
       <segment>
         <source>Plan starten</source>
@@ -6763,7 +6763,7 @@
     </unit>
     <unit id="trainingPlans.signupAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:188,190</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:189,191</note>
       </notes>
       <segment>
         <source>Konto erstellen &amp; Plan starten</source>
@@ -6771,7 +6771,7 @@
     </unit>
     <unit id="trainingPlans.loginAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:196,199</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:197,200</note>
       </notes>
       <segment>
         <source>Schon Konto? Einloggen</source>
@@ -6779,7 +6779,7 @@
     </unit>
     <unit id="trainingPlans.week">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:206,207</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:207,208</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -6787,15 +6787,31 @@
     </unit>
     <unit id="trainingPlans.unmarkAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:295,296</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:297,298</note>
       </notes>
       <segment>
         <source>Als nicht erledigt markieren</source>
       </segment>
     </unit>
-    <unit id="trainingPlans.logAria">
+    <unit id="trainingPlans.unskipAria">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:306,307</note>
+      </notes>
+      <segment>
+        <source>Übersprungen rückgängig</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipTooltip">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:308,309</note>
+      </notes>
+      <segment>
+        <source>Übersprungen rückgängig</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.logAria">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:319,320</note>
       </notes>
       <segment>
         <source>Plan-Sätze eintragen und als erledigt markieren</source>
@@ -6803,15 +6819,47 @@
     </unit>
     <unit id="trainingPlans.markAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:315,316</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:328,329</note>
       </notes>
       <segment>
         <source>Nur als erledigt markieren (ohne Eintrag)</source>
       </segment>
     </unit>
+    <unit id="trainingPlans.jumpAria">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:337,338</note>
+      </notes>
+      <segment>
+        <source>Zu diesem Tag springen</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpTooltip">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:339,340</note>
+      </notes>
+      <segment>
+        <source>Zu diesem Tag springen</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipAria">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:348,349</note>
+      </notes>
+      <segment>
+        <source>Tag überspringen</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipTooltip">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:350,351</note>
+      </notes>
+      <segment>
+        <source>Tag überspringen</source>
+      </segment>
+    </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:331,332</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:366,367</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -6819,7 +6867,7 @@
     </unit>
     <unit id="trainingPlans.autoStartFailed">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:616</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:659</note>
       </notes>
       <segment>
         <source>Plan-Start fehlgeschlagen — bitte erneut versuchen.</source>
@@ -6827,7 +6875,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:695</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:742</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -6835,15 +6883,31 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:712</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:759</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
       </segment>
     </unit>
+    <unit id="trainingPlans.skipped">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:777</note>
+      </notes>
+      <segment>
+        <source>Tag übersprungen.</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumped">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:790</note>
+      </notes>
+      <segment>
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
+      </segment>
+    </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:738</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:807</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:348</note>
       </notes>
       <segment>
@@ -6852,7 +6916,7 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:740</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:809</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:350</note>
       </notes>
       <segment>
@@ -6861,7 +6925,7 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:742</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:811</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:352</note>
       </notes>
       <segment>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -6642,13 +6642,13 @@
     </unit>
     <unit id="trainingPlans.unskipAria">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>撤销跳过</target>
       </segment>
     </unit>
     <unit id="trainingPlans.unskipTooltip">
       <segment state="translated">
-        <source>Übersprungen rückgängig</source>
+        <source>Überspringen rückgängig machen</source>
         <target>撤销跳过</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -6628,6 +6628,54 @@
         <source>Als nicht erledigt markieren</source>
       <target>标记为未完成</target></segment>
     </unit>
+    <unit id="trainingPlans.skipAria">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>跳过此天</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipTooltip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>跳过此天</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipAria">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>撤销跳过</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.unskipTooltip">
+      <segment state="translated">
+        <source>Übersprungen rückgängig</source>
+        <target>撤销跳过</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpAria">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>跳转到此天</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumpTooltip">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>跳转到此天</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.skipped">
+      <segment state="translated">
+        <source>Tag übersprungen.</source>
+        <target>已跳过此天。</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.jumped">
+      <segment state="translated">
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
+        <target>已跳转到第 <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> 天。</target>
+      </segment>
+    </unit>
     <unit id="trainingPlans.logAria">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:286,287</note>


### PR DESCRIPTION
Lets users skip individual exercise days or re-anchor the plan so
today maps to a chosen day. Skipped days are tracked in a new
`skippedDays` field and excluded from completion percent + the
`isPlanCompleted` required-set, so missing days no longer leaves the
plan permanently incomplete. Jumping forward auto-skips intervening
non-rest, non-completed days; jumping back drops skips that are now
in the future. New per-day icon-buttons on the detail page expose
both actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to skip individual training days and undo skips as needed.
  * Added "jump to day" functionality to navigate directly to specific training days.
  * Improved completion percentage calculation to exclude skipped days from progress tracking.
  * Enhanced UI with visual indicators for skipped days and new action buttons.

* **Localization**
  * Added translations for skip, unskip, and jump-to-day actions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/315)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->