### PR TITLE
fix(analysis): polish kind-filter doc + decouple visibility from labels

### DIFF
--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -64,11 +64,11 @@ type AnalysisState = {
   to: string;
   dayChartMode: '24h' | '14h' | undefined;
   /**
-   * Active exercise-kind filter for the type-pie. Empty array and
-   * `['pushup']` render the pushup-variant breakdown; any other
-   * non-empty subset switches to kind-mode (pushups collapsed into
-   * one bucket, each `exerciseId` as its own slice). Streaks/best-day
-   * KPIs stay pushup-only.
+   * Active exercise-kind filter for the type-pie. Both an empty array
+   * (default) and `['pushup']` render the pushup-variant breakdown;
+   * any other non-empty subset switches to kind-mode (pushups
+   * collapsed into one bucket, each `exerciseId` as its own slice).
+   * Streaks/best-day KPIs stay pushup-only.
    */
   kinds: ReadonlyArray<UnifiedEntryFilterKey>;
   // Reactive dependency for the fixed-window trend filters: bumped only

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -65,11 +65,10 @@ type AnalysisState = {
   dayChartMode: '24h' | '14h' | undefined;
   /**
    * Active exercise-kind filter for the type-pie. Empty array and
-   * `['pushup']` both render the pushup-variant breakdown (default);
-   * any other non-empty subset switches the pie into kind-mode where
-   * pushups collapse into one bucket and each `exerciseId` becomes a
-   * slice. Streaks/best-day KPIs stay pushup-only — per-exercise
-   * versions land with Phase 2 of the multi-exercise roadmap.
+   * `['pushup']` render the pushup-variant breakdown; any other
+   * non-empty subset switches to kind-mode (pushups collapsed into
+   * one bucket, each `exerciseId` as its own slice). Streaks/best-day
+   * KPIs stay pushup-only.
    */
   kinds: ReadonlyArray<UnifiedEntryFilterKey>;
   // Reactive dependency for the fixed-window trend filters: bumped only
@@ -274,11 +273,9 @@ export const AnalysisStore = signalStore(
     );
     const rows = computed(() => store.entriesResource.value() ?? []);
 
-    /**
-     * Browser-only: exercise entries come from the live Firestore
-     * snapshot and are filtered to the page's date range. SSR has no
-     * live store and keeps the array empty.
-     */
+    // Pushup rows come from the REST resource (works on SSR); exercise
+    // entries come from the live Firestore snapshot, so SSR yields
+    // pushups only.
     const unifiedRows = computed<UnifiedEntry[]>(() => {
       const from = store.from();
       const to = store.to();

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -2,7 +2,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { AnalysisPageComponent } from './analysis-page.component';
-import { StatsApiService, UserStatsApiService } from '@pu-stats/data-access';
+import {
+  LiveDataStore,
+  StatsApiService,
+  UserStatsApiService,
+} from '@pu-stats/data-access';
 import { AuthStore, UserContextService } from '@pu-auth/auth';
 import { makeAuthStoreMock } from '@pu-stats/testing';
 import { FilterBarComponent } from '../components/filter-bar/filter-bar.component';
@@ -12,8 +16,8 @@ import { StatsChartComponent } from '../components/stats-chart/stats-chart.compo
 import { SetsDistributionComponent } from '../components/sets-distribution/sets-distribution.component';
 
 // We don't want to render real components in unit tests.
-import { Component, input, model, output } from '@angular/core';
-import { RangeModes } from '@pu-stats/models';
+import { Component, input, model, output, signal } from '@angular/core';
+import { ExerciseEntry, RangeModes } from '@pu-stats/models';
 
 @Component({
   selector: 'app-filter-bar',
@@ -73,6 +77,15 @@ class MockSetsDistributionComponent {
 
 describe('AnalysisPageComponent', () => {
   let fixture: ComponentFixture<AnalysisPageComponent>;
+  // Mutable mirror of the LiveDataStore so tests can seed exercise
+  // entries that the analysis store reads via `unifiedRows`.
+  const liveExerciseEntries = signal<ExerciseEntry[]>([]);
+  const liveMock = {
+    connected: signal(true),
+    entries: signal([] as never[]),
+    exerciseEntries: liveExerciseEntries,
+    updateTick: signal(0),
+  };
 
   const apiMock = {
     load: vitest.fn().mockReturnValue(
@@ -153,12 +166,14 @@ describe('AnalysisPageComponent', () => {
     });
     vitest.setSystemTime(new Date(2026, 1, 15, 12));
 
+    liveExerciseEntries.set([]);
     await TestBed.configureTestingModule({
       imports: [AnalysisPageComponent],
       providers: [
         { provide: StatsApiService, useValue: apiMock },
         { provide: AuthStore, useValue: makeAuthStoreMock() },
         { provide: UserContextService, useValue: { userIdSafe: () => 'u1' } },
+        { provide: LiveDataStore, useValue: liveMock },
         {
           provide: UserStatsApiService,
           useValue: {
@@ -406,6 +421,30 @@ describe('AnalysisPageComponent', () => {
     expect(component.showKindFilter()).toBe(false);
   });
 
+  it('shows the kind filter when the range contains a non-pushup kind even with no selection', () => {
+    // OR-branch of `showKindFilter`: a user who already has sit-up
+    // entries in the visible range must see the filter without
+    // pre-selecting anything, otherwise they could never enable
+    // kind-mode for their own data.
+    const component = fixture.componentInstance;
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'abs.situps',
+        timestamp: '2026-02-12T08:00:00.000Z',
+        reps: 30,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    component.store.setKinds([]);
+    component.store.setRange('2026-02-09', '2026-02-15');
+    fixture.detectChanges();
+    const values = component.kindFilterOptions().map((o) => o.value);
+    expect(values).toContain('abs.situps');
+    expect(component.showKindFilter()).toBe(true);
+  });
+
   it('shows the kind filter when a non-pushup kind is selected even on a pushup-only range', () => {
     // Regression for Copilot finding: a user with only sit-up entries
     // would never see the filter, and the default pushup-variant pie
@@ -492,6 +531,15 @@ describe('AnalysisPageComponent empty-state CTA gating', () => {
         { provide: StatsApiService, useValue: emptyApiMock },
         { provide: AuthStore, useValue: makeAuthStoreMock() },
         { provide: UserContextService, useValue: { userIdSafe: () => 'u1' } },
+        {
+          provide: LiveDataStore,
+          useValue: {
+            connected: signal(true),
+            entries: signal([]),
+            exerciseEntries: signal([]),
+            updateTick: signal(0),
+          },
+        },
         {
           provide: UserStatsApiService,
           useValue: {

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -557,18 +557,13 @@ export class AnalysisPageComponent {
     }));
   });
 
-  /**
-   * The filter is meaningful whenever the user has any choice to make:
-   *   - any non-pushup kind is present in the range (a pushups-only
-   *     range still fully describes itself via the variant pie), OR
-   *   - a kind is already selected (so the user can always clear it,
-   *     even after narrowing the range past its last entry).
-   * Hiding it for a pure-pushup range keeps the page minimal for the
-   * default user.
-   */
+  // Hidden for pure-pushup ranges to keep the default page minimal,
+  // but always visible when a kind is selected so the user can clear it.
+  // Reads the raw keys directly so visibility doesn't trigger label
+  // resolution / `$localize`.
   readonly showKindFilter = computed(() => {
     if (this.store.kinds().length > 0) return true;
-    return this.kindFilterOptions().some((o) => o.value !== 'pushup');
+    return this.store.kindOptionsRaw().some((k) => k !== 'pushup');
   });
 
   /**


### PR DESCRIPTION
Address late review comments on #314 that landed after the auto-merge fired.

## Summary

- **`unifiedRows` doc was factually wrong** (Copilot): claimed SSR yields an empty array, but the pushup rows come from the REST resource and work on SSR. Only the live exercise-entries half is browser-only. Reworded.
- **`showKindFilter` decoupled from label resolution** (Copilot): was reading `kindFilterOptions()` which forces `$localize` + catalog lookup on every recompute. Now reads the raw `store.kindOptionsRaw()` keys — visibility no longer triggers label work and the computed depends only on what it actually needs.
- **Missing OR-branch test added** (CodeRabbit, P1): a range that already contains a non-pushup kind with empty `kinds` selection now has explicit coverage. Seeds a `LiveDataStore` mock so the synthetic exercise entry flows through `unifiedRows`; the second describe block also gets the mock so it no longer touches the real Firestore-bound store.
- **`kinds` doc trim** (CodeRabbit): dropped the "Phase 2 multi-exercise roadmap" task-tracking line per AGENTS.md.
- **`showKindFilter` doc trim** (CodeRabbit): collapsed the multi-line block to a one-liner why-comment.

## Test plan

- [x] `pnpm nx affected -t lint,test --base=main --parallel=3` — all 623 web tests pass, including the new `showKindFilter` OR-branch test.
- [x] `pnpm nx run web:build -c production` — succeeds, no missing-translation errors.
- [ ] Visual sanity check on the analysis page that the filter still appears/disappears correctly across pushup-only, mixed, and exercise-only ranges.

Refs: #313, #314


---
_Generated by [Claude Code](https://claude.ai/code/session_013YH5V3jwXERYntWb8gvTSW)_