### PR TITLE
feat(training-plans): swap play icon for empty/filled check on plan detail

### DIFF
--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -320,7 +320,7 @@ interface DayRow {
                               aria-label="Plan-Sätze eintragen und als erledigt markieren"
                               i18n-aria-label="@@trainingPlans.logAria"
                             >
-                              <mat-icon>play_circle</mat-icon>
+                              <mat-icon>check_circle_outline</mat-icon>
                             </button>
                           }
                           <button


### PR DESCRIPTION
The per-day log button on the plan detail page now uses
check_circle_outline (empty) for pending days, pairing with the existing
check_circle (filled) shown once a day is marked done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the icon for the "log plan day" action button to improve visual clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/317)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->