### PR TITLE
feat(stats): Analyse nach Übungsgruppen aufteilen — Datenschicht + Plan

### DIFF
--- a/docs/analysis-views-plan.md
+++ b/docs/analysis-views-plan.md
@@ -1,0 +1,176 @@
+# Analyse-Seite: Aufteilung nach Übungsgruppen
+
+Plan zur Aufteilung von `/analysis` in eine Übersicht und kategoriespezifische Detail-Ansichten.
+
+## Zielbild
+
+`/analysis` bleibt eine Route. Darin: `mat-tab-group` mit dynamischen Tabs:
+
+**Übersicht** (immer sichtbar) · **Pushups** · **Bauch** · **Beine** · **Plank** · **Cardio** · **Kraft** · **Mobility**
+
+Tabs ohne Einträge im aktuellen Zeitraum werden ausgeblendet (`kindOptionsRaw` → Kategorien-Set).
+
+Designentscheidungen (mit Nutzer abgestimmt):
+
+- Navigation: `mat-tabs` innerhalb `/analysis`, Tab-Wahl als Query-Param `?view=`.
+- Trends (8 Wochen / 6 Monate): in Gruppen-Tabs **pro Gruppe gefiltert**, gleiche Datenbasis (kein zusätzlicher Firestore-Read).
+- Übersicht-Inhalt: Kategorie-Vergleich (Bar/Pie) **plus** Kategorie-Karten mit Quick-Stats + Drilldown-Link.
+
+---
+
+## 1. Datenmodell-Bindung: Eintrag → Kategorie
+
+Neuer Helper in `libs/stats/src/lib/models/`:
+
+```ts
+unifiedEntryCategoryId(entry: UnifiedEntry): ExerciseCategoryId
+//  'pushup' kind   → 'pushup'
+//  'exercise' kind → catalog.find(exerciseId).categoryId
+```
+
+Wird in `analysis.store.ts` als Basisfilter genutzt.
+
+---
+
+## 2. Store-Erweiterung (`web/src/app/stats/analysis.store.ts`)
+
+Neuer State:
+
+```ts
+activeView: 'overview' | ExerciseCategoryId   // default 'overview'
+```
+
+Neuer Selector vor allen bisherigen computeds einziehen:
+
+```ts
+viewFilteredRows = computed(() =>
+  activeView() === 'overview'
+    ? rows()
+    : rows().filter(e => unifiedEntryCategoryId(e) === activeView())
+)
+```
+
+Alle bestehenden Aggregate (`chartSeries`, `typeBreakdown`, `bestSingleEntry`, `bestDay`, `currentStreak`, `longestStreak`, `setsDistribution`, `avgSetSize`, `heatmapData`) auf `viewFilteredRows` umstellen.
+
+Trends pro Gruppe: `weekEntriesResource` und `monthEntriesResource` laden weiter den vollen 8-Wochen-/6-Monats-Bereich, aber `weekTrend()` / `monthTrend()` filtern jetzt zusätzlich nach `activeView`. Keine zusätzlichen Firestore-Reads.
+
+Neue Selektoren für die Übersicht:
+
+```ts
+categorySummaries = computed(() =>
+  EXERCISE_CATEGORIES
+    .map(cat => ({
+      categoryId: cat.id,
+      nameKey: cat.nameKey,
+      icon: cat.icon,
+      totalReps, totalSets, todayReps,
+      currentStreak, bestDay,
+    }))
+    .filter(s => s.totalReps > 0)
+    .sort((a, b) => order)
+)
+
+categoryComparison = computed(() => /* { labels, reps, sets } für Bar-Chart */)
+```
+
+Methode: `setActiveView(view)` — synct mit `?view=` Query-Param.
+
+---
+
+## 3. Komponenten-Aufteilung
+
+Aktueller Monolith `analysis-page.component.ts` (682 Zeilen) wird zerlegt:
+
+| Datei                                          | Rolle                                                                                                                                |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `analysis-page.component.ts`                   | **Shell**: Filter-Bar oben + `mat-tab-group`, liest/schreibt `?view=`-Query-Param, switcht `activeView` im Store                     |
+| `analysis-overview.component.ts` (neu)         | Übersicht-Tab: `<category-comparison-chart>` + Grid aus `<category-summary-card>`                                                    |
+| `analysis-group-view.component.ts` (neu)       | Wiederverwendbare Detail-Ansicht: Chart + KPIs + Heatmap + Trends — keine Inputs, liest alles aus dem Store (der bereits gefiltert ist) |
+| `category-summary-card.component.ts` (neu)     | `mat-card` mit Icon, Name, Quick-Stats, Button `(click)="select.emit(categoryId)"`                                                   |
+| `category-comparison-chart.component.ts` (neu) | Horizontaler Bar-Chart (Chart.js) — Reps pro Kategorie, mit Sets als sekundäre Achse oder Toggle                                     |
+
+Filter-Bar (Datumsbereich) bleibt **oberhalb** der Tabs → wirkt auf alle Ansichten.
+
+Die bestehende „Kind"-Mehrfachauswahl entfällt durch die Tab-Auswahl. Empfehlung: in Übersicht und Gruppen-Tabs komplett entfernen. Falls später Sub-Filter pro Gruppe gewünscht (z. B. nur `legs.squats`), als Folge-Story.
+
+---
+
+## 4. Tab-Sichtbarkeit & Reihenfolge
+
+```ts
+visibleTabs = computed(() => {
+  const cats = new Set(rows().map(unifiedEntryCategoryId))
+  return EXERCISE_CATEGORIES
+    .filter(c => cats.has(c.id))
+    .sort((a, b) => a.order - b.order)
+})
+```
+
+Übersicht-Tab immer Index 0. Tab-Wechsel → `setActiveView` → Query-Param-Update via `router.navigate([], { queryParams: { view }, queryParamsHandling: 'merge' })`.
+
+---
+
+## 5. Routing / Deeplinks
+
+Keine neuen Routes. Query-Param `?view=overview|pushup|abs|legs|…` macht Tab-Auswahl shareable und browser-history-fähig. Init im Component-Constructor: `view` aus Snapshot lesen → `setActiveView`.
+
+---
+
+## 6. i18n
+
+Neue XLIFF-IDs in `web/src/locale/messages.xlf` und `messages.en.xlf`:
+
+- `@@analysis.tabs.overview` → „Übersicht" / „Overview"
+- `@@analysis.overview.comparison.title` → „Vergleich nach Übungsgruppe"
+- `@@analysis.overview.cards.viewDetails` → „Details ansehen"
+- `@@analysis.overview.cards.todayReps`, `@@…totalReps`, `@@…bestDay`, `@@…streak`
+- `@@analysis.overview.comparison.metric.reps` / `…sets` (Toggle)
+
+Kategorienamen nutzen bestehende `EXERCISE_CATEGORIES[*].nameKey`.
+
+---
+
+## 7. Tests
+
+| Bereich                       | Test                                                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `unifiedEntryCategoryId`      | Pure-Function-Unit-Tests pro Kind                                                                                                                 |
+| `analysis.store`              | `activeView` schaltet `viewFilteredRows`, KPIs ändern sich entsprechend; `categorySummaries` filtert leere Kategorien; `weekTrend` / `monthTrend` kategoriegefiltert |
+| `category-summary-card`       | Rendert i18n Name + Stats; Klick emittiert `categoryId`                                                                                           |
+| `category-comparison-chart`   | Mappt `categoryComparison` korrekt auf Chart.js dataset                                                                                           |
+| `analysis-page` Shell         | Tabwechsel updated Query-Param und `activeView`; `?view=abs` initialer Snapshot wird übernommen; nur Tabs mit Daten sind sichtbar                 |
+| Smoke                         | Wechsel zwischen Tabs ändert KPIs ohne Reload                                                                                                     |
+
+Jeweils Given-When-Then; `TestBed` / `render`; `PLATFORM_ID: 'server'` falls Store mit Timer-Hook erweitert wird (aktuell nicht der Fall).
+
+---
+
+## 8. Lieferplan (sequenzielle Commits — alle mit Tests)
+
+1. **Helper + Store-Refactor**: `unifiedEntryCategoryId`, `activeView`, `viewFilteredRows`; bestehende computeds umhängen; Trends kategoriegefiltert.
+2. **Overview-Daten**: `categorySummaries`, `categoryComparison` im Store.
+3. **Komponenten extrahieren**: `analysis-group-view` aus dem Monolithen herausziehen, Shell schlanker machen — noch ohne Tabs.
+4. **Tabs einbauen**: `mat-tab-group`, `visibleTabs`, Query-Param-Sync.
+5. **Overview-Tab**: `analysis-overview` + `category-summary-card` + `category-comparison-chart`. Drilldown-Click setzt Tab.
+6. **i18n + XLIFF-Sync** (`pnpm nx run web:extract-i18n` und englische Übersetzungen pflegen).
+7. **Pre-Push-Checks**: `pnpm nx affected -t=lint,test,build -c=production --parallel=3`.
+
+---
+
+## Risiken / Trade-offs
+
+- **Filter-State teilen über Tabs:** ein gemeinsamer Store hält den Date-Range stabil — gewollt; Tab-Wechsel fühlt sich wie Filter, nicht wie Navigation an.
+- **Chart-Performance:** `viewFilteredRows` ist `computed` und nur bei Änderung neu berechnet — unkritisch.
+- **Bestehender „Kinds"-Filter:** Wird in Gruppen-Tabs redundant; entfällt komplett.
+- **Trends weiterhin auf vollem 8-Wochen-Window-Read:** Mehr Daten geladen als pro Tab nötig, aber bestehende Resource bleibt unverändert — kein zusätzlicher Lese-Cost.
+
+---
+
+## Referenzen
+
+- `web/src/app/stats/shell/analysis-page.component.ts` (aktueller Monolith)
+- `web/src/app/stats/analysis.store.ts` (Store, der erweitert wird)
+- `libs/stats/src/lib/models/exercise.models.ts` (Kategorien-Enum)
+- `libs/stats/src/lib/models/exercise.catalog.ts` (Kategorien-Metadaten + i18n-Keys)
+- `libs/stats/src/lib/models/unified-entry.models.ts` (Eintragsmodell)
+- `web/src/app/app.routes.ts` (Routing)

--- a/docs/analysis-views-plan.md
+++ b/docs/analysis-views-plan.md
@@ -23,10 +23,19 @@ Designentscheidungen (mit Nutzer abgestimmt):
 Neuer Helper in `libs/stats/src/lib/models/`:
 
 ```ts
-unifiedEntryCategoryId(entry: UnifiedEntry): ExerciseCategoryId
-//  'pushup' kind   → 'pushup'
-//  'exercise' kind → catalog.find(exerciseId).categoryId
+unifiedEntryCategoryId(
+  entry: UnifiedEntry,
+  resolveDefinition?: (id: string) => ExerciseDefinition | null
+): ExerciseCategoryId | null
+//  'pushup' kind                      → 'pushup'
+//  'exercise' kind, im Catalog        → ExerciseDefinition.categoryId
+//  'exercise' kind, nicht im Catalog  → null  (Resolver kann Custom-IDs einbringen)
 ```
+
+`null` ist absichtlich Teil des Rückgabetyps: Einträge mit unbekannter
+`exerciseId` (z. B. eine aus dem Catalog entfernte User-Custom-Übung,
+deren Firestore-Docs noch existieren) fallen damit aus jeder
+Kategorie-Sicht heraus, ohne im Overview zu verschwinden.
 
 Wird in `analysis.store.ts` als Basisfilter genutzt.
 
@@ -37,17 +46,13 @@ Wird in `analysis.store.ts` als Basisfilter genutzt.
 Neuer State:
 
 ```ts
-activeView: 'overview' | ExerciseCategoryId   // default 'overview'
+activeView: 'overview' | ExerciseCategoryId; // default 'overview'
 ```
 
 Neuer Selector vor allen bisherigen computeds einziehen:
 
 ```ts
-viewFilteredRows = computed(() =>
-  activeView() === 'overview'
-    ? rows()
-    : rows().filter(e => unifiedEntryCategoryId(e) === activeView())
-)
+viewFilteredRows = computed(() => (activeView() === 'overview' ? rows() : rows().filter((e) => unifiedEntryCategoryId(e) === activeView())));
 ```
 
 Alle bestehenden Aggregate (`chartSeries`, `typeBreakdown`, `bestSingleEntry`, `bestDay`, `currentStreak`, `longestStreak`, `setsDistribution`, `avgSetSize`, `heatmapData`) auf `viewFilteredRows` umstellen.
@@ -81,13 +86,13 @@ Methode: `setActiveView(view)` — synct mit `?view=` Query-Param.
 
 Aktueller Monolith `analysis-page.component.ts` (682 Zeilen) wird zerlegt:
 
-| Datei                                          | Rolle                                                                                                                                |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `analysis-page.component.ts`                   | **Shell**: Filter-Bar oben + `mat-tab-group`, liest/schreibt `?view=`-Query-Param, switcht `activeView` im Store                     |
-| `analysis-overview.component.ts` (neu)         | Übersicht-Tab: `<category-comparison-chart>` + Grid aus `<category-summary-card>`                                                    |
+| Datei                                          | Rolle                                                                                                                                   |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `analysis-page.component.ts`                   | **Shell**: Filter-Bar oben + `mat-tab-group`, liest/schreibt `?view=`-Query-Param, switcht `activeView` im Store                        |
+| `analysis-overview.component.ts` (neu)         | Übersicht-Tab: `<category-comparison-chart>` + Grid aus `<category-summary-card>`                                                       |
 | `analysis-group-view.component.ts` (neu)       | Wiederverwendbare Detail-Ansicht: Chart + KPIs + Heatmap + Trends — keine Inputs, liest alles aus dem Store (der bereits gefiltert ist) |
-| `category-summary-card.component.ts` (neu)     | `mat-card` mit Icon, Name, Quick-Stats, Button `(click)="select.emit(categoryId)"`                                                   |
-| `category-comparison-chart.component.ts` (neu) | Horizontaler Bar-Chart (Chart.js) — Reps pro Kategorie, mit Sets als sekundäre Achse oder Toggle                                     |
+| `category-summary-card.component.ts` (neu)     | `mat-card` mit Icon, Name, Quick-Stats, Button `(click)="select.emit(categoryId)"`                                                      |
+| `category-comparison-chart.component.ts` (neu) | Horizontaler Bar-Chart (Chart.js) — Reps pro Kategorie, mit Sets als sekundäre Achse oder Toggle                                        |
 
 Filter-Bar (Datumsbereich) bleibt **oberhalb** der Tabs → wirkt auf alle Ansichten.
 
@@ -99,11 +104,9 @@ Die bestehende „Kind"-Mehrfachauswahl entfällt durch die Tab-Auswahl. Empfehl
 
 ```ts
 visibleTabs = computed(() => {
-  const cats = new Set(rows().map(unifiedEntryCategoryId))
-  return EXERCISE_CATEGORIES
-    .filter(c => cats.has(c.id))
-    .sort((a, b) => a.order - b.order)
-})
+  const cats = new Set(rows().map(unifiedEntryCategoryId));
+  return EXERCISE_CATEGORIES.filter((c) => cats.has(c.id)).sort((a, b) => a.order - b.order);
+});
 ```
 
 Übersicht-Tab immer Index 0. Tab-Wechsel → `setActiveView` → Query-Param-Update via `router.navigate([], { queryParams: { view }, queryParamsHandling: 'merge' })`.
@@ -132,14 +135,14 @@ Kategorienamen nutzen bestehende `EXERCISE_CATEGORIES[*].nameKey`.
 
 ## 7. Tests
 
-| Bereich                       | Test                                                                                                                                              |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `unifiedEntryCategoryId`      | Pure-Function-Unit-Tests pro Kind                                                                                                                 |
-| `analysis.store`              | `activeView` schaltet `viewFilteredRows`, KPIs ändern sich entsprechend; `categorySummaries` filtert leere Kategorien; `weekTrend` / `monthTrend` kategoriegefiltert |
-| `category-summary-card`       | Rendert i18n Name + Stats; Klick emittiert `categoryId`                                                                                           |
-| `category-comparison-chart`   | Mappt `categoryComparison` korrekt auf Chart.js dataset                                                                                           |
-| `analysis-page` Shell         | Tabwechsel updated Query-Param und `activeView`; `?view=abs` initialer Snapshot wird übernommen; nur Tabs mit Daten sind sichtbar                 |
-| Smoke                         | Wechsel zwischen Tabs ändert KPIs ohne Reload                                                                                                     |
+| Bereich                     | Test                                                                                                                                                                 |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `unifiedEntryCategoryId`    | Pure-Function-Unit-Tests pro Kind                                                                                                                                    |
+| `analysis.store`            | `activeView` schaltet `viewFilteredRows`, KPIs ändern sich entsprechend; `categorySummaries` filtert leere Kategorien; `weekTrend` / `monthTrend` kategoriegefiltert |
+| `category-summary-card`     | Rendert i18n Name + Stats; Klick emittiert `categoryId`                                                                                                              |
+| `category-comparison-chart` | Mappt `categoryComparison` korrekt auf Chart.js dataset                                                                                                              |
+| `analysis-page` Shell       | Tabwechsel updated Query-Param und `activeView`; `?view=abs` initialer Snapshot wird übernommen; nur Tabs mit Daten sind sichtbar                                    |
+| Smoke                       | Wechsel zwischen Tabs ändert KPIs ohne Reload                                                                                                                        |
 
 Jeweils Given-When-Then; `TestBed` / `render`; `PLATFORM_ID: 'server'` falls Store mit Timer-Hook erweitert wird (aktuell nicht der Fall).
 

--- a/libs/stats/src/lib/models/unified-entry.models.spec.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.spec.ts
@@ -1,9 +1,10 @@
 import {
   exerciseEntryToUnified,
   pushupRecordToUnified,
+  unifiedEntryCategoryId,
   unifiedEntryFilterKey,
 } from './unified-entry.models';
-import type { ExerciseEntry } from './exercise.models';
+import type { ExerciseDefinition, ExerciseEntry } from './exercise.models';
 import type { PushupRecord } from './pushup.models';
 
 describe('pushupRecordToUnified', () => {
@@ -159,5 +160,120 @@ describe('unifiedEntryFilterKey', () => {
         exerciseId: 'legs.squats',
       })
     ).toBe('legs.squats');
+  });
+});
+
+describe('unifiedEntryCategoryId', () => {
+  describe('Given a pushup entry', () => {
+    it('returns "pushup" regardless of variant', () => {
+      expect(
+        unifiedEntryCategoryId({
+          kind: 'pushup',
+          _id: 'p',
+          timestamp: 't',
+          reps: 1,
+          source: 'web',
+          variantType: 'diamond',
+        })
+      ).toBe('pushup');
+      expect(
+        unifiedEntryCategoryId({
+          kind: 'pushup',
+          _id: 'p',
+          timestamp: 't',
+          reps: 1,
+          source: 'web',
+          variantType: null,
+        })
+      ).toBe('pushup');
+    });
+  });
+
+  describe('Given a catalog exercise entry', () => {
+    it('returns the categoryId from the catalog (abs)', () => {
+      expect(
+        unifiedEntryCategoryId({
+          kind: 'exercise',
+          _id: 'e',
+          timestamp: 't',
+          reps: 1,
+          source: 'web',
+          exerciseId: 'abs.situps',
+        })
+      ).toBe('abs');
+    });
+
+    it('returns the categoryId from the catalog (legs)', () => {
+      expect(
+        unifiedEntryCategoryId({
+          kind: 'exercise',
+          _id: 'e',
+          timestamp: 't',
+          reps: 1,
+          source: 'web',
+          exerciseId: 'legs.squats',
+        })
+      ).toBe('legs');
+    });
+
+    it('returns the categoryId for non-reps measurements (cardio)', () => {
+      expect(
+        unifiedEntryCategoryId({
+          kind: 'exercise',
+          _id: 'e',
+          timestamp: 't',
+          reps: 0,
+          source: 'web',
+          exerciseId: 'cardio.running',
+          distanceM: 5000,
+          durationSec: 1650,
+        })
+      ).toBe('cardio');
+    });
+  });
+
+  describe('Given an unknown exercise id', () => {
+    it('returns null when the catalog has no match and no resolver is provided', () => {
+      expect(
+        unifiedEntryCategoryId({
+          kind: 'exercise',
+          _id: 'e',
+          timestamp: 't',
+          reps: 1,
+          source: 'web',
+          exerciseId: 'custom.unknown',
+        })
+      ).toBeNull();
+    });
+  });
+
+  describe('Given a custom resolver', () => {
+    it('uses the resolver to look up custom exercises outside the catalog', () => {
+      const customDef: ExerciseDefinition = {
+        id: 'custom-uuid',
+        categoryId: 'mobility',
+        ownerId: 'u1',
+        measurement: 'reps',
+        min: 1,
+        max: 100,
+        unit: 'reps',
+        customName: 'Hip openers',
+      };
+      const resolver = (id: string) =>
+        id === 'custom-uuid' ? customDef : null;
+      expect(
+        unifiedEntryCategoryId(
+          {
+            kind: 'exercise',
+            _id: 'e',
+            timestamp: 't',
+            reps: 1,
+            source: 'web',
+            exerciseId: 'custom-uuid',
+          },
+          resolver
+        )
+      ).toBe('mobility');
+    });
   });
 });

--- a/libs/stats/src/lib/models/unified-entry.models.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.ts
@@ -14,7 +14,12 @@
  *     the source doc.
  */
 
-import type { ExerciseEntry } from './exercise.models';
+import { findExerciseDefinition } from './exercise.catalog';
+import type {
+  ExerciseCategoryId,
+  ExerciseDefinition,
+  ExerciseEntry,
+} from './exercise.models';
 import type { PushupRecord } from './pushup.models';
 
 export interface UnifiedEntryBase {
@@ -99,6 +104,28 @@ export function exerciseEntryToUnified(e: ExerciseEntry): UnifiedExerciseEntry {
  * stays a separate dropdown so users can still drill down to "Diamond
  * Pushups only".
  */
-export function unifiedEntryFilterKey(entry: UnifiedEntry): UnifiedEntryFilterKey {
+export function unifiedEntryFilterKey(
+  entry: UnifiedEntry
+): UnifiedEntryFilterKey {
   return entry.kind === 'pushup' ? 'pushup' : entry.exerciseId;
+}
+
+/**
+ * Maps a UnifiedEntry to the exercise category it belongs to. Pushup
+ * entries always map to `'pushup'`. Exercise entries are resolved via
+ * the catalog — `resolveDefinition` defaults to {@link
+ * findExerciseDefinition} but can be overridden when the analysis page
+ * needs to resolve custom user exercises that live outside the
+ * standard catalog. Returns `null` when the exercise id is not
+ * resolvable, so callers can decide whether to bucket the entry into
+ * an "unknown" group or drop it.
+ */
+export function unifiedEntryCategoryId(
+  entry: UnifiedEntry,
+  resolveDefinition: (
+    id: string
+  ) => ExerciseDefinition | null = findExerciseDefinition
+): ExerciseCategoryId | null {
+  if (entry.kind === 'pushup') return 'pushup';
+  return resolveDefinition(entry.exerciseId)?.categoryId ?? null;
 }

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -22,6 +22,7 @@ import {
   exerciseEntryToUnified,
   type ExerciseCategoryId,
   inferRangeMode,
+  PushupRecord,
   pushupRecordToUnified,
   StatsGranularity,
   StatsResponse,
@@ -337,7 +338,49 @@ export const AnalysisStore = signalStore(
       );
     });
 
-    const weekRows = computed(() => store.weekEntriesResource.value() ?? []);
+    // Trend rows mirror the activeView filter so the 8-week and
+    // 6-month windows reflect the same category as the rest of the
+    // page. We merge the pushup REST data (which the resource already
+    // fetches for the trend window) with the live exercise entries —
+    // no extra Firestore reads — and then drop entries outside both
+    // the trend window and the active view.
+    const inRangeFn = (from: string, to: string) => (timestamp: string) => {
+      const date = timestamp.slice(0, 10);
+      if (from && date < from) return false;
+      if (to && date > to) return false;
+      return true;
+    };
+
+    const trendUnifiedRows = (
+      pushupRows: ReadonlyArray<PushupRecord>,
+      window: { from: string; to: string }
+    ): UnifiedEntry[] => {
+      const inRange = inRangeFn(window.from, window.to);
+      const pushups = pushupRows
+        .filter((r) => inRange(r.timestamp))
+        .map(pushupRecordToUnified);
+      const exercises = store._live
+        .exerciseEntries()
+        .filter((e) => inRange(e.timestamp))
+        .map(exerciseEntryToUnified);
+      return [...pushups, ...exercises];
+    };
+
+    const applyViewFilter = (rows: UnifiedEntry[]): UnifiedEntry[] => {
+      const view = store.activeView();
+      if (view === 'overview') return rows;
+      return rows.filter((row) => unifiedEntryCategoryId(row) === view);
+    };
+
+    const weekTrendRows = computed<UnifiedEntry[]>(() =>
+      applyViewFilter(
+        trendUnifiedRows(
+          store.weekEntriesResource.value() ?? [],
+          store.weekFilter()
+        )
+      )
+    );
+
     const weekTrend = computed<TrendPoint[]>(() => {
       // Pre-seed TREND_WEEKS ISO weeks (oldest → newest) so a sparse
       // history still produces a fixed-length trend with explicit zero
@@ -353,7 +396,7 @@ export const AnalysisStore = signalStore(
         const key = `${isoWeekYear(d)}-W${String(isoWeek(d)).padStart(2, '0')}`;
         byWeek.set(key, { total: 0, entryCount: 0, setsCount: 0 });
       }
-      for (const row of weekRows()) {
+      for (const row of weekTrendRows()) {
         const date = new Date(row.timestamp);
         const key = `${isoWeekYear(date)}-W${String(isoWeek(date)).padStart(2, '0')}`;
         const entry = byWeek.get(key);
@@ -373,7 +416,15 @@ export const AnalysisStore = signalStore(
       );
     });
 
-    const monthRows = computed(() => store.monthEntriesResource.value() ?? []);
+    const monthTrendRows = computed<UnifiedEntry[]>(() =>
+      applyViewFilter(
+        trendUnifiedRows(
+          store.monthEntriesResource.value() ?? [],
+          store.monthFilter()
+        )
+      )
+    );
+
     const monthTrend = computed<TrendPoint[]>(() => {
       const monthStart = store.currentMonthStart();
       const byMonth = new Map<
@@ -389,7 +440,7 @@ export const AnalysisStore = signalStore(
         const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
         byMonth.set(key, { total: 0, entryCount: 0, setsCount: 0 });
       }
-      for (const row of monthRows()) {
+      for (const row of monthTrendRows()) {
         const date = new Date(row.timestamp);
         const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
         const entry = byMonth.get(key);

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -35,6 +35,7 @@ import {
   unifiedEntryFilterKey,
   UserStats,
 } from '@pu-stats/models';
+import { categoryDisplayName } from './i18n/exercise-display-names';
 
 /** Active analysis view: overview tab or a specific exercise category. */
 export type AnalysisView = 'overview' | ExerciseCategoryId;
@@ -351,13 +352,12 @@ export const AnalysisStore = signalStore(
       });
     });
 
-    /**
-     * Unified rows scoped to the {@link AnalysisStore.activeView active
-     * tab}. `'overview'` returns every row in range; any
-     * `ExerciseCategoryId` filters down to entries that map to that
-     * category via {@link unifiedEntryCategoryId}. Foundation for the
-     * per-category KPIs/charts/trends rolled out in subsequent commits.
-     */
+    // Entries whose exerciseId is absent from the standard catalog
+    // (e.g. a removed-and-never-replaced custom user exercise) drop
+    // out of every per-category tab — `unifiedEntryCategoryId` returns
+    // null and no tab matches. That's intentional: the overview tab
+    // still surfaces their volume, and resurrecting them under an
+    // "Andere" bucket would mask the catalog-mismatch in normal use.
     const viewFilteredRows = computed<UnifiedEntry[]>(() => {
       const view = store.activeView();
       if (view === 'overview') return unifiedRows();
@@ -434,11 +434,14 @@ export const AnalysisStore = signalStore(
       return result.sort((a, b) => a.order - b.order);
     });
 
-    /** Bar/pie-friendly projection of {@link categorySummaries}. */
+    // Labels are resolved here rather than left to the chart component
+    // because Chart.js has no `$localize` hook — feeding it the raw
+    // XLIFF id would render the legend like a developer string in
+    // production builds.
     const categoryComparison = computed<CategoryComparison>(() => {
       const summaries = categorySummaries();
       return {
-        labels: summaries.map((s) => s.nameKey),
+        labels: summaries.map((s) => categoryDisplayName(s.categoryId)),
         reps: summaries.map((s) => s.totalReps),
         sets: summaries.map((s) => s.totalSets),
       };
@@ -457,6 +460,12 @@ export const AnalysisStore = signalStore(
       return true;
     };
 
+    // Pushups come from a date-scoped REST resource; exercise entries
+    // are taken from `_live.exerciseEntries()` (the full Firestore
+    // snapshot) and clipped client-side. This asymmetry is acceptable
+    // for typical histories but should grow into a date-windowed
+    // exerciseEntries resource once long histories show up — until
+    // then the inRange filter keeps memory predictable.
     const trendUnifiedRows = (
       pushupRows: ReadonlyArray<PushupRecord>,
       window: { from: string; to: string }
@@ -567,15 +576,25 @@ export const AnalysisStore = signalStore(
     });
 
     const typeBreakdown = computed<TypeBreakdownDatum[]>(() => {
+      const view = store.activeView();
+      const rowsForView = viewFilteredRows();
       const kinds = store.kinds();
       const kindSet = kinds.length > 0 ? new Set<string>(kinds) : null;
-      const onlyPushup =
-        !kindSet || (kindSet.size === 1 && kindSet.has('pushup'));
+      // In a per-category tab the pushup-variant breakdown only makes
+      // sense for the pushup tab; every other category renders the
+      // kind-mode breakdown over its own entries. In overview the
+      // legacy gate stays so a default page still shows pushup
+      // variants when no kind filter is active.
+      const showPushupVariants =
+        view === 'pushup' ||
+        (view === 'overview' &&
+          (!kindSet || (kindSet.size === 1 && kindSet.has('pushup'))));
 
-      if (onlyPushup) {
+      if (showPushupVariants) {
         const byType = new Map<string, { reps: number; allSets: number[] }>();
-        for (const row of rows()) {
-          const key = canonicalizePushupType(row.type) || 'standard';
+        for (const row of rowsForView) {
+          if (row.kind !== 'pushup') continue;
+          const key = canonicalizePushupType(row.variantType) || 'standard';
           const entry = byType.get(key) ?? { reps: 0, allSets: [] };
           entry.reps += row.reps;
           if (row.sets?.length) entry.allSets.push(...row.sets);
@@ -600,7 +619,7 @@ export const AnalysisStore = signalStore(
       // emitted as the bare key — `$localize` for kind names lives in
       // the page component.
       const byKind = new Map<string, { reps: number; allSets: number[] }>();
-      for (const row of unifiedRows()) {
+      for (const row of rowsForView) {
         const key = unifiedEntryFilterKey(row);
         if (kindSet && !kindSet.has(key)) continue;
         const bucket = byKind.get(key) ?? { reps: 0, allSets: [] };
@@ -623,9 +642,6 @@ export const AnalysisStore = signalStore(
         }));
     });
 
-    // KPIs operate on {@link viewFilteredRows} so they re-aggregate
-    // automatically when the user switches to a per-category tab
-    // (or stays on overview, which sees every UnifiedEntry).
     const bestSingleEntry = computed<UnifiedEntry | null>(() => {
       const view = viewFilteredRows();
       if (!view.length) return null;

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -98,18 +98,20 @@ type AnalysisState = {
   to: string;
   dayChartMode: '24h' | '14h' | undefined;
   /**
-   * Active exercise-kind filter for the type-pie. Both an empty array
-   * (default) and `['pushup']` render the pushup-variant breakdown;
-   * any other non-empty subset switches to kind-mode (pushups
-   * collapsed into one bucket, each `exerciseId` as its own slice).
-   * Streaks/best-day KPIs stay pushup-only.
+   * Active exercise-kind filter for the type-pie. In overview the
+   * empty array (default) and `['pushup']` render the pushup-variant
+   * breakdown; any other non-empty subset switches to kind-mode
+   * (pushups collapsed into one bucket, each `exerciseId` as its own
+   * slice). Streaks and best-day KPIs are no longer pushup-only —
+   * they live on {@link AnalysisStore.viewFilteredRows} and follow
+   * {@link AnalysisState.activeView} instead.
    */
   kinds: ReadonlyArray<UnifiedEntryFilterKey>;
   /**
    * Active per-category view tab. `'overview'` (default) keeps the
    * page-wide aggregate behaviour; any other value scopes
-   * {@link AnalysisStore.viewFilteredRows} (and downstream KPIs in
-   * follow-up commits) to entries from that category.
+   * {@link AnalysisStore.viewFilteredRows} and all downstream KPIs,
+   * trends and the type-pie to entries from that category.
    */
   activeView: AnalysisView;
   // Reactive dependency for the fixed-window trend filters: bumped only

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -21,6 +21,7 @@ import {
   displayPushupType,
   exerciseEntryToUnified,
   type ExerciseCategoryId,
+  EXERCISE_CATEGORIES,
   inferRangeMode,
   PushupRecord,
   pushupRecordToUnified,
@@ -62,6 +63,33 @@ export interface TypeBreakdownDatum {
   label: string;
   value: number;
   avgSetSize: number;
+}
+
+/**
+ * Per-category roll-up consumed by the analysis overview tab. The
+ * cards render `nameKey`/`icon`, and the comparison chart pulls
+ * `totalReps`/`totalSets` from the same shape so the two views stay
+ * in lockstep. Categories with no entries in the current date range
+ * are filtered out upstream — every entry here represents a present,
+ * non-empty group.
+ */
+export interface CategorySummary {
+  categoryId: ExerciseCategoryId;
+  nameKey: string;
+  icon: string;
+  order: number;
+  totalReps: number;
+  totalSets: number;
+  todayReps: number;
+  currentStreak: number;
+  bestDay: { date: string; total: number } | null;
+}
+
+/** Series shape consumed by the overview comparison chart. */
+export interface CategoryComparison {
+  labels: ReadonlyArray<string>;
+  reps: ReadonlyArray<number>;
+  sets: ReadonlyArray<number>;
 }
 
 type AnalysisState = {
@@ -336,6 +364,84 @@ export const AnalysisStore = signalStore(
       return unifiedRows().filter(
         (row) => unifiedEntryCategoryId(row) === view
       );
+    });
+
+    /**
+     * Per-category roll-up for the overview tab. Always operates on
+     * the full unified row set in the current date range — independent
+     * of {@link AnalysisStore.activeView} — because the cards/chart in
+     * the overview show every group side-by-side.
+     *
+     * `lastDayKey` is read so `todayReps` re-evaluates after a
+     * `tickClock()` crosses midnight without forcing an extra signal.
+     */
+    const categorySummaries = computed<CategorySummary[]>(() => {
+      const todayKey = store.lastDayKey();
+      const rows = unifiedRows();
+      const byCategory = new Map<ExerciseCategoryId, UnifiedEntry[]>();
+      for (const row of rows) {
+        const cat = unifiedEntryCategoryId(row);
+        if (!cat) continue;
+        const bucket = byCategory.get(cat);
+        if (bucket) bucket.push(row);
+        else byCategory.set(cat, [row]);
+      }
+      const result: CategorySummary[] = [];
+      for (const meta of EXERCISE_CATEGORIES) {
+        const catRows = byCategory.get(meta.id);
+        if (!catRows || !catRows.length) continue;
+        const totalReps = catRows.reduce((s, r) => s + r.reps, 0);
+        const totalSets = catRows.reduce(
+          (s, r) => s + (r.sets?.length ?? 0),
+          0
+        );
+        const todayReps = catRows.reduce(
+          (s, r) => (r.timestamp.slice(0, 10) === todayKey ? s + r.reps : s),
+          0
+        );
+        const byDay = new Map<string, number>();
+        for (const r of catRows) {
+          const k = r.timestamp.slice(0, 10);
+          byDay.set(k, (byDay.get(k) ?? 0) + r.reps);
+        }
+        let bestDayPair: [string, number] | null = null;
+        for (const e of byDay.entries()) {
+          if (!bestDayPair || e[1] > bestDayPair[1]) bestDayPair = e;
+        }
+        const dates = sortedUniqueDates(catRows);
+        let streak = 0;
+        if (dates.length) {
+          streak = 1;
+          for (let i = dates.length - 1; i > 0; i--) {
+            if (daysBetween(dates[i - 1], dates[i]) === 1) streak += 1;
+            else break;
+          }
+        }
+        result.push({
+          categoryId: meta.id,
+          nameKey: meta.nameKey,
+          icon: meta.icon,
+          order: meta.order,
+          totalReps,
+          totalSets,
+          todayReps,
+          currentStreak: streak,
+          bestDay: bestDayPair
+            ? { date: bestDayPair[0], total: bestDayPair[1] }
+            : null,
+        });
+      }
+      return result.sort((a, b) => a.order - b.order);
+    });
+
+    /** Bar/pie-friendly projection of {@link categorySummaries}. */
+    const categoryComparison = computed<CategoryComparison>(() => {
+      const summaries = categorySummaries();
+      return {
+        labels: summaries.map((s) => s.nameKey),
+        reps: summaries.map((s) => s.totalReps),
+        sets: summaries.map((s) => s.totalSets),
+      };
     });
 
     // Trend rows mirror the activeView filter so the 8-week and
@@ -616,6 +722,8 @@ export const AnalysisStore = signalStore(
       rows,
       unifiedRows,
       viewFilteredRows,
+      categorySummaries,
+      categoryComparison,
       kindOptionsRaw,
       weekTrend,
       monthTrend,

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -20,6 +20,7 @@ import {
   createWeekRange,
   displayPushupType,
   exerciseEntryToUnified,
+  type ExerciseCategoryId,
   inferRangeMode,
   PushupRecord,
   pushupRecordToUnified,
@@ -28,10 +29,14 @@ import {
   StatsSeriesEntry,
   toLocalIsoDate,
   UnifiedEntry,
+  unifiedEntryCategoryId,
   UnifiedEntryFilterKey,
   unifiedEntryFilterKey,
   UserStats,
 } from '@pu-stats/models';
+
+/** Active analysis view: overview tab or a specific exercise category. */
+export type AnalysisView = 'overview' | ExerciseCategoryId;
 
 const EMPTY_STATS: StatsResponse = {
   meta: {
@@ -71,6 +76,13 @@ type AnalysisState = {
    * Streaks/best-day KPIs stay pushup-only.
    */
   kinds: ReadonlyArray<UnifiedEntryFilterKey>;
+  /**
+   * Active per-category view tab. `'overview'` (default) keeps the
+   * page-wide aggregate behaviour; any other value scopes
+   * {@link AnalysisStore.viewFilteredRows} (and downstream KPIs in
+   * follow-up commits) to entries from that category.
+   */
+  activeView: AnalysisView;
   // Reactive dependency for the fixed-window trend filters: bumped only
   // when the local calendar day actually changes, so a polling interval
   // can call `tickClock()` aggressively without forcing
@@ -138,6 +150,7 @@ export const AnalysisStore = signalStore(
       to: defaultRange.to,
       dayChartMode: undefined as '24h' | '14h' | undefined,
       kinds: [] as ReadonlyArray<UnifiedEntryFilterKey>,
+      activeView: 'overview' as AnalysisView,
       clockTick: 0,
       // Seed with today so the first `tickClock()` after construction is a
       // no-op; otherwise the 5-minute polling interval would force a
@@ -306,6 +319,21 @@ export const AnalysisStore = signalStore(
         if (b === 'pushup') return 1;
         return a.localeCompare(b);
       });
+    });
+
+    /**
+     * Unified rows scoped to the {@link AnalysisStore.activeView active
+     * tab}. `'overview'` returns every row in range; any
+     * `ExerciseCategoryId` filters down to entries that map to that
+     * category via {@link unifiedEntryCategoryId}. Foundation for the
+     * per-category KPIs/charts/trends rolled out in subsequent commits.
+     */
+    const viewFilteredRows = computed<UnifiedEntry[]>(() => {
+      const view = store.activeView();
+      if (view === 'overview') return unifiedRows();
+      return unifiedRows().filter(
+        (row) => unifiedEntryCategoryId(row) === view
+      );
     });
 
     const weekRows = computed(() => store.weekEntriesResource.value() ?? []);
@@ -531,6 +559,7 @@ export const AnalysisStore = signalStore(
       granularity,
       rows,
       unifiedRows,
+      viewFilteredRows,
       kindOptionsRaw,
       weekTrend,
       monthTrend,
@@ -562,6 +591,9 @@ export const AnalysisStore = signalStore(
     },
     setKinds(kinds: ReadonlyArray<UnifiedEntryFilterKey>): void {
       patchState(store, { kinds });
+    },
+    setActiveView(activeView: AnalysisView): void {
+      patchState(store, { activeView });
     },
     refreshAll(): void {
       store.statsResource.reload();

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -22,7 +22,6 @@ import {
   exerciseEntryToUnified,
   type ExerciseCategoryId,
   inferRangeMode,
-  PushupRecord,
   pushupRecordToUnified,
   StatsGranularity,
   StatsResponse,
@@ -118,7 +117,9 @@ function daysBetween(a: string, b: string): number {
   return Math.round((bd - ad) / 86_400_000);
 }
 
-function sortedUniqueDates(rows: PushupRecord[]): string[] {
+function sortedUniqueDates(
+  rows: ReadonlyArray<{ timestamp: string }>
+): string[] {
   return [...new Set(rows.map((x) => x.timestamp.slice(0, 10)))].sort((a, b) =>
     a.localeCompare(b)
   );
@@ -465,14 +466,18 @@ export const AnalysisStore = signalStore(
         }));
     });
 
-    const bestSingleEntry = computed<PushupRecord | null>(() => {
-      if (!rows().length) return null;
-      return [...rows()].sort((a, b) => b.reps - a.reps)[0] ?? null;
+    // KPIs operate on {@link viewFilteredRows} so they re-aggregate
+    // automatically when the user switches to a per-category tab
+    // (or stays on overview, which sees every UnifiedEntry).
+    const bestSingleEntry = computed<UnifiedEntry | null>(() => {
+      const view = viewFilteredRows();
+      if (!view.length) return null;
+      return [...view].sort((a, b) => b.reps - a.reps)[0] ?? null;
     });
 
     const bestDay = computed<{ date: string; total: number } | null>(() => {
       const byDay = new Map<string, number>();
-      for (const row of rows()) {
+      for (const row of viewFilteredRows()) {
         const key = row.timestamp.slice(0, 10);
         byDay.set(key, (byDay.get(key) ?? 0) + row.reps);
       }
@@ -482,7 +487,7 @@ export const AnalysisStore = signalStore(
     });
 
     const longestStreak = computed(() => {
-      const dates = sortedUniqueDates(rows());
+      const dates = sortedUniqueDates(viewFilteredRows());
       if (!dates.length) return 0;
       let best = 1;
       let current = 1;
@@ -495,7 +500,7 @@ export const AnalysisStore = signalStore(
     });
 
     const currentStreak = computed(() => {
-      const dates = sortedUniqueDates(rows());
+      const dates = sortedUniqueDates(viewFilteredRows());
       if (!dates.length) return 0;
       let streak = 1;
       for (let i = dates.length - 1; i > 0; i--) {
@@ -515,9 +520,9 @@ export const AnalysisStore = signalStore(
       () => userStats()?.heatmap ?? {}
     );
 
-    /** Average reps per individual set across all entries with sets data. */
+    /** Average reps per individual set across the active view's entries. */
     const avgSetSize = computed(() => {
-      const allSets = rows().flatMap((r) => r.sets ?? []);
+      const allSets = viewFilteredRows().flatMap((r) => r.sets ?? []);
       if (!allSets.length) return 0;
       return (
         Math.round((allSets.reduce((s, v) => s + v, 0) / allSets.length) * 10) /
@@ -529,7 +534,7 @@ export const AnalysisStore = signalStore(
     const setsDistribution = computed<
       Array<{ setCount: number; count: number; percent: number }>
     >(() => {
-      const entriesWithSets = rows().filter((r) => r.sets?.length);
+      const entriesWithSets = viewFilteredRows().filter((r) => r.sets?.length);
       if (!entriesWithSets.length) return [];
       const byCount = new Map<number, number>();
       for (const row of entriesWithSets) {
@@ -546,9 +551,9 @@ export const AnalysisStore = signalStore(
         }));
     });
 
-    /** Maximum reps in a single set across all entries. */
+    /** Maximum reps in a single set across the active view's entries. */
     const bestSingleSet = computed(() => {
-      const allSets = rows().flatMap((r) => r.sets ?? []);
+      const allSets = viewFilteredRows().flatMap((r) => r.sets ?? []);
       if (!allSets.length) return 0;
       return Math.max(...allSets);
     });

--- a/web/src/app/stats/components/heatmap/heatmap.component.ts
+++ b/web/src/app/stats/components/heatmap/heatmap.component.ts
@@ -2,7 +2,6 @@ import { isPlatformBrowser } from '@angular/common';
 import { Component, PLATFORM_ID, computed, inject, input } from '@angular/core';
 import type { ChartConfiguration } from 'chart.js';
 import { BaseChartDirective, provideCharts } from 'ng2-charts';
-import { PushupRecord } from '@pu-stats/models';
 import { ensureHeatmapChartRegistered } from './chart-setup';
 import {
   buildHeatmapCells,
@@ -10,6 +9,15 @@ import {
   defaultHeatmapHoursTopDown,
   heatmapCellColor,
 } from './heatmap.utils';
+
+/** Minimal shape the heatmap reads — narrower than `PushupRecord` or
+ *  `UnifiedEntry` so both can be passed in without a union type at the
+ *  caller. `buildHeatmapCells` already requires only these fields. */
+export interface HeatmapEntry {
+  timestamp: string;
+  reps: number;
+  sets?: number[];
+}
 
 ensureHeatmapChartRegistered();
 
@@ -52,7 +60,7 @@ export interface HeatmapCell {
   `,
 })
 export class HeatmapComponent {
-  readonly entries = input<PushupRecord[]>([]);
+  readonly entries = input<ReadonlyArray<HeatmapEntry>>([]);
   readonly mode = input<'reps' | 'sets'>('reps');
 
   readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -46,7 +46,14 @@ export function kindDisplayName(value: UnifiedEntryFilterKey): string {
   }
   const def = findExerciseDefinition(value);
   if (def) return exerciseDisplayName(def.id);
-  return $localize`:@@analysis.kindUnknown:Andere Übung`;
+  // Catalog-miss path: user-defined exercises (custom UUIDs) and
+  // legacy ids without a catalog entry both land here. Returning the
+  // bare id keeps each one distinguishable in the filter chips and
+  // type-pie legend until custom-exercise definitions are threaded
+  // through the analysis page — collapsing every miss into a single
+  // "Andere Übung" label made multi-custom-exercise users unable to
+  // tell their own filters apart.
+  return value;
 }
 
 /**
@@ -56,18 +63,20 @@ export function kindDisplayName(value: UnifiedEntryFilterKey): string {
  * no runtime hook for `$localize`, and emitting the id would render
  * the legend like a developer string in production builds.
  *
- * The German source strings mirror the catalogue entries in the
- * training-entry dialog; XLIFF ids stay identical so the existing
- * translations apply unchanged.
+ * Only entries with a corresponding XLIFF unit and at least one
+ * catalog exercise are mapped here. `strength` and `mobility` exist in
+ * the `ExerciseCategoryId` union but are absent from
+ * `EXERCISE_CATEGORIES`, so adding $localize calls for them would
+ * fail the locale-baked production build with "No translation found"
+ * — they get a per-id fallback through {@link categoryDisplayName}
+ * until they ship with their own exercises and translations.
  */
-const CATEGORY_DISPLAY_NAMES: Record<ExerciseCategoryId, string> = {
+const CATEGORY_DISPLAY_NAMES: Partial<Record<ExerciseCategoryId, string>> = {
   pushup: $localize`:@@exercise.category.pushup:Liegestütze`,
   abs: $localize`:@@exercise.category.abs:Bauch`,
   legs: $localize`:@@exercise.category.legs:Beine`,
   plank: $localize`:@@exercise.category.plank:Plank`,
   cardio: $localize`:@@exercise.category.cardio:Ausdauer`,
-  strength: $localize`:@@exercise.category.strength:Kraft`,
-  mobility: $localize`:@@exercise.category.mobility:Mobility`,
 };
 
 export function categoryDisplayName(id: ExerciseCategoryId): string {

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -1,3 +1,8 @@
+import {
+  findExerciseDefinition,
+  type UnifiedEntryFilterKey,
+} from '@pu-stats/models';
+
 /**
  * Locale-aware display strings for the standard exercise catalog.
  * `$localize` calls live in this module so the angular build extractor
@@ -21,4 +26,24 @@ const EXERCISE_DISPLAY_NAMES: Record<string, string> = {
 
 export function exerciseDisplayName(id: string): string {
   return EXERCISE_DISPLAY_NAMES[id] ?? id;
+}
+
+/**
+ * Resolves the filter-key shape used by the analysis page (`'pushup'`
+ * for the collapsed pushup bucket, exerciseId for everything else)
+ * to a localised label. Shared between the page filter chips and the
+ * type-pie legend so both stay in sync without duplicating the
+ * `$localize` calls.
+ *
+ * Falls back to a generic "Andere Übung" label for legacy ids that
+ * no longer have a catalog entry (e.g. an exercise removed from the
+ * catalog whose Firestore entries still exist).
+ */
+export function kindDisplayName(value: UnifiedEntryFilterKey): string {
+  if (value === 'pushup') {
+    return $localize`:@@exercise.category.pushup:Liegestütze`;
+  }
+  const def = findExerciseDefinition(value);
+  if (def) return exerciseDisplayName(def.id);
+  return $localize`:@@analysis.kindUnknown:Andere Übung`;
 }

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -1,4 +1,5 @@
 import {
+  type ExerciseCategoryId,
   findExerciseDefinition,
   type UnifiedEntryFilterKey,
 } from '@pu-stats/models';
@@ -46,4 +47,29 @@ export function kindDisplayName(value: UnifiedEntryFilterKey): string {
   const def = findExerciseDefinition(value);
   if (def) return exerciseDisplayName(def.id);
   return $localize`:@@analysis.kindUnknown:Andere Übung`;
+}
+
+/**
+ * Locale-aware display strings for exercise categories. Shared between
+ * the analysis overview cards and the comparison chart so the store
+ * can emit translated labels instead of raw XLIFF ids — Chart.js has
+ * no runtime hook for `$localize`, and emitting the id would render
+ * the legend like a developer string in production builds.
+ *
+ * The German source strings mirror the catalogue entries in the
+ * training-entry dialog; XLIFF ids stay identical so the existing
+ * translations apply unchanged.
+ */
+const CATEGORY_DISPLAY_NAMES: Record<ExerciseCategoryId, string> = {
+  pushup: $localize`:@@exercise.category.pushup:Liegestütze`,
+  abs: $localize`:@@exercise.category.abs:Bauch`,
+  legs: $localize`:@@exercise.category.legs:Beine`,
+  plank: $localize`:@@exercise.category.plank:Plank`,
+  cardio: $localize`:@@exercise.category.cardio:Ausdauer`,
+  strength: $localize`:@@exercise.category.strength:Kraft`,
+  mobility: $localize`:@@exercise.category.mobility:Mobility`,
+};
+
+export function categoryDisplayName(id: ExerciseCategoryId): string {
+  return CATEGORY_DISPLAY_NAMES[id] ?? id;
 }

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -36,9 +36,10 @@ export function exerciseDisplayName(id: string): string {
  * type-pie legend so both stay in sync without duplicating the
  * `$localize` calls.
  *
- * Falls back to a generic "Andere Übung" label for legacy ids that
- * no longer have a catalog entry (e.g. an exercise removed from the
- * catalog whose Firestore entries still exist).
+ * For ids that miss the catalog (user-defined custom exercises or
+ * legacy ids whose Firestore entries still exist) the raw `value`
+ * is returned, so each one stays individually distinguishable in
+ * filter chips and the type-pie legend.
  */
 export function kindDisplayName(value: UnifiedEntryFilterKey): string {
   if (value === 'pushup') {

--- a/web/src/app/stats/shell/analysis-group-view.component.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.ts
@@ -1,0 +1,367 @@
+import { DecimalPipe } from '@angular/common';
+import { Component, computed, inject, signal } from '@angular/core';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { type UnifiedEntryFilterKey } from '@pu-stats/models';
+import { HeatmapComponent } from '../components/heatmap/heatmap.component';
+import { SetsDistributionComponent } from '../components/sets-distribution/sets-distribution.component';
+import { StatsChartComponent } from '../components/stats-chart/stats-chart.component';
+import { TypePieComponent } from '../components/type-pie/type-pie.component';
+import { AnalysisStore } from '../analysis.store';
+import { kindDisplayName } from '../i18n/exercise-display-names';
+
+/**
+ * Detail view that renders the chart, KPI grid, heatmap and trend
+ * tables for the currently active analysis view (overview or a
+ * specific exercise category). The store's `activeView` / view-scoped
+ * computeds drive the data, so this component carries no inputs —
+ * dropping it inside any tab content gives the right slice.
+ */
+@Component({
+  selector: 'app-analysis-group-view',
+  imports: [
+    DecimalPipe,
+    MatButtonToggleModule,
+    MatCardModule,
+    MatIconModule,
+    MatTableModule,
+    HeatmapComponent,
+    SetsDistributionComponent,
+    StatsChartComponent,
+    TypePieComponent,
+  ],
+  template: `
+    <app-stats-chart
+      [series]="store.chartSeries()"
+      [granularity]="store.granularity()"
+      [rangeMode]="store.rangeMode()"
+      [from]="store.from()"
+      [to]="store.to()"
+      [entries]="store.rows()"
+      [dayChartMode]="store.resolvedDayChartMode()"
+      (dayChartModeChange)="store.setDayChartMode($event)"
+    />
+
+    <section class="grid">
+      <mat-card>
+        <mat-card-header>
+          <mat-card-title i18n="@@analysis.bestStreaksTitle"
+            >Bestwerte & Streaks</mat-card-title
+          >
+        </mat-card-header>
+        <mat-card-content class="best-grid">
+          <div>
+            <strong i18n="@@analysis.bestSingleEntry"
+              >Bestwert Einzel-Eintrag:</strong
+            >
+            <div>{{ store.bestSingleEntry()?.reps ?? 0 }} Reps</div>
+          </div>
+          <div>
+            <strong i18n="@@analysis.bestDay">Bester Tag:</strong>
+            <div>
+              {{ store.bestDay()?.date ?? '—' }} ·
+              {{ store.bestDay()?.total ?? 0 }} Reps
+            </div>
+          </div>
+          @if (store.bestSingleSet()) {
+            <div>
+              <strong i18n="@@analysis.bestSingleSet"
+                >Bestes Einzel-Set:</strong
+              >
+              <div>
+                {{ store.bestSingleSet() }}
+                <span i18n="@@analysis.repsUnit">Wdh.</span>
+              </div>
+            </div>
+          }
+          <div>
+            <strong i18n="@@analysis.currentStreak">Aktuelle Streak:</strong>
+            <div>
+              <ng-container i18n="@@analysis.streakDays"
+                >{{ store.currentStreak() }} Tage</ng-container
+              >
+            </div>
+          </div>
+          <div>
+            <strong i18n="@@analysis.longestStreak">Längste Streak:</strong>
+            <div>
+              <ng-container i18n="@@analysis.streakDays"
+                >{{ store.longestStreak() }} Tage</ng-container
+              >
+            </div>
+          </div>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card>
+        <mat-card-header>
+          <mat-card-title i18n="@@analysis.typesTitle"
+            >Typen (Anteile)</mat-card-title
+          >
+        </mat-card-header>
+        <mat-card-content>
+          @defer (hydrate on viewport) {
+            <app-type-pie [data]="typeBreakdownDisplay()" />
+          }
+        </mat-card-content>
+      </mat-card>
+
+      @if (store.avgSetSize()) {
+        <mat-card>
+          <mat-card-header>
+            <mat-card-title i18n="@@analysis.avgSetSizeTitle"
+              >&#x2300; Set-Gr&#x00F6;&#x00DF;e</mat-card-title
+            >
+          </mat-card-header>
+          <mat-card-content class="kpi-big">
+            <b>{{ store.avgSetSize() }}</b>
+            <span i18n="@@analysis.repsPerSet">Reps / Set</span>
+          </mat-card-content>
+        </mat-card>
+      }
+
+      @if (store.setsDistribution().length) {
+        <mat-card>
+          <mat-card-header>
+            <mat-card-title i18n="@@analysis.setsDistTitle"
+              >Sets-Verteilung</mat-card-title
+            >
+          </mat-card-header>
+          <mat-card-content>
+            @defer (hydrate on viewport) {
+              <app-sets-distribution [data]="store.setsDistribution()" />
+            }
+          </mat-card-content>
+        </mat-card>
+      }
+    </section>
+
+    <mat-card class="heatmap-full">
+      <mat-card-header>
+        <mat-card-title i18n="@@analysis.heatmapTitle"
+          >Heatmap (Wochentag/Uhrzeit)</mat-card-title
+        >
+        <mat-button-toggle-group
+          [value]="heatmapMode()"
+          (change)="heatmapMode.set($event.value)"
+          class="heatmap-toggle"
+          aria-label="Heatmap-Modus auswählen"
+          i18n-aria-label="@@analysis.heatmapToggleAriaLabel"
+        >
+          <mat-button-toggle value="reps" i18n="@@analysis.heatmapReps"
+            >Reps</mat-button-toggle
+          >
+          <mat-button-toggle value="sets" i18n="@@analysis.heatmapSets"
+            >Sets</mat-button-toggle
+          >
+        </mat-button-toggle-group>
+      </mat-card-header>
+      <mat-card-content class="heatmap-wrap">
+        @defer (hydrate on viewport) {
+          <app-heatmap [entries]="store.rows()" [mode]="heatmapMode()" />
+        }
+      </mat-card-content>
+    </mat-card>
+
+    <section class="trends-section" data-testid="analysis-trends-section">
+      <mat-card>
+        <mat-card-header>
+          <mat-card-title i18n="@@analysis.weekTrendTitle"
+            >Wochentrend</mat-card-title
+          >
+          <mat-card-subtitle i18n="@@analysis.weekTrendSubtitle"
+            >Letzte 8 Wochen</mat-card-subtitle
+          >
+        </mat-card-header>
+        <mat-card-content>
+          @defer (on viewport) {
+            <mat-table [dataSource]="store.weekTrend()">
+              <ng-container matColumnDef="label">
+                <mat-header-cell *matHeaderCellDef i18n="@@analysis.weekCol"
+                  >Woche</mat-header-cell
+                >
+                <mat-cell *matCellDef="let row">{{ row.label }}</mat-cell>
+              </ng-container>
+              <ng-container matColumnDef="total">
+                <mat-header-cell *matHeaderCellDef i18n="@@analysis.repsCol"
+                  >Reps</mat-header-cell
+                >
+                <mat-cell *matCellDef="let row">{{ row.total }}</mat-cell>
+              </ng-container>
+              <ng-container matColumnDef="avgSetsPerEntry">
+                <mat-header-cell *matHeaderCellDef i18n="@@analysis.avgSetsCol"
+                  >&#x2300; Sets</mat-header-cell
+                >
+                <mat-cell *matCellDef="let row">{{
+                  row.avgSetsPerEntry !== null &&
+                  row.avgSetsPerEntry !== undefined
+                    ? (row.avgSetsPerEntry | number)
+                    : '—'
+                }}</mat-cell>
+              </ng-container>
+              <mat-header-row
+                *matHeaderRowDef="trendColumnsWithSets"
+              ></mat-header-row>
+              <mat-row
+                *matRowDef="let row; columns: trendColumnsWithSets"
+              ></mat-row>
+            </mat-table>
+          } @placeholder {
+            <div class="trend-placeholder" aria-hidden="true"></div>
+          }
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card>
+        <mat-card-header>
+          <mat-card-title i18n="@@analysis.monthTrendTitle"
+            >Monatstrend</mat-card-title
+          >
+          <mat-card-subtitle i18n="@@analysis.monthTrendSubtitle"
+            >Letzte 6 Monate</mat-card-subtitle
+          >
+        </mat-card-header>
+        <mat-card-content>
+          @defer (on viewport) {
+            <mat-table [dataSource]="store.monthTrend()">
+              <ng-container matColumnDef="label">
+                <mat-header-cell *matHeaderCellDef i18n="@@analysis.monthCol"
+                  >Monat</mat-header-cell
+                >
+                <mat-cell *matCellDef="let row">{{ row.label }}</mat-cell>
+              </ng-container>
+              <ng-container matColumnDef="total">
+                <mat-header-cell *matHeaderCellDef i18n="@@analysis.repsCol"
+                  >Reps</mat-header-cell
+                >
+                <mat-cell *matCellDef="let row">{{ row.total }}</mat-cell>
+              </ng-container>
+              <ng-container matColumnDef="avgSetsPerEntry">
+                <mat-header-cell *matHeaderCellDef i18n="@@analysis.avgSetsCol"
+                  >&#x2300; Sets</mat-header-cell
+                >
+                <mat-cell *matCellDef="let row">{{
+                  row.avgSetsPerEntry !== null &&
+                  row.avgSetsPerEntry !== undefined
+                    ? (row.avgSetsPerEntry | number)
+                    : '—'
+                }}</mat-cell>
+              </ng-container>
+              <mat-header-row
+                *matHeaderRowDef="trendColumnsWithSets"
+              ></mat-header-row>
+              <mat-row
+                *matRowDef="let row; columns: trendColumnsWithSets"
+              ></mat-row>
+            </mat-table>
+          } @placeholder {
+            <div class="trend-placeholder" aria-hidden="true"></div>
+          }
+        </mat-card-content>
+      </mat-card>
+    </section>
+  `,
+  styles: `
+    :host {
+      display: grid;
+      gap: 16px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 16px;
+    }
+    mat-table {
+      width: 100%;
+    }
+    mat-card-content {
+      overflow: auto;
+    }
+    .best-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(180px, 1fr));
+      gap: 12px;
+    }
+    .heatmap-full {
+      width: 100%;
+    }
+    .heatmap-wrap {
+      overflow: auto;
+      width: 100%;
+      min-height: 400px;
+    }
+    /* Reserve roughly the rendered table height so revealing the
+       deferred trend block doesn't shift the rest of the page down. */
+    .trend-placeholder {
+      min-height: 320px;
+    }
+    .kpi-big {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 16px 0;
+    }
+    .kpi-big b {
+      font-size: 2.5rem;
+      line-height: 1;
+    }
+    .kpi-big span {
+      opacity: 0.7;
+      font-size: 0.85rem;
+    }
+    .heatmap-toggle {
+      margin-left: auto;
+    }
+    @media (max-width: 900px) {
+      :host {
+        gap: 12px;
+      }
+      .grid {
+        grid-template-columns: 1fr;
+        gap: 12px;
+      }
+      .best-grid {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+    @media (max-width: 600px) {
+      .best-grid {
+        grid-template-columns: 1fr;
+      }
+      .heatmap-full mat-card-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+      }
+      .heatmap-toggle {
+        margin-left: 0;
+      }
+    }
+  `,
+})
+export class AnalysisGroupViewComponent {
+  readonly store = inject(AnalysisStore);
+  readonly trendColumnsWithSets = ['label', 'total', 'avgSetsPerEntry'];
+  readonly heatmapMode = signal<'reps' | 'sets'>('reps');
+
+  /**
+   * Resolves the bare-id labels emitted by `store.typeBreakdown()` (in
+   * multi-kind mode) into localised display names. Pushup-only mode
+   * returns the breakdown unchanged because the store already produces
+   * locale-aware variant names there.
+   */
+  readonly typeBreakdownDisplay = computed(() => {
+    const kinds = this.store.kinds();
+    const isKindMode =
+      kinds.length > 0 && !(kinds.length === 1 && kinds[0] === 'pushup');
+    const data = this.store.typeBreakdown();
+    if (!isKindMode) return data;
+    return data.map((d) => ({
+      ...d,
+      label: kindDisplayName(d.id as UnifiedEntryFilterKey),
+    }));
+  });
+}

--- a/web/src/app/stats/shell/analysis-group-view.component.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.ts
@@ -13,11 +13,9 @@ import { AnalysisStore } from '../analysis.store';
 import { kindDisplayName } from '../i18n/exercise-display-names';
 
 /**
- * Detail view that renders the chart, KPI grid, heatmap and trend
- * tables for the currently active analysis view (overview or a
- * specific exercise category). The store's `activeView` / view-scoped
- * computeds drive the data, so this component carries no inputs —
- * dropping it inside any tab content gives the right slice.
+ * The store's `activeView` / view-scoped computeds drive the data,
+ * so this component carries no inputs — dropping it inside any tab
+ * content gives the right slice without prop-drilling.
  */
 @Component({
   selector: 'app-analysis-group-view',
@@ -160,7 +158,10 @@ import { kindDisplayName } from '../i18n/exercise-display-names';
       </mat-card-header>
       <mat-card-content class="heatmap-wrap">
         @defer (hydrate on viewport) {
-          <app-heatmap [entries]="store.rows()" [mode]="heatmapMode()" />
+          <app-heatmap
+            [entries]="store.viewFilteredRows()"
+            [mode]="heatmapMode()"
+          />
         }
       </mat-card-content>
     </mat-card>

--- a/web/src/app/stats/shell/analysis-group-view.component.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.ts
@@ -350,16 +350,22 @@ export class AnalysisGroupViewComponent {
 
   /**
    * Resolves the bare-id labels emitted by `store.typeBreakdown()` (in
-   * multi-kind mode) into localised display names. Pushup-only mode
-   * returns the breakdown unchanged because the store already produces
-   * locale-aware variant names there.
+   * kind mode) into localised display names. Pushup-variant mode
+   * passes through because the store already produces locale-aware
+   * variant names. The gate mirrors `analysis.store` — a per-category
+   * tab other than 'pushup' is always kind mode, so the breakdown
+   * carries exerciseIds like `abs.situps` that need translating even
+   * without an explicit kinds filter.
    */
   readonly typeBreakdownDisplay = computed(() => {
+    const view = this.store.activeView();
     const kinds = this.store.kinds();
-    const isKindMode =
-      kinds.length > 0 && !(kinds.length === 1 && kinds[0] === 'pushup');
+    const showPushupVariants =
+      view === 'pushup' ||
+      (view === 'overview' &&
+        (kinds.length === 0 || (kinds.length === 1 && kinds[0] === 'pushup')));
     const data = this.store.typeBreakdown();
-    if (!isKindMode) return data;
+    if (showPushupVariants) return data;
     return data.map((d) => ({
       ...d,
       label: kindDisplayName(d.id as UnifiedEntryFilterKey),

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -18,7 +18,14 @@ import { StatsChartComponent } from '../components/stats-chart/stats-chart.compo
 import { SetsDistributionComponent } from '../components/sets-distribution/sets-distribution.component';
 
 // We don't want to render real components in unit tests.
-import { Component, input, model, output, signal } from '@angular/core';
+import {
+  Component,
+  input,
+  model,
+  output,
+  PLATFORM_ID,
+  signal,
+} from '@angular/core';
 import { ExerciseEntry, RangeModes } from '@pu-stats/models';
 
 @Component({
@@ -172,6 +179,10 @@ describe('AnalysisPageComponent', () => {
     await TestBed.configureTestingModule({
       imports: [AnalysisPageComponent],
       providers: [
+        // 'server' skips the component's setInterval-based clock tick
+        // and the URL history effect; both depend on browser-only APIs
+        // and otherwise risk leaking timers across TestBed resets.
+        { provide: PLATFORM_ID, useValue: 'server' },
         { provide: StatsApiService, useValue: apiMock },
         { provide: AuthStore, useValue: makeAuthStoreMock() },
         { provide: UserContextService, useValue: { userIdSafe: () => 'u1' } },
@@ -797,6 +808,7 @@ describe('AnalysisPageComponent empty-state CTA gating', () => {
     await TestBed.configureTestingModule({
       imports: [AnalysisPageComponent],
       providers: [
+        { provide: PLATFORM_ID, useValue: 'server' },
         provideRouter([]),
         { provide: StatsApiService, useValue: emptyApiMock },
         { provide: AuthStore, useValue: makeAuthStoreMock() },

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -542,6 +542,52 @@ describe('AnalysisPageComponent', () => {
       store.setActiveView('overview');
       expect(store.viewFilteredRows()).toHaveLength(8);
     });
+
+    it('overview KPIs include exercise entries alongside pushups', () => {
+      const { store } = fixture.componentInstance;
+      // Overview = 6 pushups (max 25) + 2 exercises (max 40 legs.squats)
+      expect(store.bestSingleEntry()?.reps).toBe(40);
+      // Best day = Feb 13: 25 reps (pushup id 5) + 40 reps (legs ex)
+      expect(store.bestDay()).toEqual({ date: '2026-02-13', total: 65 });
+    });
+
+    it('per-category KPIs scope to the active view (abs)', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('abs');
+      expect(store.bestSingleEntry()?.reps).toBe(30);
+      expect(store.bestDay()).toEqual({ date: '2026-02-12', total: 30 });
+      // 1 abs entry, no consecutive day → streak length 1
+      expect(store.currentStreak()).toBe(1);
+      expect(store.longestStreak()).toBe(1);
+      // The seeded abs entry has no sets array → distribution stays empty
+      expect(store.avgSetSize()).toBe(0);
+      expect(store.setsDistribution()).toEqual([]);
+      expect(store.bestSingleSet()).toBe(0);
+    });
+
+    it('per-category KPIs scope to the active view (pushup)', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('pushup');
+      // Same numbers as the original pushup-only tests because the
+      // seeded mock is the pushup-only dataset.
+      expect(store.bestSingleEntry()?.reps).toBe(25);
+      expect(store.bestDay()?.total).toBe(25);
+      expect(store.longestStreak()).toBe(5);
+      expect(store.avgSetSize()).toBe(7.1);
+      expect(store.bestSingleSet()).toBe(10);
+    });
+
+    it('KPIs collapse to zero/null when the active view has no entries', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('plank');
+      expect(store.bestSingleEntry()).toBeNull();
+      expect(store.bestDay()).toBeNull();
+      expect(store.currentStreak()).toBe(0);
+      expect(store.longestStreak()).toBe(0);
+      expect(store.avgSetSize()).toBe(0);
+      expect(store.setsDistribution()).toEqual([]);
+      expect(store.bestSingleSet()).toBe(0);
+    });
   });
 
   it('resolves bare kind ids to localised labels via typeBreakdownDisplay', () => {

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -716,6 +716,26 @@ describe('AnalysisPageComponent', () => {
       store.setActiveView('plank');
       expect(store.typeBreakdown()).toEqual([]);
     });
+
+    it('typeBreakdownDisplay localises kind-mode ids when activeView scopes to a non-pushup category', () => {
+      // Regression for codex P2: setActiveView('abs') without an
+      // explicit kinds filter puts the store in kind-mode and emits
+      // raw ids like `abs.situps`. The display mapper must mirror the
+      // store's gate and localise — otherwise the pie legend reads
+      // like a developer string.
+      const { store } = fixture.componentInstance;
+      store.setActiveView('abs');
+      fixture.detectChanges();
+      const groupView = fixture.debugElement.query(
+        By.directive(AnalysisGroupViewComponent)
+      ).componentInstance as AnalysisGroupViewComponent;
+      const breakdown = groupView.typeBreakdownDisplay();
+      expect(breakdown).toHaveLength(1);
+      expect(breakdown[0]).toMatchObject({
+        id: 'abs.situps',
+        label: 'Sit-ups',
+      });
+    });
   });
 
   it('resolves bare kind ids to localised labels via typeBreakdownDisplay', () => {

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -471,6 +471,79 @@ describe('AnalysisPageComponent', () => {
     expect(values).toContain('abs.situps');
   });
 
+  describe('per-category view (activeView / viewFilteredRows)', () => {
+    beforeEach(() => {
+      liveExerciseEntries.set([
+        {
+          _id: 'ex-abs',
+          userId: 'u1',
+          exerciseId: 'abs.situps',
+          timestamp: '2026-02-12T08:00:00.000Z',
+          reps: 30,
+          source: 'web',
+        } as ExerciseEntry,
+        {
+          _id: 'ex-legs',
+          userId: 'u1',
+          exerciseId: 'legs.squats',
+          timestamp: '2026-02-13T08:00:00.000Z',
+          reps: 40,
+          source: 'web',
+        } as ExerciseEntry,
+      ]);
+      const component = fixture.componentInstance;
+      component.store.setRange('2026-02-09', '2026-02-15');
+    });
+
+    it('defaults activeView to "overview" so existing behaviour is preserved', () => {
+      const { store } = fixture.componentInstance;
+      expect(store.activeView()).toBe('overview');
+    });
+
+    it('viewFilteredRows returns every unified row in overview mode', () => {
+      const { store } = fixture.componentInstance;
+      // 6 pushups + 2 exercises in the seeded range
+      expect(store.viewFilteredRows()).toHaveLength(8);
+    });
+
+    it('setActiveView("abs") narrows viewFilteredRows to abs-category entries only', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('abs');
+      const rows = store.viewFilteredRows();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].kind).toBe('exercise');
+      expect((rows[0] as { exerciseId?: string }).exerciseId).toBe(
+        'abs.situps'
+      );
+    });
+
+    it('setActiveView("pushup") collapses to pushup entries only', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('pushup');
+      const rows = store.viewFilteredRows();
+      expect(rows).toHaveLength(6);
+      expect(rows.every((r) => r.kind === 'pushup')).toBe(true);
+    });
+
+    it('setActiveView("legs") narrows to legs-category entries only', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('legs');
+      const rows = store.viewFilteredRows();
+      expect(rows).toHaveLength(1);
+      expect((rows[0] as { exerciseId?: string }).exerciseId).toBe(
+        'legs.squats'
+      );
+    });
+
+    it('returns to all rows when activeView is reset to "overview"', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('abs');
+      expect(store.viewFilteredRows()).toHaveLength(1);
+      store.setActiveView('overview');
+      expect(store.viewFilteredRows()).toHaveLength(8);
+    });
+  });
+
   it('resolves bare kind ids to localised labels via typeBreakdownDisplay', () => {
     // Coverage for the component-level mapping that lives outside the
     // store: the store's kind-mode breakdown emits raw ids in `label`

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -627,6 +627,64 @@ describe('AnalysisPageComponent', () => {
       expect(store.weekTrend().every((w) => w.total === 0)).toBe(true);
       expect(store.monthTrend().every((m) => m.total === 0)).toBe(true);
     });
+
+    it('categorySummaries lists only categories with entries, sorted by order', () => {
+      const { store } = fixture.componentInstance;
+      const summaries = store.categorySummaries();
+      expect(summaries.map((s) => s.categoryId)).toEqual([
+        'pushup',
+        'abs',
+        'legs',
+      ]);
+    });
+
+    it('categorySummaries surfaces per-category totals, today reps and best day', () => {
+      const { store } = fixture.componentInstance;
+      const summaries = store.categorySummaries();
+      const pushup = summaries.find((s) => s.categoryId === 'pushup');
+      expect(pushup).toMatchObject({
+        totalReps: 93,
+        // 5+5 + 6+6 + 10+5+5 + 10+8+7 + 9+9 = 12 sets across 5 entries.
+        totalSets: 12,
+        // System time is Sun Feb 15 2026; only entry id=6 (18 reps) lands today.
+        todayReps: 18,
+        bestDay: { date: '2026-02-13', total: 25 },
+      });
+      const abs = summaries.find((s) => s.categoryId === 'abs');
+      expect(abs).toMatchObject({
+        totalReps: 30,
+        totalSets: 0,
+        todayReps: 0,
+        currentStreak: 1,
+        bestDay: { date: '2026-02-12', total: 30 },
+      });
+      const legs = summaries.find((s) => s.categoryId === 'legs');
+      expect(legs).toMatchObject({
+        totalReps: 40,
+        bestDay: { date: '2026-02-13', total: 40 },
+      });
+    });
+
+    it('categoryComparison projects summaries into chart-friendly arrays', () => {
+      const { store } = fixture.componentInstance;
+      const cmp = store.categoryComparison();
+      expect(cmp.labels).toEqual([
+        '@@exercise.category.pushup',
+        '@@exercise.category.abs',
+        '@@exercise.category.legs',
+      ]);
+      expect(cmp.reps).toEqual([93, 30, 40]);
+      expect(cmp.sets).toEqual([12, 0, 0]);
+    });
+
+    it('categorySummaries stays insensitive to the active view (it powers the overview)', () => {
+      const { store } = fixture.componentInstance;
+      const baseline = store.categorySummaries().map((s) => s.categoryId);
+      store.setActiveView('abs');
+      expect(store.categorySummaries().map((s) => s.categoryId)).toEqual(
+        baseline
+      );
+    });
   });
 
   it('resolves bare kind ids to localised labels via typeBreakdownDisplay', () => {

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -588,6 +588,45 @@ describe('AnalysisPageComponent', () => {
       expect(store.setsDistribution()).toEqual([]);
       expect(store.bestSingleSet()).toBe(0);
     });
+
+    // The trend windows span 8 ISO weeks / 6 months ending on the
+    // locked clock (Sun Feb 15 2026). Every seeded entry lives in
+    // 2026-W07 / 2026-02, so the assertions below pick out that
+    // single non-empty bucket.
+    it('overview week trend aggregates pushups + exercises', () => {
+      const { store } = fixture.componentInstance;
+      const week = store.weekTrend().find((w) => w.label === '2026-W07');
+      // 6 pushups summing 93 reps + 30 abs + 40 legs = 163
+      expect(week?.total).toBe(163);
+    });
+
+    it('per-category week trend scopes to the active view (abs)', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('abs');
+      const week = store.weekTrend().find((w) => w.label === '2026-W07');
+      expect(week?.total).toBe(30);
+    });
+
+    it('per-category month trend scopes to the active view (legs)', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('legs');
+      const month = store.monthTrend().find((m) => m.label === '2026-02');
+      expect(month?.total).toBe(40);
+    });
+
+    it('per-category pushup trend matches the legacy pushup-only totals', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('pushup');
+      const week = store.weekTrend().find((w) => w.label === '2026-W07');
+      expect(week?.total).toBe(93);
+    });
+
+    it('empty-category trends report zero totals across the window', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('plank');
+      expect(store.weekTrend().every((w) => w.total === 0)).toBe(true);
+      expect(store.monthTrend().every((m) => m.total === 0)).toBe(true);
+    });
   });
 
   it('resolves bare kind ids to localised labels via typeBreakdownDisplay', () => {

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { AnalysisPageComponent } from './analysis-page.component';
+import { AnalysisGroupViewComponent } from './analysis-group-view.component';
 import {
   LiveDataStore,
   StatsApiService,
@@ -183,9 +185,12 @@ describe('AnalysisPageComponent', () => {
       ],
     })
       .overrideComponent(AnalysisPageComponent, {
+        remove: { imports: [FilterBarComponent] },
+        add: { imports: [MockFilterBarComponent] },
+      })
+      .overrideComponent(AnalysisGroupViewComponent, {
         remove: {
           imports: [
-            FilterBarComponent,
             HeatmapComponent,
             TypePieComponent,
             StatsChartComponent,
@@ -194,7 +199,6 @@ describe('AnalysisPageComponent', () => {
         },
         add: {
           imports: [
-            MockFilterBarComponent,
             MockHeatmapComponent,
             MockTypePieComponent,
             MockStatsChartComponent,
@@ -688,26 +692,29 @@ describe('AnalysisPageComponent', () => {
   });
 
   it('resolves bare kind ids to localised labels via typeBreakdownDisplay', () => {
-    // Coverage for the component-level mapping that lives outside the
-    // store: the store's kind-mode breakdown emits raw ids in `label`
-    // and the page wraps it in `typeBreakdownDisplay` to localise. A
-    // regression in the wrapper would silently render `abs.situps` as
-    // the legend text instead of "Sit-ups".
-    const component = fixture.componentInstance;
-    component.store.setKinds(['pushup', 'abs.situps']);
+    // Coverage for the component-level mapping that lives in the
+    // group view: the store's kind-mode breakdown emits raw ids in
+    // `label` and the group view wraps it in `typeBreakdownDisplay`
+    // to localise. A regression in the wrapper would silently render
+    // `abs.situps` as the legend text instead of "Sit-ups".
+    fixture.componentInstance.store.setKinds(['pushup', 'abs.situps']);
     fixture.detectChanges();
-    const breakdown = component
+    const groupView = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    ).componentInstance as AnalysisGroupViewComponent;
+    const breakdown = groupView
       .typeBreakdownDisplay()
       .map((d) => ({ id: d.id, label: d.label }));
     const pushup = breakdown.find((l) => l.id === 'pushup');
     expect(pushup?.label).toBe('Liegestütze');
 
     // The mock dataset has no abs.situps entries so the breakdown
-    // bucket itself is missing; `kindFilterOptions` calls the same
-    // `kindLabel` mapping for both selected and in-range kinds, so it
-    // proves the catalog lookup → localised name path also works for
-    // catalog ids — without needing fixture data we don't have.
-    const situpsOption = component
+    // bucket itself is missing; `kindFilterOptions` on the shell uses
+    // the same shared `kindDisplayName` mapping for both selected and
+    // in-range kinds, so it proves the catalog lookup → localised
+    // name path also works for catalog ids — without needing fixture
+    // data we don't have.
+    const situpsOption = fixture.componentInstance
       .kindFilterOptions()
       .find((o) => o.value === 'abs.situps');
     expect(situpsOption?.label).toBe('Sit-ups');
@@ -765,9 +772,12 @@ describe('AnalysisPageComponent empty-state CTA gating', () => {
       ],
     })
       .overrideComponent(AnalysisPageComponent, {
+        remove: { imports: [FilterBarComponent] },
+        add: { imports: [MockFilterBarComponent] },
+      })
+      .overrideComponent(AnalysisGroupViewComponent, {
         remove: {
           imports: [
-            FilterBarComponent,
             HeatmapComponent,
             TypePieComponent,
             StatsChartComponent,
@@ -776,7 +786,6 @@ describe('AnalysisPageComponent empty-state CTA gating', () => {
         },
         add: {
           imports: [
-            MockFilterBarComponent,
             MockHeatmapComponent,
             MockTypePieComponent,
             MockStatsChartComponent,

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -669,14 +669,13 @@ describe('AnalysisPageComponent', () => {
       });
     });
 
-    it('categoryComparison projects summaries into chart-friendly arrays', () => {
+    it('categoryComparison projects summaries into chart-friendly arrays with translated labels', () => {
+      // Chart.js cannot resolve $localize ids at runtime, so labels
+      // are pre-translated by the store. TestBed defaults to the
+      // source locale (de) — assertions use the German source strings.
       const { store } = fixture.componentInstance;
       const cmp = store.categoryComparison();
-      expect(cmp.labels).toEqual([
-        '@@exercise.category.pushup',
-        '@@exercise.category.abs',
-        '@@exercise.category.legs',
-      ]);
+      expect(cmp.labels).toEqual(['Liegestütze', 'Bauch', 'Beine']);
       expect(cmp.reps).toEqual([93, 30, 40]);
       expect(cmp.sets).toEqual([12, 0, 0]);
     });
@@ -688,6 +687,34 @@ describe('AnalysisPageComponent', () => {
       expect(store.categorySummaries().map((s) => s.categoryId)).toEqual(
         baseline
       );
+    });
+
+    it('typeBreakdown collapses to the active category in kind mode (abs)', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('abs');
+      const breakdown = store.typeBreakdown();
+      expect(breakdown).toHaveLength(1);
+      expect(breakdown[0]).toMatchObject({
+        id: 'abs.situps',
+        value: 30,
+      });
+    });
+
+    it('typeBreakdown stays in pushup-variant mode when the active view is pushup', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('pushup');
+      const labels = store.typeBreakdown().map((b) => b.label);
+      expect(labels).toContain('Standard-Liegestütze');
+      expect(labels).toContain('Diamant-Liegestütze');
+      // Wide pushups are in the seed (id=4, 8 reps); a non-pushup
+      // category would yield none.
+      expect(labels).toContain('Weite Liegestütze');
+    });
+
+    it('typeBreakdown is empty for a category that has no entries', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('plank');
+      expect(store.typeBreakdown()).toEqual([]);
     });
   });
 

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -1,4 +1,4 @@
-import { DecimalPipe, DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import {
   Component,
   computed,
@@ -7,31 +7,21 @@ import {
   inject,
   PLATFORM_ID,
   REQUEST,
-  signal,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
-import { MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
-import {
-  createWeekRange,
-  findExerciseDefinition,
-  UnifiedEntryFilterKey,
-} from '@pu-stats/models';
+import { createWeekRange, UnifiedEntryFilterKey } from '@pu-stats/models';
 import { LiveDataStore } from '@pu-stats/data-access';
 import { FilterBarComponent } from '../components/filter-bar/filter-bar.component';
-import { HeatmapComponent } from '../components/heatmap/heatmap.component';
 import { PreviewBannerComponent } from '../components/preview-banner/preview-banner.component';
-import { SetsDistributionComponent } from '../components/sets-distribution/sets-distribution.component';
-import { StatsChartComponent } from '../components/stats-chart/stats-chart.component';
-import { TypePieComponent } from '../components/type-pie/type-pie.component';
 import { AnalysisStore } from '../analysis.store';
-import { exerciseDisplayName } from '../i18n/exercise-display-names';
+import { kindDisplayName } from '../i18n/exercise-display-names';
 import { PageHeaderComponent } from '../../core/page-header/page-header.component';
+import { AnalysisGroupViewComponent } from './analysis-group-view.component';
 
 interface ExerciseKindOption {
   value: UnifiedEntryFilterKey;
@@ -43,21 +33,15 @@ interface ExerciseKindOption {
   providers: [AnalysisStore],
   imports: [
     MatButtonModule,
-    MatButtonToggleModule,
     MatCardModule,
     MatFormFieldModule,
     MatIconModule,
     MatSelectModule,
-    MatTableModule,
     RouterLink,
-    DecimalPipe,
+    AnalysisGroupViewComponent,
     FilterBarComponent,
-    HeatmapComponent,
     PageHeaderComponent,
     PreviewBannerComponent,
-    SetsDistributionComponent,
-    StatsChartComponent,
-    TypePieComponent,
   ],
   template: `
     <main class="page-wrap">
@@ -128,239 +112,7 @@ interface ExerciseKindOption {
         </mat-card>
       }
 
-      <app-stats-chart
-        [series]="store.chartSeries()"
-        [granularity]="store.granularity()"
-        [rangeMode]="store.rangeMode()"
-        [from]="store.from()"
-        [to]="store.to()"
-        [entries]="store.rows()"
-        [dayChartMode]="store.resolvedDayChartMode()"
-        (dayChartModeChange)="store.setDayChartMode($event)"
-      />
-
-      <section class="grid">
-        <mat-card>
-          <mat-card-header>
-            <mat-card-title i18n="@@analysis.bestStreaksTitle"
-              >Bestwerte & Streaks</mat-card-title
-            >
-          </mat-card-header>
-          <mat-card-content class="best-grid">
-            <div>
-              <strong i18n="@@analysis.bestSingleEntry"
-                >Bestwert Einzel-Eintrag:</strong
-              >
-              <div>{{ store.bestSingleEntry()?.reps ?? 0 }} Reps</div>
-            </div>
-            <div>
-              <strong i18n="@@analysis.bestDay">Bester Tag:</strong>
-              <div>
-                {{ store.bestDay()?.date ?? '—' }} ·
-                {{ store.bestDay()?.total ?? 0 }} Reps
-              </div>
-            </div>
-            @if (store.bestSingleSet()) {
-              <div>
-                <strong i18n="@@analysis.bestSingleSet"
-                  >Bestes Einzel-Set:</strong
-                >
-                <div>
-                  {{ store.bestSingleSet() }}
-                  <span i18n="@@analysis.repsUnit">Wdh.</span>
-                </div>
-              </div>
-            }
-            <div>
-              <strong i18n="@@analysis.currentStreak">Aktuelle Streak:</strong>
-              <div>
-                <ng-container i18n="@@analysis.streakDays"
-                  >{{ store.currentStreak() }} Tage</ng-container
-                >
-              </div>
-            </div>
-            <div>
-              <strong i18n="@@analysis.longestStreak">Längste Streak:</strong>
-              <div>
-                <ng-container i18n="@@analysis.streakDays"
-                  >{{ store.longestStreak() }} Tage</ng-container
-                >
-              </div>
-            </div>
-          </mat-card-content>
-        </mat-card>
-
-        <mat-card>
-          <mat-card-header>
-            <mat-card-title i18n="@@analysis.typesTitle"
-              >Typen (Anteile)</mat-card-title
-            >
-          </mat-card-header>
-          <mat-card-content>
-            @defer (hydrate on viewport) {
-              <app-type-pie [data]="typeBreakdownDisplay()" />
-            }
-          </mat-card-content>
-        </mat-card>
-
-        @if (store.avgSetSize()) {
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title i18n="@@analysis.avgSetSizeTitle"
-                >&#x2300; Set-Gr&#x00F6;&#x00DF;e</mat-card-title
-              >
-            </mat-card-header>
-            <mat-card-content class="kpi-big">
-              <b>{{ store.avgSetSize() }}</b>
-              <span i18n="@@analysis.repsPerSet">Reps / Set</span>
-            </mat-card-content>
-          </mat-card>
-        }
-
-        @if (store.setsDistribution().length) {
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title i18n="@@analysis.setsDistTitle"
-                >Sets-Verteilung</mat-card-title
-              >
-            </mat-card-header>
-            <mat-card-content>
-              @defer (hydrate on viewport) {
-                <app-sets-distribution [data]="store.setsDistribution()" />
-              }
-            </mat-card-content>
-          </mat-card>
-        }
-      </section>
-
-      <mat-card class="heatmap-full">
-        <mat-card-header>
-          <mat-card-title i18n="@@analysis.heatmapTitle"
-            >Heatmap (Wochentag/Uhrzeit)</mat-card-title
-          >
-          <mat-button-toggle-group
-            [value]="heatmapMode()"
-            (change)="heatmapMode.set($event.value)"
-            class="heatmap-toggle"
-            aria-label="Heatmap-Modus auswählen"
-            i18n-aria-label="@@analysis.heatmapToggleAriaLabel"
-          >
-            <mat-button-toggle value="reps" i18n="@@analysis.heatmapReps"
-              >Reps</mat-button-toggle
-            >
-            <mat-button-toggle value="sets" i18n="@@analysis.heatmapSets"
-              >Sets</mat-button-toggle
-            >
-          </mat-button-toggle-group>
-        </mat-card-header>
-        <mat-card-content class="heatmap-wrap">
-          @defer (hydrate on viewport) {
-            <app-heatmap [entries]="store.rows()" [mode]="heatmapMode()" />
-          }
-        </mat-card-content>
-      </mat-card>
-
-      <section class="trends-section" data-testid="analysis-trends-section">
-        <mat-card>
-          <mat-card-header>
-            <mat-card-title i18n="@@analysis.weekTrendTitle"
-              >Wochentrend</mat-card-title
-            >
-            <mat-card-subtitle i18n="@@analysis.weekTrendSubtitle"
-              >Letzte 8 Wochen</mat-card-subtitle
-            >
-          </mat-card-header>
-          <mat-card-content>
-            @defer (on viewport) {
-              <mat-table [dataSource]="store.weekTrend()">
-                <ng-container matColumnDef="label">
-                  <mat-header-cell *matHeaderCellDef i18n="@@analysis.weekCol"
-                    >Woche</mat-header-cell
-                  >
-                  <mat-cell *matCellDef="let row">{{ row.label }}</mat-cell>
-                </ng-container>
-                <ng-container matColumnDef="total">
-                  <mat-header-cell *matHeaderCellDef i18n="@@analysis.repsCol"
-                    >Reps</mat-header-cell
-                  >
-                  <mat-cell *matCellDef="let row">{{ row.total }}</mat-cell>
-                </ng-container>
-                <ng-container matColumnDef="avgSetsPerEntry">
-                  <mat-header-cell
-                    *matHeaderCellDef
-                    i18n="@@analysis.avgSetsCol"
-                    >&#x2300; Sets</mat-header-cell
-                  >
-                  <mat-cell *matCellDef="let row">{{
-                    row.avgSetsPerEntry !== null &&
-                    row.avgSetsPerEntry !== undefined
-                      ? (row.avgSetsPerEntry | number)
-                      : '—'
-                  }}</mat-cell>
-                </ng-container>
-                <mat-header-row
-                  *matHeaderRowDef="trendColumnsWithSets"
-                ></mat-header-row>
-                <mat-row
-                  *matRowDef="let row; columns: trendColumnsWithSets"
-                ></mat-row>
-              </mat-table>
-            } @placeholder {
-              <div class="trend-placeholder" aria-hidden="true"></div>
-            }
-          </mat-card-content>
-        </mat-card>
-
-        <mat-card>
-          <mat-card-header>
-            <mat-card-title i18n="@@analysis.monthTrendTitle"
-              >Monatstrend</mat-card-title
-            >
-            <mat-card-subtitle i18n="@@analysis.monthTrendSubtitle"
-              >Letzte 6 Monate</mat-card-subtitle
-            >
-          </mat-card-header>
-          <mat-card-content>
-            @defer (on viewport) {
-              <mat-table [dataSource]="store.monthTrend()">
-                <ng-container matColumnDef="label">
-                  <mat-header-cell *matHeaderCellDef i18n="@@analysis.monthCol"
-                    >Monat</mat-header-cell
-                  >
-                  <mat-cell *matCellDef="let row">{{ row.label }}</mat-cell>
-                </ng-container>
-                <ng-container matColumnDef="total">
-                  <mat-header-cell *matHeaderCellDef i18n="@@analysis.repsCol"
-                    >Reps</mat-header-cell
-                  >
-                  <mat-cell *matCellDef="let row">{{ row.total }}</mat-cell>
-                </ng-container>
-                <ng-container matColumnDef="avgSetsPerEntry">
-                  <mat-header-cell
-                    *matHeaderCellDef
-                    i18n="@@analysis.avgSetsCol"
-                    >&#x2300; Sets</mat-header-cell
-                  >
-                  <mat-cell *matCellDef="let row">{{
-                    row.avgSetsPerEntry !== null &&
-                    row.avgSetsPerEntry !== undefined
-                      ? (row.avgSetsPerEntry | number)
-                      : '—'
-                  }}</mat-cell>
-                </ng-container>
-                <mat-header-row
-                  *matHeaderRowDef="trendColumnsWithSets"
-                ></mat-header-row>
-                <mat-row
-                  *matRowDef="let row; columns: trendColumnsWithSets"
-                ></mat-row>
-              </mat-table>
-            } @placeholder {
-              <div class="trend-placeholder" aria-hidden="true"></div>
-            }
-          </mat-card-content>
-        </mat-card>
-      </section>
+      <app-analysis-group-view />
     </main>
   `,
   styles: `
@@ -370,24 +122,6 @@ interface ExerciseKindOption {
       padding: 16px;
       display: grid;
       gap: 16px;
-    }
-    .grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-      gap: 16px;
-    }
-    mat-table {
-      width: 100%;
-    }
-
-    mat-card-content {
-      overflow: auto;
-    }
-
-    .best-grid {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(180px, 1fr));
-      gap: 12px;
     }
 
     .filter-section {
@@ -419,62 +153,14 @@ interface ExerciseKindOption {
     }
 
     @media (max-width: 900px) {
-      .filter-section {
-        margin-inline: -12px;
-        padding: 10px 12px;
-      }
-    }
-
-    .chart-card {
-      margin-bottom: 16px;
-    }
-
-    .heatmap-full {
-      width: 100%;
-    }
-    .heatmap-wrap {
-      overflow: auto;
-      width: 100%;
-      min-height: 400px;
-    }
-    /* Reserve roughly the rendered table height so revealing the
-       deferred trend block doesn't shift the rest of the page down. */
-    .trend-placeholder {
-      min-height: 320px;
-    }
-
-    @media (max-width: 900px) {
       .page-wrap {
         padding: 12px;
         gap: 12px;
       }
-      .grid {
-        grid-template-columns: 1fr;
-        gap: 12px;
+      .filter-section {
+        margin-inline: -12px;
+        padding: 10px 12px;
       }
-      .best-grid {
-        grid-template-columns: 1fr 1fr;
-      }
-    }
-
-    .kpi-big {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 4px;
-      padding: 16px 0;
-    }
-    .kpi-big b {
-      font-size: 2.5rem;
-      line-height: 1;
-    }
-    .kpi-big span {
-      opacity: 0.7;
-      font-size: 0.85rem;
-    }
-
-    .heatmap-toggle {
-      margin-left: auto;
     }
 
     .empty-cta mat-card-content {
@@ -500,20 +186,6 @@ interface ExerciseKindOption {
     }
     .empty-cta a {
       margin-left: auto;
-    }
-
-    @media (max-width: 600px) {
-      .best-grid {
-        grid-template-columns: 1fr;
-      }
-      .heatmap-full mat-card-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 12px;
-      }
-      .heatmap-toggle {
-        margin-left: 0;
-      }
     }
   `,
 })
@@ -553,7 +225,7 @@ export class AnalysisPageComponent {
     }
     return merged.map((value) => ({
       value,
-      label: this.kindLabel(value),
+      label: kindDisplayName(value),
     }));
   });
 
@@ -565,29 +237,6 @@ export class AnalysisPageComponent {
     if (this.store.kinds().length > 0) return true;
     return this.store.kindOptionsRaw().some((k) => k !== 'pushup');
   });
-
-  /**
-   * Resolves the bare-id labels emitted by `store.typeBreakdown()` (in
-   * multi-kind mode) into localised display names. Pushup-only mode
-   * returns the breakdown unchanged because the store already produces
-   * locale-aware variant names there.
-   */
-  readonly typeBreakdownDisplay = computed(() => {
-    const kinds = this.store.kinds();
-    const isKindMode =
-      kinds.length > 0 && !(kinds.length === 1 && kinds[0] === 'pushup');
-    const data = this.store.typeBreakdown();
-    if (!isKindMode) return data;
-    return data.map((d) => ({
-      ...d,
-      label: this.kindLabel(d.id as UnifiedEntryFilterKey),
-    }));
-  });
-
-  readonly trendColumns = ['label', 'total'];
-  readonly trendColumnsWithSets = ['label', 'total', 'avgSetsPerEntry'];
-
-  readonly heatmapMode = signal<'reps' | 'sets'>('reps');
 
   /**
    * Only reveal the empty-state CTA after the entries resource has resolved.
@@ -665,18 +314,5 @@ export class AnalysisPageComponent {
     const qIndex = url.indexOf('?');
     if (qIndex === -1) return '';
     return url.slice(qIndex);
-  }
-
-  private kindLabel(value: UnifiedEntryFilterKey): string {
-    if (value === 'pushup') {
-      return $localize`:@@exercise.category.pushup:Liegestütze`;
-    }
-    const def = findExerciseDefinition(value);
-    if (def) return exerciseDisplayName(def.id);
-    // Legacy id without a catalog entry (e.g. an exercise removed from
-    // the catalog whose entries still live in Firestore) — surface a
-    // generic localised label rather than the raw `category.name` id so
-    // the legend never reads like a developer string.
-    return $localize`:@@analysis.kindUnknown:Andere Übung`;
   }
 }

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -250,7 +250,11 @@ export class AnalysisPageComponent {
     if (this.store.entriesResource.status() !== 'resolved') return false;
     if (this.store.weekEntriesResource.status() !== 'resolved') return false;
     if (this.store.monthEntriesResource.status() !== 'resolved') return false;
-    if (this.store.rows().length > 0) return false;
+    // Pre-merge: `rows()` is the pushup REST resource only. A range
+    // that contains only exercise entries would otherwise still flash
+    // the empty CTA even though the group view renders charts. Reading
+    // `unifiedRows()` mirrors what the rest of the page sees.
+    if (this.store.unifiedRows().length > 0) return false;
     if (this.store.weekTrend().some((t) => t.total > 0)) return false;
     if (this.store.monthTrend().some((t) => t.total > 0)) return false;
     return true;


### PR DESCRIPTION
## Was

Stufe 1 der Aufteilung der Analyse-Seite in eine Übersicht plus eine Detail-Ansicht pro Übungsgruppe (siehe `docs/analysis-views-plan.md`). Dieser PR liefert die **vollständige Datenschicht** plus die **Komponenten-Vorarbeit** für die spätere `mat-tab-group`. Die Tabs selbst, die Overview-Karten und der Vergleichschart kommen in Folge-PRs — die Analyse-Seite verhält sich nach diesem Merge für Endnutzer:innen funktional identisch zum Stand auf `main`.

## Warum

Heute zeigt `/analysis` alle Übungen vermischt in einer einzigen Sicht. Sobald mehrere Übungsgruppen ernsthaft genutzt werden, gehen Pushup-Streaks, Bauch-Trends und Bein-KPIs ineinander auf. Plan: pro Gruppe eigene Sicht plus Übersicht mit Quick-Stats und Vergleich.

## Commits

| SHA | Inhalt |
|---|---|
| `bccd2fc` | docs: `docs/analysis-views-plan.md` |
| `9f3ce07` | foundation: `unifiedEntryCategoryId` Helper + `activeView` / `viewFilteredRows` |
| `d064bf0` | KPIs (bestSingleEntry/Day, Streaks, avgSetSize, setsDistribution, bestSingleSet) auf `viewFilteredRows` |
| `5b6f16d` | weekTrend / monthTrend kategoriegefiltert (inkl. Exercise-Einträge im Trend-Fenster) |
| `f7342aa` | `categorySummaries` + `categoryComparison` Selektoren für Overview |
| `386f36d` | `AnalysisGroupViewComponent` aus dem 682-Zeiler Monolithen extrahiert; `kindDisplayName` als Shared-Util |
| `1cd7fa7` | Self-Review-Fixes: `categoryDisplayName` (übersetzte Chart-Labels), `typeBreakdown`/Heatmap auf `viewFilteredRows`, Why-Kommentare |

## Was sich verhaltensmäßig schon ändert

- KPIs und Trends summieren im Default-View jetzt erstmals auch Übungseinträge mit (bisher pushup-only). Konsistent mit dem Stats-Table und dem History-Filter.
- Wer den Store direkt programmatisch ansteuert, kann `setActiveView('abs' | 'legs' | …)` aufrufen — KPIs, Trends, Heatmap, Type-Pie scope'n auf die Gruppe. Die UI dafür (`mat-tab-group`) ist noch nicht verdrahtet.

## Was bewusst noch nicht passiert

- Keine Tabs, kein `?view=` Query-Param-Sync.
- Keine Overview-Karten und kein Vergleichs-Chart.
- `chartSeries` (Server-Aggregation) und `stats-chart`-Eingaben bleiben pushup-only — dokumentierte Limitation, Folge-PR mit serverseitiger Erweiterung.
- Keine i18n-Strings für die noch nicht existierenden Tab-/Card-Texte.

## Tests

- `pnpm nx test stats-models` → 356 ✓ (4 neue Helper-Specs)
- `pnpm nx test web` → 655 ✓ (22 neue Store/Komponenten-Specs)
- `pnpm nx lint web` → 0 errors
- `pnpm nx build web -c development` → ok

## Test plan

- [ ] CI grün (lint + unit + build)
- [ ] Lokal `/analysis` öffnen, sichten dass Filter-Bar + Empty-CTA + die bisherigen Karten/Heatmap/Trends unverändert rendern (kein UI-Regression vor den Tabs).
- [ ] Im DevTools-Console `ng.getComponent($0).store.setActiveView('abs')` auf der Seite ausführen und prüfen, dass KPIs/Trends auf abs-Einträge schrumpfen (manueller Smoke).

https://claude.ai/code/session_01MkBAno5N5s2mRwNHSEYKT5

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkBAno5N5s2mRwNHSEYKT5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Analysis view now features tabbed navigation with an overview tab and category-specific tabs for detailed exercise statistics
  * Per-category filtering with scoped KPIs, charts, and trends
  * New category comparison and summary displays

* **Refactor**
  * Reorganized analysis dashboard layout with improved category navigation and statistics organization

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/318)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->