### PR TITLE
refactor(training-plans): collapse day actions into single overflow menu

### DIFF
--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -16,6 +16,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -54,6 +55,7 @@ interface DayRow {
     MatButtonModule,
     MatChipsModule,
     MatIconModule,
+    MatMenuModule,
     MatProgressBarModule,
     MatSnackBarModule,
     MatTooltipModule,
@@ -289,72 +291,92 @@ interface DayRow {
                     }
                   </div>
                   <div class="day-actions">
-                    @if (isThisPlanActive()) {
-                      @if (row.day.kind !== 'rest') {
+                    @if (
+                      isThisPlanActive() &&
+                      (row.day.kind !== 'rest' || !row.isToday)
+                    ) {
+                      <button
+                        mat-icon-button
+                        [matMenuTriggerFor]="dayMenu"
+                        aria-label="Tagesaktionen öffnen"
+                        i18n-aria-label="@@trainingPlans.menu.triggerAria"
+                      >
                         @if (row.isCompleted) {
-                          <button
-                            mat-icon-button
-                            (click)="unmark(row.day.dayIndex)"
-                            aria-label="Als nicht erledigt markieren"
-                            i18n-aria-label="@@trainingPlans.unmarkAria"
-                          >
-                            <mat-icon>check_circle</mat-icon>
-                          </button>
+                          <mat-icon>check_circle</mat-icon>
                         } @else if (row.isSkipped) {
-                          <button
-                            mat-icon-button
-                            (click)="unskip(row.day.dayIndex)"
-                            aria-label="Überspringen rückgängig machen"
-                            i18n-aria-label="@@trainingPlans.unskipAria"
-                            matTooltip="Überspringen rückgängig machen"
-                            i18n-matTooltip="@@trainingPlans.unskipTooltip"
-                          >
-                            <mat-icon>redo</mat-icon>
-                          </button>
+                          <mat-icon>skip_next</mat-icon>
                         } @else {
-                          @if (row.day.targetReps > 0) {
+                          <mat-icon>more_vert</mat-icon>
+                        }
+                      </button>
+                      <mat-menu #dayMenu="matMenu">
+                        @if (row.day.kind !== 'rest') {
+                          @if (row.isCompleted) {
                             <button
-                              mat-icon-button
-                              color="primary"
-                              (click)="logPlanDay(row.day.dayIndex)"
-                              aria-label="Plan-Sätze eintragen und als erledigt markieren"
-                              i18n-aria-label="@@trainingPlans.logAria"
+                              mat-menu-item
+                              (click)="unmark(row.day.dayIndex)"
                             >
-                              <mat-icon>check_circle_outline</mat-icon>
+                              <mat-icon>undo</mat-icon>
+                              <span i18n="@@trainingPlans.menu.undoDone"
+                                >Erledigt rückgängig machen</span
+                              >
+                            </button>
+                          } @else if (row.isSkipped) {
+                            <button
+                              mat-menu-item
+                              (click)="unskip(row.day.dayIndex)"
+                            >
+                              <mat-icon>undo</mat-icon>
+                              <span i18n="@@trainingPlans.menu.undoSkip"
+                                >Überspringen rückgängig machen</span
+                              >
+                            </button>
+                          } @else {
+                            @if (row.day.targetReps > 0) {
+                              <button
+                                mat-menu-item
+                                (click)="logPlanDay(row.day.dayIndex)"
+                              >
+                                <mat-icon color="primary"
+                                  >check_circle</mat-icon
+                                >
+                                <span i18n="@@trainingPlans.menu.logDone"
+                                  >Plan-Sätze eintragen & abhaken</span
+                                >
+                              </button>
+                            }
+                            <button
+                              mat-menu-item
+                              (click)="mark(row.day.dayIndex)"
+                            >
+                              <mat-icon>check</mat-icon>
+                              <span i18n="@@trainingPlans.menu.markDone"
+                                >Nur abhaken (ohne Eintrag)</span
+                              >
+                            </button>
+                            <button
+                              mat-menu-item
+                              (click)="skip(row.day.dayIndex)"
+                            >
+                              <mat-icon>skip_next</mat-icon>
+                              <span i18n="@@trainingPlans.menu.skip"
+                                >Tag überspringen</span
+                              >
                             </button>
                           }
+                        }
+                        @if (!row.isToday) {
                           <button
-                            mat-icon-button
-                            (click)="mark(row.day.dayIndex)"
-                            aria-label="Nur als erledigt markieren (ohne Eintrag)"
-                            i18n-aria-label="@@trainingPlans.markAria"
+                            mat-menu-item
+                            (click)="jumpToDay(row.day.dayIndex)"
                           >
-                            <mat-icon>radio_button_unchecked</mat-icon>
-                          </button>
-                          <button
-                            mat-icon-button
-                            (click)="skip(row.day.dayIndex)"
-                            aria-label="Tag überspringen"
-                            i18n-aria-label="@@trainingPlans.skipAria"
-                            matTooltip="Tag überspringen"
-                            i18n-matTooltip="@@trainingPlans.skipTooltip"
-                          >
-                            <mat-icon>skip_next</mat-icon>
+                            <mat-icon>fast_forward</mat-icon>
+                            <span i18n="@@trainingPlans.menu.jump"
+                              >Zu diesem Tag springen</span
+                            >
                           </button>
                         }
-                      }
-                      @if (!row.isToday) {
-                        <button
-                          mat-icon-button
-                          (click)="jumpToDay(row.day.dayIndex)"
-                          aria-label="Zu diesem Tag springen"
-                          i18n-aria-label="@@trainingPlans.jumpAria"
-                          matTooltip="Zu diesem Tag springen"
-                          i18n-matTooltip="@@trainingPlans.jumpTooltip"
-                        >
-                          <mat-icon>fast_forward</mat-icon>
-                        </button>
-                      }
+                      </mat-menu>
                     }
                   </div>
                 </li>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -6101,51 +6101,6 @@
         <target>εβδομάδα</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.unmarkAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:243,244</note>
-      </notes>
-      <segment state="translated">
-        <source>Als nicht erledigt markieren</source>
-        <target>Επισήμανση ως μη ολοκληρωμένη</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipAria">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Παράλειψη ημέρας</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipTooltip">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Παράλειψη ημέρας</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipAria">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Αναίρεση παράλειψης</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipTooltip">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Αναίρεση παράλειψης</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpAria">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Μετάβαση σε αυτή την ημέρα</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpTooltip">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Μετάβαση σε αυτή την ημέρα</target>
-      </segment>
-    </unit>
     <unit id="trainingPlans.skipped">
       <segment state="translated">
         <source>Tag übersprungen.</source>
@@ -6156,24 +6111,6 @@
       <segment state="translated">
         <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
         <target>Μετάβαση στην ημέρα <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.logAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>
-      </notes>
-      <segment state="translated">
-        <source>Plan-Sätze eintragen und als erledigt markieren</source>
-        <target>Εισαγάγετε εγγραφές σχεδίου και σημειώστε τις ως ολοκληρωμένες</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.markAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:263,264</note>
-      </notes>
-      <segment state="translated">
-        <source>Nur als erledigt markieren (ohne Eintrag)</source>
-        <target>Επισήμανση ως ολοκληρωμένου μόνο (χωρίς καταχώριση)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.notFound">
@@ -6249,6 +6186,48 @@
       <segment state="translated">
         <source>Trainingspläne</source>
         <target>Προπονητικά σχέδια</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.triggerAria">
+      <segment state="translated">
+        <source>Tagesaktionen öffnen</source>
+        <target>Tagesaktionen öffnen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoDone">
+      <segment state="translated">
+        <source>Erledigt rückgängig machen</source>
+        <target>Erledigt rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoSkip">
+      <segment state="translated">
+        <source>Überspringen rückgängig machen</source>
+        <target>Überspringen rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.logDone">
+      <segment state="translated">
+        <source>Plan-Sätze eintragen &amp; abhaken</source>
+        <target>Plan-Sätze eintragen &amp; abhaken</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.markDone">
+      <segment state="translated">
+        <source>Nur abhaken (ohne Eintrag)</source>
+        <target>Nur abhaken (ohne Eintrag)</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.skip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Tag überspringen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.jump">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Zu diesem Tag springen</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -6271,49 +6271,43 @@ Deine Position: # ·  Reps        </source>
         <target>Current day:</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.markAria">
+    <unit id="trainingPlans.menu.triggerAria">
       <segment state="translated">
-        <source>Nur als erledigt markieren (ohne Eintrag)</source>
-        <target>Mark as done only (no entry created)</target>
+        <source>Tagesaktionen öffnen</source>
+        <target>Open day actions</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.unmarkAria">
+    <unit id="trainingPlans.menu.undoDone">
       <segment state="translated">
-        <source>Als nicht erledigt markieren</source>
-        <target>Mark as not done</target>
+        <source>Erledigt rückgängig machen</source>
+        <target>Undo done</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.skipAria">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Skip day</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipTooltip">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Skip day</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipAria">
+    <unit id="trainingPlans.menu.undoSkip">
       <segment state="translated">
         <source>Überspringen rückgängig machen</source>
         <target>Undo skip</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.unskipTooltip">
+    <unit id="trainingPlans.menu.logDone">
       <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Undo skip</target>
+        <source>Plan-Sätze eintragen &amp; abhaken</source>
+        <target>Log plan sets &amp; mark done</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.jumpAria">
+    <unit id="trainingPlans.menu.markDone">
       <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Jump to this day</target>
+        <source>Nur abhaken (ohne Eintrag)</source>
+        <target>Mark done only (no entry)</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.jumpTooltip">
+    <unit id="trainingPlans.menu.skip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Skip day</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.jump">
       <segment state="translated">
         <source>Zu diesem Tag springen</source>
         <target>Jump to this day</target>
@@ -6461,12 +6455,6 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source>Heute eintragen</source>
         <target>Log today</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.logAria">
-      <segment state="translated">
-        <source>Plan-Sätze eintragen und als erledigt markieren</source>
-        <target>Log plan sets and mark as done</target>
       </segment>
     </unit>
     <unit id="trainingPlans.logged">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -6101,51 +6101,6 @@
         <target>semana</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.unmarkAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:243,244</note>
-      </notes>
-      <segment state="translated">
-        <source>Als nicht erledigt markieren</source>
-        <target>Marcar como no completado</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipAria">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Saltar día</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipTooltip">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Saltar día</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipAria">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Deshacer salto</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipTooltip">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Deshacer salto</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpAria">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Ir a este día</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpTooltip">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Ir a este día</target>
-      </segment>
-    </unit>
     <unit id="trainingPlans.skipped">
       <segment state="translated">
         <source>Tag übersprungen.</source>
@@ -6156,24 +6111,6 @@
       <segment state="translated">
         <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
         <target>Saltado al día <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.logAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>
-      </notes>
-      <segment state="translated">
-        <source>Plan-Sätze eintragen und als erledigt markieren</source>
-        <target>Ingrese los registros del plan y márquelos como completados</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.markAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:263,264</note>
-      </notes>
-      <segment state="translated">
-        <source>Nur als erledigt markieren (ohne Eintrag)</source>
-        <target>Marcar como completado únicamente (sin entrada)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.notFound">
@@ -6249,6 +6186,48 @@
       <segment state="translated">
         <source>Trainingspläne</source>
         <target>Planes de formación</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.triggerAria">
+      <segment state="translated">
+        <source>Tagesaktionen öffnen</source>
+        <target>Tagesaktionen öffnen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoDone">
+      <segment state="translated">
+        <source>Erledigt rückgängig machen</source>
+        <target>Erledigt rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoSkip">
+      <segment state="translated">
+        <source>Überspringen rückgängig machen</source>
+        <target>Überspringen rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.logDone">
+      <segment state="translated">
+        <source>Plan-Sätze eintragen &amp; abhaken</source>
+        <target>Plan-Sätze eintragen &amp; abhaken</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.markDone">
+      <segment state="translated">
+        <source>Nur abhaken (ohne Eintrag)</source>
+        <target>Nur abhaken (ohne Eintrag)</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.skip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Tag überspringen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.jump">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Zu diesem Tag springen</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -6101,51 +6101,6 @@
         <target>semaine</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.unmarkAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:243,244</note>
-      </notes>
-      <segment state="translated">
-        <source>Als nicht erledigt markieren</source>
-        <target>Marquer comme non terminé</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipAria">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Passer le jour</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipTooltip">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Passer le jour</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipAria">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Annuler le saut</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipTooltip">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Annuler le saut</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpAria">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Aller à ce jour</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpTooltip">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Aller à ce jour</target>
-      </segment>
-    </unit>
     <unit id="trainingPlans.skipped">
       <segment state="translated">
         <source>Tag übersprungen.</source>
@@ -6156,24 +6111,6 @@
       <segment state="translated">
         <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
         <target>Saut au jour <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.logAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>
-      </notes>
-      <segment state="translated">
-        <source>Plan-Sätze eintragen und als erledigt markieren</source>
-        <target>Saisir les enregistrements du plan et les marquer comme terminés</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.markAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:263,264</note>
-      </notes>
-      <segment state="translated">
-        <source>Nur als erledigt markieren (ohne Eintrag)</source>
-        <target>Marquer comme terminé uniquement (sans saisie)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.notFound">
@@ -6249,6 +6186,48 @@
       <segment state="translated">
         <source>Trainingspläne</source>
         <target>Plans de formation</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.triggerAria">
+      <segment state="translated">
+        <source>Tagesaktionen öffnen</source>
+        <target>Tagesaktionen öffnen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoDone">
+      <segment state="translated">
+        <source>Erledigt rückgängig machen</source>
+        <target>Erledigt rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoSkip">
+      <segment state="translated">
+        <source>Überspringen rückgängig machen</source>
+        <target>Überspringen rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.logDone">
+      <segment state="translated">
+        <source>Plan-Sätze eintragen &amp; abhaken</source>
+        <target>Plan-Sätze eintragen &amp; abhaken</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.markDone">
+      <segment state="translated">
+        <source>Nur abhaken (ohne Eintrag)</source>
+        <target>Nur abhaken (ohne Eintrag)</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.skip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Tag überspringen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.jump">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Zu diesem Tag springen</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -6101,51 +6101,6 @@
         <target>settimana</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.unmarkAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:243,244</note>
-      </notes>
-      <segment state="translated">
-        <source>Als nicht erledigt markieren</source>
-        <target>Contrassegna come non completato</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipAria">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Salta giorno</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipTooltip">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Salta giorno</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipAria">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Annulla salto</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipTooltip">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Annulla salto</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpAria">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Vai a questo giorno</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpTooltip">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Vai a questo giorno</target>
-      </segment>
-    </unit>
     <unit id="trainingPlans.skipped">
       <segment state="translated">
         <source>Tag übersprungen.</source>
@@ -6156,24 +6111,6 @@
       <segment state="translated">
         <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
         <target>Saltato al giorno <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.logAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>
-      </notes>
-      <segment state="translated">
-        <source>Plan-Sätze eintragen und als erledigt markieren</source>
-        <target>Inserisci i record del piano e contrassegnali come completati</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.markAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:263,264</note>
-      </notes>
-      <segment state="translated">
-        <source>Nur als erledigt markieren (ohne Eintrag)</source>
-        <target>Contrassegna solo come completato (senza voce)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.notFound">
@@ -6249,6 +6186,48 @@
       <segment state="translated">
         <source>Trainingspläne</source>
         <target>Piani formativi</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.triggerAria">
+      <segment state="translated">
+        <source>Tagesaktionen öffnen</source>
+        <target>Tagesaktionen öffnen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoDone">
+      <segment state="translated">
+        <source>Erledigt rückgängig machen</source>
+        <target>Erledigt rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoSkip">
+      <segment state="translated">
+        <source>Überspringen rückgängig machen</source>
+        <target>Überspringen rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.logDone">
+      <segment state="translated">
+        <source>Plan-Sätze eintragen &amp; abhaken</source>
+        <target>Plan-Sätze eintragen &amp; abhaken</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.markDone">
+      <segment state="translated">
+        <source>Nur abhaken (ohne Eintrag)</source>
+        <target>Nur abhaken (ohne Eintrag)</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.skip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Tag überspringen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.jump">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Zu diesem Tag springen</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -6101,51 +6101,6 @@
         <target>hebdomade</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.unmarkAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:243,244</note>
-      </notes>
-      <segment state="translated">
-        <source>Als nicht erledigt markieren</source>
-        <target>Mark non perficitur</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipAria">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Diem praeteri</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipTooltip">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Diem praeteri</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipAria">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Praeteritum revoca</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipTooltip">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Praeteritum revoca</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpAria">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Ad hunc diem salta</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpTooltip">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Ad hunc diem salta</target>
-      </segment>
-    </unit>
     <unit id="trainingPlans.skipped">
       <segment state="translated">
         <source>Tag übersprungen.</source>
@@ -6156,24 +6111,6 @@
       <segment state="translated">
         <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
         <target>Saltatum ad diem <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.logAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>
-      </notes>
-      <segment state="translated">
-        <source>Plan-Sätze eintragen und als erledigt markieren</source>
-        <target>Intrant consilium monumenta et ea ut perficitur</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.markAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:263,264</note>
-      </notes>
-      <segment state="translated">
-        <source>Nur als erledigt markieren (ohne Eintrag)</source>
-        <target>Mark ut solum perficitur (sine viscus)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.notFound">
@@ -6249,6 +6186,48 @@
       <segment state="translated">
         <source>Trainingspläne</source>
         <target>Disciplina consilia</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.triggerAria">
+      <segment state="translated">
+        <source>Tagesaktionen öffnen</source>
+        <target>Tagesaktionen öffnen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoDone">
+      <segment state="translated">
+        <source>Erledigt rückgängig machen</source>
+        <target>Erledigt rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoSkip">
+      <segment state="translated">
+        <source>Überspringen rückgängig machen</source>
+        <target>Überspringen rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.logDone">
+      <segment state="translated">
+        <source>Plan-Sätze eintragen &amp; abhaken</source>
+        <target>Plan-Sätze eintragen &amp; abhaken</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.markDone">
+      <segment state="translated">
+        <source>Nur abhaken (ohne Eintrag)</source>
+        <target>Nur abhaken (ohne Eintrag)</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.skip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Tag überspringen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.jump">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Zu diesem Tag springen</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -6101,51 +6101,6 @@
         <target>week</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.unmarkAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:243,244</note>
-      </notes>
-      <segment state="translated">
-        <source>Als nicht erledigt markieren</source>
-        <target>Markeer als niet voltooid</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipAria">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Dag overslaan</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipTooltip">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Dag overslaan</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipAria">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Overslaan ongedaan maken</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipTooltip">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Overslaan ongedaan maken</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpAria">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Naar deze dag springen</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpTooltip">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Naar deze dag springen</target>
-      </segment>
-    </unit>
     <unit id="trainingPlans.skipped">
       <segment state="translated">
         <source>Tag übersprungen.</source>
@@ -6156,24 +6111,6 @@
       <segment state="translated">
         <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
         <target>Gesprongen naar dag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.logAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>
-      </notes>
-      <segment state="translated">
-        <source>Plan-Sätze eintragen und als erledigt markieren</source>
-        <target>Voer planrecords in en markeer deze als voltooid</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.markAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:263,264</note>
-      </notes>
-      <segment state="translated">
-        <source>Nur als erledigt markieren (ohne Eintrag)</source>
-        <target>Alleen als voltooid markeren (zonder invoer)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.notFound">
@@ -6249,6 +6186,48 @@
       <segment state="translated">
         <source>Trainingspläne</source>
         <target>Trainingsplannen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.triggerAria">
+      <segment state="translated">
+        <source>Tagesaktionen öffnen</source>
+        <target>Tagesaktionen öffnen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoDone">
+      <segment state="translated">
+        <source>Erledigt rückgängig machen</source>
+        <target>Erledigt rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoSkip">
+      <segment state="translated">
+        <source>Überspringen rückgängig machen</source>
+        <target>Überspringen rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.logDone">
+      <segment state="translated">
+        <source>Plan-Sätze eintragen &amp; abhaken</source>
+        <target>Plan-Sätze eintragen &amp; abhaken</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.markDone">
+      <segment state="translated">
+        <source>Nur abhaken (ohne Eintrag)</source>
+        <target>Nur abhaken (ohne Eintrag)</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.skip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Tag überspringen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.jump">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Zu diesem Tag springen</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -5,51 +5,36 @@
       <notes>
         <note category="location">web/src/app/app.ts:81</note>
 
-
             </notes>
       <segment state="translated">
         <source>Neue Version verfügbar</source>
         <target>Ny versjon tilgjengelig</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="1933013871016789910">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:34</note>
 
-
             </notes>
       <segment state="translated">
         <source>Gesamt</source>
         <target>Totalt</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="2361265238320887165">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:26,27</note>
 
-
             </notes>
       <segment state="translated">
         <source>Abmelden</source>
         <target>Logg ut</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="2721806142807617942">
@@ -62,17 +47,12 @@
       <notes>
         <note category="location">web/src/app/app.ts:82</note>
 
-
             </notes>
       <segment state="translated">
         <source>Neu laden</source>
         <target>Oppdater</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="6031063121455734122">
@@ -85,23 +65,17 @@
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:25,26</note>
 
-
             </notes>
       <segment state="translated">
         <source>Anmeldung erfolgreich!</source>
         <target>Innlogging vellykket!</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="activeUser">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:64,65</note>
-
 
             </notes>
       <segment state="translated">
@@ -112,11 +86,7 @@ Aktiv:         </source>
           <ph id="0" equiv="INTERPOLATION" disp="{{ activeUserId() }}"/>
 Aktiv:         </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="ads.dashboard.aria">
@@ -124,10 +94,7 @@ Aktiv:         </target>
         <source>Werbung</source>
         <target>Annonse</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="ads.landing.aria">
@@ -135,231 +102,163 @@ Aktiv:         </target>
         <source>Werbung</source>
         <target>Annonse</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="allTimeAvg">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:92,93</note>
 
-
             </notes>
       <segment state="translated">
         <source>All-Time Ø/Tag</source>
         <target>Gjennomsnitt per dag (hele tiden)</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="allTimeDays">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:84,85</note>
 
-
             </notes>
       <segment state="translated">
         <source>All-Time Tage</source>
         <target>Dager (hele tiden)</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="allTimeEntries">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:88,89</note>
 
-
             </notes>
       <segment state="translated">
         <source>All-Time Einträge</source>
         <target>Oppføringer (hele tiden)</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="allTimeSummaryAria">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:76,77</note>
 
-
             </notes>
       <segment state="translated">
         <source>All-Time Kurzübersicht</source>
         <target>Sammendrag hele tiden</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="allTimeTotal">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:80,81</note>
 
-
             </notes>
       <segment state="translated">
         <source>All-Time Gesamt</source>
         <target>Totalt (hele tiden)</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.bestDay">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:87,89</note>
 
-
             </notes>
       <segment state="translated">
         <source>Bester Tag:</source>
         <target>Beste dag:</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.bestSingleEntry">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:82,84</note>
 
-
             </notes>
       <segment state="translated">
         <source>Bestwert Einzel-Eintrag:</source>
         <target>Beste enkeltoppføring:</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.bestStreaksTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:76,78</note>
 
-
             </notes>
       <segment state="translated">
         <source>Bestwerte &amp; Streaks</source>
         <target>Besteresultater &amp; serier</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.currentStreak">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:93,95</note>
 
-
             </notes>
       <segment state="translated">
         <source>Aktuelle Streak:</source>
         <target>Nåværende serie:</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.heatmapTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:126,128</note>
 
-
             </notes>
       <segment state="translated">
         <source>Heatmap (Wochentag/Uhrzeit)</source>
         <target>Heatmap (ukedag/tidspunkt)</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.longestStreak">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:101,103</note>
 
-
             </notes>
       <segment state="translated">
         <source>Längste Streak:</source>
         <target>Lengste serie:</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.monthCol">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:57,58</note>
 
-
             </notes>
       <segment state="translated">
         <source>Monat</source>
         <target>Måned</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.monthTrendTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:50,52</note>
 
-
             </notes>
       <segment state="translated">
         <source>Monatstrend</source>
         <target>Månedsutvikling</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.monthTrendSubtitle">
@@ -376,26 +275,18 @@ Aktiv:         </target>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:37,38</note>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:63,64</note>
 
-
-
             </notes>
       <segment state="translated">
         <source>Reps</source>
         <target>Repetisjoner</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.streakDays">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:96,97</note>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:104,105</note>
-
-
 
             </notes>
       <segment state="translated">
@@ -406,60 +297,43 @@ Aktiv:         </target>
           <ph id="0" equiv="INTERPOLATION" disp="{{ currentStreak() }}"/>
  dager        </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.typesTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:114,116</note>
 
-
             </notes>
       <segment state="translated">
         <source>Typen (Anteile)</source>
         <target>Typer (andeler)</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.weekCol">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:31,32</note>
 
-
             </notes>
       <segment state="translated">
         <source>Woche</source>
         <target>Uke</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="analysis.weekTrendTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:24,26</note>
 
-
             </notes>
       <segment state="translated">
         <source>Wochentrend</source>
         <target>Ukesutvikling</target>
 
-
             </segment>
-
 
         </unit>
     <unit id="analysis.weekTrendSubtitle">
@@ -599,18 +473,12 @@ Aktiv:         </target>
         <note category="location">web/src/app/app.html:11,12</note>
         <note category="location">web/src/app/app.html:114,115</note>
 
-
-
             </notes>
       <segment state="translated">
         <source>Pushups</source>
         <target>Pushup Stats</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="auth.email">
@@ -928,11 +796,7 @@ Aktiv:         </target>
         <source>Pushup Tracker Logo</source>
         <target>Pushup Tracker-logo</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="cancel">
@@ -940,154 +804,108 @@ Aktiv:         </target>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:215,217</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:297,299</note>
 
-
-
             </notes>
       <segment state="translated">
         <source> Abbrechen </source>
         <target> Avbryt </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="chart.dayIntegral">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:54,55</note>
 
-
             </notes>
       <segment state="translated">
         <source>Tages-Integral</source>
         <target>Daglig integral</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="chart.interval">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:48,49</note>
 
-
             </notes>
       <segment state="translated">
         <source>Intervallwert</source>
         <target>Intervallverdi</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="chart.legendAria">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43</note>
 
-
             </notes>
       <segment state="translated">
         <source>Legende</source>
         <target>Forklaring</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="chart.movingAvg">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:60,61</note>
 
-
             </notes>
       <segment state="translated">
         <source>Gleitender Durchschnitt</source>
         <target>Glidende gjennomsnitt</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="chart.subtitle">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:30,31</note>
 
-
             </notes>
       <segment state="translated">
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
         <target>Søylene viser repetisjonene dine per tidsperiode. Den oransje linjen summerer dagen, den grønne viser trenden din.</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="chart.titleDaily">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:82</note>
 
-
             </notes>
       <segment state="translated">
         <source>Verlauf (Tageswerte)</source>
         <target>Progresjon (daglige verdier)</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="chart.titleHourly">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:81</note>
 
-
             </notes>
       <segment state="translated">
         <source>Verlauf (Stundenwerte)</source>
         <target>Progresjon (timeverdier)</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="colActions">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:102,103</note>
 
-
             </notes>
       <segment state="translated">
         <source>Aktion</source>
         <target>Handling</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="colExercise">
@@ -1106,91 +924,65 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:75,76</note>
 
-
             </notes>
       <segment state="translated">
         <source>Reps</source>
         <target>Reps</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="colSource">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:93,94</note>
 
-
             </notes>
       <segment state="translated">
         <source>Quelle</source>
         <target>Kilde</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="colTime">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:66,67</note>
 
-
             </notes>
       <segment state="translated">
         <source>Zeit</source>
         <target>Tid</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="colType">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:84,85</note>
 
-
             </notes>
       <segment state="translated">
         <source>Typ</source>
         <target>Type</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="createDialogTitle">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:147,149</note>
 
-
             </notes>
       <segment state="translated">
         <source>Neuen Eintrag anlegen</source>
         <target>Opprett nytt oppføring</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="createNewEntry">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:27,30</note>
-
 
             </notes>
       <segment state="translated">
@@ -1201,45 +993,31 @@ Aktiv:         </target>
           <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc>
  Ny         </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="dailyGoalLabel">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:80,81</note>
 
-
             </notes>
       <segment state="translated">
         <source>Tagesziel (Reps)</source>
         <target>Daglig mål (reps)</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="dailyGoalPlaceholder">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:88</note>
 
-
             </notes>
       <segment state="translated">
         <source>10</source>
         <target>10</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="weeklyGoalLabel">
@@ -1336,68 +1114,48 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>Daily · Weekly · Monthly</source>
         <target>Daglig · Ukentlig · Månedlig</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="dashboard.leaderboard.title">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>Bestenliste</source>
         <target>Rangert liste</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="dashboardSubtitle">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:13,16</note>
 
-
             </notes>
       <segment state="translated">
         <source> Behalte Trainingsvolumen und Verlauf im Blick – klar, schnell und mobil optimiert. </source>
         <target> Hold øye med treningsvolumet og progresjon – klar, rask og mobil optimert. </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="dashboardTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:11,12</note>
 
-
             </notes>
       <segment state="translated">
         <source>Liegestütze Statistik</source>
         <target>Armhevingsstatistikk</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="dayChartMode14h">
@@ -1422,119 +1180,84 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:121</note>
 
-
             </notes>
       <segment state="translated">
         <source>Löschen</source>
         <target>Slett</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="deleteTitle">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:123</note>
 
-
             </notes>
       <segment state="translated">
         <source>Löschen</source>
         <target>Slett</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="displayNameLabel">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:69,70</note>
 
-
             </notes>
       <segment state="translated">
         <source>Anzeigename</source>
         <target>Visningsnavn</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="displayNamePlaceholder">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:75</note>
 
-
             </notes>
       <segment state="translated">
         <source>Wolf</source>
         <target>Wolf</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="editAria">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:108,109</note>
 
-
             </notes>
       <segment state="translated">
         <source>Bearbeiten</source>
         <target>Rediger</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="editDialogTitle">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:234,236</note>
 
-
             </notes>
       <segment state="translated">
         <source>Eintrag bearbeiten</source>
         <target>Rediger oppføring</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="editTitle">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:110,111</note>
 
-
             </notes>
       <segment state="translated">
         <source>Bearbeiten</source>
         <target>Rediger</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entries.allOption">
@@ -1542,160 +1265,113 @@ Aktiv:         </target>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:64,66</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:76,78</note>
 
-
-
             </notes>
       <segment state="translated">
         <source>Alle</source>
         <target>Alle</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entries.dateFrom">
       <notes>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:41,42</note>
 
-
             </notes>
       <segment state="translated">
         <source>Datum von</source>
         <target>Dato fra</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entries.dateTo">
       <notes>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:51,52</note>
 
-
             </notes>
       <segment state="translated">
         <source>Datum bis</source>
         <target>Dato til</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entries.repsMax">
       <notes>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:96,97</note>
 
-
             </notes>
       <segment state="translated">
         <source>Reps max</source>
         <target>Reps max</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entries.repsMin">
       <notes>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:85,86</note>
 
-
             </notes>
       <segment state="translated">
         <source>Reps min</source>
         <target>Reps min</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entries.sourceFilter">
       <notes>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:61,62</note>
 
-
             </notes>
       <segment state="translated">
         <source>Quelle</source>
         <target>Kilde</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entries.subtitle">
       <notes>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:34,35</note>
 
-
             </notes>
       <segment state="translated">
         <source>Zeitraum und Kriterien</source>
         <target>Periode og kriterier</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entries.title">
       <notes>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:32,33</note>
 
-
             </notes>
       <segment state="translated">
         <source>Filter</source>
         <target>Filter</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entries.typeFilter">
       <notes>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:73,74</note>
 
-
             </notes>
       <segment state="translated">
         <source>Typ</source>
         <target>Type</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entriesCount">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:5</note>
-
 
             </notes>
       <segment state="translated">
@@ -1706,96 +1382,67 @@ Aktiv:         </target>
           <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/>
  oppføringer        </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entriesInSelectedRange">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:175,177</note>
 
-
             </notes>
       <segment state="translated">
         <source>Einträge im gewählten Zeitraum</source>
         <target>Oppføringer i valgt periode</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="entriesTitle">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:3,4</note>
 
-
             </notes>
       <segment state="translated">
         <source>Historie</source>
         <target>Historikk</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="eyebrowTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:10,11</note>
 
-
             </notes>
       <segment state="translated">
         <source>Pushup Stats</source>
         <target>Pushup Stats</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="goalProgressTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:45,47</note>
 
-
             </notes>
       <segment state="translated">
         <source>Zielfortschritt</source>
         <target>Målprogresjon</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="heatmap.loading">
       <notes>
         <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:36,39</note>
 
-
             </notes>
       <segment state="translated">
         <source> Heatmap wird im Browser geladen… </source>
         <target> Laster varmekart i nettleser… </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="landing.cta.dashboard">
@@ -1811,68 +1458,48 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>Als Gast ausprobieren</source>
         <target>Prøv som gjest</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="landing.cta.login">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>Einloggen</source>
         <target>Logg inn</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="landing.cta.signup">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>Jetzt registrieren</source>
         <target>Registrer deg nå</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="landing.eyebrow">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>Pushup Tracker</source>
         <target>Pushup Tracker</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="landing.feature.analytics.body">
@@ -2104,34 +1731,24 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>Tag</source>
         <target>Dag</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="landing.leaderboard.empty">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>Noch keine Daten</source>
         <target>Ingen data ennå</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="landing.leaderboard.last30">
@@ -2147,7 +1764,6 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>
@@ -2156,28 +1772,19 @@ Aktiv:         </target>
 Deine Position: # ·  Reps        </source>
         <target> Din posisjon: #{$INTERPOLATION} · {$INTERPOLATION_1} armhevninger </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="landing.leaderboard.reps">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>Reps</source>
         <target>Armhevninger</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="landing.leaderboard.last7">
@@ -2319,57 +1926,41 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
         <target> Spor push-ups på sekunder — med trender, streaks og live-sync. Pluss sit-ups, knebøy, plank og løping når du vil ha mer. </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="landing.title">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>Dein Training. Klar visualisiert.</source>
         <target>Ditt trening. Klart visualisert.</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="lastEntryTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:59,60</note>
 
-
             </notes>
       <segment state="translated">
         <source>Letzter Eintrag</source>
         <target>Siste oppføring</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="latEntryReps">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:64,66</note>
-
 
             </notes>
       <segment state="translated">
@@ -2382,11 +1973,7 @@ Deine Position: # ·  Reps        </source>
           <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/>
   armhevninger ·          </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="leaderboard.page.subtitle">
@@ -2405,7 +1992,6 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:21,23</note>
 
-
             </notes>
       <segment state="translated">
         <source>
@@ -2415,164 +2001,115 @@ Deine Position: # ·  Reps        </source>
           <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;connected&apos; : &apos;disconnected&apos; }}"/>
  Direkte:          </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="loadingStats">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:162,166</note>
 
-
             </notes>
       <segment state="translated">
         <source> Lade Statistikdaten… </source>
         <target> Laster statistikkdata… </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.account">
       <notes>
         <note category="location">web/src/app/app.html:91,93</note>
 
-
             </notes>
       <segment state="translated">
         <source> Account </source>
         <target> Konto </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.analysis">
       <notes>
         <note category="location">web/src/app/app.html:43,46</note>
 
-
             </notes>
       <segment state="translated">
         <source>Analyse</source>
         <target>Analyse</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.aria">
       <notes>
         <note category="location">web/src/app/app.html:101,102</note>
 
-
             </notes>
       <segment state="translated">
         <source>Pushup Navigation</source>
         <target>Pushup navigasjon</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.dashboard">
       <notes>
         <note category="location">web/src/app/app.html:23,26</note>
 
-
             </notes>
       <segment state="translated">
         <source>Dashboard</source>
         <target>Dashbord</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.history">
       <notes>
         <note category="location">web/src/app/app.html:33,36</note>
 
-
             </notes>
       <segment state="translated">
         <source>Historie</source>
         <target>Historikk</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.lang.de">
       <notes>
         <note category="location">web/src/app/app.html:74,77</note>
 
-
             </notes>
       <segment state="translated">
         <source>Deutsch</source>
         <target>Tysk</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.lang.en">
       <notes>
         <note category="location">web/src/app/app.html:83,85</note>
 
-
             </notes>
       <segment state="translated">
         <source>English</source>
         <target>Engelsk</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.language">
       <notes>
         <note category="location">web/src/app/app.html:65,68</note>
 
-
             </notes>
       <segment state="translated">
         <source> Sprache </source>
         <target> Språk </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.leaderboard">
@@ -2585,238 +2122,168 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/app.html:109,111</note>
 
-
             </notes>
       <segment state="translated">
         <source>Login</source>
         <target>Innlogging</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.logout">
       <notes>
         <note category="location">web/src/app/app.html:104,106</note>
 
-
             </notes>
       <segment state="translated">
         <source>Logout</source>
         <target>Logg ut</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.openMenu">
       <notes>
         <note category="location">web/src/app/app.html:107,108</note>
 
-
             </notes>
       <segment state="translated">
         <source>Menü öffnen</source>
         <target>Åpne meny</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.settings">
       <notes>
         <note category="location">web/src/app/app.html:55,58</note>
 
-
             </notes>
       <segment state="translated">
         <source>Einstellungen</source>
         <target>Innstillinger</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="nav.toLanding">
       <notes>
         <note category="location">web/src/app/app.html</note>
 
-
             </notes>
       <segment state="translated">
         <source>Zur Landingpage</source>
         <target>Gå til landingsside</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="noEntriesInSelectedRange">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:50,53</note>
 
-
             </notes>
       <segment state="translated">
         <source> Keine Einträge im gewählten Zeitraum. </source>
         <target> Ingen oppføringer i valgt periode. </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="noEntryInPeriod">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:68,70</note>
 
-
             </notes>
       <segment state="translated">
         <source>Noch kein Eintrag für diesen Zeitraum.</source>
         <target>Ingen oppføring for denne perioden ennå.</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="period.day">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:52</note>
 
-
             </notes>
       <segment state="translated">
         <source>Tag</source>
         <target>Dag</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="period.month">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:54</note>
 
-
             </notes>
       <segment state="translated">
         <source>Monat</source>
         <target>Måned</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="period.range">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:56</note>
 
-
             </notes>
       <segment state="translated">
         <source>Zeitraum</source>
         <target>Periode</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="period.today">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:51</note>
 
-
             </notes>
       <segment state="translated">
         <source>Heute</source>
         <target>I dag</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="period.week">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:53</note>
 
-
             </notes>
       <segment state="translated">
         <source>Woche</source>
         <target>Uke</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="period.year">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:55</note>
 
-
             </notes>
       <segment state="translated">
         <source>Jahr</source>
         <target>År</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="pie.noData">
       <notes>
         <note category="location">web/src/app/stats/components/type-pie/type-pie.component.ts:46,49</note>
 
-
             </notes>
       <segment state="translated">
         <source>Keine Daten</source>
         <target>Ingen data</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="pie.distributionAria">
@@ -2844,34 +2311,24 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:103,105</note>
 
-
             </notes>
       <segment state="translated">
         <source>Schnell eintragen ohne Dialog</source>
         <target>Rask registrering uten dialog</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="quickActionsTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:100,102</note>
 
-
             </notes>
       <segment state="translated">
         <source>Schnellaktionen</source>
         <target>Hurtighandlinger</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="dashboard.quickAdd.button">
@@ -2959,17 +2416,12 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:35,36</note>
 
-
             </notes>
       <segment state="translated">
         <source>Schnellwahl Zeitraum</source>
         <target>Rask periode-valg</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="rangeBackAria">
@@ -3012,85 +2464,60 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:90</note>
 
-
             </notes>
       <segment state="translated">
         <source>Von</source>
         <target>Fra</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="rangeLabel">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:84,85</note>
 
-
             </notes>
       <segment state="translated">
         <source>Zeitraum</source>
         <target>Tidsperiode</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="rangeModeDay">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:43,44</note>
 
-
             </notes>
       <segment state="translated">
         <source>Tag</source>
         <target>Dag</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="rangeModeMonth">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:49,50</note>
 
-
             </notes>
       <segment state="translated">
         <source>Monat</source>
         <target>Måned</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="rangeModeWeek">
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:46,47</note>
 
-
             </notes>
       <segment state="translated">
         <source>Woche</source>
         <target>Uke</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="rangeModeYear">
@@ -3106,17 +2533,12 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:96</note>
 
-
             </notes>
       <segment state="translated">
         <source>Bis</source>
         <target>Til</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="rangeTodayAria">
@@ -3151,18 +2573,12 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:162,163</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:249,250</note>
 
-
-
             </notes>
       <segment state="translated">
         <source>Reps</source>
         <target>Reps</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="addSetTooltip">
@@ -3199,7 +2615,6 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:306,312</note>
 
-
             </notes>
       <segment state="translated">
         <source>
@@ -3215,11 +2630,7 @@ Deine Position: # ·  Reps        </source>
           <pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Lagre </pc>
         </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="saveEntry">
@@ -3451,17 +2862,12 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/stats/components/filter-bar/filter-bar.component.ts:30,33</note>
 
-
             </notes>
       <segment state="translated">
         <source>Zeitraum auswählen</source>
         <target>Velg tidsperiode</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="seo.analysis.description">
@@ -3469,10 +2875,7 @@ Deine Position: # ·  Reps        </source>
         <source>Analysiere Trends, Verteilungen und Streaks deines Trainings.</source>
         <target>Analyser trender, distribusjoner og treningsserier.</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.analysis.title">
@@ -3480,10 +2883,7 @@ Deine Position: # ·  Reps        </source>
         <source>Analyse – Pushup Tracker</source>
         <target>Analyse – Pushup Stats</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.dashboard.description">
@@ -3491,10 +2891,7 @@ Deine Position: # ·  Reps        </source>
         <source>Behalte Trainingsvolumen und Verlauf im Blick – klar, schnell und mobil optimiert.</source>
         <target>Behold treningsvolum og progresjon – klar, rask og mobil optimalisert.</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.dashboard.title">
@@ -3502,10 +2899,7 @@ Deine Position: # ·  Reps        </source>
         <source>Dashboard – Pushup Tracker</source>
         <target>Dashboard – Pushup Stats</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.history.description">
@@ -3513,10 +2907,7 @@ Deine Position: # ·  Reps        </source>
         <source>Durchsuche deine Trainingshistorie, filtere nach Zeitraum und behalte den Überblick.</source>
         <target>Søk i treningshistorikken din, filtrer etter tidsperiode og hold oversikten.</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.history.title">
@@ -3524,10 +2915,7 @@ Deine Position: # ·  Reps        </source>
         <source>Historie – Pushup Tracker</source>
         <target>Historie – Pushup Stats</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.default.description">
@@ -3535,10 +2923,7 @@ Deine Position: # ·  Reps        </source>
         <source>Tracke Reps, Trends und Streaks mit Pushup Tracker.</source>
         <target>Spor reps, trender og treningsserier med Pushup Stats.</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.default.title">
@@ -3546,10 +2931,7 @@ Deine Position: # ·  Reps        </source>
         <source>Pushup Tracker</source>
         <target>Pushup Stats</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.landing.description">
@@ -3557,10 +2939,7 @@ Deine Position: # ·  Reps        </source>
         <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
         <target>Spor push-ups med en gratis nettapp: treningsplaner, 30-dagers utfordring, daglig mål, streaks og topplister — nå også med sit-ups, knebøy, plank og løping. Mobil, offline, live-sync.</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.landing.title">
@@ -3568,10 +2947,7 @@ Deine Position: # ·  Reps        </source>
         <source>Liegestütze Tracker: Trainingsplan, Streaks &amp; Bestenliste</source>
         <target>Push-up-tracker: treningsplaner, streaks &amp; topplister</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.leaderboard.description">
@@ -3579,10 +2955,7 @@ Deine Position: # ·  Reps        </source>
         <source>Öffentliche Bestenliste mit Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage.</source>
         <target>Offentlig rangliste med topp-reps for i dag, de siste 7 dagene og de siste 30 dagene.</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.leaderboard.title">
@@ -3590,10 +2963,7 @@ Deine Position: # ·  Reps        </source>
         <source>Bestenliste – Pushup Tracker</source>
         <target>Rangliste – Pushup Stats</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.login.description">
@@ -3601,10 +2971,7 @@ Deine Position: # ·  Reps        </source>
         <source>Melde dich an und tracke dein Pushup-Training über alle Geräte.</source>
         <target>Logg inn og spor armhevingstreningen din på tvers av alle enheter.</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.login.title">
@@ -3612,10 +2979,7 @@ Deine Position: # ·  Reps        </source>
         <source>Login – Pushup Tracker</source>
         <target>Logg inn – Pushup Stats</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.register.description">
@@ -3623,10 +2987,7 @@ Deine Position: # ·  Reps        </source>
         <source>Erstelle dein Konto und richte Profil, Tagesziel und Einwilligungen ein.</source>
         <target>Opprett kontoen din og konfigurer profil, daglig mål og samtykkeasettinger.</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.register.title">
@@ -3634,10 +2995,7 @@ Deine Position: # ·  Reps        </source>
         <source>Registrierung – Pushup Tracker</source>
         <target>Registrer deg – Pushup Stats</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.settings.description">
@@ -3645,10 +3003,7 @@ Deine Position: # ·  Reps        </source>
         <source>Verwalte Profil, Leaderboard-Sichtbarkeit und Tagesziel-Einstellungen.</source>
         <target>Administrer profil, rangliste-synlighet og daglige målinnstillinger.</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="seo.settings.title">
@@ -3656,10 +3011,7 @@ Deine Position: # ·  Reps        </source>
         <source>Einstellungen – Pushup Tracker</source>
         <target>Innstillinger – Pushup Stats</target>
 
-
-
             </segment>
-
 
         </unit>
     <unit id="settings.adsConsentHint">
@@ -3882,40 +3234,29 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:33,34</note>
 
-
             </notes>
       <segment state="translated">
         <source>User-Profil &amp; Tagesziel</source>
         <target>Brukerprofil &amp; daglig mål</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="settingsTitle">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:31,32</note>
 
-
             </notes>
       <segment state="translated">
         <source>Einstellungen</source>
         <target>Innstillinger</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="sourceColumnToggle">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:15,20</note>
-
 
             </notes>
       <segment state="translated">
@@ -3934,11 +3275,7 @@ Deine Position: # ·  Reps        </source>
           </pc>
  Kilde         </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="sourceLabel">
@@ -3946,18 +3283,12 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:191,193</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:278,280</note>
 
-
-
             </notes>
       <segment state="translated">
         <source>Quelle</source>
         <target>Kilde</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="sourcePlaceholder">
@@ -3965,24 +3296,17 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:197,198</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:284,285</note>
 
-
-
             </notes>
       <segment state="translated">
         <source>web / whatsapp / eigene Quelle</source>
         <target>web / whatsapp / egendefinert kilde</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="switchUser">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:60,62</note>
-
 
             </notes>
       <segment state="translated">
@@ -3993,11 +3317,7 @@ Deine Position: # ·  Reps        </source>
           <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">switch_account</pc>
  Bytt bruker         </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="timestampLabel">
@@ -4005,52 +3325,36 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:151,153</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:238,240</note>
 
-
-
             </notes>
       <segment state="translated">
         <source>Zeitpunkt</source>
         <target>Tidsstempel</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="title.fallback">
       <notes>
         <note category="location">web/src/app/app.ts:65</note>
 
-
             </notes>
       <segment state="translated">
         <source>Dein Name 💪</source>
         <target>Ditt navn 💪</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="todayFocusAria">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:28,29</note>
 
-
             </notes>
       <segment state="translated">
         <source>Tagesfokus</source>
         <target>Dagens fokus</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="toolbarDailyGoal">
@@ -4064,18 +3368,12 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:174,175</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:261,262</note>
 
-
-
             </notes>
       <segment state="translated">
         <source>Typ</source>
         <target>Type</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="typePlaceholder">
@@ -4083,18 +3381,12 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:180,181</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:267,268</note>
 
-
-
             </notes>
       <segment state="translated">
         <source>Auswählen oder eintippen</source>
         <target>Velg eller skriv inn egendefinert</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="typeWikiLinkAria">
@@ -4119,119 +3411,84 @@ Deine Position: # ·  Reps        </source>
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:49,50</note>
 
-
             </notes>
       <segment state="translated">
         <source> Wird für Multi-User-Zuordnung genutzt (Auth kommt später). </source>
         <target> Brukes til tildeling av flere brukere (autentisering kommer senere). </target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="userIdLabel">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:40,41</note>
 
-
             </notes>
       <segment state="translated">
         <source>User ID</source>
         <target>Bruker-ID</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="userIdPlaceholder">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:45,46</note>
 
-
             </notes>
       <segment state="translated">
         <source>z.B. wolf</source>
         <target>f.eks. wolf</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="validate.email.email">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:69</note>
 
-
             </notes>
       <segment state="translated">
         <source>Bitte gültige E-Mail eingeben!</source>
         <target>Vennligst oppgi en gyldig e-post!</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="validate.email.required">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:66</note>
 
-
             </notes>
       <segment state="translated">
         <source>Bitte E-Mail eingeben!</source>
         <target>Vennligst oppgi e-post!</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="validate.password.minLength">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:75</note>
 
-
             </notes>
       <segment state="translated">
         <source>Passwort muss mindestens 6 Zeichen lang sein!</source>
         <target>Passordet må være minst 6 tegn langt!</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="validate.password.required">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:72</note>
 
-
             </notes>
       <segment state="translated">
         <source>Bitte Passwort eingeben!</source>
         <target>Vennligst oppgi passord!</target>
 
-
-
             </segment>
-
-
 
         </unit>
     <unit id="validate.password.policy">
@@ -4243,199 +3500,6 @@ Deine Position: # ·  Reps        </source>
         <target>Passordet må inneholde store og små bokstaver, tall og spesialtegn.</target>
             </segment>
         </unit>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
         <unit id="user.guestName">
       <notes>
@@ -6093,6 +5157,48 @@ Deine Position: # ·  Reps        </source>
         <target>Treningsplaner</target>
       </segment>
     </unit>
+    <unit id="trainingPlans.menu.triggerAria">
+      <segment state="translated">
+        <source>Tagesaktionen öffnen</source>
+        <target>Tagesaktionen öffnen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoDone">
+      <segment state="translated">
+        <source>Erledigt rückgängig machen</source>
+        <target>Erledigt rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoSkip">
+      <segment state="translated">
+        <source>Überspringen rückgängig machen</source>
+        <target>Überspringen rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.logDone">
+      <segment state="translated">
+        <source>Plan-Sätze eintragen &amp; abhaken</source>
+        <target>Plan-Sätze eintragen &amp; abhaken</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.markDone">
+      <segment state="translated">
+        <source>Nur abhaken (ohne Eintrag)</source>
+        <target>Nur abhaken (ohne Eintrag)</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.skip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Tag überspringen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.jump">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Zu diesem Tag springen</target>
+      </segment>
+    </unit>
     <unit id="trainingPlans.intro">
       <segment state="translated">
         <source>Strukturierte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Starte einen Plan, und dein Tagesziel im Dashboard wird automatisch gesetzt.</source>
@@ -6303,54 +5409,6 @@ Deine Position: # ·  Reps        </source>
         <target>Gjeldende dag:</target>
       </segment>
     </unit>
-    <unit id="trainingPlans.markAria">
-      <segment state="translated">
-        <source>Nur als erledigt markieren (ohne Eintrag)</source>
-        <target>Marker som gjort (uten å opprette oppføring)</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unmarkAria">
-      <segment state="translated">
-        <source>Als nicht erledigt markieren</source>
-        <target>Marker som ikke gjort</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipAria">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Hopp over dag</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipTooltip">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>Hopp over dag</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipAria">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Angre hopp</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipTooltip">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>Angre hopp</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpAria">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Hopp til denne dagen</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpTooltip">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>Hopp til denne dagen</target>
-      </segment>
-    </unit>
     <unit id="trainingPlans.skipped">
       <segment state="translated">
         <source>Tag übersprungen.</source>
@@ -6493,12 +5551,6 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source>Heute eintragen</source>
         <target>Logg i dag</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.logAria">
-      <segment state="translated">
-        <source>Plan-Sätze eintragen und als erledigt markieren</source>
-        <target>Logg plan-sett og marker som gjort</target>
       </segment>
     </unit>
     <unit id="trainingPlans.logged">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4584,7 +4584,7 @@
     </unit>
     <unit id="heatmap.loading">
       <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:37,40</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:45,48</note>
       </notes>
       <segment>
         <source> Heatmap wird im Browser geladen… </source>
@@ -4592,7 +4592,7 @@
     </unit>
     <unit id="heatmap.unit.sets">
       <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:65</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:73</note>
       </notes>
       <segment>
         <source>Sätze</source>
@@ -4600,7 +4600,7 @@
     </unit>
     <unit id="heatmap.unit.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:66</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:74</note>
       </notes>
       <segment>
         <source>Wiederholungen</source>
@@ -4912,7 +4912,8 @@
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:200</note>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1093</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:677</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:46</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:76</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:277</note>
       </notes>
       <segment>
@@ -5148,6 +5149,7 @@
     <unit id="exercise.category.abs">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1094</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:77</note>
       </notes>
       <segment>
         <source>Bauch</source>
@@ -5156,6 +5158,7 @@
     <unit id="exercise.category.legs">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1095</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:78</note>
       </notes>
       <segment>
         <source>Beine</source>
@@ -5164,6 +5167,7 @@
     <unit id="exercise.category.plank">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1096</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:79</note>
       </notes>
       <segment>
         <source>Plank</source>
@@ -5172,6 +5176,7 @@
     <unit id="exercise.category.cardio">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1097</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:80</note>
       </notes>
       <segment>
         <source>Ausdauer</source>
@@ -5267,7 +5272,7 @@
     </unit>
     <unit id="exercise.abs.situps.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:8</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:14</note>
       </notes>
       <segment>
         <source>Sit-ups</source>
@@ -5275,7 +5280,7 @@
     </unit>
     <unit id="exercise.abs.crunches.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:9</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:15</note>
       </notes>
       <segment>
         <source>Crunches</source>
@@ -5283,7 +5288,7 @@
     </unit>
     <unit id="exercise.abs.legraises.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:10</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:16</note>
       </notes>
       <segment>
         <source>Beinheben</source>
@@ -5291,7 +5296,7 @@
     </unit>
     <unit id="exercise.abs.russiantwist.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:11</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:17</note>
       </notes>
       <segment>
         <source>Russian Twist</source>
@@ -5299,7 +5304,7 @@
     </unit>
     <unit id="exercise.abs.mountainclimbers.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:12</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:18</note>
       </notes>
       <segment>
         <source>Mountain Climbers</source>
@@ -5307,7 +5312,7 @@
     </unit>
     <unit id="exercise.legs.squats.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:13</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:19</note>
       </notes>
       <segment>
         <source>Kniebeugen</source>
@@ -5315,7 +5320,7 @@
     </unit>
     <unit id="exercise.legs.lunges.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:14</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:20</note>
       </notes>
       <segment>
         <source>Ausfallschritte</source>
@@ -5323,7 +5328,7 @@
     </unit>
     <unit id="exercise.legs.glutebridge.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:15</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:21</note>
       </notes>
       <segment>
         <source>Hüftheben</source>
@@ -5331,7 +5336,7 @@
     </unit>
     <unit id="exercise.legs.calfraises.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:16</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:22</note>
       </notes>
       <segment>
         <source>Wadenheben</source>
@@ -5339,7 +5344,7 @@
     </unit>
     <unit id="exercise.legs.jumpsquats.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:17</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:23</note>
       </notes>
       <segment>
         <source>Jump Squats</source>
@@ -5347,7 +5352,7 @@
     </unit>
     <unit id="exercise.plank.standard.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:18</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:24</note>
       </notes>
       <segment>
         <source>Plank</source>
@@ -5355,63 +5360,15 @@
     </unit>
     <unit id="exercise.cardio.running.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:19</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:25</note>
       </notes>
       <segment>
         <source>Laufen</source>
       </segment>
     </unit>
-    <unit id="analysisHeaderTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:67,68</note>
-      </notes>
-      <segment>
-        <source>Analyse</source>
-      </segment>
-    </unit>
-    <unit id="analysisHeaderSubtitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:69,71</note>
-      </notes>
-      <segment>
-        <source> Trends, Verteilungen und Streaks deines Trainings auf einen Blick. </source>
-      </segment>
-    </unit>
-    <unit id="analysis.exerciseFilter">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:87,89</note>
-      </notes>
-      <segment>
-        <source>Übung</source>
-      </segment>
-    </unit>
-    <unit id="analysis.empty.title">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:110,112</note>
-      </notes>
-      <segment>
-        <source>Noch keine Daten zum Analysieren.</source>
-      </segment>
-    </unit>
-    <unit id="analysis.empty.body">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:113,115</note>
-      </notes>
-      <segment>
-        <source> Starte einen Trainingsplan oder trage deinen ersten Satz ein — dann zeigen wir dir hier Trends und Streaks. </source>
-      </segment>
-    </unit>
-    <unit id="analysis.empty.cta">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:124,126</note>
-      </notes>
-      <segment>
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Trainingsplan wählen </source>
-      </segment>
-    </unit>
     <unit id="analysis.bestStreaksTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:146,148</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:49,51</note>
       </notes>
       <segment>
         <source>Bestwerte &amp; Streaks</source>
@@ -5419,7 +5376,7 @@
     </unit>
     <unit id="analysis.bestSingleEntry">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:152,154</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:55,57</note>
       </notes>
       <segment>
         <source>Bestwert Einzel-Eintrag:</source>
@@ -5427,7 +5384,7 @@
     </unit>
     <unit id="analysis.bestDay">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:157,159</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:60,62</note>
       </notes>
       <segment>
         <source>Bester Tag:</source>
@@ -5435,7 +5392,7 @@
     </unit>
     <unit id="analysis.bestSingleSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:166,168</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:69,71</note>
       </notes>
       <segment>
         <source>Bestes Einzel-Set:</source>
@@ -5443,7 +5400,7 @@
     </unit>
     <unit id="analysis.repsUnit">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:170,172</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:73,75</note>
       </notes>
       <segment>
         <source>Wdh.</source>
@@ -5451,7 +5408,7 @@
     </unit>
     <unit id="analysis.currentStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:175,177</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:78,80</note>
       </notes>
       <segment>
         <source>Aktuelle Streak:</source>
@@ -5459,8 +5416,8 @@
     </unit>
     <unit id="analysis.streakDays">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:178,179</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:186,187</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:81,82</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:89,90</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}"/> Tage</source>
@@ -5468,7 +5425,7 @@
     </unit>
     <unit id="analysis.longestStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:183,185</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:86,88</note>
       </notes>
       <segment>
         <source>Längste Streak:</source>
@@ -5476,7 +5433,7 @@
     </unit>
     <unit id="analysis.typesTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:196,198</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:99,101</note>
       </notes>
       <segment>
         <source>Typen (Anteile)</source>
@@ -5484,7 +5441,7 @@
     </unit>
     <unit id="analysis.avgSetSizeTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:210,211</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:113,114</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
@@ -5492,7 +5449,7 @@
     </unit>
     <unit id="analysis.repsPerSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:215,216</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:118,119</note>
       </notes>
       <segment>
         <source>Reps / Set</source>
@@ -5500,7 +5457,7 @@
     </unit>
     <unit id="analysis.setsDistTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:224,226</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:127,129</note>
       </notes>
       <segment>
         <source>Sets-Verteilung</source>
@@ -5508,7 +5465,7 @@
     </unit>
     <unit id="analysis.heatmapTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:239,241</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:142,144</note>
       </notes>
       <segment>
         <source>Heatmap (Wochentag/Uhrzeit)</source>
@@ -5516,7 +5473,7 @@
     </unit>
     <unit id="analysis.heatmapToggleAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:245,246</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:148,149</note>
       </notes>
       <segment>
         <source>Heatmap-Modus auswählen</source>
@@ -5524,7 +5481,7 @@
     </unit>
     <unit id="analysis.heatmapReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:249,251</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:152,154</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5532,7 +5489,7 @@
     </unit>
     <unit id="analysis.heatmapSets">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:252,254</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:155,157</note>
       </notes>
       <segment>
         <source>Sets</source>
@@ -5540,7 +5497,7 @@
     </unit>
     <unit id="analysis.weekTrendTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:267,269</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:173,175</note>
       </notes>
       <segment>
         <source>Wochentrend</source>
@@ -5548,7 +5505,7 @@
     </unit>
     <unit id="analysis.weekTrendSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:270,272</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:176,178</note>
       </notes>
       <segment>
         <source>Letzte 8 Wochen</source>
@@ -5556,7 +5513,7 @@
     </unit>
     <unit id="analysis.weekCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:278,279</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:184,185</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -5564,8 +5521,8 @@
     </unit>
     <unit id="analysis.repsCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:284,285</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:334,335</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:190,191</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:238,239</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5573,8 +5530,8 @@
     </unit>
     <unit id="analysis.avgSetsCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:292,293</note>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:342,343</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:196,197</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:244,245</note>
       </notes>
       <segment>
         <source>⌀ Sets</source>
@@ -5582,7 +5539,7 @@
     </unit>
     <unit id="analysis.monthTrendTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:317,319</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:221,223</note>
       </notes>
       <segment>
         <source>Monatstrend</source>
@@ -5590,7 +5547,7 @@
     </unit>
     <unit id="analysis.monthTrendSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:320,322</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:224,226</note>
       </notes>
       <segment>
         <source>Letzte 6 Monate</source>
@@ -5598,18 +5555,58 @@
     </unit>
     <unit id="analysis.monthCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:328,329</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:232,233</note>
       </notes>
       <segment>
         <source>Monat</source>
       </segment>
     </unit>
-    <unit id="analysis.kindUnknown">
+    <unit id="analysisHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:685</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:51,52</note>
       </notes>
       <segment>
-        <source>Andere Übung</source>
+        <source>Analyse</source>
+      </segment>
+    </unit>
+    <unit id="analysisHeaderSubtitle">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:53,55</note>
+      </notes>
+      <segment>
+        <source> Trends, Verteilungen und Streaks deines Trainings auf einen Blick. </source>
+      </segment>
+    </unit>
+    <unit id="analysis.exerciseFilter">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:71,73</note>
+      </notes>
+      <segment>
+        <source>Übung</source>
+      </segment>
+    </unit>
+    <unit id="analysis.empty.title">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:94,96</note>
+      </notes>
+      <segment>
+        <source>Noch keine Daten zum Analysieren.</source>
+      </segment>
+    </unit>
+    <unit id="analysis.empty.body">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:97,99</note>
+      </notes>
+      <segment>
+        <source> Starte einen Trainingsplan oder trage deinen ersten Satz ein — dann zeigen wir dir hier Trends und Streaks. </source>
+      </segment>
+    </unit>
+    <unit id="analysis.empty.cta">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:108,110</note>
+      </notes>
+      <segment>
+        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Trainingsplan wählen </source>
       </segment>
     </unit>
     <unit id="historyHeaderTitle">
@@ -6330,7 +6327,7 @@
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:77,78</note>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:170,172</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:239,240</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:241,242</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:107,108</note>
       </notes>
       <segment>
@@ -6340,7 +6337,7 @@
     <unit id="trainingPlans.kind.light">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:80,81</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:246,248</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:248,250</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:110,111</note>
       </notes>
       <segment>
@@ -6350,7 +6347,7 @@
     <unit id="trainingPlans.kind.test">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:82,84</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:242,244</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:244,246</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:113,115</note>
       </notes>
       <segment>
@@ -6361,8 +6358,8 @@
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:85,87</note>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:183,185</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:252,253</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:258,259</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:254,255</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:260,261</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:125,127</note>
       </notes>
       <segment>
@@ -6621,8 +6618,8 @@
     </unit>
     <unit id="trainingPlans.back">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:75</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:371,373</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:77</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:391,393</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -6630,7 +6627,7 @@
     </unit>
     <unit id="trainingPlans.daysSuffix">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:84,86</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:86,88</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:180,182</note>
       </notes>
       <segment>
@@ -6639,7 +6636,7 @@
     </unit>
     <unit id="trainingPlans.level.beginner">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:88,89</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:90,91</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:185,187</note>
       </notes>
       <segment>
@@ -6648,7 +6645,7 @@
     </unit>
     <unit id="trainingPlans.level.intermediate">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:90,92</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:92,94</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:189,191</note>
       </notes>
       <segment>
@@ -6657,7 +6654,7 @@
     </unit>
     <unit id="trainingPlans.level.advanced">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:92,94</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:94,96</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:193,195</note>
       </notes>
       <segment>
@@ -6666,7 +6663,7 @@
     </unit>
     <unit id="trainingPlans.progress">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:101,102</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:103,104</note>
       </notes>
       <segment>
         <source>Fortschritt</source>
@@ -6674,7 +6671,7 @@
     </unit>
     <unit id="trainingPlans.currentDay">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:110,111</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:112,113</note>
       </notes>
       <segment>
         <source>Aktueller Tag:</source>
@@ -6682,7 +6679,7 @@
     </unit>
     <unit id="trainingPlans.goalOverrideHint">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:117,119</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:119,121</note>
       </notes>
       <segment>
         <source> Tagesziel wird vom Plan gesetzt. </source>
@@ -6690,7 +6687,7 @@
     </unit>
     <unit id="trainingPlans.goalOverrideHint.cta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:123,126</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:125,128</note>
       </notes>
       <segment>
         <source>Manuelle Ziele anpassen</source>
@@ -6698,7 +6695,7 @@
     </unit>
     <unit id="trainingPlans.abandon">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:134,136</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:136,138</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:140,142</note>
       </notes>
       <segment>
@@ -6707,7 +6704,7 @@
     </unit>
     <unit id="trainingPlans.startCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:144,146</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:146,148</note>
       </notes>
       <segment>
         <source> Starte den Plan und das Tagesziel im Dashboard wird automatisch nach diesem Plan gesetzt. </source>
@@ -6715,7 +6712,7 @@
     </unit>
     <unit id="trainingPlans.signupCta">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:149,151</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:151,153</note>
       </notes>
       <segment>
         <source> Erstelle ein kostenloses Konto, um diesen Plan zu starten. Wir tracken deinen Fortschritt automatisch und setzen dein Tagesziel passend zum Plan. </source>
@@ -6723,7 +6720,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.tracking">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:155,157</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:157,159</note>
       </notes>
       <segment>
         <source> Automatische Fortschrittsverfolgung </source>
@@ -6731,7 +6728,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.goal">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:158,160</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:160,162</note>
       </notes>
       <segment>
         <source> Tagesziel passt sich täglich an deinen Plan an </source>
@@ -6739,7 +6736,7 @@
     </unit>
     <unit id="trainingPlans.signupBenefit.streak">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:161,163</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:163,165</note>
       </notes>
       <segment>
         <source> Streaks, Statistiken und Bestenliste </source>
@@ -6747,7 +6744,7 @@
     </unit>
     <unit id="trainingPlans.replaceWarn">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:173,174</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:175,176</note>
       </notes>
       <segment>
         <source> Achtung: Dies ersetzt den aktuell aktiven Plan. </source>
@@ -6755,7 +6752,7 @@
     </unit>
     <unit id="trainingPlans.start">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:178,180</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:180,182</note>
       </notes>
       <segment>
         <source>Plan starten</source>
@@ -6763,7 +6760,7 @@
     </unit>
     <unit id="trainingPlans.signupAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:189,191</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:191,193</note>
       </notes>
       <segment>
         <source>Konto erstellen &amp; Plan starten</source>
@@ -6771,7 +6768,7 @@
     </unit>
     <unit id="trainingPlans.loginAndStart">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:197,200</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:199,202</note>
       </notes>
       <segment>
         <source>Schon Konto? Einloggen</source>
@@ -6779,79 +6776,63 @@
     </unit>
     <unit id="trainingPlans.week">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:207,208</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:209,210</note>
       </notes>
       <segment>
         <source>Woche</source>
       </segment>
     </unit>
-    <unit id="trainingPlans.unmarkAria">
+    <unit id="trainingPlans.menu.triggerAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:298,299</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:301,302</note>
       </notes>
       <segment>
-        <source>Als nicht erledigt markieren</source>
+        <source>Tagesaktionen öffnen</source>
       </segment>
     </unit>
-    <unit id="trainingPlans.unskipAria">
+    <unit id="trainingPlans.menu.undoDone">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:307,308</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:321,323</note>
+      </notes>
+      <segment>
+        <source>Erledigt rückgängig machen</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoSkip">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:331,333</note>
       </notes>
       <segment>
         <source>Überspringen rückgängig machen</source>
       </segment>
     </unit>
-    <unit id="trainingPlans.unskipTooltip">
+    <unit id="trainingPlans.menu.logDone">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:309,310</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:342,344</note>
       </notes>
       <segment>
-        <source>Überspringen rückgängig machen</source>
+        <source>Plan-Sätze eintragen &amp; abhaken</source>
       </segment>
     </unit>
-    <unit id="trainingPlans.logAria">
+    <unit id="trainingPlans.menu.markDone">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:320,321</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:352,354</note>
       </notes>
       <segment>
-        <source>Plan-Sätze eintragen und als erledigt markieren</source>
+        <source>Nur abhaken (ohne Eintrag)</source>
       </segment>
     </unit>
-    <unit id="trainingPlans.markAria">
+    <unit id="trainingPlans.menu.skip">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:329,330</note>
-      </notes>
-      <segment>
-        <source>Nur als erledigt markieren (ohne Eintrag)</source>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:337,338</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:361,362</note>
       </notes>
       <segment>
         <source>Tag überspringen</source>
       </segment>
     </unit>
-    <unit id="trainingPlans.skipTooltip">
+    <unit id="trainingPlans.menu.jump">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:339,340</note>
-      </notes>
-      <segment>
-        <source>Tag überspringen</source>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:350,351</note>
-      </notes>
-      <segment>
-        <source>Zu diesem Tag springen</source>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpTooltip">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:352,353</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:373,375</note>
       </notes>
       <segment>
         <source>Zu diesem Tag springen</source>
@@ -6859,7 +6840,7 @@
     </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:368,369</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:388,389</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -6867,7 +6848,7 @@
     </unit>
     <unit id="trainingPlans.autoStartFailed">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:661</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:681</note>
       </notes>
       <segment>
         <source>Plan-Start fehlgeschlagen — bitte erneut versuchen.</source>
@@ -6875,7 +6856,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:744</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:764</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -6883,7 +6864,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:761</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:781</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
@@ -6891,7 +6872,7 @@
     </unit>
     <unit id="trainingPlans.skipped">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:779</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:799</note>
       </notes>
       <segment>
         <source>Tag übersprungen.</source>
@@ -6899,7 +6880,7 @@
     </unit>
     <unit id="trainingPlans.jumped">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:792</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:812</note>
       </notes>
       <segment>
         <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
@@ -6907,7 +6888,7 @@
     </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:809</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:829</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:348</note>
       </notes>
       <segment>
@@ -6916,7 +6897,7 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:811</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:831</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:350</note>
       </notes>
       <segment>
@@ -6925,7 +6906,7 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:813</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:833</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:352</note>
       </notes>
       <segment>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -6620,50 +6620,6 @@
         <source>Woche</source>
       <target>周</target></segment>
     </unit>
-    <unit id="trainingPlans.unmarkAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:275,276</note>
-      </notes>
-      <segment state="translated">
-        <source>Als nicht erledigt markieren</source>
-      <target>标记为未完成</target></segment>
-    </unit>
-    <unit id="trainingPlans.skipAria">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>跳过此天</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.skipTooltip">
-      <segment state="translated">
-        <source>Tag überspringen</source>
-        <target>跳过此天</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipAria">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>撤销跳过</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.unskipTooltip">
-      <segment state="translated">
-        <source>Überspringen rückgängig machen</source>
-        <target>撤销跳过</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpAria">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>跳转到此天</target>
-      </segment>
-    </unit>
-    <unit id="trainingPlans.jumpTooltip">
-      <segment state="translated">
-        <source>Zu diesem Tag springen</source>
-        <target>跳转到此天</target>
-      </segment>
-    </unit>
     <unit id="trainingPlans.skipped">
       <segment state="translated">
         <source>Tag übersprungen.</source>
@@ -6675,22 +6631,6 @@
         <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
         <target>已跳转到第 <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> 天。</target>
       </segment>
-    </unit>
-    <unit id="trainingPlans.logAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:286,287</note>
-      </notes>
-      <segment state="translated">
-        <source>Plan-Sätze eintragen und als erledigt markieren</source>
-      <target>记录计划组数并标记为完成</target></segment>
-    </unit>
-    <unit id="trainingPlans.markAria">
-      <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:295,296</note>
-      </notes>
-      <segment state="translated">
-        <source>Nur als erledigt markieren (ohne Eintrag)</source>
-      <target>仅标记为完成（无记录）</target></segment>
     </unit>
     <unit id="trainingPlans.notFound">
       <notes>
@@ -6758,6 +6698,48 @@
       <segment state="translated">
         <source>Trainingspläne</source>
       <target>训练计划</target></segment>
+    </unit>
+    <unit id="trainingPlans.menu.triggerAria">
+      <segment state="translated">
+        <source>Tagesaktionen öffnen</source>
+        <target>Tagesaktionen öffnen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoDone">
+      <segment state="translated">
+        <source>Erledigt rückgängig machen</source>
+        <target>Erledigt rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.undoSkip">
+      <segment state="translated">
+        <source>Überspringen rückgängig machen</source>
+        <target>Überspringen rückgängig machen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.logDone">
+      <segment state="translated">
+        <source>Plan-Sätze eintragen &amp; abhaken</source>
+        <target>Plan-Sätze eintragen &amp; abhaken</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.markDone">
+      <segment state="translated">
+        <source>Nur abhaken (ohne Eintrag)</source>
+        <target>Nur abhaken (ohne Eintrag)</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.skip">
+      <segment state="translated">
+        <source>Tag überspringen</source>
+        <target>Tag überspringen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.menu.jump">
+      <segment state="translated">
+        <source>Zu diesem Tag springen</source>
+        <target>Zu diesem Tag springen</target>
+      </segment>
     </unit>
     <unit id="trainingPlans.intro">
       <notes>


### PR DESCRIPTION
## Summary
- Collapses the per-day icon cluster on the plan detail page into a single overflow menu (`mat-menu`) with labelled actions.
- Trigger icon mirrors day state: `check_circle` (done), `skip_next` (skipped), `more_vert` (pending).
- Menu items: log & check, mark only, skip, undo, jump to day — each with icon + clear German label instead of icon-only buttons.
- i18n: old `*Aria`/`*Tooltip` keys removed, new `trainingPlans.menu.*` keys added across all 9 locales.

## Test plan
- [x] `pnpm nx lint web` — 0 errors
- [x] `pnpm nx test web` for `training-plan-detail.component.spec.ts` — 15 passed
- [x] `pnpm nx build web -c production` — green (i18n complete for all locales)
- [ ] Smoke-check menu on active plan: open menu on pending / completed / skipped / non-today day rows

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFiPcYeMTtDbbz625kGMAQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized training plan day actions into a dropdown menu for improved UI organization and accessibility.

* **Documentation**
  * Updated localization strings across all supported languages to reflect the new menu-based interface for training plan actions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/323)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->