### PR TITLE
fix(training-plans): translate menu labels for all non-German locales

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -6191,43 +6191,43 @@
     <unit id="trainingPlans.menu.triggerAria">
       <segment state="translated">
         <source>Tagesaktionen öffnen</source>
-        <target>Tagesaktionen öffnen</target>
+        <target>Άνοιγμα ενεργειών ημέρας</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoDone">
       <segment state="translated">
         <source>Erledigt rückgängig machen</source>
-        <target>Erledigt rückgängig machen</target>
+        <target>Επισήμανση ως μη ολοκληρωμένη</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoSkip">
       <segment state="translated">
         <source>Überspringen rückgängig machen</source>
-        <target>Überspringen rückgängig machen</target>
+        <target>Αναίρεση παράλειψης</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logDone">
       <segment state="translated">
         <source>Plan-Sätze eintragen &amp; abhaken</source>
-        <target>Plan-Sätze eintragen &amp; abhaken</target>
+        <target>Εισαγάγετε εγγραφές σχεδίου και σημειώστε τις ως ολοκληρωμένες</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.markDone">
       <segment state="translated">
         <source>Nur abhaken (ohne Eintrag)</source>
-        <target>Nur abhaken (ohne Eintrag)</target>
+        <target>Επισήμανση ως ολοκληρωμένου μόνο (χωρίς καταχώριση)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.skip">
       <segment state="translated">
         <source>Tag überspringen</source>
-        <target>Tag überspringen</target>
+        <target>Παράλειψη ημέρας</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.jump">
       <segment state="translated">
         <source>Zu diesem Tag springen</source>
-        <target>Zu diesem Tag springen</target>
+        <target>Μετάβαση σε αυτή την ημέρα</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -6191,43 +6191,43 @@
     <unit id="trainingPlans.menu.triggerAria">
       <segment state="translated">
         <source>Tagesaktionen öffnen</source>
-        <target>Tagesaktionen öffnen</target>
+        <target>Abrir acciones del día</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoDone">
       <segment state="translated">
         <source>Erledigt rückgängig machen</source>
-        <target>Erledigt rückgängig machen</target>
+        <target>Marcar como no completado</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoSkip">
       <segment state="translated">
         <source>Überspringen rückgängig machen</source>
-        <target>Überspringen rückgängig machen</target>
+        <target>Deshacer salto</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logDone">
       <segment state="translated">
         <source>Plan-Sätze eintragen &amp; abhaken</source>
-        <target>Plan-Sätze eintragen &amp; abhaken</target>
+        <target>Ingrese los registros del plan y márquelos como completados</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.markDone">
       <segment state="translated">
         <source>Nur abhaken (ohne Eintrag)</source>
-        <target>Nur abhaken (ohne Eintrag)</target>
+        <target>Marcar como completado únicamente (sin entrada)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.skip">
       <segment state="translated">
         <source>Tag überspringen</source>
-        <target>Tag überspringen</target>
+        <target>Saltar día</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.jump">
       <segment state="translated">
         <source>Zu diesem Tag springen</source>
-        <target>Zu diesem Tag springen</target>
+        <target>Ir a este día</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -6191,43 +6191,43 @@
     <unit id="trainingPlans.menu.triggerAria">
       <segment state="translated">
         <source>Tagesaktionen öffnen</source>
-        <target>Tagesaktionen öffnen</target>
+        <target>Ouvrir les actions du jour</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoDone">
       <segment state="translated">
         <source>Erledigt rückgängig machen</source>
-        <target>Erledigt rückgängig machen</target>
+        <target>Marquer comme non terminé</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoSkip">
       <segment state="translated">
         <source>Überspringen rückgängig machen</source>
-        <target>Überspringen rückgängig machen</target>
+        <target>Annuler le saut</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logDone">
       <segment state="translated">
         <source>Plan-Sätze eintragen &amp; abhaken</source>
-        <target>Plan-Sätze eintragen &amp; abhaken</target>
+        <target>Saisir les enregistrements du plan et les marquer comme terminés</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.markDone">
       <segment state="translated">
         <source>Nur abhaken (ohne Eintrag)</source>
-        <target>Nur abhaken (ohne Eintrag)</target>
+        <target>Marquer comme terminé uniquement (sans saisie)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.skip">
       <segment state="translated">
         <source>Tag überspringen</source>
-        <target>Tag überspringen</target>
+        <target>Passer le jour</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.jump">
       <segment state="translated">
         <source>Zu diesem Tag springen</source>
-        <target>Zu diesem Tag springen</target>
+        <target>Aller à ce jour</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -6191,43 +6191,43 @@
     <unit id="trainingPlans.menu.triggerAria">
       <segment state="translated">
         <source>Tagesaktionen öffnen</source>
-        <target>Tagesaktionen öffnen</target>
+        <target>Apri azioni del giorno</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoDone">
       <segment state="translated">
         <source>Erledigt rückgängig machen</source>
-        <target>Erledigt rückgängig machen</target>
+        <target>Contrassegna come non completato</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoSkip">
       <segment state="translated">
         <source>Überspringen rückgängig machen</source>
-        <target>Überspringen rückgängig machen</target>
+        <target>Annulla salto</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logDone">
       <segment state="translated">
         <source>Plan-Sätze eintragen &amp; abhaken</source>
-        <target>Plan-Sätze eintragen &amp; abhaken</target>
+        <target>Inserisci i record del piano e contrassegnali come completati</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.markDone">
       <segment state="translated">
         <source>Nur abhaken (ohne Eintrag)</source>
-        <target>Nur abhaken (ohne Eintrag)</target>
+        <target>Contrassegna solo come completato (senza voce)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.skip">
       <segment state="translated">
         <source>Tag überspringen</source>
-        <target>Tag überspringen</target>
+        <target>Salta giorno</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.jump">
       <segment state="translated">
         <source>Zu diesem Tag springen</source>
-        <target>Zu diesem Tag springen</target>
+        <target>Vai a questo giorno</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -6191,43 +6191,43 @@
     <unit id="trainingPlans.menu.triggerAria">
       <segment state="translated">
         <source>Tagesaktionen öffnen</source>
-        <target>Tagesaktionen öffnen</target>
+        <target>Aperi actiones diei</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoDone">
       <segment state="translated">
         <source>Erledigt rückgängig machen</source>
-        <target>Erledigt rückgängig machen</target>
+        <target>Mark non perficitur</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoSkip">
       <segment state="translated">
         <source>Überspringen rückgängig machen</source>
-        <target>Überspringen rückgängig machen</target>
+        <target>Praeteritum revoca</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logDone">
       <segment state="translated">
         <source>Plan-Sätze eintragen &amp; abhaken</source>
-        <target>Plan-Sätze eintragen &amp; abhaken</target>
+        <target>Intrant consilium monumenta et ea ut perficitur</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.markDone">
       <segment state="translated">
         <source>Nur abhaken (ohne Eintrag)</source>
-        <target>Nur abhaken (ohne Eintrag)</target>
+        <target>Mark ut solum perficitur (sine viscus)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.skip">
       <segment state="translated">
         <source>Tag überspringen</source>
-        <target>Tag überspringen</target>
+        <target>Diem praeteri</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.jump">
       <segment state="translated">
         <source>Zu diesem Tag springen</source>
-        <target>Zu diesem Tag springen</target>
+        <target>Ad hunc diem salta</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -6191,43 +6191,43 @@
     <unit id="trainingPlans.menu.triggerAria">
       <segment state="translated">
         <source>Tagesaktionen öffnen</source>
-        <target>Tagesaktionen öffnen</target>
+        <target>Acties voor dag openen</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoDone">
       <segment state="translated">
         <source>Erledigt rückgängig machen</source>
-        <target>Erledigt rückgängig machen</target>
+        <target>Markeer als niet voltooid</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoSkip">
       <segment state="translated">
         <source>Überspringen rückgängig machen</source>
-        <target>Überspringen rückgängig machen</target>
+        <target>Overslaan ongedaan maken</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logDone">
       <segment state="translated">
         <source>Plan-Sätze eintragen &amp; abhaken</source>
-        <target>Plan-Sätze eintragen &amp; abhaken</target>
+        <target>Voer planrecords in en markeer deze als voltooid</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.markDone">
       <segment state="translated">
         <source>Nur abhaken (ohne Eintrag)</source>
-        <target>Nur abhaken (ohne Eintrag)</target>
+        <target>Alleen als voltooid markeren (zonder invoer)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.skip">
       <segment state="translated">
         <source>Tag überspringen</source>
-        <target>Tag überspringen</target>
+        <target>Dag overslaan</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.jump">
       <segment state="translated">
         <source>Zu diesem Tag springen</source>
-        <target>Zu diesem Tag springen</target>
+        <target>Naar deze dag springen</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -5160,43 +5160,43 @@ Deine Position: # ·  Reps        </source>
     <unit id="trainingPlans.menu.triggerAria">
       <segment state="translated">
         <source>Tagesaktionen öffnen</source>
-        <target>Tagesaktionen öffnen</target>
+        <target>Åpne dagsmeny</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoDone">
       <segment state="translated">
         <source>Erledigt rückgängig machen</source>
-        <target>Erledigt rückgängig machen</target>
+        <target>Marker som ikke gjort</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoSkip">
       <segment state="translated">
         <source>Überspringen rückgängig machen</source>
-        <target>Überspringen rückgängig machen</target>
+        <target>Angre hopp</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logDone">
       <segment state="translated">
         <source>Plan-Sätze eintragen &amp; abhaken</source>
-        <target>Plan-Sätze eintragen &amp; abhaken</target>
+        <target>Logg plan-sett og marker som gjort</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.markDone">
       <segment state="translated">
         <source>Nur abhaken (ohne Eintrag)</source>
-        <target>Nur abhaken (ohne Eintrag)</target>
+        <target>Marker som gjort (uten å opprette oppføring)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.skip">
       <segment state="translated">
         <source>Tag überspringen</source>
-        <target>Tag überspringen</target>
+        <target>Hopp over dag</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.jump">
       <segment state="translated">
         <source>Zu diesem Tag springen</source>
-        <target>Zu diesem Tag springen</target>
+        <target>Hopp til denne dagen</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -6702,43 +6702,43 @@
     <unit id="trainingPlans.menu.triggerAria">
       <segment state="translated">
         <source>Tagesaktionen öffnen</source>
-        <target>Tagesaktionen öffnen</target>
+        <target>打开当日操作</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoDone">
       <segment state="translated">
         <source>Erledigt rückgängig machen</source>
-        <target>Erledigt rückgängig machen</target>
+        <target>标记为未完成</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.undoSkip">
       <segment state="translated">
         <source>Überspringen rückgängig machen</source>
-        <target>Überspringen rückgängig machen</target>
+        <target>撤销跳过</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logDone">
       <segment state="translated">
         <source>Plan-Sätze eintragen &amp; abhaken</source>
-        <target>Plan-Sätze eintragen &amp; abhaken</target>
+        <target>记录计划组数并标记为完成</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.markDone">
       <segment state="translated">
         <source>Nur abhaken (ohne Eintrag)</source>
-        <target>Nur abhaken (ohne Eintrag)</target>
+        <target>仅标记为完成（无记录）</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.skip">
       <segment state="translated">
         <source>Tag überspringen</source>
-        <target>Tag überspringen</target>
+        <target>跳过此天</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.jump">
       <segment state="translated">
         <source>Zu diesem Tag springen</source>
-        <target>Zu diesem Tag springen</target>
+        <target>跳转到此天</target>
       </segment>
     </unit>
     <unit id="trainingPlans.intro">


### PR DESCRIPTION
## Summary
Follow-up to #323. The new `trainingPlans.menu.*` keys had German text copied into `<target>` for every non-German locale, which would have shipped a mixed-language overflow menu in el/es/fr/it/la/nl/no/zh. Reviewers (CodeRabbit, Codex, Copilot) flagged the regression on the merged PR.

Reuses the prior translations from the removed `trainingPlans.*Aria/*Tooltip` units (semantic 1:1 mapping) and adds a localized target for the new `triggerAria` label per locale.

## Test plan
- [x] `pnpm nx build web -c production` — green (i18n complete for all locales)
- [ ] Visual smoke on staging preview: switch language to fr/it/es/nl and verify the per-day overflow menu shows translated labels.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFiPcYeMTtDbbz625kGMAQ)_