### PR TITLE
fix(dashboard): show all exercises in Verlauf chart and name them in the title

### DIFF
--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.spec.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { Component, input, signal } from '@angular/core';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { AnalysisTeaserCardComponent } from './analysis-teaser-card.component';
 import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
 import { AuthStore } from '@pu-auth/auth';
@@ -88,9 +88,20 @@ describe('AnalysisTeaserCardComponent', () => {
     await fixture.whenStable();
   }
 
+  // Frozen "today" so week-boundary helpers below don't flake around
+  // midnight / timezone rollovers. 2026-04-08 is a Wednesday — the Monday
+  // of its ISO week is 2026-04-06.
+  const FROZEN_TODAY = new Date(2026, 3, 8, 12, 0, 0);
+
   beforeEach(async () => {
     vitest.clearAllMocks();
+    vitest.useFakeTimers({ shouldAdvanceTime: true });
+    vitest.setSystemTime(FROZEN_TODAY);
     await setupWithLiveStore();
+  });
+
+  afterEach(() => {
+    vitest.useRealTimers();
   });
 
   describe('Given the component is rendered', () => {
@@ -262,9 +273,9 @@ describe('AnalysisTeaserCardComponent', () => {
   });
 
   describe('Given the chart heading', () => {
-    it('Then chartKindLabel is set so the chart can name its exercises', () => {
-      expect(component.chartKindLabel).toBeTruthy();
-      expect(typeof component.chartKindLabel).toBe('string');
+    it('Then chartKindLabel returns a non-empty string', () => {
+      expect(component.chartKindLabel()).toBeTruthy();
+      expect(typeof component.chartKindLabel()).toBe('string');
     });
 
     it('Then the kindLabel is forwarded to the stats chart', () => {
@@ -275,7 +286,7 @@ describe('AnalysisTeaserCardComponent', () => {
       const stub = chart?.componentInstance as
         | StubStatsChartComponent
         | undefined;
-      expect(stub?.kindLabel()).toBe(component.chartKindLabel);
+      expect(stub?.kindLabel()).toBe(component.chartKindLabel());
     });
   });
 
@@ -289,27 +300,21 @@ describe('AnalysisTeaserCardComponent', () => {
         { bucket: '2026-03-30', total: 20, dayIntegral: 20 },
       ]);
     });
+
+    it('Then chartKindLabel names the pushup-only REST source', () => {
+      // Disconnected ⇒ REST data only ⇒ label must not claim "all exercises".
+      expect(component.chartKindLabel()).not.toBe('');
+      expect(component.chartKindLabel()).not.toMatch(/Alle Übungen/i);
+    });
   });
 
   describe('Given the live store has connected with unified entries', () => {
-    let liveFixture: ComponentFixture<AnalysisTeaserCardComponent>;
-    let liveComponent: AnalysisTeaserCardComponent;
-
-    function freshMonday(): { weekStart: string; weekMid: string } {
-      const today = new Date();
-      const dayOfWeek = (today.getDay() + 6) % 7;
-      const monday = new Date(today);
-      monday.setDate(today.getDate() - dayOfWeek);
-      const wednesday = new Date(monday);
-      wednesday.setDate(monday.getDate() + 2);
-      const pad = (n: number) => String(n).padStart(2, '0');
-      const fmt = (d: Date) =>
-        `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-      return { weekStart: fmt(monday), weekMid: fmt(wednesday) };
-    }
+    // Deterministic — derived from FROZEN_TODAY above so the asserted bucket
+    // dates match what the component computes.
+    const weekStart = '2026-04-06'; // Monday
+    const weekMid = '2026-04-08'; // Wednesday (== FROZEN_TODAY)
 
     beforeEach(async () => {
-      const { weekStart, weekMid } = freshMonday();
       TestBed.resetTestingModule();
       await setupWithLiveStore({
         connected: true,
@@ -333,16 +338,12 @@ describe('AnalysisTeaserCardComponent', () => {
           },
         ],
       });
-      liveFixture = fixture;
-      liveComponent = component;
-      liveFixture.detectChanges();
-      await liveFixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
     });
 
     it('Then chartSeries combines pushups and exercise reps per day', () => {
-      const series = liveComponent.chartSeries();
-      const { weekStart, weekMid } = freshMonday();
-
+      const series = component.chartSeries();
       // Pushups on Monday: 10 reps
       // Situps on Wednesday: 15 reps (plank has no reps → excluded)
       const monday = series.find((s) => s.bucket === weekStart);
@@ -352,10 +353,14 @@ describe('AnalysisTeaserCardComponent', () => {
     });
 
     it('Then dayIntegral is cumulative across the merged days', () => {
-      const series = liveComponent.chartSeries();
+      const series = component.chartSeries();
       // 10 on Monday, +15 on Wednesday → 25 cumulative on Wednesday
       const cumulativeTotals = series.map((s) => s.dayIntegral);
       expect(cumulativeTotals[cumulativeTotals.length - 1]).toBe(25);
+    });
+
+    it('Then chartKindLabel reports "Alle Übungen" when multiple kinds contribute reps', () => {
+      expect(component.chartKindLabel()).toMatch(/Alle Übungen/i);
     });
 
     it('Then entries outside the week range are excluded', async () => {
@@ -370,6 +375,60 @@ describe('AnalysisTeaserCardComponent', () => {
       fixture.detectChanges();
       await fixture.whenStable();
       expect(component.chartSeries()).toEqual([]);
+      // No reps in the current week ⇒ label collapses to empty.
+      expect(component.chartKindLabel()).toBe('');
+    });
+  });
+
+  describe('Given the live store has connected with only pushup entries this week', () => {
+    const weekStart = '2026-04-06';
+
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+      await setupWithLiveStore({
+        connected: true,
+        entries: [
+          { _id: 'p1', timestamp: `${weekStart}T08:00:00+01:00`, reps: 10 },
+        ],
+        exerciseEntries: [],
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+    });
+
+    it('Then chartKindLabel names pushups and does not claim "Alle Übungen"', () => {
+      const label = component.chartKindLabel();
+      expect(label).not.toBe('');
+      expect(label).not.toMatch(/Alle Übungen/i);
+    });
+  });
+
+  describe('Given the REST resource errored but live data is connected', () => {
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+      apiMock.load.mockReturnValueOnce(
+        // Mimic a REST failure: emit nothing, then error.
+        new Observable((subscriber) => {
+          subscriber.error(new Error('boom'));
+        })
+      );
+      await setupWithLiveStore({
+        connected: true,
+        entries: [
+          { _id: 'p1', timestamp: '2026-04-06T08:00:00+01:00', reps: 12 },
+        ],
+        exerciseEntries: [],
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+    });
+
+    it('Then the chart still renders (error fallback suppressed while live is connected)', () => {
+      const errorFallback =
+        fixture.nativeElement.querySelector('.error-fallback');
+      const chart = fixture.nativeElement.querySelector('app-stats-chart');
+      expect(errorFallback).toBeFalsy();
+      expect(chart).toBeTruthy();
     });
   });
 });

--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.spec.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
-import { Component, input } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import { of } from 'rxjs';
 import { AnalysisTeaserCardComponent } from './analysis-teaser-card.component';
-import { StatsApiService } from '@pu-stats/data-access';
+import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
 import { AuthStore } from '@pu-auth/auth';
 import { makeAuthStoreMock } from '@pu-stats/testing';
 import { StatsChartComponent } from '../stats-chart/stats-chart.component';
@@ -20,6 +21,22 @@ class StubStatsChartComponent {
   readonly from = input<string>('');
   readonly to = input<string>('');
   readonly entries = input<unknown[]>([]);
+  readonly kindLabel = input<string>('');
+}
+
+function makeLiveStoreMock(
+  overrides: {
+    connected?: boolean;
+    entries?: unknown[];
+    exerciseEntries?: unknown[];
+  } = {}
+) {
+  return {
+    connected: signal(overrides.connected ?? false),
+    entries: signal(overrides.entries ?? []),
+    exerciseEntries: signal(overrides.exerciseEntries ?? []),
+    updateTick: signal(0),
+  };
 }
 
 describe('AnalysisTeaserCardComponent', () => {
@@ -43,8 +60,9 @@ describe('AnalysisTeaserCardComponent', () => {
     ),
   };
 
-  beforeEach(async () => {
-    vitest.clearAllMocks();
+  async function setupWithLiveStore(
+    liveStoreOverrides: Parameters<typeof makeLiveStoreMock>[0] = {}
+  ) {
     routerSpy = { navigate: vitest.fn() };
 
     await TestBed.configureTestingModule({
@@ -53,6 +71,10 @@ describe('AnalysisTeaserCardComponent', () => {
         { provide: StatsApiService, useValue: apiMock },
         { provide: Router, useValue: routerSpy },
         { provide: AuthStore, useValue: makeAuthStoreMock() },
+        {
+          provide: LiveDataStore,
+          useValue: makeLiveStoreMock(liveStoreOverrides),
+        },
       ],
     })
       .overrideComponent(AnalysisTeaserCardComponent, {
@@ -64,6 +86,11 @@ describe('AnalysisTeaserCardComponent', () => {
     fixture = TestBed.createComponent(AnalysisTeaserCardComponent);
     component = fixture.componentInstance;
     await fixture.whenStable();
+  }
+
+  beforeEach(async () => {
+    vitest.clearAllMocks();
+    await setupWithLiveStore();
   });
 
   describe('Given the component is rendered', () => {
@@ -231,6 +258,118 @@ describe('AnalysisTeaserCardComponent', () => {
       const [y, m, d] = dateStr.split('-').map(Number);
       // getUTCDay() returns 0 for Sunday
       expect(new Date(Date.UTC(y, m - 1, d)).getUTCDay()).toBe(0);
+    });
+  });
+
+  describe('Given the chart heading', () => {
+    it('Then chartKindLabel is set so the chart can name its exercises', () => {
+      expect(component.chartKindLabel).toBeTruthy();
+      expect(typeof component.chartKindLabel).toBe('string');
+    });
+
+    it('Then the kindLabel is forwarded to the stats chart', () => {
+      fixture.detectChanges();
+      const chart = fixture.debugElement.query(
+        By.directive(StubStatsChartComponent)
+      );
+      const stub = chart?.componentInstance as
+        | StubStatsChartComponent
+        | undefined;
+      expect(stub?.kindLabel()).toBe(component.chartKindLabel);
+    });
+  });
+
+  describe('Given the live store has not connected yet', () => {
+    it('Then chartSeries falls back to the REST resource (pushup-only)', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // REST mock returns one bucket; live store is disconnected.
+      expect(component.chartSeries()).toEqual([
+        { bucket: '2026-03-30', total: 20, dayIntegral: 20 },
+      ]);
+    });
+  });
+
+  describe('Given the live store has connected with unified entries', () => {
+    let liveFixture: ComponentFixture<AnalysisTeaserCardComponent>;
+    let liveComponent: AnalysisTeaserCardComponent;
+
+    function freshMonday(): { weekStart: string; weekMid: string } {
+      const today = new Date();
+      const dayOfWeek = (today.getDay() + 6) % 7;
+      const monday = new Date(today);
+      monday.setDate(today.getDate() - dayOfWeek);
+      const wednesday = new Date(monday);
+      wednesday.setDate(monday.getDate() + 2);
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const fmt = (d: Date) =>
+        `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+      return { weekStart: fmt(monday), weekMid: fmt(wednesday) };
+    }
+
+    beforeEach(async () => {
+      const { weekStart, weekMid } = freshMonday();
+      TestBed.resetTestingModule();
+      await setupWithLiveStore({
+        connected: true,
+        entries: [
+          { _id: 'p1', timestamp: `${weekStart}T08:00:00+01:00`, reps: 10 },
+        ],
+        exerciseEntries: [
+          {
+            _id: 'e1',
+            exerciseId: 'abs.situps',
+            timestamp: `${weekMid}T12:00:00+01:00`,
+            reps: 15,
+            source: 'web',
+          },
+          {
+            _id: 'e2',
+            exerciseId: 'plank.standard',
+            timestamp: `${weekMid}T13:00:00+01:00`,
+            durationSec: 60,
+            source: 'web',
+          },
+        ],
+      });
+      liveFixture = fixture;
+      liveComponent = component;
+      liveFixture.detectChanges();
+      await liveFixture.whenStable();
+    });
+
+    it('Then chartSeries combines pushups and exercise reps per day', () => {
+      const series = liveComponent.chartSeries();
+      const { weekStart, weekMid } = freshMonday();
+
+      // Pushups on Monday: 10 reps
+      // Situps on Wednesday: 15 reps (plank has no reps → excluded)
+      const monday = series.find((s) => s.bucket === weekStart);
+      const wednesday = series.find((s) => s.bucket === weekMid);
+      expect(monday?.total).toBe(10);
+      expect(wednesday?.total).toBe(15);
+    });
+
+    it('Then dayIntegral is cumulative across the merged days', () => {
+      const series = liveComponent.chartSeries();
+      // 10 on Monday, +15 on Wednesday → 25 cumulative on Wednesday
+      const cumulativeTotals = series.map((s) => s.dayIntegral);
+      expect(cumulativeTotals[cumulativeTotals.length - 1]).toBe(25);
+    });
+
+    it('Then entries outside the week range are excluded', async () => {
+      TestBed.resetTestingModule();
+      await setupWithLiveStore({
+        connected: true,
+        entries: [
+          { _id: 'p-old', timestamp: '2020-01-01T08:00:00+01:00', reps: 999 },
+        ],
+        exerciseEntries: [],
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(component.chartSeries()).toEqual([]);
     });
   });
 });

--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
@@ -60,7 +60,7 @@ const EMPTY_STATS: StatsResponse = {
         </mat-card-subtitle>
       </mat-card-header>
       <mat-card-content>
-        @if (statsResource.error()) {
+        @if (statsResource.error() && !liveConnected()) {
           <p class="error-fallback" i18n="@@dashboard.analysisTeaserError">
             Daten konnten nicht geladen werden.
           </p>
@@ -72,7 +72,7 @@ const EMPTY_STATS: StatsResponse = {
               [rangeMode]="'week'"
               [from]="from()"
               [to]="to()"
-              [kindLabel]="chartKindLabel"
+              [kindLabel]="chartKindLabel()"
             />
           </div>
         }
@@ -139,13 +139,15 @@ export class AnalysisTeaserCardComponent {
   /** Increment to trigger a data reload (e.g. after entry creation). */
   readonly refreshTrigger = input(0);
 
+  private readonly allExercisesLabel = $localize`:@@chart.kindLabel.all:Alle Übungen`;
   /**
-   * Localised heading label so the user can tell which exercises feed
-   * this chart. The dashboard teaser aggregates pushups together with
-   * every other tracked exercise, so the label reads "Alle Übungen"
-   * rather than naming a single exercise.
+   * Pushup label reused from the analysis page i18n catalog so we don't
+   * spawn a parallel XLIFF unit for the same German string.
    */
-  readonly chartKindLabel = $localize`:@@chart.kindLabel.all:Alle Übungen`;
+  private readonly pushupLabel = $localize`:@@exercise.category.pushup:Liegestütze`;
+
+  /** Exposed for the template's error-fallback gate. */
+  readonly liveConnected = computed(() => this.live.connected());
 
   private readonly weekRange = computed(() => {
     const today = new Date();
@@ -159,6 +161,39 @@ export class AnalysisTeaserCardComponent {
 
   readonly from = computed(() => this.weekRange().from);
   readonly to = computed(() => this.weekRange().to);
+
+  /**
+   * Honest heading label that tracks the *actual* data the chart is
+   * showing — not a fixed string. Without this, the cold-start / SSR
+   * fallback labels REST-only pushup data as "Alle Übungen" and a
+   * live-but-pushup-only week still claims to aggregate every exercise.
+   *
+   * Note: the chart axis is reps, so duration-only entries (plank …)
+   * legitimately don't contribute bars. We therefore avoid promising
+   * "Alle Übungen" when no other rep-bearing kind is present.
+   */
+  readonly chartKindLabel = computed(() => {
+    const { from, to } = this.weekRange();
+    const inRange = (timestamp: string): boolean => {
+      const day = timestamp.slice(0, 10);
+      return day >= from && day <= to;
+    };
+
+    if (!this.live.connected()) {
+      return this.pushupLabel;
+    }
+
+    const hasPushupReps = this.live
+      .entries()
+      .some((e) => inRange(e.timestamp) && e.reps > 0);
+    const hasOtherReps = this.live
+      .exerciseEntries()
+      .some((e) => inRange(e.timestamp) && (e.reps ?? 0) > 0);
+
+    if (hasOtherReps) return this.allExercisesLabel;
+    if (hasPushupReps) return this.pushupLabel;
+    return '';
+  });
 
   readonly statsResource = resource({
     params: () => ({ ...this.weekRange(), _refresh: this.refreshTrigger() }),

--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
@@ -9,8 +9,12 @@ import {
 import { Router } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import { StatsApiService } from '@pu-stats/data-access';
-import { StatsResponse, toLocalIsoDate } from '@pu-stats/models';
+import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
+import {
+  StatsResponse,
+  StatsSeriesEntry,
+  toLocalIsoDate,
+} from '@pu-stats/models';
 import { firstValueFrom } from 'rxjs';
 import { StatsChartComponent } from '../stats-chart/stats-chart.component';
 
@@ -68,6 +72,7 @@ const EMPTY_STATS: StatsResponse = {
               [rangeMode]="'week'"
               [from]="from()"
               [to]="to()"
+              [kindLabel]="chartKindLabel"
             />
           </div>
         }
@@ -125,6 +130,7 @@ const EMPTY_STATS: StatsResponse = {
 })
 export class AnalysisTeaserCardComponent {
   private readonly api = inject(StatsApiService);
+  private readonly live = inject(LiveDataStore);
   private readonly router = inject(Router);
 
   readonly streak = input(0);
@@ -132,6 +138,14 @@ export class AnalysisTeaserCardComponent {
   readonly weeklyGoal = input(0);
   /** Increment to trigger a data reload (e.g. after entry creation). */
   readonly refreshTrigger = input(0);
+
+  /**
+   * Localised heading label so the user can tell which exercises feed
+   * this chart. The dashboard teaser aggregates pushups together with
+   * every other tracked exercise, so the label reads "Alle Übungen"
+   * rather than naming a single exercise.
+   */
+  readonly chartKindLabel = $localize`:@@chart.kindLabel.all:Alle Übungen`;
 
   private readonly weekRange = computed(() => {
     const today = new Date();
@@ -152,9 +166,48 @@ export class AnalysisTeaserCardComponent {
       firstValueFrom(this.api.load({ from: params.from, to: params.to })),
   });
 
-  readonly chartSeries = computed(
-    () => (this.statsResource.value() ?? EMPTY_STATS).series
-  );
+  /**
+   * Daily totals for the current week summed across **every** tracked
+   * exercise. The REST resource serves the SSR/cold-start window (and
+   * still feeds the unauthenticated demo render via the API). Once the
+   * Firestore listener has connected we switch to the live unified
+   * stream so pushups *and* exercise entries (sit-ups, squats, …)
+   * both contribute — otherwise users who train other exercises see
+   * an empty "Verlauf" chart even when they were active that week.
+   */
+  readonly chartSeries = computed<StatsSeriesEntry[]>(() => {
+    const { from, to } = this.weekRange();
+    if (!this.live.connected()) {
+      return (this.statsResource.value() ?? EMPTY_STATS).series;
+    }
+
+    const totals = new Map<string, number>();
+    const inRange = (timestamp: string): boolean => {
+      const day = timestamp.slice(0, 10);
+      return day >= from && day <= to;
+    };
+
+    for (const entry of this.live.entries()) {
+      if (!inRange(entry.timestamp)) continue;
+      const day = entry.timestamp.slice(0, 10);
+      totals.set(day, (totals.get(day) ?? 0) + entry.reps);
+    }
+    for (const entry of this.live.exerciseEntries()) {
+      if (!inRange(entry.timestamp)) continue;
+      const reps = entry.reps ?? 0;
+      if (reps <= 0) continue;
+      const day = entry.timestamp.slice(0, 10);
+      totals.set(day, (totals.get(day) ?? 0) + reps);
+    }
+
+    const sortedDays = [...totals.keys()].sort((a, b) => a.localeCompare(b));
+    let cumulative = 0;
+    return sortedDays.map((day) => {
+      const total = totals.get(day) ?? 0;
+      cumulative += total;
+      return { bucket: day, total, dayIntegral: cumulative };
+    });
+  });
 
   navigateToAnalysis(): void {
     this.router.navigate(['/analysis']);

--- a/web/src/app/stats/components/stats-chart/stats-chart.component.ts
+++ b/web/src/app/stats/components/stats-chart/stats-chart.component.ts
@@ -36,8 +36,8 @@ Chart.register(...registerables);
   template: `
     <mat-card class="chart">
       <mat-card-header>
-        <mat-card-title>{{
-          granularity() === 'hourly' ? hourlyTitle : dailyTitle
+        <mat-card-title data-testid="stats-chart-title">{{
+          chartTitle()
         }}</mat-card-title>
         <mat-card-subtitle i18n="@@chart.subtitle"
           >Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange
@@ -120,9 +120,23 @@ export class StatsChartComponent implements AfterViewInit {
   readonly to = input<string | null>(null);
   readonly dayChartMode = model<'24h' | '14h'>('14h');
   readonly entries = input<PushupRecord[]>([]);
+  /**
+   * Localised label naming the exercise (or group of exercises) the
+   * series represents — appended to the title so users can tell at a
+   * glance whether they are looking at pushups, sit-ups, an aggregated
+   * "all exercises" view, etc. Empty string keeps the legacy bare
+   * title.
+   */
+  readonly kindLabel = input<string>('');
 
   readonly hourlyTitle = $localize`:@@chart.titleHourly:Verlauf (Stundenwerte)`;
   readonly dailyTitle = $localize`:@@chart.titleDaily:Verlauf (Tageswerte)`;
+  readonly chartTitle = computed(() => {
+    const base =
+      this.granularity() === 'hourly' ? this.hourlyTitle : this.dailyTitle;
+    const label = this.kindLabel().trim();
+    return label ? `${base} – ${label}` : base;
+  });
   readonly intervalLabel = $localize`:@@chart.interval:Intervallwert`;
   readonly dayIntegralLabel = $localize`:@@chart.dayIntegral:Tages-Integral`;
   readonly movingAvgLabel = $localize`:@@chart.movingAvg:Gleitender Durchschnitt`;

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -159,6 +159,7 @@ describe('StatsDashboardComponent', () => {
     liveTick.set(0);
     liveConnected.set(false);
     liveEntries.set([]);
+    liveExerciseEntries.set([]);
     window.history.replaceState({}, '', '/');
 
     dialogOpenSpy.mockClear();

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -93,10 +93,20 @@ describe('StatsDashboardComponent', () => {
       type?: string;
     }>
   >([]);
+  const liveExerciseEntries = signal<
+    Array<{
+      _id: string;
+      exerciseId: string;
+      timestamp: string;
+      reps?: number;
+      source?: string;
+    }>
+  >([]);
   const liveMock = {
     updateTick: liveTick.asReadonly(),
     connected: liveConnected.asReadonly(),
     entries: liveEntries.asReadonly(),
+    exerciseEntries: liveExerciseEntries.asReadonly(),
   };
 
   const adsConfigMock = {

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -4600,6 +4600,15 @@
         <target>Ιστορικό (ημερήσιες τιμές)</target>
       </segment>
     </unit>
+    <unit id="chart.kindLabel.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle Übungen</source>
+        <target>Όλες οι ασκήσεις</target>
+      </segment>
+    </unit>
     <unit id="chart.setsTooltip">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:153</note>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1029,19 +1029,28 @@ Active:         </target>
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:82</note>
 
-        
+
             </notes>
       <segment state="translated">
         <source>Verlauf (Tageswerte)</source>
         <target>Progress (daily values)</target>
 
-        
-        
+
+
             </segment>
 
-      
-      
+
+
         </unit>
+    <unit id="chart.kindLabel.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle Übungen</source>
+        <target>All exercises</target>
+      </segment>
+    </unit>
     <unit id="chart.titleHourly">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:81</note>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -4600,6 +4600,15 @@
         <target>Historial (valores diarios)</target>
       </segment>
     </unit>
+    <unit id="chart.kindLabel.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle Übungen</source>
+        <target>Todos los ejercicios</target>
+      </segment>
+    </unit>
     <unit id="chart.setsTooltip">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:153</note>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -4600,6 +4600,15 @@
         <target>Historique (valeurs quotidiennes)</target>
       </segment>
     </unit>
+    <unit id="chart.kindLabel.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle Übungen</source>
+        <target>Tous les exercices</target>
+      </segment>
+    </unit>
     <unit id="chart.setsTooltip">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:153</note>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -4600,6 +4600,15 @@
         <target>Storico (valori giornalieri)</target>
       </segment>
     </unit>
+    <unit id="chart.kindLabel.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle Übungen</source>
+        <target>Tutti gli esercizi</target>
+      </segment>
+    </unit>
     <unit id="chart.setsTooltip">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:153</note>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -4600,6 +4600,15 @@
         <target>Historiae (valores quotidianae)</target>
       </segment>
     </unit>
+    <unit id="chart.kindLabel.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle Übungen</source>
+        <target>Omnes exercitationes</target>
+      </segment>
+    </unit>
     <unit id="chart.setsTooltip">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:153</note>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -4600,6 +4600,15 @@
         <target>Geschiedenis (dagwaarden)</target>
       </segment>
     </unit>
+    <unit id="chart.kindLabel.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle Übungen</source>
+        <target>Alle oefeningen</target>
+      </segment>
+    </unit>
     <unit id="chart.setsTooltip">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:153</note>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -450,6 +450,15 @@ Aktiv:         </target>
         <target>24h</target>
       </segment>
     </unit>
+    <unit id="chart.kindLabel.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle Übungen</source>
+        <target>Alle øvelser</target>
+      </segment>
+    </unit>
     <unit id="chart.setsTooltip">
       <segment state="translated">
         <source>Sets</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4778,6 +4778,14 @@
         <source>Verlauf (Tageswerte)</source>
       </segment>
     </unit>
+    <unit id="chart.kindLabel.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
+      </notes>
+      <segment>
+        <source>Alle Übungen</source>
+      </segment>
+    </unit>
     <unit id="chart.setsTooltip">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:153</note>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -5157,6 +5157,15 @@
         <source>Verlauf (Tageswerte)</source>
       <target>趋势（按日）</target></segment>
     </unit>
+    <unit id="chart.kindLabel.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
+      </notes>
+      <segment state="translated">
+        <source>Alle Übungen</source>
+        <target>所有训练</target>
+      </segment>
+    </unit>
     <unit id="chart.setsTooltip">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:153</note>


### PR DESCRIPTION
The dashboard's "Verlauf (Tageswerte)" teaser only fetched pushup data
via the REST API, so users who tracked other exercises this week saw
an empty chart and had no hint that the chart was pushup-only.

Once the Firestore listener is connected, build the daily series from
both `LiveDataStore.entries()` (pushups) and `exerciseEntries()`
(sit-ups, squats, planks, …), summed per day. The REST resource
remains the SSR / cold-start fallback.

Also added a `kindLabel` input on `StatsChartComponent` so the title
reads "Verlauf (Tageswerte) – Alle Übungen" (and the localised
equivalents), telling the user exactly which exercise group the chart
represents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chart titles now display exercise kind labels alongside granularity information
  * Stats overview integrates live exercise data for real-time updates

* **Internationalization**
  * Added "All exercises" label translations in English, Greek, Spanish, French, Italian, Latin, Dutch, Norwegian, and Chinese

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/325)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->