### PR TITLE
fix(dashboard): show trailing 7 days in Verlauf chart, not just the ISO week

### DIFF
--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.spec.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.spec.ts
@@ -248,27 +248,26 @@ describe('AnalysisTeaserCardComponent', () => {
     });
   });
 
-  describe('Given the week range computation', () => {
-    it('Then from should be a Monday date string', () => {
-      // Given / When
-      const dateStr = component.from();
-
-      // Then
-      expect(dateStr).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-      const [y, m, d] = dateStr.split('-').map(Number);
-      // getUTCDay() returns 1 for Monday
-      expect(new Date(Date.UTC(y, m - 1, d)).getUTCDay()).toBe(1);
+  describe('Given the chart range computation', () => {
+    // FROZEN_TODAY = 2026-04-08 (Wed). Trailing 7-day window (inclusive)
+    // → 2026-04-02 .. 2026-04-08.
+    it('Then to is today', () => {
+      expect(component.to()).toBe('2026-04-08');
     });
 
-    it('Then to should be a Sunday date string', () => {
-      // Given / When
-      const dateStr = component.to();
+    it('Then from is six days before today (inclusive 7-day window)', () => {
+      expect(component.from()).toBe('2026-04-02');
+    });
 
-      // Then
-      expect(dateStr).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-      const [y, m, d] = dateStr.split('-').map(Number);
-      // getUTCDay() returns 0 for Sunday
-      expect(new Date(Date.UTC(y, m - 1, d)).getUTCDay()).toBe(0);
+    it('Then the window covers exactly 7 calendar days', () => {
+      const [fy, fm, fd] = component.from().split('-').map(Number);
+      const [ty, tm, td] = component.to().split('-').map(Number);
+      const fromDate = new Date(Date.UTC(fy, fm - 1, fd));
+      const toDate = new Date(Date.UTC(ty, tm - 1, td));
+      const days = Math.round(
+        (toDate.getTime() - fromDate.getTime()) / 86_400_000
+      );
+      expect(days).toBe(6); // 0..6 inclusive ⇒ 7 days
     });
   });
 

--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
@@ -149,14 +149,18 @@ export class AnalysisTeaserCardComponent {
   /** Exposed for the template's error-fallback gate. */
   readonly liveConnected = computed(() => this.live.connected());
 
+  /**
+   * Rolling 7-day window ending today (inclusive). The earlier
+   * Monday-to-Sunday ISO-week range collapses to a single visible day
+   * whenever today *is* Monday, which made the teaser chart look broken
+   * — users only saw today's bar with six empty future days. A trailing
+   * window always shows seven days of history regardless of weekday.
+   */
   private readonly weekRange = computed(() => {
     const today = new Date();
-    const dayOfWeek = (today.getDay() + 6) % 7; // Monday = 0
-    const monday = new Date(today);
-    monday.setDate(today.getDate() - dayOfWeek);
-    const sunday = new Date(monday);
-    sunday.setDate(monday.getDate() + 6);
-    return { from: toLocalIsoDate(monday), to: toLocalIsoDate(sunday) };
+    const start = new Date(today);
+    start.setDate(today.getDate() - 6);
+    return { from: toLocalIsoDate(start), to: toLocalIsoDate(today) };
   });
 
   readonly from = computed(() => this.weekRange().from);


### PR DESCRIPTION
The teaser chart used a Monday-to-Sunday ISO-week window, which on a Monday (like today) collapses to just today plus six empty future days — that's why users reported seeing "only today" in the chart.

Switched to a trailing 7-day window ending today (inclusive) so the chart always shows seven days of history regardless of weekday.

## Test plan

- [x] `pnpm nx test web` — 667 passing (updated assertions for trailing-window semantics under frozen system time)
- [x] `pnpm nx lint web` — clean
- [x] `pnpm nx run web:build -c production` — all 10 locales compile

https://claude.ai/code/session_01UnuBuaHvwFz3BYGHpisq9W

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnuBuaHvwFz3BYGHpisq9W)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stats teaser card to display data from a rolling 7-day window ending today, rather than a fixed calendar week.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/326)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->