### PR TITLE
fix(dashboard): stop clipping the Verlauf chart in the Analyse teaser

### DIFF
--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.spec.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.spec.ts
@@ -246,6 +246,21 @@ describe('AnalysisTeaserCardComponent', () => {
       // Must NOT contain the old fixed 180px for mini-chart
       expect(joined).not.toMatch(/\.mini-chart[^}]*height:\s*180px/);
     });
+
+    it('Then .mini-chart must not clip the embedded chart bottom/right', () => {
+      // Regression guard: the embedded <app-stats-chart> renders its own
+      // header (title + subtitle) plus a chart-host sized to
+      // clamp(260px, 34vw, 360px) plus a legend. A fixed `height` combined
+      // with `overflow: hidden` on .mini-chart clipped the legend and the
+      // x-axis ticks. Use `min-height` (reserve, allow growth) and do not
+      // clip.
+      const cmpDef = (AnalysisTeaserCardComponent as any).ɵcmp;
+      const allStyles: string[] = cmpDef?.styles ?? [];
+      const joined = allStyles.join(' ');
+
+      expect(joined).not.toMatch(/\.mini-chart[^}]*overflow:\s*hidden/);
+      expect(joined).toMatch(/\.mini-chart[^}]*min-height:\s*clamp\(260px/);
+    });
   });
 
   describe('Given the chart range computation', () => {

--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
@@ -106,13 +106,12 @@ const EMPTY_STATS: StatsResponse = {
     }
 
     .mini-chart {
-      height: clamp(260px, 34vw, 360px);
-      overflow: hidden;
+      min-height: clamp(260px, 34vw, 360px);
       pointer-events: none;
     }
 
     .error-fallback {
-      height: clamp(260px, 34vw, 360px);
+      min-height: clamp(260px, 34vw, 360px);
       display: flex;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
The .mini-chart wrapper enforced a fixed `height: clamp(260px, 34vw, 360px)`
plus `overflow: hidden`. The embedded <app-stats-chart> renders a card
header (title + long subtitle), a chart-host sized to the same clamp(), and
a legend below — total content always exceeded the wrapper, so the legend
and the x-axis tick row were clipped (and the right-axis labels looked
cramped).

Switch the wrapper to `min-height` so it reserves space for SSR / loading
but lets the inner chart card grow naturally. Drop `overflow: hidden`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved chart visibility in analysis teaser cards by updating container sizing rules to use flexible dimensions instead of fixed constraints, eliminating unwanted content clipping and improving responsive layout.

**Tests**
- Added regression test coverage to verify proper chart display in analysis cards without clipping constraints, ensuring consistent rendering across updates and preventing regression.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/327)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->