### PR TITLE
fix(dashboard): include all workout kinds in the recent-history list

### DIFF
--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -247,19 +247,9 @@ export const DashboardStore = signalStore(
       () => configuredDailyGoal() > 0 && todayTotal() >= configuredDailyGoal()
     );
 
-    /**
-     * Unified read shape for the dashboard's history-related cards
-     * ("Letzter Eintrag", "Letzte Einträge"). Combines the legacy
-     * `pushups` collection with the new `exerciseEntries` collection so
-     * sit-ups, squats, plank, etc. appear alongside pushups instead of
-     * being silently hidden. Goal/streak totals stay on the
-     * pushup-specific `entryRows()` because those metrics are currently
-     * pushup-only — only the recent-history surfaces are unified here.
-     *
-     * SSR only sees pushups via the REST resource; the exercise
-     * collection has no SSR endpoint yet and the dashboard's "recent
-     * entries" preview is not a SEO surface.
-     */
+    // SSR only sees pushups (no exerciseEntries REST endpoint). Goal /
+    // streak / total metrics stay on the pushup-only `entryRows()` —
+    // only the history surfaces consume `unifiedRows`.
     const unifiedRows = computed<UnifiedEntry[]>(() => {
       const pushups = entryRows().map(pushupRecordToUnified);
       if (!store._isBrowser) return pushups;

--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -19,10 +19,13 @@ import {
   UserStatsApiService,
 } from '@pu-stats/data-access';
 import {
+  exerciseEntryToUnified,
   PushupRecord,
+  pushupRecordToUnified,
   StatsResponse,
   toBerlinIsoDate,
   toLocalIsoDate,
+  UnifiedEntry,
   UserStats,
 } from '@pu-stats/models';
 import { AdsStore } from '@pu-stats/ads';
@@ -244,8 +247,30 @@ export const DashboardStore = signalStore(
       () => configuredDailyGoal() > 0 && todayTotal() >= configuredDailyGoal()
     );
 
-    const lastEntry = computed<PushupRecord | null>(() => {
-      const rows = entryRows();
+    /**
+     * Unified read shape for the dashboard's history-related cards
+     * ("Letzter Eintrag", "Letzte Einträge"). Combines the legacy
+     * `pushups` collection with the new `exerciseEntries` collection so
+     * sit-ups, squats, plank, etc. appear alongside pushups instead of
+     * being silently hidden. Goal/streak totals stay on the
+     * pushup-specific `entryRows()` because those metrics are currently
+     * pushup-only — only the recent-history surfaces are unified here.
+     *
+     * SSR only sees pushups via the REST resource; the exercise
+     * collection has no SSR endpoint yet and the dashboard's "recent
+     * entries" preview is not a SEO surface.
+     */
+    const unifiedRows = computed<UnifiedEntry[]>(() => {
+      const pushups = entryRows().map(pushupRecordToUnified);
+      if (!store._isBrowser) return pushups;
+      const exercises = store._live
+        .exerciseEntries()
+        .map(exerciseEntryToUnified);
+      return [...pushups, ...exercises];
+    });
+
+    const lastEntry = computed<UnifiedEntry | null>(() => {
+      const rows = unifiedRows();
       if (!rows.length) return null;
       return (
         [...rows].sort(
@@ -255,8 +280,8 @@ export const DashboardStore = signalStore(
       );
     });
 
-    const latestEntries = computed<PushupRecord[]>(() => {
-      return [...entryRows()]
+    const latestEntries = computed<UnifiedEntry[]>(() => {
+      return [...unifiedRows()]
         .sort(
           (a, b) =>
             new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()

--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -238,9 +238,16 @@
       </mat-card-header>
       <mat-card-content>
         @if (lastEntry(); as latest) {
-          <p i18n="@@latEntryReps">
-            {{ latest.reps }} Reps · {{ typeLabel(latest) }}
-          </p>
+          @if (latest.kind === 'pushup') {
+            <p i18n="@@latEntryReps">
+              {{ latest.reps }} Reps · {{ pushupTypeLabel(latest) }}
+            </p>
+          } @else {
+            <p data-testid="dashboard-last-entry-exercise">
+              {{ exerciseEntryValue(latest) }} ·
+              {{ exerciseEntryLabel(latest) }}
+            </p>
+          }
           <small>{{ latest.timestamp | date: 'short' }}</small>
         } @else {
           <p i18n="@@dashboard.noEntryYet">Noch kein Eintrag.</p>

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -375,6 +375,76 @@ describe('StatsDashboardComponent', () => {
         expect(component.latestEntries()).toHaveLength(2);
       });
     });
+
+    // Regression: the "Letzte Einträge" preview was previously fed only
+    // by the pushups collection, so sit-ups / squats / plank entries
+    // were silently hidden from the dashboard even though the History
+    // page rendered them. The unified row source merges both Firestore
+    // collections so every kind of workout shows up here.
+    describe('When live exercise entries exist alongside pushups', () => {
+      it('Then latestEntries surfaces both pushups and exercise entries', async () => {
+        // Given the live store has connected with one pushup and one
+        // exercise entry (sit-ups).
+        liveConnected.set(true);
+        liveEntries.set([
+          {
+            _id: 'p1',
+            timestamp: '2025-01-15T10:00:00',
+            reps: 10,
+            source: 'web',
+            type: 'Standard',
+          },
+        ]);
+        liveExerciseEntries.set([
+          {
+            _id: 'e1',
+            exerciseId: 'abs.situps',
+            timestamp: '2025-01-15T11:00:00',
+            reps: 20,
+            source: 'web',
+          },
+        ]);
+        await fixture.whenStable();
+        const component = fixture.componentInstance;
+
+        // Then both entries are part of the dashboard's recent history.
+        const ids = component.latestEntries().map((e) => e._id);
+        expect(ids).toEqual(expect.arrayContaining(['p1', 'e1']));
+        // Latest by timestamp is the exercise entry (11:00 > 10:00) —
+        // proves the unified merge isn't accidentally pushup-biased.
+        expect(component.lastEntry()?._id).toBe('e1');
+        expect(component.lastEntry()?.kind).toBe('exercise');
+      });
+
+      it('Then the "Letzter Eintrag" card renders the exercise label and value', async () => {
+        // Given the live store has a single plank entry (time-based).
+        liveConnected.set(true);
+        liveEntries.set([]);
+        liveExerciseEntries.set([
+          {
+            _id: 'e1',
+            exerciseId: 'plank.standard',
+            timestamp: '2025-01-15T11:00:00',
+            // Plank is measured in durationSec; reps is undefined on
+            // the source doc — the mapper normalizes to 0 reps.
+            // @ts-expect-error - durationSec missing from the loose mock type
+            durationSec: 90,
+            source: 'web',
+          },
+        ]);
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        // Then the exercise-branch template renders, NOT the legacy
+        // "X Reps · variant" pushup branch.
+        const root = fixture.nativeElement as HTMLElement;
+        const card = root.querySelector<HTMLElement>(
+          '[data-testid="dashboard-last-entry-exercise"]'
+        );
+        expect(card).not.toBeNull();
+        expect(card!.textContent ?? '').toContain('Plank');
+      });
+    });
   });
 
   describe('Given a quick entry is added', () => {

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -99,6 +99,8 @@ describe('StatsDashboardComponent', () => {
       exerciseId: string;
       timestamp: string;
       reps?: number;
+      durationSec?: number;
+      distanceM?: number;
       source?: string;
     }>
   >([]);
@@ -416,7 +418,7 @@ describe('StatsDashboardComponent', () => {
         expect(component.lastEntry()?.kind).toBe('exercise');
       });
 
-      it('Then the "Letzter Eintrag" card renders the exercise label and value', async () => {
+      it('Then the "Letzter Eintrag" card renders the exercise label and the measurement-aware value', async () => {
         // Given the live store has a single plank entry (time-based).
         liveConnected.set(true);
         liveEntries.set([]);
@@ -425,9 +427,6 @@ describe('StatsDashboardComponent', () => {
             _id: 'e1',
             exerciseId: 'plank.standard',
             timestamp: '2025-01-15T11:00:00',
-            // Plank is measured in durationSec; reps is undefined on
-            // the source doc — the mapper normalizes to 0 reps.
-            // @ts-expect-error - durationSec missing from the loose mock type
             durationSec: 90,
             source: 'web',
           },
@@ -435,14 +434,17 @@ describe('StatsDashboardComponent', () => {
         await fixture.whenStable();
         fixture.detectChanges();
 
-        // Then the exercise-branch template renders, NOT the legacy
-        // "X Reps · variant" pushup branch.
+        // Then the exercise-branch template renders the label AND the
+        // measurement-aware value: a 90-second plank reads as "1:30"
+        // (m:ss via formatExerciseValue), not "0 Reps" or "90".
         const root = fixture.nativeElement as HTMLElement;
         const card = root.querySelector<HTMLElement>(
           '[data-testid="dashboard-last-entry-exercise"]'
         );
         expect(card).not.toBeNull();
-        expect(card!.textContent ?? '').toContain('Plank');
+        const text = card!.textContent ?? '';
+        expect(text).toContain('Plank');
+        expect(text).toContain('1:30');
       });
     });
   });

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -82,22 +82,13 @@ export class StatsDashboardComponent {
   private readonly appData = inject(AppDataFacade);
   private readonly locale = inject(LOCALE_ID) as string;
 
-  /**
-   * Pushup-variant label for the "Letzter Eintrag" card. Kept narrow to
-   * `UnifiedPushupEntry` so the template branches on `latest.kind` and
-   * keeps the legacy `{{ reps }} Reps · {{ variant }}` format for the
-   * existing i18n message (@@latEntryReps).
-   */
   readonly pushupTypeLabel = (
     entry: Extract<UnifiedEntry, { kind: 'pushup' }>
   ): string => displayPushupType(entry.variantType, this.locale);
 
-  /**
-   * Measurement-aware value for the "Letzter Eintrag" card on
-   * non-pushup workouts: reps for sit-ups/squats, duration for plank,
-   * distance + time for cardio.running. Mirrors the stats-table's
-   * `formatEntry` so the dashboard preview matches the history page.
-   */
+  // Mirrors stats-table.formatEntry so the dashboard preview matches
+  // the history page when a catalog definition exists (plank → m:ss,
+  // cardio.running → distance · time (pace), etc.).
   readonly exerciseEntryValue = (
     entry: Extract<UnifiedEntry, { kind: 'exercise' }>
   ): string => {
@@ -106,7 +97,6 @@ export class StatsDashboardComponent {
     return formatEntryDisplay(entry, def);
   };
 
-  /** Localised exercise name (e.g. "Sit-ups", "Plank"). */
   readonly exerciseEntryLabel = (
     entry: Extract<UnifiedEntry, { kind: 'exercise' }>
   ): string => exerciseDisplayName(entry.exerciseId);

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -27,10 +27,13 @@ import { UserContextService } from '@pu-auth/auth';
 import {
   appendLocalOffset,
   displayPushupType,
-  PushupRecord,
+  findExerciseDefinition,
+  formatEntryDisplay,
   QUICK_LOG_REPS_MAX,
   QUICK_LOG_REPS_MIN,
+  UnifiedEntry,
 } from '@pu-stats/models';
+import { exerciseDisplayName } from '../i18n/exercise-display-names';
 import { firstValueFrom } from 'rxjs';
 import { QuickAddBridgeService } from '@pu-stats/quick-add';
 import { QuickAddOrchestrationService } from '../../core/quick-add-orchestration.service';
@@ -79,8 +82,34 @@ export class StatsDashboardComponent {
   private readonly appData = inject(AppDataFacade);
   private readonly locale = inject(LOCALE_ID) as string;
 
-  readonly typeLabel = (entry: PushupRecord): string =>
-    displayPushupType(entry.type, this.locale);
+  /**
+   * Pushup-variant label for the "Letzter Eintrag" card. Kept narrow to
+   * `UnifiedPushupEntry` so the template branches on `latest.kind` and
+   * keeps the legacy `{{ reps }} Reps · {{ variant }}` format for the
+   * existing i18n message (@@latEntryReps).
+   */
+  readonly pushupTypeLabel = (
+    entry: Extract<UnifiedEntry, { kind: 'pushup' }>
+  ): string => displayPushupType(entry.variantType, this.locale);
+
+  /**
+   * Measurement-aware value for the "Letzter Eintrag" card on
+   * non-pushup workouts: reps for sit-ups/squats, duration for plank,
+   * distance + time for cardio.running. Mirrors the stats-table's
+   * `formatEntry` so the dashboard preview matches the history page.
+   */
+  readonly exerciseEntryValue = (
+    entry: Extract<UnifiedEntry, { kind: 'exercise' }>
+  ): string => {
+    const def = findExerciseDefinition(entry.exerciseId);
+    if (!def) return String(entry.reps);
+    return formatEntryDisplay(entry, def);
+  };
+
+  /** Localised exercise name (e.g. "Sit-ups", "Plank"). */
+  readonly exerciseEntryLabel = (
+    entry: Extract<UnifiedEntry, { kind: 'exercise' }>
+  ): string => exerciseDisplayName(entry.exerciseId);
 
   readonly shareDayAriaLabel = $localize`:@@dashboard.share.aria:Tagesleistung teilen`;
   readonly shareDayLabel = $localize`:@@dashboard.share:Teilen`;


### PR DESCRIPTION
The "Letzte Einträge" preview and the "Letzter Eintrag" card on the
dashboard sourced their rows from `LiveDataStore.entries()` only, which
mirrors the legacy `pushups` Firestore collection. Sit-ups, squats,
plank, etc. live in `exerciseEntries` and were therefore silently
hidden from the dashboard even though the History page already
rendered them via the unified row pipeline.

Merge both collections through `pushupRecordToUnified` /
`exerciseEntryToUnified` so the dashboard surfaces every kind of
workout. Goal/streak/total computations stay on the pushup-only rows —
those metrics are still pushup-specific.

The "Letzter Eintrag" card now branches on `latest.kind`: the existing
`@@latEntryReps` i18n message keeps rendering pushups unchanged, and a
new measurement-aware branch handles reps / duration / distance for
catalog exercises.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity history now unifies pushup and exercise entries, showing the most recent entry and the latest five items across all types in chronological order
  * Latest activity card renders type-specific values and labels (e.g., reps, duration, distance) for each entry kind

* **Tests**
  * Added regression tests for mixed pushup/exercise history and the latest-entry UI rendering

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/328)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->