### PR TITLE
Refactor analysis page to tabbed layout with overview dashboard

### DIFF
--- a/web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.spec.ts
+++ b/web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.spec.ts
@@ -1,0 +1,108 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonToggleHarness } from '@angular/material/button-toggle/testing';
+import { Component, signal } from '@angular/core';
+
+import type { CategoryComparison } from '../../analysis.store';
+import { CategoryComparisonChartComponent } from './category-comparison-chart.component';
+
+@Component({
+  selector: 'app-host',
+  standalone: true,
+  imports: [CategoryComparisonChartComponent],
+  template: `<app-category-comparison-chart [data]="data()" />`,
+})
+class HostComponent {
+  readonly data = signal<CategoryComparison>({
+    labels: [],
+    reps: [],
+    sets: [],
+  });
+}
+
+describe('CategoryComparisonChartComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  it('renders the empty state when there are no categories', () => {
+    fixture.componentInstance.data.set({ labels: [], reps: [], sets: [] });
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(
+      host.querySelector('[data-testid="category-comparison-empty"]')
+    ).toBeTruthy();
+    expect(
+      host.querySelector('[data-testid="category-comparison-bars"]')
+    ).toBeNull();
+  });
+
+  it('renders one bar per category with reps as the default metric', () => {
+    fixture.componentInstance.data.set({
+      labels: ['Pushups', 'Abs', 'Legs'],
+      reps: [100, 50, 25],
+      sets: [10, 5, 2],
+    });
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    const rows = host.querySelectorAll('.bar-row');
+    expect(rows).toHaveLength(3);
+
+    const labels = Array.from(host.querySelectorAll('.bar-label')).map((el) =>
+      el.textContent?.trim()
+    );
+    expect(labels).toEqual(['Pushups', 'Abs', 'Legs']);
+
+    // First row carries the max — fill is 100%.
+    const firstFill = host.querySelector('.bar-row .bar-fill') as HTMLElement;
+    expect(firstFill.style.width).toBe('100%');
+  });
+
+  it('switching to sets scales the bars by sets and updates the displayed value', async () => {
+    fixture.componentInstance.data.set({
+      labels: ['Pushups', 'Abs'],
+      reps: [100, 50],
+      sets: [10, 40],
+    });
+    fixture.detectChanges();
+
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    const toggles = await loader.getAllHarnesses(MatButtonToggleHarness);
+    // `Array.prototype.find` with an async predicate is a footgun — the
+    // predicate always returns a truthy Promise, so the first toggle
+    // wins regardless of its label. Resolve labels first and match by
+    // value.
+    const labels = await Promise.all(toggles.map((t) => t.getText()));
+    const setsIdx = labels.findIndex((l) => l.trim() === 'Sätze');
+    expect(setsIdx).toBeGreaterThanOrEqual(0);
+    await toggles[setsIdx].toggle();
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    const values = Array.from(host.querySelectorAll('.bar-value')).map((el) =>
+      el.textContent?.trim()
+    );
+    expect(values).toEqual(['10', '40']);
+    // Max is now Abs (40), so its bar fills the full track.
+    const fills = host.querySelectorAll('.bar-fill');
+    expect((fills[0] as HTMLElement).style.width).toBe('25%');
+    expect((fills[1] as HTMLElement).style.width).toBe('100%');
+  });
+
+  it('renders zero-width fills without dividing by zero when every value is zero', () => {
+    fixture.componentInstance.data.set({
+      labels: ['Pushups'],
+      reps: [0],
+      sets: [0],
+    });
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    const fill = host.querySelector('.bar-fill') as HTMLElement;
+    expect(fill.style.width).toBe('0%');
+  });
+});

--- a/web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts
+++ b/web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts
@@ -1,0 +1,158 @@
+import { DecimalPipe } from '@angular/common';
+import { Component, computed, input, signal } from '@angular/core';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+
+import type { CategoryComparison } from '../../analysis.store';
+
+type Metric = 'reps' | 'sets';
+
+/**
+ * Horizontal bar comparison across exercise categories. Sits in the
+ * Overview tab next to the per-category cards and shares the same
+ * `CategorySummary`-derived data, so a category visible here always
+ * has a matching card and a matching tab.
+ *
+ * CSS bars rather than Chart.js: with at most ~7 categories the SVG
+ * chart pulls in framework, registration and PLATFORM_ID/canvas
+ * guards for no real gain over a flex row with a width-percent fill.
+ */
+@Component({
+  selector: 'app-category-comparison-chart',
+  standalone: true,
+  imports: [DecimalPipe, MatButtonToggleModule],
+  template: `
+    <header class="head">
+      <h3 class="title" i18n="@@analysis.overview.comparison.title">
+        Vergleich nach Übungsgruppe
+      </h3>
+      <mat-button-toggle-group
+        [value]="metric()"
+        (change)="metric.set($event.value)"
+        aria-label="Kennzahl"
+        i18n-aria-label="@@analysis.overview.comparison.metricAria"
+        data-testid="category-comparison-metric"
+      >
+        <mat-button-toggle
+          value="reps"
+          i18n="@@analysis.overview.comparison.metric.reps"
+        >
+          Wdh.
+        </mat-button-toggle>
+        <mat-button-toggle
+          value="sets"
+          i18n="@@analysis.overview.comparison.metric.sets"
+        >
+          Sätze
+        </mat-button-toggle>
+      </mat-button-toggle-group>
+    </header>
+
+    @if (rows().length === 0) {
+      <p
+        class="empty"
+        data-testid="category-comparison-empty"
+        i18n="@@analysis.overview.comparison.empty"
+      >
+        Keine Daten im aktuellen Zeitraum.
+      </p>
+    } @else {
+      <ul class="bars" role="list" data-testid="category-comparison-bars">
+        @for (row of rows(); track row.label) {
+          <li class="bar-row">
+            <span class="bar-label">{{ row.label }}</span>
+            <span class="bar-track" aria-hidden="true">
+              <span class="bar-fill" [style.width.%]="row.fillPercent"></span>
+            </span>
+            <span class="bar-value">{{ row.value | number }}</span>
+          </li>
+        }
+      </ul>
+    }
+  `,
+  styles: `
+    :host {
+      display: block;
+    }
+    .head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 12px;
+      flex-wrap: wrap;
+    }
+    .title {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+    .bars {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 8px;
+    }
+    .bar-row {
+      display: grid;
+      grid-template-columns: minmax(80px, 140px) 1fr auto;
+      align-items: center;
+      gap: 12px;
+    }
+    .bar-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .bar-track {
+      position: relative;
+      height: 10px;
+      background: rgba(0, 0, 0, 0.08);
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    :host-context(html:not(.light-theme)) .bar-track {
+      background: rgba(255, 255, 255, 0.08);
+    }
+    .bar-fill {
+      position: absolute;
+      inset: 0 auto 0 0;
+      background: var(--mat-sys-primary, #1976d2);
+      border-radius: 6px;
+      transition: width 0.25s ease;
+    }
+    .bar-value {
+      font-variant-numeric: tabular-nums;
+      min-width: 4ch;
+      text-align: right;
+    }
+    .empty {
+      opacity: 0.7;
+      margin: 0;
+    }
+    @media (max-width: 600px) {
+      .bar-row {
+        grid-template-columns: minmax(64px, 100px) 1fr auto;
+        gap: 8px;
+      }
+    }
+  `,
+})
+export class CategoryComparisonChartComponent {
+  readonly data = input.required<CategoryComparison>();
+  readonly metric = signal<Metric>('reps');
+
+  readonly rows = computed(() => {
+    const data = this.data();
+    const values = this.metric() === 'reps' ? data.reps : data.sets;
+    const max = values.reduce((m, v) => (v > m ? v : m), 0);
+    return data.labels.map((label, idx) => {
+      const value = values[idx] ?? 0;
+      return {
+        label,
+        value,
+        fillPercent: max > 0 ? (value / max) * 100 : 0,
+      };
+    });
+  });
+}

--- a/web/src/app/stats/components/category-summary-card/category-summary-card.component.spec.ts
+++ b/web/src/app/stats/components/category-summary-card/category-summary-card.component.spec.ts
@@ -1,0 +1,96 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, signal } from '@angular/core';
+import { By } from '@angular/platform-browser';
+
+import type { CategorySummary } from '../../analysis.store';
+import { CategorySummaryCardComponent } from './category-summary-card.component';
+
+@Component({
+  selector: 'app-host',
+  standalone: true,
+  imports: [CategorySummaryCardComponent],
+  template: `
+    <app-category-summary-card
+      [summary]="summary()"
+      (viewSelect)="lastEmitted.set($event)"
+    />
+  `,
+})
+class HostComponent {
+  readonly summary = signal<CategorySummary>({
+    categoryId: 'pushup',
+    nameKey: '@@exercise.category.pushup',
+    icon: 'fitness_center',
+    order: 10,
+    totalReps: 123,
+    totalSets: 12,
+    todayReps: 7,
+    currentStreak: 3,
+    bestDay: { date: '2026-02-13', total: 25 },
+  });
+  readonly lastEmitted = signal<string | null>(null);
+}
+
+describe('CategorySummaryCardComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders the localised category name and quick stats', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    // TestBed default locale is `de` — categoryDisplayName returns the
+    // German source string.
+    expect(host.textContent).toContain('Liegestütze');
+    const totalReps = host.querySelector(
+      '[data-testid="category-summary-card-totalReps-pushup"]'
+    );
+    expect(totalReps?.textContent?.trim()).toBe('123');
+  });
+
+  it('renders the bestDay placeholder when no best day is available', () => {
+    fixture.componentInstance.summary.set({
+      ...fixture.componentInstance.summary(),
+      bestDay: null,
+    });
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.textContent).toContain('—');
+  });
+
+  it('emits the categoryId when the details button is clicked', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    const button = host.querySelector(
+      '[data-testid="category-summary-card-drilldown-pushup"]'
+    ) as HTMLButtonElement;
+    expect(button).toBeTruthy();
+    button.click();
+    expect(fixture.componentInstance.lastEmitted()).toBe('pushup');
+  });
+
+  it('carries a category-scoped data-testid so multiple cards stay addressable', () => {
+    fixture.componentInstance.summary.set({
+      ...fixture.componentInstance.summary(),
+      categoryId: 'abs',
+      icon: 'self_improvement',
+    });
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(
+      host.querySelector('[data-testid="category-summary-card-abs"]')
+    ).toBeTruthy();
+    expect(
+      host.querySelector('[data-testid="category-summary-card-drilldown-abs"]')
+    ).toBeTruthy();
+  });
+
+  it('reflects the icon prop on the mat-icon avatar', () => {
+    const icon = fixture.debugElement.query(By.css('mat-icon'));
+    expect(icon.nativeElement.textContent.trim()).toBe('fitness_center');
+  });
+});

--- a/web/src/app/stats/components/category-summary-card/category-summary-card.component.ts
+++ b/web/src/app/stats/components/category-summary-card/category-summary-card.component.ts
@@ -1,0 +1,123 @@
+import { DecimalPipe } from '@angular/common';
+import { Component, input, output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import type { ExerciseCategoryId } from '@pu-stats/models';
+
+import type { CategorySummary } from '../../analysis.store';
+import { categoryDisplayName } from '../../i18n/exercise-display-names';
+
+/**
+ * Per-category quick-stats card shown in the Overview tab. Emits
+ * `select` with the category id so the parent shell can switch the
+ * mat-tab to the matching detail view without prop-drilling the store.
+ */
+@Component({
+  selector: 'app-category-summary-card',
+  standalone: true,
+  imports: [DecimalPipe, MatButtonModule, MatCardModule, MatIconModule],
+  template: `
+    <mat-card
+      class="card"
+      [attr.data-testid]="'category-summary-card-' + summary().categoryId"
+    >
+      <mat-card-header>
+        <mat-icon mat-card-avatar aria-hidden="true">{{
+          summary().icon
+        }}</mat-icon>
+        <mat-card-title>{{ displayName() }}</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <dl class="stats">
+          <div>
+            <dt i18n="@@analysis.overview.cards.totalReps">Reps gesamt</dt>
+            <dd
+              [attr.data-testid]="
+                'category-summary-card-totalReps-' + summary().categoryId
+              "
+            >
+              {{ summary().totalReps | number }}
+            </dd>
+          </div>
+          <div>
+            <dt i18n="@@analysis.overview.cards.todayReps">Heute</dt>
+            <dd>{{ summary().todayReps | number }}</dd>
+          </div>
+          <div>
+            <dt i18n="@@analysis.overview.cards.streak">Streak</dt>
+            <dd>
+              <ng-container i18n="@@analysis.streakDays"
+                >{{ summary().currentStreak }} Tage</ng-container
+              >
+            </dd>
+          </div>
+          <div>
+            <dt i18n="@@analysis.overview.cards.bestDay">Bester Tag</dt>
+            @if (summary().bestDay; as best) {
+              <dd>{{ best.date }} · {{ best.total | number }}</dd>
+            } @else {
+              <dd>—</dd>
+            }
+          </div>
+        </dl>
+      </mat-card-content>
+      <mat-card-actions align="end">
+        <button
+          mat-flat-button
+          color="primary"
+          (click)="viewSelect.emit(summary().categoryId)"
+          [attr.data-testid]="
+            'category-summary-card-drilldown-' + summary().categoryId
+          "
+        >
+          <span i18n="@@analysis.overview.cards.viewDetails"
+            >Details ansehen</span
+          >
+        </button>
+      </mat-card-actions>
+    </mat-card>
+  `,
+  styles: `
+    :host {
+      display: block;
+    }
+    .card {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+    mat-card-content {
+      flex: 1;
+    }
+    .stats {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      margin: 8px 0 0;
+    }
+    .stats > div {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    dt {
+      font-size: 0.75rem;
+      opacity: 0.7;
+      margin: 0;
+    }
+    dd {
+      margin: 0;
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+    }
+  `,
+})
+export class CategorySummaryCardComponent {
+  readonly summary = input.required<CategorySummary>();
+  readonly viewSelect = output<ExerciseCategoryId>();
+
+  displayName(): string {
+    return categoryDisplayName(this.summary().categoryId);
+  }
+}

--- a/web/src/app/stats/shell/analysis-group-view.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.spec.ts
@@ -1,5 +1,6 @@
 import { Component, input, model, PLATFORM_ID, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
 import {
   LiveDataStore,
@@ -199,5 +200,42 @@ describe('AnalysisGroupViewComponent', () => {
     );
     expect(headerToggle).toBeTruthy();
     expect(headerToggle?.tagName.toLowerCase()).toBe('mat-button-toggle-group');
+  });
+
+  it('typeBreakdownDisplay localises bare exerciseIds in kind mode', async () => {
+    // Regression: in kind mode (a non-pushup active view, or a kinds
+    // filter that excludes pushups) the store emits raw catalog ids
+    // like `abs.situps`. The component wraps them in `kindDisplayName`
+    // so the pie legend reads "Sit-ups" instead of the developer id.
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'abs.situps',
+        timestamp: '2026-02-12T08:00:00.000Z',
+        reps: 30,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    // Pull the store from the group-view's own injector — the HostComponent
+    // provides AnalysisStore on its own tree, so TestBed.inject would
+    // resolve a different (or missing) instance.
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('abs');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const groupView =
+      groupViewEl.componentInstance as AnalysisGroupViewComponent;
+    const breakdown = groupView.typeBreakdownDisplay();
+    expect(breakdown).toHaveLength(1);
+    expect(breakdown[0]).toMatchObject({
+      id: 'abs.situps',
+      label: 'Sit-ups',
+    });
   });
 });

--- a/web/src/app/stats/shell/analysis-group-view.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.spec.ts
@@ -1,0 +1,203 @@
+import { Component, input, model, PLATFORM_ID, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import {
+  LiveDataStore,
+  StatsApiService,
+  UserStatsApiService,
+} from '@pu-stats/data-access';
+import { AuthStore, UserContextService } from '@pu-auth/auth';
+import { makeAuthStoreMock } from '@pu-stats/testing';
+import { ExerciseEntry, RangeModes } from '@pu-stats/models';
+
+import { AnalysisStore } from '../analysis.store';
+import { AnalysisGroupViewComponent } from './analysis-group-view.component';
+import { HeatmapComponent } from '../components/heatmap/heatmap.component';
+import { TypePieComponent } from '../components/type-pie/type-pie.component';
+import { StatsChartComponent } from '../components/stats-chart/stats-chart.component';
+import { SetsDistributionComponent } from '../components/sets-distribution/sets-distribution.component';
+
+@Component({
+  selector: 'app-heatmap',
+  standalone: true,
+  template: '',
+})
+class MockHeatmapComponent {
+  readonly entries = input<unknown[]>([]);
+  readonly mode = input<string>('reps');
+}
+
+@Component({
+  selector: 'app-type-pie',
+  standalone: true,
+  template: '',
+})
+class MockTypePieComponent {
+  readonly data = input<unknown[]>([]);
+}
+
+@Component({
+  selector: 'app-stats-chart',
+  standalone: true,
+  template: '',
+})
+class MockStatsChartComponent {
+  readonly series = input<unknown[]>([]);
+  readonly granularity = input<string>('daily');
+  readonly rangeMode = input<RangeModes>('week' as RangeModes);
+  readonly from = input<string>('');
+  readonly to = input<string>('');
+  readonly entries = input<unknown[]>([]);
+  readonly dayChartMode = model<string>('14h');
+}
+
+@Component({
+  selector: 'app-sets-distribution',
+  standalone: true,
+  template: '',
+})
+class MockSetsDistributionComponent {
+  readonly data = input<unknown[]>([]);
+}
+
+// Wraps the group-view in a provider context so its `inject(AnalysisStore)`
+// resolves without going through the analysis-page shell (and its
+// mat-tab-group, which doesn't hydrate its lazy body template reliably
+// under PLATFORM_ID=server in jsdom). Tests can manipulate the store
+// directly to drive view filters.
+@Component({
+  selector: 'app-host',
+  standalone: true,
+  imports: [AnalysisGroupViewComponent],
+  providers: [AnalysisStore],
+  template: '<app-analysis-group-view />',
+})
+class HostComponent {}
+
+describe('AnalysisGroupViewComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  const liveExerciseEntries = signal<ExerciseEntry[]>([]);
+  const liveMock = {
+    connected: signal(true),
+    entries: signal([] as never[]),
+    exerciseEntries: liveExerciseEntries,
+    updateTick: signal(0),
+  };
+
+  const apiMock = {
+    load: vitest.fn().mockReturnValue(
+      of({
+        meta: {
+          from: null,
+          to: null,
+          entries: 1,
+          days: 1,
+          total: 25,
+          granularity: 'daily',
+        },
+        series: [],
+      })
+    ),
+    listPushups: vitest.fn().mockReturnValue(
+      of([
+        {
+          _id: '1',
+          timestamp: '2026-02-13T08:00:00',
+          reps: 25,
+          sets: [10, 8, 7],
+          source: 'web',
+          type: 'Standard',
+        },
+      ])
+    ),
+  };
+
+  beforeEach(async () => {
+    vitest.useFakeTimers({ toFake: ['Date'] });
+    vitest.setSystemTime(new Date(2026, 1, 15, 12));
+    liveExerciseEntries.set([]);
+
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'server' },
+        { provide: StatsApiService, useValue: apiMock },
+        { provide: AuthStore, useValue: makeAuthStoreMock() },
+        { provide: UserContextService, useValue: { userIdSafe: () => 'u1' } },
+        { provide: LiveDataStore, useValue: liveMock },
+        {
+          provide: UserStatsApiService,
+          useValue: {
+            getUserStats: vitest.fn().mockReturnValue(of(null)),
+          },
+        },
+      ],
+    })
+      .overrideComponent(AnalysisGroupViewComponent, {
+        remove: {
+          imports: [
+            HeatmapComponent,
+            TypePieComponent,
+            StatsChartComponent,
+            SetsDistributionComponent,
+          ],
+        },
+        add: {
+          imports: [
+            MockHeatmapComponent,
+            MockTypePieComponent,
+            MockStatsChartComponent,
+            MockSetsDistributionComponent,
+          ],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vitest.useRealTimers();
+  });
+
+  it('renders fixed-window labels for trend cards', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    const trends = host.querySelector(
+      '[data-testid="analysis-trends-section"]'
+    );
+    expect(trends?.textContent).toContain('Wochentrend');
+    expect(trends?.textContent).toContain('Letzte 8 Wochen');
+    expect(trends?.textContent).toContain('Monatstrend');
+    expect(trends?.textContent).toContain('Letzte 6 Monate');
+  });
+
+  it('places the trend section after the heatmap card in the DOM', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    const heatmap = host.querySelector('.heatmap-full');
+    const trends = host.querySelector(
+      '[data-testid="analysis-trends-section"]'
+    );
+    expect(heatmap).toBeTruthy();
+    expect(trends).toBeTruthy();
+    if (!heatmap || !trends) return;
+    expect(
+      heatmap.compareDocumentPosition(trends) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('places the heatmap reps/sets toggle inside the heatmap card header so the mobile stacked layout applies', () => {
+    const host: HTMLElement = fixture.nativeElement;
+
+    const heatmapCard = host.querySelector('.heatmap-full');
+    expect(heatmapCard).toBeTruthy();
+
+    const headerToggle = heatmapCard?.querySelector(
+      'mat-card-header .heatmap-toggle'
+    );
+    expect(headerToggle).toBeTruthy();
+    expect(headerToggle?.tagName.toLowerCase()).toBe('mat-button-toggle-group');
+  });
+});

--- a/web/src/app/stats/shell/analysis-overview.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-overview.component.spec.ts
@@ -175,6 +175,45 @@ describe('AnalysisOverviewComponent', () => {
     ).toBeNull();
   });
 
+  it('prefers the category overview over the uncategorised fallback when both signals are populated', () => {
+    // Precedence regression guard: if a future refactor swaps the order
+    // of the `@if` / `@else if` branches in the template, this test
+    // would catch the regression. The Overview must show the
+    // comparison + cards (not the uncategorised notice) whenever any
+    // category roll-up exists, regardless of whether unifiedRows also
+    // carries rows.
+    store.categorySummaries.set([
+      {
+        categoryId: 'pushup',
+        nameKey: '@@exercise.category.pushup',
+        icon: 'fitness_center',
+        order: 10,
+        totalReps: 100,
+        totalSets: 12,
+        todayReps: 7,
+        currentStreak: 3,
+        bestDay: { date: '2026-02-13', total: 25 },
+      },
+    ]);
+    store.unifiedRows.set([{ id: 'orphan' }]);
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(
+      host.querySelector('[data-testid="analysis-overview-cards"]')
+    ).toBeTruthy();
+    expect(host.querySelectorAll('app-category-summary-card')).toHaveLength(1);
+    expect(host.querySelector('app-category-comparison-chart')).toBeTruthy();
+    expect(host.querySelector('[data-testid="stub-group-view"]')).toBeNull();
+    expect(
+      host.querySelector(
+        '[data-testid="analysis-overview-uncategorised-notice"]'
+      )
+    ).toBeNull();
+    expect(
+      host.querySelector('[data-testid="analysis-overview-empty"]')
+    ).toBeNull();
+  });
+
   it('forwards viewSelect emissions from a summary card up to the parent', () => {
     store.categorySummaries.set([
       {

--- a/web/src/app/stats/shell/analysis-overview.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-overview.component.spec.ts
@@ -48,9 +48,12 @@ interface FakeStore {
   categorySummaries: ReturnType<typeof signal<CategorySummary[]>>;
   categoryComparison: ReturnType<typeof signal<CategoryComparison>>;
   unifiedRows: ReturnType<typeof signal<unknown[]>>;
+  activeView: ReturnType<typeof signal<string>>;
+  setActiveView: (view: string) => void;
 }
 
 function makeFakeStore(): FakeStore {
+  const activeView = signal<string>('overview');
   return {
     categorySummaries: signal<CategorySummary[]>([]),
     categoryComparison: signal<CategoryComparison>({
@@ -59,6 +62,8 @@ function makeFakeStore(): FakeStore {
       sets: [],
     }),
     unifiedRows: signal<unknown[]>([]),
+    activeView,
+    setActiveView: (view: string) => activeView.set(view),
   };
 }
 
@@ -238,5 +243,43 @@ describe('AnalysisOverviewComponent', () => {
     button.click();
     fixture.detectChanges();
     expect(fixture.componentInstance.lastEmitted()).toBe('pushup');
+  });
+
+  it('snaps activeView to overview in the uncategorised fallback so the embedded group-view is not stale-filtered', () => {
+    // Regression for Copilot finding: a stale `?view=plank` deep link
+    // leaves `activeView` pointing at an empty category. The embedded
+    // `<app-analysis-group-view />` then reads `viewFilteredRows()`
+    // scoped to plank → empty subset, defeating the fallback's whole
+    // point of surfacing the uncategorised rows. The component's
+    // effect must re-sync activeView to 'overview' as soon as it
+    // enters the fallback branch.
+    store.activeView.set('plank');
+    store.unifiedRows.set([{ id: 'orphan' }]);
+    fixture.detectChanges();
+    expect(store.activeView()).toBe('overview');
+  });
+
+  it('leaves activeView alone when the category overview branch is active', () => {
+    // Guard against the snap firing too eagerly: when category data
+    // exists, the user may have legitimately landed via `?view=plank`
+    // and is currently looking at the overview tab only because the
+    // shell rendered it as the default Overview view. Snapping then
+    // would corrupt the deep-link intent.
+    store.activeView.set('plank');
+    store.categorySummaries.set([
+      {
+        categoryId: 'pushup',
+        nameKey: '@@exercise.category.pushup',
+        icon: 'fitness_center',
+        order: 10,
+        totalReps: 100,
+        totalSets: 12,
+        todayReps: 7,
+        currentStreak: 3,
+        bestDay: null,
+      },
+    ]);
+    fixture.detectChanges();
+    expect(store.activeView()).toBe('plank');
   });
 });

--- a/web/src/app/stats/shell/analysis-overview.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-overview.component.spec.ts
@@ -1,0 +1,203 @@
+import { Component, input, output, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import type { CategoryComparison, CategorySummary } from '../analysis.store';
+import { AnalysisStore } from '../analysis.store';
+
+type AnalysisStoreType = InstanceType<typeof AnalysisStore>;
+import { AnalysisOverviewComponent } from './analysis-overview.component';
+import { AnalysisGroupViewComponent } from './analysis-group-view.component';
+import { CategoryComparisonChartComponent } from '../components/category-comparison-chart/category-comparison-chart.component';
+import { CategorySummaryCardComponent } from '../components/category-summary-card/category-summary-card.component';
+
+// Replace the heavy real children with no-op stubs so the spec stays
+// focused on the overview component's own branching/wiring (empty-state,
+// uncategorised fallback, viewSelect forward).
+@Component({
+  selector: 'app-category-comparison-chart',
+  standalone: true,
+  template: '',
+})
+class StubComparisonChartComponent {
+  // Mirror the real component's signal input surface so the overview's
+  // `[data]="..."` binding type-checks against the stub.
+  readonly data = input<CategoryComparison>({ labels: [], reps: [], sets: [] });
+}
+
+@Component({
+  selector: 'app-category-summary-card',
+  standalone: true,
+  template: '<button type="button" (click)="emit()">drill</button>',
+})
+class StubSummaryCardComponent {
+  readonly summary = input.required<CategorySummary>();
+  readonly viewSelect = output<string>();
+  emit(): void {
+    this.viewSelect.emit(this.summary().categoryId);
+  }
+}
+
+@Component({
+  selector: 'app-analysis-group-view',
+  standalone: true,
+  template: '<div data-testid="stub-group-view"></div>',
+})
+class StubAnalysisGroupViewComponent {}
+
+interface FakeStore {
+  categorySummaries: ReturnType<typeof signal<CategorySummary[]>>;
+  categoryComparison: ReturnType<typeof signal<CategoryComparison>>;
+  unifiedRows: ReturnType<typeof signal<unknown[]>>;
+}
+
+function makeFakeStore(): FakeStore {
+  return {
+    categorySummaries: signal<CategorySummary[]>([]),
+    categoryComparison: signal<CategoryComparison>({
+      labels: [],
+      reps: [],
+      sets: [],
+    }),
+    unifiedRows: signal<unknown[]>([]),
+  };
+}
+
+@Component({
+  selector: 'app-host',
+  standalone: true,
+  imports: [AnalysisOverviewComponent],
+  template: `<app-analysis-overview (viewSelect)="lastEmitted.set($event)" />`,
+})
+class HostComponent {
+  readonly lastEmitted = signal<string | null>(null);
+}
+
+describe('AnalysisOverviewComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let store: FakeStore;
+
+  beforeEach(async () => {
+    store = makeFakeStore();
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [
+        {
+          provide: AnalysisStore,
+          useValue: store as unknown as AnalysisStoreType,
+        },
+      ],
+    })
+      .overrideComponent(AnalysisOverviewComponent, {
+        remove: {
+          imports: [
+            CategoryComparisonChartComponent,
+            CategorySummaryCardComponent,
+            AnalysisGroupViewComponent,
+          ],
+        },
+        add: {
+          imports: [
+            StubComparisonChartComponent,
+            StubSummaryCardComponent,
+            StubAnalysisGroupViewComponent,
+          ],
+        },
+      })
+      .compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  it('renders the empty state when there are no rows and no categories', () => {
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(
+      host.querySelector('[data-testid="analysis-overview-empty"]')
+    ).toBeTruthy();
+    expect(
+      host.querySelector('[data-testid="analysis-overview-cards"]')
+    ).toBeNull();
+    expect(host.querySelector('[data-testid="stub-group-view"]')).toBeNull();
+  });
+
+  it('falls back to the group-view when rows exist but no category mapped', () => {
+    // Plan requirement: entries whose `exerciseId` is missing from the
+    // catalog (so `categorySummaries` skips them) must still surface in
+    // the Overview tab. The dedicated notice + group-view render in
+    // place of the "no entries" message.
+    store.unifiedRows.set([{ id: 'orphan' }]);
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.querySelector('[data-testid="stub-group-view"]')).toBeTruthy();
+    expect(
+      host.querySelector(
+        '[data-testid="analysis-overview-uncategorised-notice"]'
+      )
+    ).toBeTruthy();
+    expect(
+      host.querySelector('[data-testid="analysis-overview-empty"]')
+    ).toBeNull();
+  });
+
+  it('renders the chart and one card per summary when categories exist', () => {
+    store.categorySummaries.set([
+      {
+        categoryId: 'pushup',
+        nameKey: '@@exercise.category.pushup',
+        icon: 'fitness_center',
+        order: 10,
+        totalReps: 100,
+        totalSets: 12,
+        todayReps: 7,
+        currentStreak: 3,
+        bestDay: { date: '2026-02-13', total: 25 },
+      },
+      {
+        categoryId: 'abs',
+        nameKey: '@@exercise.category.abs',
+        icon: 'self_improvement',
+        order: 20,
+        totalReps: 30,
+        totalSets: 0,
+        todayReps: 0,
+        currentStreak: 1,
+        bestDay: { date: '2026-02-12', total: 30 },
+      },
+    ]);
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(
+      host.querySelector('[data-testid="analysis-overview-cards"]')
+    ).toBeTruthy();
+    expect(host.querySelectorAll('app-category-summary-card')).toHaveLength(2);
+    expect(host.querySelector('app-category-comparison-chart')).toBeTruthy();
+    expect(
+      host.querySelector('[data-testid="analysis-overview-empty"]')
+    ).toBeNull();
+  });
+
+  it('forwards viewSelect emissions from a summary card up to the parent', () => {
+    store.categorySummaries.set([
+      {
+        categoryId: 'pushup',
+        nameKey: '@@exercise.category.pushup',
+        icon: 'fitness_center',
+        order: 10,
+        totalReps: 100,
+        totalSets: 12,
+        todayReps: 7,
+        currentStreak: 3,
+        bestDay: null,
+      },
+    ]);
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    const button = host.querySelector(
+      'app-category-summary-card button'
+    ) as HTMLButtonElement;
+    expect(button).toBeTruthy();
+    button.click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.lastEmitted()).toBe('pushup');
+  });
+});

--- a/web/src/app/stats/shell/analysis-overview.component.ts
+++ b/web/src/app/stats/shell/analysis-overview.component.ts
@@ -1,17 +1,28 @@
-import { Component, inject, output } from '@angular/core';
+import { Component, computed, inject, output } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import type { ExerciseCategoryId } from '@pu-stats/models';
 
 import { AnalysisStore } from '../analysis.store';
 import { CategoryComparisonChartComponent } from '../components/category-comparison-chart/category-comparison-chart.component';
 import { CategorySummaryCardComponent } from '../components/category-summary-card/category-summary-card.component';
+import { AnalysisGroupViewComponent } from './analysis-group-view.component';
 
 /**
  * Overview tab content for the analysis page: comparison chart on top,
  * one summary card per visible category below. Drilldown clicks bubble
- * up through `select` so the shell can switch the active mat-tab — the
- * store is updated by the shell rather than here to keep the URL
+ * up through `viewSelect` so the shell can switch the active mat-tab —
+ * the store is updated by the shell rather than here to keep the URL
  * `?view=` sync in one place.
+ *
+ * Entries whose `exerciseId` is missing from {@link EXERCISE_CATALOG}
+ * (e.g. a Firestore doc for a deleted custom exercise) drop out of
+ * every per-category roll-up — that's the point of `categorySummaries`
+ * filtering on a non-null category. But the plan calls out that those
+ * entries must **not** disappear from the Overview, so when the date
+ * range contains data with zero categorisable rows we fall back to the
+ * aggregate group-view rather than show "no entries". The shell's
+ * own empty CTA handles the genuinely-empty case before this component
+ * mounts.
  */
 @Component({
   selector: 'app-analysis-overview',
@@ -20,17 +31,10 @@ import { CategorySummaryCardComponent } from '../components/category-summary-car
     MatCardModule,
     CategoryComparisonChartComponent,
     CategorySummaryCardComponent,
+    AnalysisGroupViewComponent,
   ],
   template: `
-    @if (store.categorySummaries().length === 0) {
-      <p
-        class="empty"
-        data-testid="analysis-overview-empty"
-        i18n="@@analysis.overview.empty"
-      >
-        Im aktuellen Zeitraum gibt es noch keine Einträge.
-      </p>
-    } @else {
+    @if (showCategoryOverview()) {
       <mat-card class="chart-card">
         <mat-card-content>
           <app-category-comparison-chart [data]="store.categoryComparison()" />
@@ -45,6 +49,23 @@ import { CategorySummaryCardComponent } from '../components/category-summary-car
           />
         }
       </section>
+    } @else if (hasUncategorisedRows()) {
+      <p
+        class="notice"
+        data-testid="analysis-overview-uncategorised-notice"
+        i18n="@@analysis.overview.uncategorisedNotice"
+      >
+        Diese Einträge gehören zu keiner bekannten Kategorie — Aggregat unten.
+      </p>
+      <app-analysis-group-view />
+    } @else {
+      <p
+        class="empty"
+        data-testid="analysis-overview-empty"
+        i18n="@@analysis.overview.empty"
+      >
+        Im aktuellen Zeitraum gibt es noch keine Einträge.
+      </p>
     }
   `,
   styles: `
@@ -57,7 +78,8 @@ import { CategorySummaryCardComponent } from '../components/category-summary-car
       grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
       gap: 16px;
     }
-    .empty {
+    .empty,
+    .notice {
       opacity: 0.7;
       margin: 0;
     }
@@ -75,4 +97,12 @@ import { CategorySummaryCardComponent } from '../components/category-summary-car
 export class AnalysisOverviewComponent {
   readonly store = inject(AnalysisStore);
   readonly viewSelect = output<ExerciseCategoryId>();
+
+  readonly showCategoryOverview = computed(
+    () => this.store.categorySummaries().length > 0
+  );
+
+  readonly hasUncategorisedRows = computed(
+    () => this.store.unifiedRows().length > 0
+  );
 }

--- a/web/src/app/stats/shell/analysis-overview.component.ts
+++ b/web/src/app/stats/shell/analysis-overview.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, output } from '@angular/core';
+import { Component, computed, effect, inject, output } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import type { ExerciseCategoryId } from '@pu-stats/models';
 
@@ -105,4 +105,27 @@ export class AnalysisOverviewComponent {
   readonly hasUncategorisedRows = computed(
     () => this.store.unifiedRows().length > 0
   );
+
+  constructor() {
+    // The uncategorised-fallback branch embeds <app-analysis-group-view />,
+    // which reads `viewFilteredRows()` (scoped by `activeView`). If a
+    // stale `?view=<category>` deep link left `activeView` pointing at
+    // an empty category, the group-view would filter out the very rows
+    // we're trying to surface. Snap `activeView` back to `'overview'`
+    // whenever this branch is active.
+    //
+    // Narrow guard: we only run when there are zero category summaries
+    // AND non-zero unified rows — i.e. the exact uncategorised-fallback
+    // condition. That's mutually exclusive with the "data with known
+    // categories exists" case, so this can't race with a `?view=plank`
+    // deep link whose data hasn't loaded yet (the empty-state branch
+    // handles that until rows arrive).
+    effect(() => {
+      if (this.showCategoryOverview()) return;
+      if (!this.hasUncategorisedRows()) return;
+      if (this.store.activeView() !== 'overview') {
+        this.store.setActiveView('overview');
+      }
+    });
+  }
 }

--- a/web/src/app/stats/shell/analysis-overview.component.ts
+++ b/web/src/app/stats/shell/analysis-overview.component.ts
@@ -1,0 +1,78 @@
+import { Component, inject, output } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import type { ExerciseCategoryId } from '@pu-stats/models';
+
+import { AnalysisStore } from '../analysis.store';
+import { CategoryComparisonChartComponent } from '../components/category-comparison-chart/category-comparison-chart.component';
+import { CategorySummaryCardComponent } from '../components/category-summary-card/category-summary-card.component';
+
+/**
+ * Overview tab content for the analysis page: comparison chart on top,
+ * one summary card per visible category below. Drilldown clicks bubble
+ * up through `select` so the shell can switch the active mat-tab — the
+ * store is updated by the shell rather than here to keep the URL
+ * `?view=` sync in one place.
+ */
+@Component({
+  selector: 'app-analysis-overview',
+  standalone: true,
+  imports: [
+    MatCardModule,
+    CategoryComparisonChartComponent,
+    CategorySummaryCardComponent,
+  ],
+  template: `
+    @if (store.categorySummaries().length === 0) {
+      <p
+        class="empty"
+        data-testid="analysis-overview-empty"
+        i18n="@@analysis.overview.empty"
+      >
+        Im aktuellen Zeitraum gibt es noch keine Einträge.
+      </p>
+    } @else {
+      <mat-card class="chart-card">
+        <mat-card-content>
+          <app-category-comparison-chart [data]="store.categoryComparison()" />
+        </mat-card-content>
+      </mat-card>
+
+      <section class="cards" data-testid="analysis-overview-cards">
+        @for (summary of store.categorySummaries(); track summary.categoryId) {
+          <app-category-summary-card
+            [summary]="summary"
+            (viewSelect)="viewSelect.emit($event)"
+          />
+        }
+      </section>
+    }
+  `,
+  styles: `
+    :host {
+      display: grid;
+      gap: 16px;
+    }
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 16px;
+    }
+    .empty {
+      opacity: 0.7;
+      margin: 0;
+    }
+    @media (max-width: 600px) {
+      :host {
+        gap: 12px;
+      }
+      .cards {
+        grid-template-columns: 1fr;
+        gap: 12px;
+      }
+    }
+  `,
+})
+export class AnalysisOverviewComponent {
+  readonly store = inject(AnalysisStore);
+  readonly viewSelect = output<ExerciseCategoryId>();
+}

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -255,38 +255,11 @@ describe('AnalysisPageComponent', () => {
     expect(nextDay.getDate()).toBe(1);
   });
 
-  it('renders fixed-window labels for trend cards', () => {
-    fixture.detectChanges();
-    const host: HTMLElement = fixture.nativeElement;
-    const trends = host.querySelector(
-      '[data-testid="analysis-trends-section"]'
-    );
-    expect(trends?.textContent).toContain('Wochentrend');
-    expect(trends?.textContent).toContain('Letzte 8 Wochen');
-    expect(trends?.textContent).toContain('Monatstrend');
-    expect(trends?.textContent).toContain('Letzte 6 Monate');
-  });
-
-  // The trend cards are wrapped in `@defer (on viewport)`, but verifying
-  // hydration in jsdom is fragile (it requires mocking IntersectionObserver
-  // and using Angular's still-evolving defer-test helpers). This test
-  // narrowly guards the intentional DOM ordering — heatmap above the
-  // trends — which is the stable structural invariant the lazy load
-  // depends on; the @defer behaviour itself is covered by the framework.
-  it('places the trend section after the heatmap card in the DOM', () => {
-    fixture.detectChanges();
-    const host: HTMLElement = fixture.nativeElement;
-    const heatmap = host.querySelector('.heatmap-full');
-    const trends = host.querySelector(
-      '[data-testid="analysis-trends-section"]'
-    );
-    expect(heatmap).toBeTruthy();
-    expect(trends).toBeTruthy();
-    if (!heatmap || !trends) return;
-    expect(
-      heatmap.compareDocumentPosition(trends) & Node.DOCUMENT_POSITION_FOLLOWING
-    ).toBeTruthy();
-  });
+  // NOTE: DOM-level tests for the group-view (trends section ordering,
+  // heatmap toggle position, kind-id localisation) live in
+  // `analysis-group-view.component.spec.ts` — they need the group-view
+  // rendered without mat-tab's lazy body template, which doesn't
+  // hydrate reliably under PLATFORM_ID=server in jsdom.
 
   it('computes type breakdown, treating missing type as Standard', () => {
     const { store } = fixture.componentInstance;
@@ -363,20 +336,6 @@ describe('AnalysisPageComponent', () => {
     expect(wide?.avgSetSize).toBe(0);
   });
 
-  it('places the heatmap reps/sets toggle inside the heatmap card header so the mobile stacked layout applies', () => {
-    fixture.detectChanges();
-    const host: HTMLElement = fixture.nativeElement;
-
-    const heatmapCard = host.querySelector('.heatmap-full');
-    expect(heatmapCard).toBeTruthy();
-
-    const headerToggle = heatmapCard?.querySelector(
-      'mat-card-header .heatmap-toggle'
-    );
-    expect(headerToggle).toBeTruthy();
-    expect(headerToggle?.tagName.toLowerCase()).toBe('mat-button-toggle-group');
-  });
-
   it('keeps the date range filter sticky so it stays visible while scrolling', () => {
     fixture.detectChanges();
     const host: HTMLElement = fixture.nativeElement;
@@ -424,66 +383,6 @@ describe('AnalysisPageComponent', () => {
     // an empty list — no "abs.situps" bucket without source data, no
     // pushup variants either because the filter excludes pushups.
     expect(store.typeBreakdown()).toEqual([]);
-  });
-
-  it('hides the kind filter for pushup-only ranges to keep the default page minimal', () => {
-    // Mock dataset has only pushup entries; the filter would just show
-    // a single "Pushup" option which is redundant with the variant pie.
-    const component = fixture.componentInstance;
-    expect(component.kindFilterOptions().map((o) => o.value)).toEqual([
-      'pushup',
-    ]);
-    expect(component.showKindFilter()).toBe(false);
-  });
-
-  it('shows the kind filter when the range contains a non-pushup kind even with no selection', () => {
-    // OR-branch of `showKindFilter`: a user who already has sit-up
-    // entries in the visible range must see the filter without
-    // pre-selecting anything, otherwise they could never enable
-    // kind-mode for their own data.
-    const component = fixture.componentInstance;
-    liveExerciseEntries.set([
-      {
-        _id: 'e1',
-        userId: 'u1',
-        exerciseId: 'abs.situps',
-        timestamp: '2026-02-12T08:00:00.000Z',
-        reps: 30,
-        source: 'web',
-      } as ExerciseEntry,
-    ]);
-    component.store.setKinds([]);
-    component.store.setRange('2026-02-09', '2026-02-15');
-    fixture.detectChanges();
-    const values = component.kindFilterOptions().map((o) => o.value);
-    expect(values).toContain('abs.situps');
-    expect(component.showKindFilter()).toBe(true);
-  });
-
-  it('shows the kind filter when a non-pushup kind is selected even on a pushup-only range', () => {
-    // Regression for Copilot finding: a user with only sit-up entries
-    // would never see the filter, and the default pushup-variant pie
-    // would render empty. Setting a non-pushup kind via the store —
-    // which the page also does when handling URL params or stale
-    // selections — must immediately surface the filter so the user
-    // can adjust it.
-    const component = fixture.componentInstance;
-    component.store.setKinds(['abs.situps']);
-    fixture.detectChanges();
-    expect(component.showKindFilter()).toBe(true);
-  });
-
-  it('keeps stale kind selections in the option list so the user can always clear them', () => {
-    // Regression for codex P1: after picking a kind that is not present
-    // in the current date range, the filter would disappear entirely
-    // because `kindFilterOptions` only listed in-range kinds. The chip
-    // stayed selected with no matching option to deselect, leaving the
-    // pie filtered to nothing.
-    const component = fixture.componentInstance;
-    component.store.setKinds(['abs.situps']);
-    fixture.detectChanges();
-    const values = component.kindFilterOptions().map((o) => o.value);
-    expect(values).toContain('abs.situps');
   });
 
   describe('per-category view (activeView / viewFilteredRows)', () => {
@@ -749,33 +648,91 @@ describe('AnalysisPageComponent', () => {
     });
   });
 
-  it('resolves bare kind ids to localised labels via typeBreakdownDisplay', () => {
-    // Coverage for the component-level mapping that lives in the
-    // group view: the store's kind-mode breakdown emits raw ids in
-    // `label` and the group view wraps it in `typeBreakdownDisplay`
-    // to localise. A regression in the wrapper would silently render
-    // `abs.situps` as the legend text instead of "Sit-ups".
-    fixture.componentInstance.store.setKinds(['pushup', 'abs.situps']);
-    fixture.detectChanges();
-    const groupView = fixture.debugElement.query(
-      By.directive(AnalysisGroupViewComponent)
-    ).componentInstance as AnalysisGroupViewComponent;
-    const breakdown = groupView
-      .typeBreakdownDisplay()
-      .map((d) => ({ id: d.id, label: d.label }));
-    const pushup = breakdown.find((l) => l.id === 'pushup');
-    expect(pushup?.label).toBe('Liegestütze');
+  describe('tabs + URL sync', () => {
+    it('shows only the Overview tab plus one tab per category with entries', () => {
+      const component = fixture.componentInstance;
+      // Seeded dataset has only pushup entries → one visible category tab.
+      expect(component.visibleTabs().map((t) => t.id)).toEqual(['pushup']);
 
-    // The mock dataset has no abs.situps entries so the breakdown
-    // bucket itself is missing; `kindFilterOptions` on the shell uses
-    // the same shared `kindDisplayName` mapping for both selected and
-    // in-range kinds, so it proves the catalog lookup → localised
-    // name path also works for catalog ids — without needing fixture
-    // data we don't have.
-    const situpsOption = fixture.componentInstance
-      .kindFilterOptions()
-      .find((o) => o.value === 'abs.situps');
-    expect(situpsOption?.label).toBe('Sit-ups');
+      liveExerciseEntries.set([
+        {
+          _id: 'e1',
+          userId: 'u1',
+          exerciseId: 'abs.situps',
+          timestamp: '2026-02-12T08:00:00.000Z',
+          reps: 30,
+          source: 'web',
+        } as ExerciseEntry,
+        {
+          _id: 'e2',
+          userId: 'u1',
+          exerciseId: 'legs.squats',
+          timestamp: '2026-02-13T08:00:00.000Z',
+          reps: 40,
+          source: 'web',
+        } as ExerciseEntry,
+      ]);
+      component.store.setRange('2026-02-09', '2026-02-15');
+      fixture.detectChanges();
+
+      // Order follows EXERCISE_CATEGORIES.order (pushup=10, abs=20, legs=30).
+      expect(component.visibleTabs().map((t) => t.id)).toEqual([
+        'pushup',
+        'abs',
+        'legs',
+      ]);
+    });
+
+    it('switches activeView when a tab is selected', () => {
+      const component = fixture.componentInstance;
+      // Overview = 0, pushup tab = 1 (the only category visible by default).
+      component.onTabIndexChange(1);
+      expect(component.store.activeView()).toBe('pushup');
+
+      component.onTabIndexChange(0);
+      expect(component.store.activeView()).toBe('overview');
+    });
+
+    it('maps activeView back to the matching tab index for the mat-tab-group binding', () => {
+      const component = fixture.componentInstance;
+      component.store.setActiveView('pushup');
+      expect(component.selectedTabIndex()).toBe(1);
+      component.store.setActiveView('overview');
+      expect(component.selectedTabIndex()).toBe(0);
+    });
+
+    it('falls back to Overview when activeView points at a tab that is not visible', () => {
+      // The seeded dataset only has pushup entries, so the abs/legs/plank
+      // tabs never render. Pointing activeView at one of them — e.g. via
+      // a stale `?view=plank` deep link — must surface index 0 rather
+      // than leaving the binding referencing an out-of-range slot.
+      const component = fixture.componentInstance;
+      component.store.setActiveView('plank');
+      fixture.detectChanges();
+      expect(component.visibleTabs().some((t) => t.id === 'plank')).toBe(false);
+      expect(component.selectedTabIndex()).toBe(0);
+    });
+
+    it('selecting an overview card emits the category and switches the active view', () => {
+      const component = fixture.componentInstance;
+      component.onOverviewSelect('pushup');
+      expect(component.store.activeView()).toBe('pushup');
+    });
+
+    it('renders a mat-tab-group with the Overview tab plus the visible categories', () => {
+      fixture.detectChanges();
+      const host: HTMLElement = fixture.nativeElement;
+      const tabGroup = host.querySelector('[data-testid="analysis-tabs"]');
+      expect(tabGroup).toBeTruthy();
+      const overviewTab = host.querySelector(
+        '[data-testid="analysis-tab-overview"]'
+      );
+      const pushupTab = host.querySelector(
+        '[data-testid="analysis-tab-pushup"]'
+      );
+      expect(overviewTab).toBeTruthy();
+      expect(pushupTab).toBeTruthy();
+    });
   });
 });
 

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -255,10 +255,10 @@ describe('AnalysisPageComponent', () => {
     expect(nextDay.getDate()).toBe(1);
   });
 
-  // NOTE: DOM-level tests for the group-view (trends section ordering,
-  // heatmap toggle position, kind-id localisation) live in
-  // `analysis-group-view.component.spec.ts` — they need the group-view
-  // rendered without mat-tab's lazy body template, which doesn't
+  // NOTE: DOM-level group-view tests (trend section ordering, heatmap
+  // toggle position, kind-id localisation via `typeBreakdownDisplay`)
+  // live in `analysis-group-view.component.spec.ts`. They render the
+  // group-view directly because mat-tab's lazy body template doesn't
   // hydrate reliably under PLATFORM_ID=server in jsdom.
 
   it('computes type breakdown, treating missing type as Standard', () => {

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -111,9 +111,19 @@ interface VisibleTab {
               <mat-icon aria-hidden="true">dashboard</mat-icon>
               <span i18n="@@analysis.tabs.overview">Übersicht</span>
             </ng-template>
-            <div class="tab-body">
-              <app-analysis-overview (viewSelect)="onOverviewSelect($event)" />
-            </div>
+            <!--
+              matTabContent defers per-tab instantiation until that tab is
+              actually selected, so visiting /analysis with N visible
+              categories doesn't construct N copies of analysis-group-view
+              up front (charts, tables, computeds).
+            -->
+            <ng-template matTabContent>
+              <div class="tab-body">
+                <app-analysis-overview
+                  (viewSelect)="onOverviewSelect($event)"
+                />
+              </div>
+            </ng-template>
           </mat-tab>
           @for (tab of visibleTabs(); track tab.id) {
             <mat-tab [attr.data-testid]="'analysis-tab-' + tab.id">
@@ -121,9 +131,11 @@ interface VisibleTab {
                 <mat-icon aria-hidden="true">{{ tab.icon }}</mat-icon>
                 <span>{{ tab.label }}</span>
               </ng-template>
-              <div class="tab-body">
-                <app-analysis-group-view />
-              </div>
+              <ng-template matTabContent>
+                <div class="tab-body">
+                  <app-analysis-group-view />
+                </div>
+              </ng-template>
             </mat-tab>
           }
         </mat-tab-group>

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -10,22 +10,32 @@ import {
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSelectModule } from '@angular/material/select';
+import { MatTabsModule } from '@angular/material/tabs';
 import { RouterLink } from '@angular/router';
-import { createWeekRange, UnifiedEntryFilterKey } from '@pu-stats/models';
+import {
+  createWeekRange,
+  type ExerciseCategoryId,
+  EXERCISE_CATEGORIES,
+} from '@pu-stats/models';
 import { LiveDataStore } from '@pu-stats/data-access';
 import { FilterBarComponent } from '../components/filter-bar/filter-bar.component';
 import { PreviewBannerComponent } from '../components/preview-banner/preview-banner.component';
-import { AnalysisStore } from '../analysis.store';
-import { kindDisplayName } from '../i18n/exercise-display-names';
+import { AnalysisStore, type AnalysisView } from '../analysis.store';
+import { categoryDisplayName } from '../i18n/exercise-display-names';
 import { PageHeaderComponent } from '../../core/page-header/page-header.component';
 import { AnalysisGroupViewComponent } from './analysis-group-view.component';
+import { AnalysisOverviewComponent } from './analysis-overview.component';
 
-interface ExerciseKindOption {
-  value: UnifiedEntryFilterKey;
+const VALID_VIEWS: ReadonlySet<AnalysisView> = new Set<AnalysisView>([
+  'overview',
+  ...EXERCISE_CATEGORIES.map((c) => c.id),
+]);
+
+interface VisibleTab {
+  id: ExerciseCategoryId;
   label: string;
+  icon: string;
 }
 
 @Component({
@@ -34,11 +44,11 @@ interface ExerciseKindOption {
   imports: [
     MatButtonModule,
     MatCardModule,
-    MatFormFieldModule,
     MatIconModule,
-    MatSelectModule,
+    MatTabsModule,
     RouterLink,
     AnalysisGroupViewComponent,
+    AnalysisOverviewComponent,
     FilterBarComponent,
     PageHeaderComponent,
     PreviewBannerComponent,
@@ -61,28 +71,6 @@ interface ExerciseKindOption {
           (fromChange)="store.setFrom($event)"
           (toChange)="store.setTo($event)"
         />
-
-        @if (showKindFilter()) {
-          <mat-form-field
-            class="kind-filter"
-            appearance="outline"
-            subscriptSizing="dynamic"
-          >
-            <mat-label i18n="@@analysis.exerciseFilter">Übung</mat-label>
-            <mat-select
-              multiple
-              [value]="store.kinds()"
-              (valueChange)="store.setKinds($event)"
-              data-testid="analysis-kind-filter"
-            >
-              @for (option of kindFilterOptions(); track option.value) {
-                <mat-option [value]="option.value">{{
-                  option.label
-                }}</mat-option>
-              }
-            </mat-select>
-          </mat-form-field>
-        }
       </section>
 
       @if (showEmptyCta()) {
@@ -110,9 +98,36 @@ interface ExerciseKindOption {
             </a>
           </mat-card-content>
         </mat-card>
+      } @else {
+        <mat-tab-group
+          class="analysis-tabs"
+          [selectedIndex]="selectedTabIndex()"
+          (selectedIndexChange)="onTabIndexChange($event)"
+          mat-align-tabs="start"
+          data-testid="analysis-tabs"
+        >
+          <mat-tab data-testid="analysis-tab-overview">
+            <ng-template mat-tab-label>
+              <mat-icon aria-hidden="true">dashboard</mat-icon>
+              <span i18n="@@analysis.tabs.overview">Übersicht</span>
+            </ng-template>
+            <div class="tab-body">
+              <app-analysis-overview (viewSelect)="onOverviewSelect($event)" />
+            </div>
+          </mat-tab>
+          @for (tab of visibleTabs(); track tab.id) {
+            <mat-tab [attr.data-testid]="'analysis-tab-' + tab.id">
+              <ng-template mat-tab-label>
+                <mat-icon aria-hidden="true">{{ tab.icon }}</mat-icon>
+                <span>{{ tab.label }}</span>
+              </ng-template>
+              <div class="tab-body">
+                <app-analysis-group-view />
+              </div>
+            </mat-tab>
+          }
+        </mat-tab-group>
       }
-
-      <app-analysis-group-view />
     </main>
   `,
   styles: `
@@ -187,6 +202,24 @@ interface ExerciseKindOption {
     .empty-cta a {
       margin-left: auto;
     }
+
+    .analysis-tabs {
+      width: 100%;
+    }
+    .analysis-tabs ::ng-deep .mat-mdc-tab-label-container {
+      border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    }
+    .tab-body {
+      display: grid;
+      gap: 16px;
+      padding: 16px 0;
+    }
+    @media (max-width: 900px) {
+      .tab-body {
+        gap: 12px;
+        padding: 12px 0;
+      }
+    }
   `,
 })
 export class AnalysisPageComponent {
@@ -199,43 +232,31 @@ export class AnalysisPageComponent {
   } | null;
 
   /**
-   * Multi-select options for the "Übung" filter on the analysis page.
-   * Mirrors the pattern in `EntriesPageComponent.kindFilterOptions` —
-   * the store exposes the raw filter keys; `$localize` lives here in the
-   * component layer so the per-locale bundle baking still works.
-   *
-   * Currently-selected kinds are merged in even when they no longer
-   * appear in the visible date range, so the user can always see and
-   * deselect a stale filter (e.g. after narrowing the range past the
-   * last entry of that kind). Without this, `mat-select` would render a
-   * chip with no matching `mat-option` and the dropdown would dead-end.
+   * Categories that have at least one entry in the active date range.
+   * Mirrors `categorySummaries` because both consume the same per-range
+   * roll-up, so a card in the overview always matches a tab here.
    */
-  readonly kindFilterOptions = computed<ExerciseKindOption[]>(() => {
-    const seen = new Set<UnifiedEntryFilterKey>();
-    const merged: UnifiedEntryFilterKey[] = [];
-    for (const k of this.store.kindOptionsRaw()) {
-      if (seen.has(k)) continue;
-      seen.add(k);
-      merged.push(k);
-    }
-    for (const k of this.store.kinds()) {
-      if (seen.has(k)) continue;
-      seen.add(k);
-      merged.push(k);
-    }
-    return merged.map((value) => ({
-      value,
-      label: kindDisplayName(value),
-    }));
-  });
+  readonly visibleTabs = computed<VisibleTab[]>(() =>
+    this.store.categorySummaries().map((s) => ({
+      id: s.categoryId,
+      label: categoryDisplayName(s.categoryId),
+      icon: s.icon,
+    }))
+  );
 
-  // Hidden for pure-pushup ranges to keep the default page minimal,
-  // but always visible when a kind is selected so the user can clear it.
-  // Reads the raw keys directly so visibility doesn't trigger label
-  // resolution / `$localize`.
-  readonly showKindFilter = computed(() => {
-    if (this.store.kinds().length > 0) return true;
-    return this.store.kindOptionsRaw().some((k) => k !== 'pushup');
+  /**
+   * Overview is index 0; category tabs follow in `visibleTabs` order.
+   * When the active view points at a category that isn't visible (e.g.
+   * the user narrowed the range past its last entry, or arrived via a
+   * stale deep link), we surface the Overview tab rather than leave the
+   * group falsely selected — the category will reappear once the range
+   * widens again, which also brings its data back.
+   */
+  readonly selectedTabIndex = computed<number>(() => {
+    const view = this.store.activeView();
+    if (view === 'overview') return 0;
+    const idx = this.visibleTabs().findIndex((t) => t.id === view);
+    return idx < 0 ? 0 : idx + 1;
   });
 
   /**
@@ -250,10 +271,6 @@ export class AnalysisPageComponent {
     if (this.store.entriesResource.status() !== 'resolved') return false;
     if (this.store.weekEntriesResource.status() !== 'resolved') return false;
     if (this.store.monthEntriesResource.status() !== 'resolved') return false;
-    // Pre-merge: `rows()` is the pushup REST resource only. A range
-    // that contains only exercise entries would otherwise still flash
-    // the empty CTA even though the group view renders charts. Reading
-    // `unifiedRows()` mirrors what the rest of the page sees.
     if (this.store.unifiedRows().length > 0) return false;
     if (this.store.weekTrend().some((t) => t.total > 0)) return false;
     if (this.store.monthTrend().some((t) => t.total > 0)) return false;
@@ -264,11 +281,12 @@ export class AnalysisPageComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   constructor() {
-    // Resolve initial range from URL query params (SSR-aware)
-    const initialRange = this.resolveInitialRange();
-    this.store.setRange(initialRange.from, initialRange.to);
+    const initial = this.resolveInitialParams();
+    this.store.setRange(initial.from, initial.to);
+    if (initial.view !== 'overview') {
+      this.store.setActiveView(initial.view);
+    }
 
-    // Reload stats when live data changes (new entries via websocket)
     effect(() => {
       if (!isPlatformBrowser(this.platformId)) return;
       const tick = this.live.updateTick();
@@ -276,23 +294,20 @@ export class AnalysisPageComponent {
       this.store.refreshAll();
     });
 
-    // Bump the store clock every 5 minutes so the fixed-window trend
-    // filters re-evaluate when the calendar day rolls over during a
-    // long-running session. Cleared on component destroy to keep tests
-    // and SSR free of leaking timers.
     if (isPlatformBrowser(this.platformId)) {
       const interval = setInterval(() => this.store.tickClock(), 5 * 60 * 1000);
       this.destroyRef.onDestroy(() => clearInterval(interval));
     }
 
-    // URL history tracking effect (UI side effect, stays in component)
     effect(() => {
       if (!isPlatformBrowser(this.platformId)) return;
       const params = new URLSearchParams();
       const from = this.store.from();
       const to = this.store.to();
+      const view = this.store.activeView();
       if (from) params.set('from', from);
       if (to) params.set('to', to);
+      if (view !== 'overview') params.set('view', view);
 
       const query = params.toString();
       const nextUrl = `${this.document.location.pathname}${query ? `?${query}` : ''}`;
@@ -300,13 +315,39 @@ export class AnalysisPageComponent {
     });
   }
 
-  private resolveInitialRange(): { from: string; to: string } {
+  onTabIndexChange(index: number): void {
+    if (index <= 0) {
+      this.store.setActiveView('overview');
+      return;
+    }
+    const tab = this.visibleTabs()[index - 1];
+    if (!tab) {
+      this.store.setActiveView('overview');
+      return;
+    }
+    this.store.setActiveView(tab.id);
+  }
+
+  onOverviewSelect(categoryId: ExerciseCategoryId): void {
+    this.store.setActiveView(categoryId);
+  }
+
+  private resolveInitialParams(): {
+    from: string;
+    to: string;
+    view: AnalysisView;
+  } {
     const defaultRange = createWeekRange();
     const search = this.resolveSearchString();
     const params = new URLSearchParams(search);
     const from = params.get('from') ?? defaultRange.from;
     const to = params.get('to') ?? defaultRange.to;
-    return { from, to };
+    const viewParam = params.get('view');
+    const view: AnalysisView =
+      viewParam && VALID_VIEWS.has(viewParam as AnalysisView)
+        ? (viewParam as AnalysisView)
+        : 'overview';
+    return { from, to, view };
   }
 
   private resolveSearchString(): string {

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -7432,73 +7432,79 @@
     <unit id="analysis.tabs.overview">
       <segment state="translated">
         <source/>
-        <target>Overview</target>
+        <target>Επισκόπηση</target>
       </segment>
     </unit>
     <unit id="analysis.overview.empty">
       <segment state="translated">
         <source/>
-        <target>No entries in the current date range yet.</target>
+        <target>Δεν υπάρχουν ακόμη καταχωρίσεις στο τρέχον εύρος ημερομηνιών.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.uncategorisedNotice">
+      <segment state="translated">
+        <source/>
+        <target>Αυτές οι καταχωρίσεις δεν ανήκουν σε καμία γνωστή κατηγορία — σύνολο παρακάτω.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
         <source/>
-        <target>Comparison by exercise group</target>
+        <target>Σύγκριση ανά ομάδα ασκήσεων</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metricAria">
       <segment state="translated">
         <source/>
-        <target>Metric</target>
+        <target>Μέγεθος</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.reps">
       <segment state="translated">
         <source/>
-        <target>Reps</target>
+        <target>Επαναλήψεις</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.sets">
       <segment state="translated">
         <source/>
-        <target>Sets</target>
+        <target>Σετ</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
-        <target>No data in the current date range.</target>
+        <target>Δεν υπάρχουν δεδομένα στο τρέχον εύρος ημερομηνιών.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalReps">
       <segment state="translated">
         <source/>
-        <target>Total reps</target>
+        <target>Συνολικές επαναλήψεις</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <segment state="translated">
         <source/>
-        <target>Today</target>
+        <target>Σήμερα</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
         <source/>
-        <target>Streak</target>
+        <target>Σερί</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">
       <segment state="translated">
         <source/>
-        <target>Best day</target>
+        <target>Καλύτερη ημέρα</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <segment state="translated">
         <source/>
-        <target>View details</target>
+        <target>Προβολή λεπτομερειών</target>
       </segment>
     </unit>
     <unit id="entries.empty.title">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -7429,6 +7429,78 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Επιλογή προγράμματος προπόνησης </target>
       </segment>
     </unit>
+    <unit id="analysis.tabs.overview">
+      <segment state="translated">
+        <source/>
+        <target>Overview</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.empty">
+      <segment state="translated">
+        <source/>
+        <target>No entries in the current date range yet.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.title">
+      <segment state="translated">
+        <source/>
+        <target>Comparison by exercise group</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricAria">
+      <segment state="translated">
+        <source/>
+        <target>Metric</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.reps">
+      <segment state="translated">
+        <source/>
+        <target>Reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.sets">
+      <segment state="translated">
+        <source/>
+        <target>Sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.empty">
+      <segment state="translated">
+        <source/>
+        <target>No data in the current date range.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalReps">
+      <segment state="translated">
+        <source/>
+        <target>Total reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayReps">
+      <segment state="translated">
+        <source/>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.streak">
+      <segment state="translated">
+        <source/>
+        <target>Streak</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <segment state="translated">
+        <source/>
+        <target>Best day</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.viewDetails">
+      <segment state="translated">
+        <source/>
+        <target>View details</target>
+      </segment>
+    </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
         <source/>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -7699,6 +7699,12 @@ Deine Position: # ·  Reps        </source>
         <target>No entries in the current date range yet.</target>
       </segment>
     </unit>
+    <unit id="analysis.overview.uncategorisedNotice">
+      <segment state="translated">
+        <source/>
+        <target>These entries don't belong to a known category — aggregate below.</target>
+      </segment>
+    </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
         <source/>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -7687,6 +7687,78 @@ Deine Position: # ·  Reps        </source>
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Pick a training plan</target>
       </segment>
     </unit>
+    <unit id="analysis.tabs.overview">
+      <segment state="translated">
+        <source/>
+        <target>Overview</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.empty">
+      <segment state="translated">
+        <source/>
+        <target>No entries in the current date range yet.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.title">
+      <segment state="translated">
+        <source/>
+        <target>Comparison by exercise group</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricAria">
+      <segment state="translated">
+        <source/>
+        <target>Metric</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.reps">
+      <segment state="translated">
+        <source/>
+        <target>Reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.sets">
+      <segment state="translated">
+        <source/>
+        <target>Sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.empty">
+      <segment state="translated">
+        <source/>
+        <target>No data in the current date range.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalReps">
+      <segment state="translated">
+        <source/>
+        <target>Total reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayReps">
+      <segment state="translated">
+        <source/>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.streak">
+      <segment state="translated">
+        <source/>
+        <target>Streak</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <segment state="translated">
+        <source/>
+        <target>Best day</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.viewDetails">
+      <segment state="translated">
+        <source/>
+        <target>View details</target>
+      </segment>
+    </unit>
     <unit id="dashboard.allTimeBadges.cta">
       <segment state="translated">
         <source/>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -7429,6 +7429,78 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Elegir plan de entrenamiento </target>
       </segment>
     </unit>
+    <unit id="analysis.tabs.overview">
+      <segment state="translated">
+        <source/>
+        <target>Overview</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.empty">
+      <segment state="translated">
+        <source/>
+        <target>No entries in the current date range yet.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.title">
+      <segment state="translated">
+        <source/>
+        <target>Comparison by exercise group</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricAria">
+      <segment state="translated">
+        <source/>
+        <target>Metric</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.reps">
+      <segment state="translated">
+        <source/>
+        <target>Reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.sets">
+      <segment state="translated">
+        <source/>
+        <target>Sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.empty">
+      <segment state="translated">
+        <source/>
+        <target>No data in the current date range.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalReps">
+      <segment state="translated">
+        <source/>
+        <target>Total reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayReps">
+      <segment state="translated">
+        <source/>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.streak">
+      <segment state="translated">
+        <source/>
+        <target>Streak</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <segment state="translated">
+        <source/>
+        <target>Best day</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.viewDetails">
+      <segment state="translated">
+        <source/>
+        <target>View details</target>
+      </segment>
+    </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
         <source/>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -7432,73 +7432,79 @@
     <unit id="analysis.tabs.overview">
       <segment state="translated">
         <source/>
-        <target>Overview</target>
+        <target>Resumen</target>
       </segment>
     </unit>
     <unit id="analysis.overview.empty">
       <segment state="translated">
         <source/>
-        <target>No entries in the current date range yet.</target>
+        <target>Aún no hay entradas en el rango de fechas actual.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.uncategorisedNotice">
+      <segment state="translated">
+        <source/>
+        <target>Estas entradas no pertenecen a ninguna categoría conocida — agregado abajo.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
         <source/>
-        <target>Comparison by exercise group</target>
+        <target>Comparación por grupo de ejercicios</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metricAria">
       <segment state="translated">
         <source/>
-        <target>Metric</target>
+        <target>Métrica</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.reps">
       <segment state="translated">
         <source/>
-        <target>Reps</target>
+        <target>Repeticiones</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.sets">
       <segment state="translated">
         <source/>
-        <target>Sets</target>
+        <target>Series</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
-        <target>No data in the current date range.</target>
+        <target>No hay datos en el rango de fechas actual.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalReps">
       <segment state="translated">
         <source/>
-        <target>Total reps</target>
+        <target>Repeticiones totales</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <segment state="translated">
         <source/>
-        <target>Today</target>
+        <target>Hoy</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
         <source/>
-        <target>Streak</target>
+        <target>Racha</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">
       <segment state="translated">
         <source/>
-        <target>Best day</target>
+        <target>Mejor día</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <segment state="translated">
         <source/>
-        <target>View details</target>
+        <target>Ver detalles</target>
       </segment>
     </unit>
     <unit id="entries.empty.title">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -7429,6 +7429,78 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Choisir un plan d'entraînement </target>
       </segment>
     </unit>
+    <unit id="analysis.tabs.overview">
+      <segment state="translated">
+        <source/>
+        <target>Overview</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.empty">
+      <segment state="translated">
+        <source/>
+        <target>No entries in the current date range yet.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.title">
+      <segment state="translated">
+        <source/>
+        <target>Comparison by exercise group</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricAria">
+      <segment state="translated">
+        <source/>
+        <target>Metric</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.reps">
+      <segment state="translated">
+        <source/>
+        <target>Reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.sets">
+      <segment state="translated">
+        <source/>
+        <target>Sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.empty">
+      <segment state="translated">
+        <source/>
+        <target>No data in the current date range.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalReps">
+      <segment state="translated">
+        <source/>
+        <target>Total reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayReps">
+      <segment state="translated">
+        <source/>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.streak">
+      <segment state="translated">
+        <source/>
+        <target>Streak</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <segment state="translated">
+        <source/>
+        <target>Best day</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.viewDetails">
+      <segment state="translated">
+        <source/>
+        <target>View details</target>
+      </segment>
+    </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
         <source/>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -7432,73 +7432,79 @@
     <unit id="analysis.tabs.overview">
       <segment state="translated">
         <source/>
-        <target>Overview</target>
+        <target>Aperçu</target>
       </segment>
     </unit>
     <unit id="analysis.overview.empty">
       <segment state="translated">
         <source/>
-        <target>No entries in the current date range yet.</target>
+        <target>Aucune entrée dans la plage de dates actuelle.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.uncategorisedNotice">
+      <segment state="translated">
+        <source/>
+        <target>Ces entrées n'appartiennent à aucune catégorie connue — agrégat ci-dessous.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
         <source/>
-        <target>Comparison by exercise group</target>
+        <target>Comparaison par groupe d'exercices</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metricAria">
       <segment state="translated">
         <source/>
-        <target>Metric</target>
+        <target>Métrique</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.reps">
       <segment state="translated">
         <source/>
-        <target>Reps</target>
+        <target>Répétitions</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.sets">
       <segment state="translated">
         <source/>
-        <target>Sets</target>
+        <target>Séries</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
-        <target>No data in the current date range.</target>
+        <target>Aucune donnée dans la plage de dates actuelle.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalReps">
       <segment state="translated">
         <source/>
-        <target>Total reps</target>
+        <target>Total des répétitions</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <segment state="translated">
         <source/>
-        <target>Today</target>
+        <target>Aujourd'hui</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
         <source/>
-        <target>Streak</target>
+        <target>Série</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">
       <segment state="translated">
         <source/>
-        <target>Best day</target>
+        <target>Meilleur jour</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <segment state="translated">
         <source/>
-        <target>View details</target>
+        <target>Voir les détails</target>
       </segment>
     </unit>
     <unit id="entries.empty.title">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -7429,6 +7429,78 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Scegli piano di allenamento </target>
       </segment>
     </unit>
+    <unit id="analysis.tabs.overview">
+      <segment state="translated">
+        <source/>
+        <target>Overview</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.empty">
+      <segment state="translated">
+        <source/>
+        <target>No entries in the current date range yet.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.title">
+      <segment state="translated">
+        <source/>
+        <target>Comparison by exercise group</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricAria">
+      <segment state="translated">
+        <source/>
+        <target>Metric</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.reps">
+      <segment state="translated">
+        <source/>
+        <target>Reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.sets">
+      <segment state="translated">
+        <source/>
+        <target>Sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.empty">
+      <segment state="translated">
+        <source/>
+        <target>No data in the current date range.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalReps">
+      <segment state="translated">
+        <source/>
+        <target>Total reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayReps">
+      <segment state="translated">
+        <source/>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.streak">
+      <segment state="translated">
+        <source/>
+        <target>Streak</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <segment state="translated">
+        <source/>
+        <target>Best day</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.viewDetails">
+      <segment state="translated">
+        <source/>
+        <target>View details</target>
+      </segment>
+    </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
         <source/>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -7432,73 +7432,79 @@
     <unit id="analysis.tabs.overview">
       <segment state="translated">
         <source/>
-        <target>Overview</target>
+        <target>Panoramica</target>
       </segment>
     </unit>
     <unit id="analysis.overview.empty">
       <segment state="translated">
         <source/>
-        <target>No entries in the current date range yet.</target>
+        <target>Nessuna voce nell'intervallo di date selezionato.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.uncategorisedNotice">
+      <segment state="translated">
+        <source/>
+        <target>Queste voci non appartengono a nessuna categoria nota — aggregato qui sotto.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
         <source/>
-        <target>Comparison by exercise group</target>
+        <target>Confronto per gruppo di esercizi</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metricAria">
       <segment state="translated">
         <source/>
-        <target>Metric</target>
+        <target>Metrica</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.reps">
       <segment state="translated">
         <source/>
-        <target>Reps</target>
+        <target>Ripetizioni</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.sets">
       <segment state="translated">
         <source/>
-        <target>Sets</target>
+        <target>Serie</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
-        <target>No data in the current date range.</target>
+        <target>Nessun dato nell'intervallo di date selezionato.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalReps">
       <segment state="translated">
         <source/>
-        <target>Total reps</target>
+        <target>Ripetizioni totali</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <segment state="translated">
         <source/>
-        <target>Today</target>
+        <target>Oggi</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
         <source/>
-        <target>Streak</target>
+        <target>Serie consecutiva</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">
       <segment state="translated">
         <source/>
-        <target>Best day</target>
+        <target>Miglior giorno</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <segment state="translated">
         <source/>
-        <target>View details</target>
+        <target>Visualizza dettagli</target>
       </segment>
     </unit>
     <unit id="entries.empty.title">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -7441,6 +7441,12 @@
         <target>No entries in the current date range yet.</target>
       </segment>
     </unit>
+    <unit id="analysis.overview.uncategorisedNotice">
+      <segment state="translated">
+        <source/>
+        <target>These entries don't belong to a known category — aggregate below.</target>
+      </segment>
+    </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
         <source/>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -7429,6 +7429,78 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Exercitii consilium eligere </target>
       </segment>
     </unit>
+    <unit id="analysis.tabs.overview">
+      <segment state="translated">
+        <source/>
+        <target>Overview</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.empty">
+      <segment state="translated">
+        <source/>
+        <target>No entries in the current date range yet.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.title">
+      <segment state="translated">
+        <source/>
+        <target>Comparison by exercise group</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricAria">
+      <segment state="translated">
+        <source/>
+        <target>Metric</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.reps">
+      <segment state="translated">
+        <source/>
+        <target>Reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.sets">
+      <segment state="translated">
+        <source/>
+        <target>Sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.empty">
+      <segment state="translated">
+        <source/>
+        <target>No data in the current date range.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalReps">
+      <segment state="translated">
+        <source/>
+        <target>Total reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayReps">
+      <segment state="translated">
+        <source/>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.streak">
+      <segment state="translated">
+        <source/>
+        <target>Streak</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <segment state="translated">
+        <source/>
+        <target>Best day</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.viewDetails">
+      <segment state="translated">
+        <source/>
+        <target>View details</target>
+      </segment>
+    </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
         <source/>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -7444,7 +7444,7 @@
     <unit id="analysis.overview.uncategorisedNotice">
       <segment state="translated">
         <source/>
-        <target>These entries don't belong to a known category — aggregate below.</target>
+        <target>These entries don't belong to a known category — shown in aggregate below.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -7432,31 +7432,37 @@
     <unit id="analysis.tabs.overview">
       <segment state="translated">
         <source/>
-        <target>Overview</target>
+        <target>Overzicht</target>
       </segment>
     </unit>
     <unit id="analysis.overview.empty">
       <segment state="translated">
         <source/>
-        <target>No entries in the current date range yet.</target>
+        <target>Nog geen invoer in het huidige datumbereik.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.uncategorisedNotice">
+      <segment state="translated">
+        <source/>
+        <target>Deze invoer hoort niet bij een bekende categorie — totaal hieronder.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
         <source/>
-        <target>Comparison by exercise group</target>
+        <target>Vergelijking per oefeningsgroep</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metricAria">
       <segment state="translated">
         <source/>
-        <target>Metric</target>
+        <target>Eenheid</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.reps">
       <segment state="translated">
         <source/>
-        <target>Reps</target>
+        <target>Herhalingen</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.sets">
@@ -7468,37 +7474,37 @@
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
-        <target>No data in the current date range.</target>
+        <target>Geen gegevens in het huidige datumbereik.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalReps">
       <segment state="translated">
         <source/>
-        <target>Total reps</target>
+        <target>Totaal herhalingen</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <segment state="translated">
         <source/>
-        <target>Today</target>
+        <target>Vandaag</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
         <source/>
-        <target>Streak</target>
+        <target>Reeks</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">
       <segment state="translated">
         <source/>
-        <target>Best day</target>
+        <target>Beste dag</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <segment state="translated">
         <source/>
-        <target>View details</target>
+        <target>Details bekijken</target>
       </segment>
     </unit>
     <unit id="entries.empty.title">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -7429,6 +7429,78 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Trainingsplan kiezen </target>
       </segment>
     </unit>
+    <unit id="analysis.tabs.overview">
+      <segment state="translated">
+        <source/>
+        <target>Overview</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.empty">
+      <segment state="translated">
+        <source/>
+        <target>No entries in the current date range yet.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.title">
+      <segment state="translated">
+        <source/>
+        <target>Comparison by exercise group</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricAria">
+      <segment state="translated">
+        <source/>
+        <target>Metric</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.reps">
+      <segment state="translated">
+        <source/>
+        <target>Reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.sets">
+      <segment state="translated">
+        <source/>
+        <target>Sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.empty">
+      <segment state="translated">
+        <source/>
+        <target>No data in the current date range.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalReps">
+      <segment state="translated">
+        <source/>
+        <target>Total reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayReps">
+      <segment state="translated">
+        <source/>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.streak">
+      <segment state="translated">
+        <source/>
+        <target>Streak</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <segment state="translated">
+        <source/>
+        <target>Best day</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.viewDetails">
+      <segment state="translated">
+        <source/>
+        <target>View details</target>
+      </segment>
+    </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
         <source/>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -6707,7 +6707,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="analysis.overview.uncategorisedNotice">
       <segment state="translated">
         <source/>
-        <target>Disse oppføringene tilhører ingen kjent kategori — aggregat under.</target>
+        <target>Disse oppføringene tilhører ingen kjent kategori — aggregert nedenfor.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -6692,6 +6692,78 @@ Deine Position: # ·  Reps        </source>
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Velg treningsplan </target>
       </segment>
     </unit>
+    <unit id="analysis.tabs.overview">
+      <segment state="translated">
+        <source/>
+        <target>Overview</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.empty">
+      <segment state="translated">
+        <source/>
+        <target>No entries in the current date range yet.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.title">
+      <segment state="translated">
+        <source/>
+        <target>Comparison by exercise group</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricAria">
+      <segment state="translated">
+        <source/>
+        <target>Metric</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.reps">
+      <segment state="translated">
+        <source/>
+        <target>Reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.sets">
+      <segment state="translated">
+        <source/>
+        <target>Sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.empty">
+      <segment state="translated">
+        <source/>
+        <target>No data in the current date range.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalReps">
+      <segment state="translated">
+        <source/>
+        <target>Total reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayReps">
+      <segment state="translated">
+        <source/>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.streak">
+      <segment state="translated">
+        <source/>
+        <target>Streak</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <segment state="translated">
+        <source/>
+        <target>Best day</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.viewDetails">
+      <segment state="translated">
+        <source/>
+        <target>View details</target>
+      </segment>
+    </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
         <source/>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -6695,73 +6695,79 @@ Deine Position: # ·  Reps        </source>
     <unit id="analysis.tabs.overview">
       <segment state="translated">
         <source/>
-        <target>Overview</target>
+        <target>Oversikt</target>
       </segment>
     </unit>
     <unit id="analysis.overview.empty">
       <segment state="translated">
         <source/>
-        <target>No entries in the current date range yet.</target>
+        <target>Ingen oppføringer i valgt datointervall ennå.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.uncategorisedNotice">
+      <segment state="translated">
+        <source/>
+        <target>Disse oppføringene tilhører ingen kjent kategori — aggregat under.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
         <source/>
-        <target>Comparison by exercise group</target>
+        <target>Sammenligning etter øvelsesgruppe</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metricAria">
       <segment state="translated">
         <source/>
-        <target>Metric</target>
+        <target>Måleverdi</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.reps">
       <segment state="translated">
         <source/>
-        <target>Reps</target>
+        <target>Repetisjoner</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.sets">
       <segment state="translated">
         <source/>
-        <target>Sets</target>
+        <target>Sett</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
-        <target>No data in the current date range.</target>
+        <target>Ingen data i valgt datointervall.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalReps">
       <segment state="translated">
         <source/>
-        <target>Total reps</target>
+        <target>Totale repetisjoner</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <segment state="translated">
         <source/>
-        <target>Today</target>
+        <target>I dag</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
         <source/>
-        <target>Streak</target>
+        <target>Serie</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">
       <segment state="translated">
         <source/>
-        <target>Best day</target>
+        <target>Beste dag</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <segment state="translated">
         <source/>
-        <target>View details</target>
+        <target>Vis detaljer</target>
       </segment>
     </unit>
     <unit id="entries.empty.title">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4224,7 +4224,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:40,41</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:44,45</note>
       </notes>
       <segment>
         <source>Analyse öffnen</source>
@@ -4232,7 +4232,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:45,47</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:49,51</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -4240,7 +4240,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserStreak">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:49,50</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:53,54</note>
       </notes>
       <segment>
         <source>Streak: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}"/> Tage</source>
@@ -4248,7 +4248,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserWeekReps">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:53,55</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:57,59</note>
       </notes>
       <segment>
         <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> Reps</source>
@@ -4256,7 +4256,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserError">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:61,63</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:65,67</note>
       </notes>
       <segment>
         <source> Daten konnten nicht geladen werden. </source>
@@ -4264,7 +4264,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:78,79</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:83,84</note>
       </notes>
       <segment>
         <source>Zur Analyse navigieren</source>
@@ -4272,10 +4272,121 @@
     </unit>
     <unit id="dashboard.analysisTeaserCta">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:82,84</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:87,89</note>
       </notes>
       <segment>
         <source>Zur Analyse</source>
+      </segment>
+    </unit>
+    <unit id="chart.kindLabel.all">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:142</note>
+      </notes>
+      <segment>
+        <source>Alle Übungen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <notes>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:147</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:200</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1093</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:46</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:76</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:277</note>
+      </notes>
+      <segment>
+        <source>Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.title">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:26,28</note>
+      </notes>
+      <segment>
+        <source> Vergleich nach Übungsgruppe </source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:31,32</note>
+      </notes>
+      <segment>
+        <source>Kennzahl</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.reps">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:39,41</note>
+      </notes>
+      <segment>
+        <source> Wdh. </source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.sets">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:45,47</note>
+      </notes>
+      <segment>
+        <source> Sätze </source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.empty">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:56,59</note>
+      </notes>
+      <segment>
+        <source> Keine Daten im aktuellen Zeitraum. </source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalReps">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:34,36</note>
+      </notes>
+      <segment>
+        <source>Reps gesamt</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayReps">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:44,45</note>
+      </notes>
+      <segment>
+        <source>Heute</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.streak">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:48,50</note>
+      </notes>
+      <segment>
+        <source>Streak</source>
+      </segment>
+    </unit>
+    <unit id="analysis.streakDays">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:51,52</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:81,82</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:89,90</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ summary().currentStreak }}"/> Tage</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:56,57</note>
+      </notes>
+      <segment>
+        <source>Bester Tag</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.viewDetails">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:75,78</note>
+      </notes>
+      <segment>
+        <source>Details ansehen</source>
       </segment>
     </unit>
     <unit id="selectRangeTitle">
@@ -4729,7 +4840,7 @@
     <unit id="chart.interval">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:78,79</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:126</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:140</note>
       </notes>
       <segment>
         <source>Intervallwert</source>
@@ -4738,7 +4849,7 @@
     <unit id="chart.dayIntegral">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:84,85</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:127</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:141</note>
       </notes>
       <segment>
         <source>Tages-Integral</source>
@@ -4747,7 +4858,7 @@
     <unit id="chart.movingAvg">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:90,91</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:128</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:142</note>
       </notes>
       <segment>
         <source>Gleitender Durchschnitt</source>
@@ -4756,7 +4867,7 @@
     <unit id="chart.withSets">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:97,98</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:154</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:168</note>
       </notes>
       <segment>
         <source>Mit Sets</source>
@@ -4764,7 +4875,7 @@
     </unit>
     <unit id="chart.titleHourly">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:124</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:132</note>
       </notes>
       <segment>
         <source>Verlauf (Stundenwerte)</source>
@@ -4772,23 +4883,15 @@
     </unit>
     <unit id="chart.titleDaily">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:125</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:133</note>
       </notes>
       <segment>
         <source>Verlauf (Tageswerte)</source>
       </segment>
     </unit>
-    <unit id="chart.kindLabel.all">
-      <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
-      </notes>
-      <segment>
-        <source>Alle Übungen</source>
-      </segment>
-    </unit>
     <unit id="chart.setsTooltip">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:153</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:167</note>
       </notes>
       <segment>
         <source>Sets</source>
@@ -4914,18 +5017,6 @@
       </notes>
       <segment>
         <source>Übung</source>
-      </segment>
-    </unit>
-    <unit id="exercise.category.pushup">
-      <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:200</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1093</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:46</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:76</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:277</note>
-      </notes>
-      <segment>
-        <source>Liegestütze</source>
       </segment>
     </unit>
     <unit id="editDialogTitle">
@@ -5422,15 +5513,6 @@
         <source>Aktuelle Streak:</source>
       </segment>
     </unit>
-    <unit id="analysis.streakDays">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:81,82</note>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:89,90</note>
-      </notes>
-      <segment>
-        <source><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}"/> Tage</source>
-      </segment>
-    </unit>
     <unit id="analysis.longestStreak">
       <notes>
         <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:86,88</note>
@@ -5569,9 +5651,17 @@
         <source>Monat</source>
       </segment>
     </unit>
+    <unit id="analysis.overview.empty">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-overview.component.ts:31,34</note>
+      </notes>
+      <segment>
+        <source> Im aktuellen Zeitraum gibt es noch keine Einträge. </source>
+      </segment>
+    </unit>
     <unit id="analysisHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:51,52</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:61,62</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -5579,23 +5669,15 @@
     </unit>
     <unit id="analysisHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:53,55</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:63,65</note>
       </notes>
       <segment>
         <source> Trends, Verteilungen und Streaks deines Trainings auf einen Blick. </source>
       </segment>
     </unit>
-    <unit id="analysis.exerciseFilter">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:71,73</note>
-      </notes>
-      <segment>
-        <source>Übung</source>
-      </segment>
-    </unit>
     <unit id="analysis.empty.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:94,96</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:82,84</note>
       </notes>
       <segment>
         <source>Noch keine Daten zum Analysieren.</source>
@@ -5603,7 +5685,7 @@
     </unit>
     <unit id="analysis.empty.body">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:97,99</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:85,87</note>
       </notes>
       <segment>
         <source> Starte einen Trainingsplan oder trage deinen ersten Satz ein — dann zeigen wir dir hier Trends und Streaks. </source>
@@ -5611,10 +5693,18 @@
     </unit>
     <unit id="analysis.empty.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:108,110</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:96,98</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Trainingsplan wählen </source>
+      </segment>
+    </unit>
+    <unit id="analysis.tabs.overview">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:112,114</note>
+      </notes>
+      <segment>
+        <source>Übersicht</source>
       </segment>
     </unit>
     <unit id="historyHeaderTitle">
@@ -6627,7 +6717,7 @@
     <unit id="trainingPlans.back">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:77</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:391,393</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:393,395</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -6816,7 +6906,7 @@
     </unit>
     <unit id="trainingPlans.menu.logDone">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:342,344</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:344,346</note>
       </notes>
       <segment>
         <source>Plan-Sätze eintragen &amp; abhaken</source>
@@ -6824,7 +6914,7 @@
     </unit>
     <unit id="trainingPlans.menu.markDone">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:352,354</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:354,356</note>
       </notes>
       <segment>
         <source>Nur abhaken (ohne Eintrag)</source>
@@ -6832,7 +6922,7 @@
     </unit>
     <unit id="trainingPlans.menu.skip">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:361,362</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:363,364</note>
       </notes>
       <segment>
         <source>Tag überspringen</source>
@@ -6840,7 +6930,7 @@
     </unit>
     <unit id="trainingPlans.menu.jump">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:373,375</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:375,377</note>
       </notes>
       <segment>
         <source>Zu diesem Tag springen</source>
@@ -6848,7 +6938,7 @@
     </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:388,389</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:390,391</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -6856,7 +6946,7 @@
     </unit>
     <unit id="trainingPlans.autoStartFailed">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:681</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:683</note>
       </notes>
       <segment>
         <source>Plan-Start fehlgeschlagen — bitte erneut versuchen.</source>
@@ -6864,7 +6954,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:764</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:766</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -6872,7 +6962,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:781</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:783</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
@@ -6880,7 +6970,7 @@
     </unit>
     <unit id="trainingPlans.skipped">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:799</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:801</note>
       </notes>
       <segment>
         <source>Tag übersprungen.</source>
@@ -6888,7 +6978,7 @@
     </unit>
     <unit id="trainingPlans.jumped">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:812</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:814</note>
       </notes>
       <segment>
         <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
@@ -6896,7 +6986,7 @@
     </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:829</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:831</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:348</note>
       </notes>
       <segment>
@@ -6905,7 +6995,7 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:831</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:833</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:350</note>
       </notes>
       <segment>
@@ -6914,7 +7004,7 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:833</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:835</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:352</note>
       </notes>
       <segment>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -5651,9 +5651,17 @@
         <source>Monat</source>
       </segment>
     </unit>
+    <unit id="analysis.overview.uncategorisedNotice">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-overview.component.ts:58,61</note>
+      </notes>
+      <segment>
+        <source> Diese Einträge gehören zu keiner bekannten Kategorie — Aggregat unten. </source>
+      </segment>
+    </unit>
     <unit id="analysis.overview.empty">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-overview.component.ts:31,34</note>
+        <note category="location">web/src/app/stats/shell/analysis-overview.component.ts:68,72</note>
       </notes>
       <segment>
         <source> Im aktuellen Zeitraum gibt es noch keine Einträge. </source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -7109,7 +7109,7 @@
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
         <source/>
-        <target>连击</target>
+        <target>连续天数</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -7046,6 +7046,78 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> 选择训练计划 </target>
       </segment>
     </unit>
+    <unit id="analysis.tabs.overview">
+      <segment state="translated">
+        <source/>
+        <target>Overview</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.empty">
+      <segment state="translated">
+        <source/>
+        <target>No entries in the current date range yet.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.title">
+      <segment state="translated">
+        <source/>
+        <target>Comparison by exercise group</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricAria">
+      <segment state="translated">
+        <source/>
+        <target>Metric</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.reps">
+      <segment state="translated">
+        <source/>
+        <target>Reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metric.sets">
+      <segment state="translated">
+        <source/>
+        <target>Sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.empty">
+      <segment state="translated">
+        <source/>
+        <target>No data in the current date range.</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalReps">
+      <segment state="translated">
+        <source/>
+        <target>Total reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayReps">
+      <segment state="translated">
+        <source/>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.streak">
+      <segment state="translated">
+        <source/>
+        <target>Streak</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <segment state="translated">
+        <source/>
+        <target>Best day</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.viewDetails">
+      <segment state="translated">
+        <source/>
+        <target>View details</target>
+      </segment>
+    </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
         <source/>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -7049,73 +7049,79 @@
     <unit id="analysis.tabs.overview">
       <segment state="translated">
         <source/>
-        <target>Overview</target>
+        <target>概览</target>
       </segment>
     </unit>
     <unit id="analysis.overview.empty">
       <segment state="translated">
         <source/>
-        <target>No entries in the current date range yet.</target>
+        <target>当前日期范围内尚无条目。</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.uncategorisedNotice">
+      <segment state="translated">
+        <source/>
+        <target>这些条目不属于任何已知类别 — 下方为汇总。</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
         <source/>
-        <target>Comparison by exercise group</target>
+        <target>按训练组对比</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metricAria">
       <segment state="translated">
         <source/>
-        <target>Metric</target>
+        <target>指标</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.reps">
       <segment state="translated">
         <source/>
-        <target>Reps</target>
+        <target>次数</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metric.sets">
       <segment state="translated">
         <source/>
-        <target>Sets</target>
+        <target>组数</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
-        <target>No data in the current date range.</target>
+        <target>当前日期范围内暂无数据。</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalReps">
       <segment state="translated">
         <source/>
-        <target>Total reps</target>
+        <target>总次数</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <segment state="translated">
         <source/>
-        <target>Today</target>
+        <target>今天</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
         <source/>
-        <target>Streak</target>
+        <target>连击</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">
       <segment state="translated">
         <source/>
-        <target>Best day</target>
+        <target>最佳日</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <segment state="translated">
         <source/>
-        <target>View details</target>
+        <target>查看详情</target>
       </segment>
     </unit>
     <unit id="entries.empty.title">


### PR DESCRIPTION
## Summary
Restructures the analysis page from a single-view layout into a tabbed interface with an overview dashboard and per-category detail views. This improves navigation and provides users with a high-level summary of their exercise performance across all categories.

## Key Changes

- **Tabbed Navigation**: Replaced the flat analysis view with a `mat-tab-group` containing:
  - Overview tab (new) with comparison chart and per-category summary cards
  - Individual tabs for each exercise category (pushup, abs, legs, etc.)

- **New Overview Components**:
  - `AnalysisOverviewComponent`: Container for the overview tab content
  - `CategorySummaryCardComponent`: Per-category quick-stats card showing total reps, today's reps, streak, and best day
  - `CategoryComparisonChartComponent`: Horizontal bar chart comparing reps/sets across categories with metric toggle

- **Refactored Analysis Store**: Extended `AnalysisStore` to compute:
  - `categorySummaries()`: Array of summary data per category
  - `categoryComparison()`: Aggregated comparison data for the chart
  - `selectedView()` and `setView()`: Track active tab for URL sync

- **Removed Kind Filter**: Eliminated the exercise kind multi-select filter from the main filter bar; category selection now happens via tab navigation instead

- **Extracted Group View Tests**: Moved DOM-level tests for trends section, heatmap toggle positioning, and kind localization from `analysis-page.component.spec.ts` to new `analysis-group-view.component.spec.ts` to avoid mat-tab lazy-body hydration issues in jsdom

- **Updated Localization**: Added i18n strings for new overview UI elements across all supported languages (de, en, es, fr, it, la, nl, no, zh)

## Implementation Details

- The shell (`AnalysisPageComponent`) manages tab state and URL synchronization via `?view=` query parameter
- Overview drilldown buttons emit category IDs to switch tabs without prop-drilling the store
- Category comparison chart uses CSS bars instead of Chart.js for simplicity with ~7 categories
- Tests use a host component wrapper to isolate `AnalysisGroupViewComponent` from mat-tab's lazy rendering behavior

https://claude.ai/code/session_01FwFCj3w7PmzzwzZ9fSJZsQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overview tab with category comparison chart, reps/sets toggle, and per-category summary cards with drill‑down; tabbed analysis UI with URL‑synced selection and sensible fallbacks.

* **Bug Fixes**
  * Prevented divide‑by‑zero in chart fills and ensured active view resets to avoid stale filtering.

* **Tests**
  * Added extensive unit tests covering overview, group view, comparison chart, metric toggle, values, and event forwarding.

* **Localization**
  * Added Analysis overview and comparison translations for multiple languages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/329)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->