### PR TITLE
Goal-reached dialog: transparent surface + toolbar replay

### DIFF
--- a/web/src/app/app.html
+++ b/web/src/app/app.html
@@ -145,7 +145,16 @@
       </a>
       <span class="app-title" i18n="@@app.title">Pushups</span>
       <span class="spacer"></span>
-      <span class="goal-pill"
+      <span
+        class="goal-pill"
+        [class.is-clickable]="goalReached()"
+        [attr.role]="goalReached() ? 'button' : null"
+        [attr.tabindex]="goalReached() ? 0 : null"
+        [attr.aria-label]="goalReached() ? reopenDailyAriaLabel : null"
+        data-testid="toolbar-goal-pill"
+        (click)="handleGoalPillClick()"
+        (keydown.enter)="handleGoalPillClick()"
+        (keydown.space)="handleGoalPillClick(); $event.preventDefault()"
         ><small i18n="@@toolbarDailyGoal">Tagesziel</small>
         <strong>{{ todayProgress() }} / {{ dailyGoal() }}</strong></span
       >

--- a/web/src/app/app.html
+++ b/web/src/app/app.html
@@ -153,8 +153,8 @@
         [attr.aria-label]="goalReached() ? reopenDailyAriaLabel : null"
         data-testid="toolbar-goal-pill"
         (click)="handleGoalPillClick()"
-        (keydown.enter)="handleGoalPillClick()"
-        (keydown.space)="handleGoalPillClick(); $event.preventDefault()"
+        (keydown.enter)="!$event.repeat && handleGoalPillClick()"
+        (keydown.space)="!$event.repeat && handleGoalPillClick(); $event.preventDefault()"
         ><small i18n="@@toolbarDailyGoal">Tagesziel</small>
         <strong>{{ todayProgress() }} / {{ dailyGoal() }}</strong></span
       >

--- a/web/src/app/app.html
+++ b/web/src/app/app.html
@@ -153,8 +153,8 @@
         [attr.aria-label]="goalReached() ? reopenDailyAriaLabel : null"
         data-testid="toolbar-goal-pill"
         (click)="handleGoalPillClick()"
-        (keydown.enter)="!$event.repeat && handleGoalPillClick()"
-        (keydown.space)="!$event.repeat && handleGoalPillClick(); $event.preventDefault()"
+        (keydown.enter)="handleGoalPillKeydown($event)"
+        (keydown.space)="handleGoalPillKeydown($event); $event.preventDefault()"
         ><small i18n="@@toolbarDailyGoal">Tagesziel</small>
         <strong>{{ todayProgress() }} / {{ dailyGoal() }}</strong></span
       >

--- a/web/src/app/app.scss
+++ b/web/src/app/app.scss
@@ -153,7 +153,7 @@ mat-sidenav-content {
         border-color 120ms ease;
 
       &:hover {
-        background: rgba(30, 47, 84, 0.6);
+        background-color: rgba(30, 47, 84, 0.6);
         border-color: rgba(129, 161, 232, 0.55);
       }
 
@@ -329,7 +329,7 @@ html.light-theme {
 
       &.is-clickable {
         &:hover {
-          background: rgba(219, 234, 254, 0.95);
+          background-color: rgba(219, 234, 254, 0.95);
           border-color: rgba(59, 130, 246, 0.55);
         }
 

--- a/web/src/app/app.scss
+++ b/web/src/app/app.scss
@@ -144,6 +144,28 @@ mat-sidenav-content {
       font-size: 0.95rem;
       font-variant-numeric: tabular-nums;
     }
+
+    &.is-clickable {
+      cursor: pointer;
+      transition:
+        background-color 120ms ease,
+        transform 120ms ease,
+        border-color 120ms ease;
+
+      &:hover {
+        background: rgba(30, 47, 84, 0.6);
+        border-color: rgba(129, 161, 232, 0.55);
+      }
+
+      &:active {
+        transform: scale(0.97);
+      }
+
+      &:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 2px rgba(125, 154, 219, 0.85);
+      }
+    }
   }
 }
 
@@ -304,6 +326,17 @@ html.light-theme {
       background: rgba(240, 245, 255, 0.9);
       border-color: rgba(59, 130, 246, 0.35);
       color: #1e293b;
+
+      &.is-clickable {
+        &:hover {
+          background: rgba(219, 234, 254, 0.95);
+          border-color: rgba(59, 130, 246, 0.55);
+        }
+
+        &:focus-visible {
+          box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.6);
+        }
+      }
     }
   }
 

--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -242,6 +242,7 @@ describe('App (testing-library)', () => {
         })
       );
       const notifierMock = makeNotifierMock();
+      const user = userEvent.setup();
       await render(App, {
         providers: commonProviders(notifierMock),
       });
@@ -250,7 +251,7 @@ describe('App (testing-library)', () => {
       await screen.findByText((content) => content.includes('80 / 50'));
 
       // When
-      await userEvent.click(screen.getByTestId('toolbar-goal-pill'));
+      await user.click(screen.getByTestId('toolbar-goal-pill'));
 
       // Then
       expect(notifierMock.reopen).toHaveBeenCalledTimes(1);
@@ -274,13 +275,14 @@ describe('App (testing-library)', () => {
         })
       );
       const notifierMock = makeNotifierMock();
+      const user = userEvent.setup();
       await render(App, {
         providers: commonProviders(notifierMock),
       });
       await screen.findByText((content) => content.includes('10 / 100'));
 
       // When
-      await userEvent.click(screen.getByTestId('toolbar-goal-pill'));
+      await user.click(screen.getByTestId('toolbar-goal-pill'));
 
       // Then
       expect(notifierMock.reopen).not.toHaveBeenCalled();

--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 import { signal, WritableSignal, PLATFORM_ID } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { Title } from '@angular/platform-browser';
@@ -241,15 +242,15 @@ describe('App (testing-library)', () => {
         })
       );
       const notifierMock = makeNotifierMock();
-      const { fixture } = await render(App, {
+      await render(App, {
         providers: commonProviders(notifierMock),
       });
       // Wait for the dailyProgressResource to resolve so goalReached() flips
-      // to true before we exercise the click handler.
+      // to true and the pill is wired into the DOM.
       await screen.findByText((content) => content.includes('80 / 50'));
 
       // When
-      fixture.componentInstance.handleGoalPillClick();
+      await userEvent.click(screen.getByTestId('toolbar-goal-pill'));
 
       // Then
       expect(notifierMock.reopen).toHaveBeenCalledTimes(1);
@@ -273,13 +274,13 @@ describe('App (testing-library)', () => {
         })
       );
       const notifierMock = makeNotifierMock();
-      const { fixture } = await render(App, {
+      await render(App, {
         providers: commonProviders(notifierMock),
       });
       await screen.findByText((content) => content.includes('10 / 100'));
 
       // When
-      fixture.componentInstance.handleGoalPillClick();
+      await userEvent.click(screen.getByTestId('toolbar-goal-pill'));
 
       // Then
       expect(notifierMock.reopen).not.toHaveBeenCalled();

--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -12,6 +12,7 @@ import { AuthService, AuthStore, UserContextService } from '@pu-auth/auth';
 import { AdsStore } from '@pu-stats/ads';
 import { VAPID_PUBLIC_KEY } from '@pu-reminders/reminders';
 import { App } from './app';
+import { GoalReachedNotificationService } from './core/goal-reached-notification.service';
 
 describe('App (testing-library)', () => {
   let userNameSignal: WritableSignal<string>;
@@ -183,6 +184,165 @@ describe('App (testing-library)', () => {
     expect(
       await screen.findByText((content) => content.includes('42 / 137'))
     ).toBeTruthy();
+  });
+
+  describe('toolbar goal-pill replay', () => {
+    function makeNotifierMock(): { reopen: ReturnType<typeof vitest.fn> } {
+      return { reopen: vitest.fn() };
+    }
+
+    function commonProviders(notifierMock: {
+      reopen: ReturnType<typeof vitest.fn>;
+    }) {
+      return [
+        provideRouter([]),
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        {
+          provide: UserContextService,
+          useValue: {
+            userNameSafe: userNameSignal.asReadonly(),
+            userIdSafe: () => 'u1',
+            isAdmin: () => false,
+            isGuest: () => false,
+          },
+        },
+        { provide: AuthStore, useValue: authMock },
+        { provide: AuthService, useValue: authServiceMock },
+        { provide: Auth, useValue: firebaseAuthMock },
+        { provide: UserConfigApiService, useValue: userConfigApiMock },
+        { provide: StatsApiService, useValue: statsApiMock },
+        { provide: AdsStore, useValue: adsStoreMock },
+        { provide: VAPID_PUBLIC_KEY, useValue: 'test-vapid-key' },
+        // Stub the notifier so its constructor-time effects (which inject
+        // many other root services) don't run in this minimal harness.
+        { provide: GoalReachedNotificationService, useValue: notifierMock },
+      ];
+    }
+
+    it('given the daily goal is reached, when the pill is clicked, then it replays the daily celebration', async () => {
+      // Given — dailyGoal=50, todayProgress=80 → goalReached === true.
+      userConfigApiMock.getConfig.mockReturnValue(of({ dailyGoal: 50 }));
+      statsApiMock.load.mockReturnValue(
+        of({
+          meta: {
+            from: null,
+            to: null,
+            entries: 1,
+            days: 1,
+            total: 80,
+            granularity: 'daily',
+          },
+          series: [],
+        })
+      );
+      const notifierMock = makeNotifierMock();
+      const { fixture } = await render(App, {
+        providers: commonProviders(notifierMock),
+      });
+      // Wait for the dailyProgressResource to resolve so goalReached() flips
+      // to true before we exercise the click handler.
+      await screen.findByText((content) => content.includes('80 / 50'));
+
+      // When
+      fixture.componentInstance.handleGoalPillClick();
+
+      // Then
+      expect(notifierMock.reopen).toHaveBeenCalledTimes(1);
+      expect(notifierMock.reopen).toHaveBeenCalledWith('daily');
+    });
+
+    it('given the daily goal has NOT been reached, when the pill is clicked, then the notifier stays quiet', async () => {
+      // Given — dailyGoal=100, todayProgress=10 → goalReached === false.
+      userConfigApiMock.getConfig.mockReturnValue(of({ dailyGoal: 100 }));
+      statsApiMock.load.mockReturnValue(
+        of({
+          meta: {
+            from: null,
+            to: null,
+            entries: 1,
+            days: 1,
+            total: 10,
+            granularity: 'daily',
+          },
+          series: [],
+        })
+      );
+      const notifierMock = makeNotifierMock();
+      const { fixture } = await render(App, {
+        providers: commonProviders(notifierMock),
+      });
+      await screen.findByText((content) => content.includes('10 / 100'));
+
+      // When
+      fixture.componentInstance.handleGoalPillClick();
+
+      // Then
+      expect(notifierMock.reopen).not.toHaveBeenCalled();
+    });
+
+    it('exposes role="button", tabindex="0" and a localized aria-label on the pill once the daily goal is reached', async () => {
+      // Given
+      userConfigApiMock.getConfig.mockReturnValue(of({ dailyGoal: 50 }));
+      statsApiMock.load.mockReturnValue(
+        of({
+          meta: {
+            from: null,
+            to: null,
+            entries: 1,
+            days: 1,
+            total: 80,
+            granularity: 'daily',
+          },
+          series: [],
+        })
+      );
+      const notifierMock = makeNotifierMock();
+      await render(App, { providers: commonProviders(notifierMock) });
+      await screen.findByText((content) => content.includes('80 / 50'));
+
+      // Then — the source-locale (de) build serves the German aria copy.
+      const pill = document.querySelector<HTMLElement>(
+        '[data-testid="toolbar-goal-pill"]'
+      );
+      expect(pill).toBeTruthy();
+      expect(pill?.classList.contains('is-clickable')).toBe(true);
+      expect(pill?.getAttribute('role')).toBe('button');
+      expect(pill?.getAttribute('tabindex')).toBe('0');
+      expect(pill?.getAttribute('aria-label')).toBe(
+        'Tagesziel-Animation erneut abspielen'
+      );
+    });
+
+    it('omits role/tabindex/aria-label on the pill while the daily goal is not yet reached', async () => {
+      // Given
+      userConfigApiMock.getConfig.mockReturnValue(of({ dailyGoal: 100 }));
+      statsApiMock.load.mockReturnValue(
+        of({
+          meta: {
+            from: null,
+            to: null,
+            entries: 1,
+            days: 1,
+            total: 10,
+            granularity: 'daily',
+          },
+          series: [],
+        })
+      );
+      const notifierMock = makeNotifierMock();
+      await render(App, { providers: commonProviders(notifierMock) });
+      await screen.findByText((content) => content.includes('10 / 100'));
+
+      // Then
+      const pill = document.querySelector<HTMLElement>(
+        '[data-testid="toolbar-goal-pill"]'
+      );
+      expect(pill).toBeTruthy();
+      expect(pill?.classList.contains('is-clickable')).toBe(false);
+      expect(pill?.getAttribute('role')).toBeNull();
+      expect(pill?.getAttribute('tabindex')).toBeNull();
+      expect(pill?.getAttribute('aria-label')).toBeNull();
+    });
   });
 
   describe('setLanguage', () => {

--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -196,7 +196,12 @@ describe('App (testing-library)', () => {
     }) {
       return [
         provideRouter([]),
-        { provide: PLATFORM_ID, useValue: 'browser' },
+        // PLATFORM_ID 'server' so the TrainingPlanStore's once-a-minute
+        // setInterval in withHooks (browser-only branch) doesn't leak
+        // across TestBed.resetTestingModule(). The pill state we assert on
+        // is driven purely by signals/resource, both of which work on
+        // server.
+        { provide: PLATFORM_ID, useValue: 'server' },
         {
           provide: UserContextService,
           useValue: {

--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -348,6 +348,113 @@ describe('App (testing-library)', () => {
       expect(pill?.getAttribute('tabindex')).toBeNull();
       expect(pill?.getAttribute('aria-label')).toBeNull();
     });
+
+    it('replays the celebration when Enter is pressed on the pill after the goal is reached', async () => {
+      // Given — goal reached + pill focusable.
+      userConfigApiMock.getConfig.mockReturnValue(of({ dailyGoal: 50 }));
+      statsApiMock.load.mockReturnValue(
+        of({
+          meta: {
+            from: null,
+            to: null,
+            entries: 1,
+            days: 1,
+            total: 80,
+            granularity: 'daily',
+          },
+          series: [],
+        })
+      );
+      const notifierMock = makeNotifierMock();
+      await render(App, { providers: commonProviders(notifierMock) });
+      await screen.findByText((content) => content.includes('80 / 50'));
+      const pill = document.querySelector<HTMLElement>(
+        '[data-testid="toolbar-goal-pill"]'
+      );
+
+      // When
+      pill?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+
+      // Then
+      expect(notifierMock.reopen).toHaveBeenCalledTimes(1);
+      expect(notifierMock.reopen).toHaveBeenCalledWith('daily');
+    });
+
+    it('replays the celebration when Space is pressed and suppresses the default page-scroll', async () => {
+      // Given
+      userConfigApiMock.getConfig.mockReturnValue(of({ dailyGoal: 50 }));
+      statsApiMock.load.mockReturnValue(
+        of({
+          meta: {
+            from: null,
+            to: null,
+            entries: 1,
+            days: 1,
+            total: 80,
+            granularity: 'daily',
+          },
+          series: [],
+        })
+      );
+      const notifierMock = makeNotifierMock();
+      await render(App, { providers: commonProviders(notifierMock) });
+      await screen.findByText((content) => content.includes('80 / 50'));
+      const pill = document.querySelector<HTMLElement>(
+        '[data-testid="toolbar-goal-pill"]'
+      );
+      const spaceEvent = new KeyboardEvent('keydown', {
+        key: ' ',
+        bubbles: true,
+        cancelable: true,
+      });
+
+      // When
+      pill?.dispatchEvent(spaceEvent);
+
+      // Then
+      expect(notifierMock.reopen).toHaveBeenCalledTimes(1);
+      expect(notifierMock.reopen).toHaveBeenCalledWith('daily');
+      expect(spaceEvent.defaultPrevented).toBe(true);
+    });
+
+    it('does NOT replay the celebration on auto-repeat keydown events (held key)', async () => {
+      // Given — held Enter emits repeated keydown events; WAI-ARIA Button
+      // Pattern says only the first press activates.
+      userConfigApiMock.getConfig.mockReturnValue(of({ dailyGoal: 50 }));
+      statsApiMock.load.mockReturnValue(
+        of({
+          meta: {
+            from: null,
+            to: null,
+            entries: 1,
+            days: 1,
+            total: 80,
+            granularity: 'daily',
+          },
+          series: [],
+        })
+      );
+      const notifierMock = makeNotifierMock();
+      await render(App, { providers: commonProviders(notifierMock) });
+      await screen.findByText((content) => content.includes('80 / 50'));
+      const pill = document.querySelector<HTMLElement>(
+        '[data-testid="toolbar-goal-pill"]'
+      );
+
+      // When — repeat: true on the synthetic event flags it as auto-repeat.
+      pill?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          bubbles: true,
+          repeat: true,
+        })
+      );
+
+      // Then
+      expect(notifierMock.reopen).not.toHaveBeenCalled();
+    });
   });
 
   describe('setLanguage', () => {

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -361,10 +361,10 @@ export class App {
   // filter bindings as the base `Event` (no `.repeat`), so the WAI-ARIA
   // Button Pattern's auto-repeat guard can't live inline. The method also
   // accepts `Event` (not `KeyboardEvent`) so the template call passes
-  // strict type-checking (TS2345); we narrow with a runtime cast since
-  // (keydown.*) only ever fires for KeyboardEvents at runtime.
+  // strict type-checking (TS2345); narrow via `instanceof` to read
+  // `.repeat` safely.
   handleGoalPillKeydown(event: Event): void {
-    if ((event as KeyboardEvent).repeat) return;
+    if (event instanceof KeyboardEvent && event.repeat) return;
     this.handleGoalPillClick();
   }
 

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -357,6 +357,15 @@ export class App {
     this._goalReachedNotifier.reopen('daily');
   }
 
+  // Angular templates type `$event` for `(keydown.*)` as the base `Event`,
+  // so the WAI-ARIA Button Pattern's `event.repeat` guard cannot live in
+  // the template binding (it would fail strict template type-checking with
+  // TS2339). Narrow to KeyboardEvent here instead.
+  handleGoalPillKeydown(event: KeyboardEvent): void {
+    if (event.repeat) return;
+    this.handleGoalPillClick();
+  }
+
   protected readonly reopenDailyAriaLabel = $localize`:@@toolbarDailyGoal.replayAria:Tagesziel-Animation erneut abspielen`;
 
   openFeedbackDialog(prefill = true): void {

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -357,12 +357,14 @@ export class App {
     this._goalReachedNotifier.reopen('daily');
   }
 
-  // Angular templates type `$event` for `(keydown.*)` as the base `Event`,
-  // so the WAI-ARIA Button Pattern's `event.repeat` guard cannot live in
-  // the template binding (it would fail strict template type-checking with
-  // TS2339). Narrow to KeyboardEvent here instead.
-  handleGoalPillKeydown(event: KeyboardEvent): void {
-    if (event.repeat) return;
+  // Angular's strictTemplates mode types `$event` for `(keydown.*)` key-
+  // filter bindings as the base `Event` (no `.repeat`), so the WAI-ARIA
+  // Button Pattern's auto-repeat guard can't live inline. The method also
+  // accepts `Event` (not `KeyboardEvent`) so the template call passes
+  // strict type-checking (TS2345); we narrow with a runtime cast since
+  // (keydown.*) only ever fires for KeyboardEvents at runtime.
+  handleGoalPillKeydown(event: Event): void {
+    if ((event as KeyboardEvent).repeat) return;
     this.handleGoalPillClick();
   }
 

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -347,6 +347,18 @@ export class App {
     this.appData.reloadAfterMutation();
   }
 
+  /**
+   * Toolbar "Tagesziel" pill click — when today's goal has already been
+   * reached, replay the snap-celebration dialog on demand. No-op while the
+   * pill is still counting up to the goal.
+   */
+  handleGoalPillClick(): void {
+    if (!this.goalReached()) return;
+    this._goalReachedNotifier.reopen('daily');
+  }
+
+  protected readonly reopenDailyAriaLabel = $localize`:@@toolbarDailyGoal.replayAria:Tagesziel-Animation erneut abspielen`;
+
   openFeedbackDialog(prefill = true): void {
     const data: FeedbackDialogData = prefill
       ? {

--- a/web/src/app/core/goal-reached-notification.service.spec.ts
+++ b/web/src/app/core/goal-reached-notification.service.spec.ts
@@ -697,6 +697,84 @@ describe('GoalReachedNotificationService', () => {
     });
   });
 
+  describe('Given the user explicitly re-triggers the daily celebration', () => {
+    it('Then reopen("daily") re-opens the snap dialog even after the auto-fired one was dismissed', async () => {
+      // Given — auto-fire happens once, then we clear the spy to assert the
+      // manual re-open is a separate, independent call (not just a leftover).
+      const service = setup({
+        dailyGoal: 10,
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 12,
+          } as PushupRecord,
+        ],
+      });
+      await flushAll();
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      dialogOpenSpy.mockClear();
+
+      // When — user clicks the toolbar pill to replay the snap.
+      service.reopen('daily');
+      await flushAll();
+
+      // Then — dialog opens again with the current totals + goal.
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      const [, config] = dialogOpenSpy.mock.calls[0];
+      expect(config?.data).toMatchObject({
+        kind: 'daily',
+        total: 12,
+        goal: 10,
+      });
+    });
+
+    it('Then reopen("daily") no-ops while the goal has not yet been reached', async () => {
+      // Given — daily goal set but progress still below it.
+      const service = setup({
+        dailyGoal: 10,
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 5,
+          } as PushupRecord,
+        ],
+      });
+      await flushAll();
+      dialogOpenSpy.mockClear();
+
+      // When
+      service.reopen('daily');
+      await flushAll();
+
+      // Then
+      expect(dialogOpenSpy).not.toHaveBeenCalled();
+    });
+
+    it('Then reopen("daily") no-ops when no daily goal is configured', async () => {
+      // Given
+      const service = setup({
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 100,
+          } as PushupRecord,
+        ],
+      });
+      await flushAll();
+      dialogOpenSpy.mockClear();
+
+      // When
+      service.reopen('daily');
+      await flushAll();
+
+      // Then
+      expect(dialogOpenSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Given an active plan but no configured daily goal', () => {
     it('Then the plan dialog stays silent (the daily-loading-state guard)', async () => {
       // Given — no `dailyGoal` set in the user config (resource resolves to 0).

--- a/web/src/app/core/goal-reached-notification.service.spec.ts
+++ b/web/src/app/core/goal-reached-notification.service.spec.ts
@@ -3,7 +3,7 @@ import { signal } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { LiveDataStore, UserConfigApiService } from '@pu-stats/data-access';
 import { UserContextService } from '@pu-auth/auth';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { PushupRecord, TrainingPlanDay } from '@pu-stats/models';
 import { TrainingPlanStore } from '../training-plans/training-plan.store';
 import { GoalReachedNotificationService } from './goal-reached-notification.service';
@@ -750,6 +750,48 @@ describe('GoalReachedNotificationService', () => {
 
       // Then
       expect(dialogOpenSpy).not.toHaveBeenCalled();
+    });
+
+    it('Then back-to-back reopen("daily") calls do not stack overlays while a dialog is open', async () => {
+      // Given — auto-fire opens the first dialog and the mock's afterClosed
+      // is a held-open Subject, so the in-memory `activeDialogs` map for
+      // 'daily' stays populated (i.e. the real dialog is still on screen).
+      const afterClosed = new Subject<unknown>();
+      const heldRef = {
+        afterClosed: () => afterClosed.asObservable(),
+        close: vi.fn(),
+      } as unknown as MatDialogRef<unknown>;
+      dialogOpenSpy.mockReturnValueOnce(heldRef);
+
+      const service = setup({
+        dailyGoal: 10,
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 12,
+          } as PushupRecord,
+        ],
+      });
+      await flushAll();
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      dialogOpenSpy.mockClear();
+
+      // When — rapid double-click / held Enter on the toolbar pill.
+      service.reopen('daily');
+      service.reopen('daily');
+      await flushAll();
+
+      // Then — both reopens are dedupe-blocked by the still-open first dialog.
+      expect(dialogOpenSpy).not.toHaveBeenCalled();
+
+      // And once the first dialog closes, a fresh reopen can fire again
+      // (proves the cleanup subscription releases the per-kind slot).
+      afterClosed.next(null);
+      afterClosed.complete();
+      service.reopen('daily');
+      await flushAll();
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
     });
 
     it('Then reopen("daily") no-ops when no daily goal is configured', async () => {

--- a/web/src/app/core/goal-reached-notification.service.ts
+++ b/web/src/app/core/goal-reached-notification.service.ts
@@ -8,7 +8,7 @@ import {
   Signal,
   untracked,
 } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { LiveDataStore } from '@pu-stats/data-access';
 import {
   PushupRecord,
@@ -160,6 +160,14 @@ export class GoalReachedNotificationService {
 
   private readonly opened = new Set<string>();
   /**
+   * Per-kind dedupe for live dialog instances. Without it, rapid clicks /
+   * held Enter on the toolbar pill (or two near-simultaneous goal crossings
+   * on the same kind) would stack overlays and trap focus inside the
+   * top-most one. We cap at one open dialog per kind; the second trigger
+   * silently no-ops while the first is still on screen.
+   */
+  private readonly activeDialogs = new Map<GoalKind, MatDialogRef<unknown>>();
+  /**
    * Last-seen goal value per kind. Used to detect upward changes so that an
    * earlier "shown" flag for the current period is cleared — otherwise the
    * user would never see a celebration after raising the bar mid-period.
@@ -232,10 +240,15 @@ export class GoalReachedNotificationService {
     kind: GoalKind,
     snapshot: { total: number; goal: number; maxParticleCount: number }
   ): Promise<void> {
+    if (this.activeDialogs.has(kind)) return;
     const { GoalReachedDialogComponent } =
       await import('../stats/components/goal-reached-dialog/goal-reached-dialog.component');
+    // Re-check after the dynamic import resolves: an auto-fire effect and
+    // a manual reopen() can race across the await, and we still only want
+    // one dialog per kind.
+    if (this.activeDialogs.has(kind)) return;
     const titleId = `goal-reached-dialog-title-${nextDialogTitleId++}`;
-    this.dialog.open(GoalReachedDialogComponent, {
+    const ref = this.dialog.open(GoalReachedDialogComponent, {
       panelClass: 'goal-reached-dialog-panel',
       backdropClass: 'goal-reached-dialog-backdrop',
       autoFocus: 'dialog',
@@ -250,6 +263,10 @@ export class GoalReachedNotificationService {
         titleId,
         maxParticleCount: snapshot.maxParticleCount,
       },
+    });
+    this.activeDialogs.set(kind, ref);
+    ref.afterClosed().subscribe(() => {
+      this.activeDialogs.delete(kind);
     });
   }
 

--- a/web/src/app/core/goal-reached-notification.service.ts
+++ b/web/src/app/core/goal-reached-notification.service.ts
@@ -252,6 +252,28 @@ export class GoalReachedNotificationService {
       },
     });
   }
+
+  /**
+   * Manually re-open the celebration dialog for a goal that has already
+   * been reached this period. Used by the toolbar "Tagesziel" pill so the
+   * user can replay the snap animation on demand.
+   *
+   * Bypasses the per-period `opened` / localStorage gating — that gate
+   * suppresses the auto-fire during navigation, not intentional re-opens.
+   * Silently no-ops when the goal isn't configured or hasn't been reached.
+   */
+  reopen(kind: GoalKind): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    const spec = this.specs.find((s) => s.kind === kind);
+    if (!spec) return;
+    const goal = spec.goal();
+    if (goal <= 0) return;
+    const total = spec.total();
+    if (total < goal) return;
+    const maxParticleCount =
+      SNAP_QUALITY_PARTICLES[this.userConfig.snapQuality()];
+    void this.openDialog(kind, { total, goal, maxParticleCount });
+  }
 }
 
 /**

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.html
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.html
@@ -2,6 +2,7 @@
   #card
   class="goal-card"
   [class.is-snapping]="snapping()"
+  [style.--goal-snap-duration]="snapDurationCss"
   data-testid="goal-reached-card"
 >
   <button

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.html
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.html
@@ -2,7 +2,6 @@
   #card
   class="goal-card"
   [class.is-snapping]="snapping()"
-  [style.--goal-snap-duration]="snapDurationCss"
   data-testid="goal-reached-card"
 >
   <button

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
@@ -41,22 +41,17 @@
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
     transform-origin: bottom left;
     transition:
-      transform 700ms cubic-bezier(0.16, 1, 0.3, 1),
-      opacity 700ms ease-out;
+      transform 300ms ease-out,
+      opacity 300ms ease-out;
   }
 
   &.is-snapping {
-    // Allow the expanding frame to bleed past the original card box —
-    // and out of the Material dialog surface, which is forced transparent
-    // via the global .goal-reached-dialog-panel rule in styles.scss.
+    // Allow the expanding frame to bleed past the original card box.
     overflow: visible;
 
     &::before {
-      // Sweep the frame from the card's bottom-left corner toward the
-      // viewport's top-right while fading out. The scale is intentionally
-      // huge so the frame reaches past any realistic viewport corner; the
-      // simultaneous opacity fade hides the gradient stretch.
-      transform: scale(10);
+      // Grow up and to the right (origin: bottom left); fade to transparent.
+      transform: scale(1.3);
       opacity: 0;
     }
   }

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
@@ -41,8 +41,8 @@
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
     transform-origin: bottom left;
     transition:
-      transform 300ms ease-out,
-      opacity 300ms ease-out;
+      transform 5000ms ease-out,
+      opacity 5000ms ease-out;
   }
 
   &.is-snapping {

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
@@ -40,9 +40,13 @@
       );
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
     transform-origin: bottom left;
+    // Duration is owned by GOAL_SNAP_DURATION_MS in the component and
+    // piped in via the --goal-snap-duration CSS custom property on the
+    // card element. The literal fallback keeps standalone style previews
+    // (Storybook, plain HTML harness) animating at the right speed.
     transition:
-      transform 5000ms ease-out,
-      opacity 5000ms ease-out;
+      transform var(--goal-snap-duration, 5000ms) ease-out,
+      opacity var(--goal-snap-duration, 5000ms) ease-out;
   }
 
   &.is-snapping {

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
@@ -41,17 +41,22 @@
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
     transform-origin: bottom left;
     transition:
-      transform 300ms ease-out,
-      opacity 300ms ease-out;
+      transform 700ms cubic-bezier(0.16, 1, 0.3, 1),
+      opacity 700ms ease-out;
   }
 
   &.is-snapping {
-    // Allow the expanding frame to bleed past the original card box.
+    // Allow the expanding frame to bleed past the original card box —
+    // and out of the Material dialog surface, which is forced transparent
+    // via the global .goal-reached-dialog-panel rule in styles.scss.
     overflow: visible;
 
     &::before {
-      // Grow up and to the right (origin: bottom left); fade to transparent.
-      transform: scale(1.3);
+      // Sweep the frame from the card's bottom-left corner toward the
+      // viewport's top-right while fading out. The scale is intentionally
+      // huge so the frame reaches past any realistic viewport corner; the
+      // simultaneous opacity fade hides the gradient stretch.
+      transform: scale(10);
       opacity: 0;
     }
   }

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.scss
@@ -40,24 +40,18 @@
       );
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
     transform-origin: bottom left;
-    // Duration is owned by GOAL_SNAP_DURATION_MS in the component and
-    // piped in via the --goal-snap-duration CSS custom property on the
-    // card element. The literal fallback keeps standalone style previews
-    // (Storybook, plain HTML harness) animating at the right speed.
-    transition:
-      transform var(--goal-snap-duration, 5000ms) ease-out,
-      opacity var(--goal-snap-duration, 5000ms) ease-out;
+    // The frame is animated directly off the @wolsok/thanos particle
+    // progress: each vaporize() frame writes `--snap-progress` (0..1) on
+    // the card, and we interpolate transform/opacity from it. No parallel
+    // CSS transition — keeps the frame fade locked to the actual snap.
+    transform: scale(calc(1 + 0.3 * var(--snap-progress, 0)));
+    opacity: calc(1 - var(--snap-progress, 0));
   }
 
   &.is-snapping {
-    // Allow the expanding frame to bleed past the original card box.
+    // Let the expanding frame bleed past the original card box (the
+    // border-radius clip would otherwise crop the scaled pseudo-element).
     overflow: visible;
-
-    &::before {
-      // Grow up and to the right (origin: bottom left); fade to transparent.
-      transform: scale(1.3);
-      opacity: 0;
-    }
   }
 }
 

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.spec.ts
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.spec.ts
@@ -220,6 +220,51 @@ describe('GoalReachedDialogComponent', () => {
       expect(vaporizeSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('Then each vaporize frame writes its animationT to --snap-progress on the card', async () => {
+      // Given — drives the SCSS frame fade off the actual particle progress
+      // instead of a parallel CSS transition, so the card frame stays in
+      // lockstep with the vaporize animation.
+      await setup({
+        kind: 'daily',
+        total: 50,
+        goal: 50,
+        titleId: 'test-title-progress',
+      });
+      const card = fixture.nativeElement.querySelector(
+        '[data-testid="goal-reached-card"]'
+      ) as HTMLElement;
+      const snapBtn = fixture.nativeElement.querySelector(
+        '[data-testid="goal-reached-snap"]'
+      ) as HTMLButtonElement;
+
+      // When — snap starts and three particle frames emit at progress 0/0.5/1.
+      snapBtn.click();
+      await fixture.whenStable();
+      vaporizeSubject.next({
+        deltaTSec: 0,
+        animationT: 0,
+        maxWidth: 100,
+        maxHeight: 100,
+      });
+      expect(card.style.getPropertyValue('--snap-progress')).toBe('0');
+      vaporizeSubject.next({
+        deltaTSec: 0.016,
+        animationT: 0.5,
+        maxWidth: 100,
+        maxHeight: 100,
+      });
+      expect(card.style.getPropertyValue('--snap-progress')).toBe('0.5');
+      // A real run can emit animationT slightly > 1 on the last frame —
+      // confirm the subscriber clamps so the CSS stays in 0..1.
+      vaporizeSubject.next({
+        deltaTSec: 0.016,
+        animationT: 1.05,
+        maxWidth: 100,
+        maxHeight: 100,
+      });
+      expect(card.style.getPropertyValue('--snap-progress')).toBe('1');
+    });
+
     it('Then it still closes the dialog if vaporize emits an error', async () => {
       // Given — html2canvas can throw on modern CSS color() functions
       await setup({

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts
@@ -19,6 +19,15 @@ import { ShareService } from '../../../core/share.service';
 
 const SHARE_URL = 'https://pushup-stats.com';
 
+/**
+ * Single source of truth for the snap-celebration animation length.
+ * The same value is consumed by `@wolsok/thanos` (via `animationLength`)
+ * and the `.goal-card::before` frame transition (via the
+ * `--goal-snap-duration` CSS custom property bound on the card element).
+ * Changing it here propagates to both.
+ */
+export const GOAL_SNAP_DURATION_MS = 5000;
+
 export type GoalKind = 'daily' | 'weekly' | 'monthly' | 'plan';
 
 export interface GoalReachedDialogData {
@@ -110,6 +119,8 @@ export class GoalReachedDialogComponent {
     }
   });
 
+  protected readonly snapDurationCss = `${GOAL_SNAP_DURATION_MS}ms`;
+
   protected readonly snapAriaLabel = $localize`:@@goalReached.snapAria:Erfolg vaporisieren`;
   protected readonly snapLabel = $localize`:@@goalReached.snap:Snap!`;
   protected readonly closeAriaLabel = $localize`:@@goalReached.closeAria:Schließen`;
@@ -160,7 +171,7 @@ export class GoalReachedDialogComponent {
           {
             provide: WS_THANOS_OPTIONS_TOKEN,
             useValue: createWsThanosOptions({
-              animationLength: 5000,
+              animationLength: GOAL_SNAP_DURATION_MS,
               maxParticleCount,
             }),
           },

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts
@@ -159,7 +159,10 @@ export class GoalReachedDialogComponent {
           WsThanosService,
           {
             provide: WS_THANOS_OPTIONS_TOKEN,
-            useValue: createWsThanosOptions({ maxParticleCount }),
+            useValue: createWsThanosOptions({
+              animationLength: 5000,
+              maxParticleCount,
+            }),
           },
         ],
         this.envInjector,

--- a/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts
+++ b/web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts
@@ -20,11 +20,12 @@ import { ShareService } from '../../../core/share.service';
 const SHARE_URL = 'https://pushup-stats.com';
 
 /**
- * Single source of truth for the snap-celebration animation length.
- * The same value is consumed by `@wolsok/thanos` (via `animationLength`)
- * and the `.goal-card::before` frame transition (via the
- * `--goal-snap-duration` CSS custom property bound on the card element).
- * Changing it here propagates to both.
+ * Length of the @wolsok/thanos vaporize animation. The card's frame fade
+ * is no longer time-driven via a parallel CSS transition; instead each
+ * vaporize frame writes its normalized progress (`animationT`, 0..1) to
+ * the `--snap-progress` custom property on the card, and SCSS reads that
+ * to interpolate transform/opacity. So this constant is the sole source
+ * of the celebration duration.
  */
 export const GOAL_SNAP_DURATION_MS = 5000;
 
@@ -119,8 +120,6 @@ export class GoalReachedDialogComponent {
     }
   });
 
-  protected readonly snapDurationCss = `${GOAL_SNAP_DURATION_MS}ms`;
-
   protected readonly snapAriaLabel = $localize`:@@goalReached.snapAria:Erfolg vaporisieren`;
   protected readonly snapLabel = $localize`:@@goalReached.snap:Snap!`;
   protected readonly closeAriaLabel = $localize`:@@goalReached.closeAria:Schließen`;
@@ -191,7 +190,17 @@ export class GoalReachedDialogComponent {
               this.dialogRef.close();
             })
           )
-          .subscribe({ error: () => undefined });
+          .subscribe({
+            // Drive the frame's transform/opacity off the actual particle
+            // progress instead of a parallel CSS transition. Clamped to
+            // 0..1 because the last frame can emit animationT slightly > 1
+            // before the stream completes.
+            next: (state) => {
+              const t = Math.min(1, Math.max(0, state.animationT));
+              el.style.setProperty('--snap-progress', String(t));
+            },
+            error: () => undefined,
+          });
       });
     } catch {
       this.dialogRef.close();

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -7627,5 +7627,11 @@
         <target>Κάμψεις</target>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.replayAria">
+      <segment state="translated">
+        <source>Tagesziel-Animation erneut abspielen</source>
+        <target>Επανάληψη κινούμενης εικόνας ημερήσιου στόχου</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -7795,5 +7795,11 @@ Deine Position: # ·  Reps        </source>
         <target>Push-ups</target>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.replayAria">
+      <segment state="translated">
+        <source>Tagesziel-Animation erneut abspielen</source>
+        <target>Replay daily goal animation</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -7627,5 +7627,11 @@
         <target>Flexiones</target>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.replayAria">
+      <segment state="translated">
+        <source>Tagesziel-Animation erneut abspielen</source>
+        <target>Repetir animación de la meta diaria</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -7627,5 +7627,11 @@
         <target>Pompes</target>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.replayAria">
+      <segment state="translated">
+        <source>Tagesziel-Animation erneut abspielen</source>
+        <target>Rejouer l'animation de l'objectif quotidien</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -7627,5 +7627,11 @@
         <target>Flessioni</target>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.replayAria">
+      <segment state="translated">
+        <source>Tagesziel-Animation erneut abspielen</source>
+        <target>Riproduci animazione obiettivo giornaliero</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -7627,5 +7627,11 @@
         <target>Pushups</target>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.replayAria">
+      <segment state="translated">
+        <source>Tagesziel-Animation erneut abspielen</source>
+        <target>Animationem metae diurnae iterum ludere</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -7627,5 +7627,11 @@
         <target>Push-ups</target>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.replayAria">
+      <segment state="translated">
+        <source>Tagesziel-Animation erneut abspielen</source>
+        <target>Animatie dagdoel opnieuw afspelen</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -6890,5 +6890,11 @@ Deine Position: # ·  Reps        </source>
         <target>Armhevinger</target>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.replayAria">
+      <segment state="translated">
+        <source>Tagesziel-Animation erneut abspielen</source>
+        <target>Spill av animasjon for dagsmål på nytt</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2228,6 +2228,14 @@
         <source>Tagesziel</source>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.replayAria">
+      <notes>
+        <note category="location">web/src/app/app.ts</note>
+      </notes>
+      <segment>
+        <source>Tagesziel-Animation erneut abspielen</source>
+      </segment>
+    </unit>
     <unit id="nav.admin">
       <notes>
         <note category="location">web/src/app/app.html:157,158</note>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -7244,5 +7244,11 @@
         <target>俯卧撑</target>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.replayAria">
+      <segment state="translated">
+        <source>Tagesziel-Animation erneut abspielen</source>
+        <target>重播每日目标动画</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -211,11 +211,11 @@ mat-card-header + mat-card-footer {
 }
 
 // Goal-reached celebration dialog: the .goal-card paints its own gold-gradient
-// frame on a ::before pseudo. Material's own dialog surface must therefore be
-// invisible — otherwise the snap-out animation (frame fade + expand) reveals
-// the dark/light Material surface underneath instead of the page background.
-// We also let the surface overflow so the expanding frame can sweep toward
-// the viewport's top-right corner.
+// frame on a ::before pseudo, and the @wolsok/thanos snap animation rasterises
+// the card into a particle canvas that flows beyond the dialog bounds.
+// Material's own dialog surface must therefore be invisible — otherwise the
+// dark/light Material surface shows underneath the fading frame, and clips
+// the snap canvas at the dialog edges.
 .goal-reached-dialog-panel {
   --mdc-dialog-container-color: transparent;
   --mdc-dialog-container-elevation-shadow: none;

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -209,3 +209,25 @@ mat-card-header + mat-card-footer {
   color: var(--mat-sys-on-tertiary-container, #31111d) !important;
   font-weight: 600;
 }
+
+// Goal-reached celebration dialog: the .goal-card paints its own gold-gradient
+// frame on a ::before pseudo. Material's own dialog surface must therefore be
+// invisible — otherwise the snap-out animation (frame fade + expand) reveals
+// the dark/light Material surface underneath instead of the page background.
+// We also let the surface overflow so the expanding frame can sweep toward
+// the viewport's top-right corner.
+.goal-reached-dialog-panel {
+  --mdc-dialog-container-color: transparent;
+  --mdc-dialog-container-elevation-shadow: none;
+
+  .mat-mdc-dialog-surface,
+  .mdc-dialog__surface {
+    background: transparent !important;
+    box-shadow: none !important;
+    overflow: visible !important;
+  }
+}
+
+.cdk-overlay-pane.goal-reached-dialog-panel {
+  overflow: visible;
+}

--- a/web/src/types/wolsok-thanos.d.ts
+++ b/web/src/types/wolsok-thanos.d.ts
@@ -8,9 +8,12 @@ declare module '@wolsok/thanos' {
   import type { Observable } from 'rxjs';
 
   export interface AnimationState {
-    readonly progress?: number;
-    readonly running?: boolean;
-    readonly [key: string]: unknown;
+    /** Seconds elapsed since the previous frame. */
+    readonly deltaTSec: number;
+    /** Normalized animation progress, 0 at start and 1 at completion. */
+    readonly animationT: number;
+    readonly maxWidth: number;
+    readonly maxHeight: number;
   }
 
   export interface WsThanosOptions {


### PR DESCRIPTION
## Summary

Two related changes around the goal-reached celebration dialog:

1. **Transparent dialog surface** so the gold-gradient frame + thanos snap particle canvas isn't clipped or backed by Material's dark/light surface.
2. **New "Tagesziel" pill replay** — once today's goal has been reached, clicking the toolbar pill (or activating it with Enter/Space) re-opens the snap dialog on demand.

## Changes

### Dialog transparency (`web/src/styles.scss`, `goal-reached-dialog.component.scss`)
- Globally scope `.goal-reached-dialog-panel`:
  - `--mdc-dialog-container-color: transparent`, surface `background: transparent`, `box-shadow: none`, `overflow: visible`
  - `.cdk-overlay-pane.goal-reached-dialog-panel { overflow: visible }`
- Lets the existing `.goal-card::before` gold frame + thanos particle canvas render past the dialog rect without revealing Material's surface or being clipped.

### Toolbar pill replay (new user-facing feature)
- `GoalReachedNotificationService.reopen(kind: GoalKind)` — new public method that re-opens the celebration with the current `total` / `goal` / `maxParticleCount`. Bypasses the per-period `opened` / localStorage gate (which exists to dedupe auto-fires during navigation, not intentional re-opens) and silently no-ops when the goal isn't configured or hasn't been reached.
- `App.handleGoalPillClick()` + `App.handleGoalPillKeydown(event)` — wired to the toolbar `.goal-pill`. Click + `keydown.enter` + `keydown.space` (with `preventDefault` for page-scroll suppression and `event.repeat` guard per [WAI-ARIA Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)).
- Pill is conditionally focusable only after `goalReached() === true` (`role="button"`, `tabindex="0"`, `aria-label`, `is-clickable` styling for hover/active/focus-visible in both dark and light themes).

### i18n
- New unit `@@toolbarDailyGoal.replayAria` ("Tagesziel-Animation erneut abspielen") added to the source `messages.xlf` and translated into all 9 target locales (`en`, `es`, `fr`, `it`, `nl`, `el`, `la`, `no`, `zh`) — staging/production builds set `i18nMissingTranslation: error`, so all locales must carry the key.

### Tests
- `goal-reached-notification.service.spec.ts`: three new tests for `reopen('daily')` (replays after dismiss / no-op below threshold / no-op without configured goal).
- `app.spec.ts` `toolbar goal-pill replay` describe block (7 tests):
  - click path: replays when goal reached, no-op when not
  - ARIA wiring: role/tabindex/aria-label present when reached, stripped otherwise
  - keyboard path: Enter triggers replay, Space triggers replay + suppresses page scroll, auto-repeat keydown does NOT trigger replay
- Shared `commonProviders` helper for these tests runs on `PLATFORM_ID: 'server'` per the project's [withHooks-setInterval guideline](docs/gotchas/testing.md) — TrainingPlanStore (a transitive root dep of `App`) starts a once-a-minute timer in its browser-only init branch that would otherwise leak across TestBed resets.

## Test plan
- [x] `goal-reached-notification.service.spec` covers reopen() (3 new tests)
- [x] `app.spec` covers handleGoalPillClick + handleGoalPillKeydown + ARIA wiring (7 new tests)
- [x] CI: lint-test-build / e2e / build_and_preview / CodeQL all green
- [ ] Manual: click toolbar pill in dark mode after dailyGoal reached → snap dialog replays cleanly without black surface artifacts
- [ ] Manual: held Enter on the pill activates exactly once
- [ ] Manual: Space activation doesn't scroll the page

https://claude.ai/code/session_01YAy4sydGsDcfMaXBHQwDz6

## Summary by CodeRabbit

* **New Features**
  * Toolbar "daily goal" pill can be activated to replay the daily-goal celebration.
* **Accessibility**
  * Keyboard (Enter/Space), role/tabindex and localized ARIA labels added for the replay control (multiple languages).
* **Style**
  * Celebration dialog visuals refined (transparent surface, overflow allowed) and clickable pill interaction styles (hover/press/focus).
* **Tests**
  * Added tests covering manual replay behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/330)
