### PR TITLE
fix(analysis): scope group-view chart to the active category tab

### DIFF
--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -320,14 +320,10 @@ export const AnalysisStore = signalStore(
     const rows = computed(() => store.entriesResource.value() ?? []);
 
     // The stats-chart's stacked-bar layer reads `timestamp`, `reps` and
-    // optional `sets[]`. Both PushupRecord and UnifiedEntry expose all
-    // three, so a structural shape is enough — no need to round-trip
-    // through pushupRecordToUnified just to satisfy a stricter type.
-    type ChartFeedEntry = {
-      timestamp: string;
-      reps: number;
-      sets?: number[];
-    };
+    // optional `sets[]`. UnifiedEntry already declares all three on its
+    // base, so Pick keeps the structural feed in lockstep with the
+    // canonical model — no parallel field list to drift.
+    type ChartFeedEntry = Pick<UnifiedEntry, 'timestamp' | 'reps' | 'sets'>;
 
     // Pushup rows come from the REST resource (works on SSR); exercise
     // entries come from the live Firestore snapshot, so SSR yields
@@ -379,6 +375,19 @@ export const AnalysisStore = signalStore(
     });
 
     /**
+     * Granularity of {@link viewChartSeries}. Tracked separately from
+     * the REST-derived {@link granularity} (which lags the resource
+     * during cold-start / filter changes) so the chart's axis mode,
+     * dayChartMode toggle visibility and sets-stacking bucket-keying
+     * stay locked to the bucketing actually produced for the view.
+     */
+    const viewGranularity = computed<StatsGranularity>(() => {
+      const from = store.from();
+      const to = store.to();
+      return !!from && !!to && from === to ? 'hourly' : 'daily';
+    });
+
+    /**
      * Chart series scoped to {@link AnalysisState.activeView}. The
      * REST-backed {@link chartSeries} aggregates pushups-only on the
      * server, so consuming it from a per-category tab would always
@@ -393,8 +402,7 @@ export const AnalysisStore = signalStore(
      */
     const viewChartSeries = computed<StatsSeriesEntry[]>(() => {
       const from = store.from();
-      const to = store.to();
-      const isDayRange = !!from && !!to && from === to;
+      const isDayRange = viewGranularity() === 'hourly';
       const rowsForView = viewFilteredRows();
 
       if (isDayRange) {
@@ -836,6 +844,7 @@ export const AnalysisStore = signalStore(
       chartSeries,
       viewChartSeries,
       viewChartEntries,
+      viewGranularity,
       granularity,
       rows,
       unifiedRows,

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -319,6 +319,16 @@ export const AnalysisStore = signalStore(
     );
     const rows = computed(() => store.entriesResource.value() ?? []);
 
+    // The stats-chart's stacked-bar layer reads `timestamp`, `reps` and
+    // optional `sets[]`. Both PushupRecord and UnifiedEntry expose all
+    // three, so a structural shape is enough — no need to round-trip
+    // through pushupRecordToUnified just to satisfy a stricter type.
+    type ChartFeedEntry = {
+      timestamp: string;
+      reps: number;
+      sets?: number[];
+    };
+
     // Pushup rows come from the REST resource (works on SSR); exercise
     // entries come from the live Firestore snapshot, so SSR yields
     // pushups only.
@@ -367,6 +377,94 @@ export const AnalysisStore = signalStore(
         (row) => unifiedEntryCategoryId(row) === view
       );
     });
+
+    /**
+     * Chart series scoped to {@link AnalysisState.activeView}. The
+     * REST-backed {@link chartSeries} aggregates pushups-only on the
+     * server, so consuming it from a per-category tab would always
+     * render the pushup history regardless of which tab is active.
+     * This computed mirrors the daily/hourly bucketing in
+     * `StatsApiService.toStatsResponse` but feeds on the view-filtered
+     * unified rows so each tab's chart matches its KPIs. Hourly
+     * bucketing is gated on `from === to` (the same condition the
+     * server uses) rather than `granularity()` so the series doesn't
+     * lag behind during a cold-start where the resource hasn't yet
+     * resolved to its `'hourly'` meta.
+     */
+    const viewChartSeries = computed<StatsSeriesEntry[]>(() => {
+      const from = store.from();
+      const to = store.to();
+      const isDayRange = !!from && !!to && from === to;
+      const rowsForView = viewFilteredRows();
+
+      if (isDayRange) {
+        const hourTotals = Array.from({ length: 24 }, () => 0);
+        for (const row of rowsForView) {
+          const hour = new Date(row.timestamp).getHours();
+          if (hour >= 0 && hour <= 23) hourTotals[hour] += row.reps;
+        }
+        let cumulative = 0;
+        if (resolvedDayChartMode() === '24h') {
+          return hourTotals.map((total, hour) => {
+            cumulative += total;
+            return {
+              bucket: `${from}T${String(hour).padStart(2, '0')}:00:00`,
+              total,
+              dayIntegral: cumulative,
+            };
+          });
+        }
+        const result: StatsSeriesEntry[] = [];
+        const nightTotal = hourTotals
+          .slice(0, 8)
+          .reduce((sum, value) => sum + value, 0);
+        cumulative += nightTotal;
+        result.push({
+          bucket: `${from}T00:00:00`,
+          bucketLabel: '00-07',
+          total: nightTotal,
+          dayIntegral: cumulative,
+        });
+        for (let hour = 8; hour <= 21; hour++) {
+          const total = hourTotals[hour] ?? 0;
+          cumulative += total;
+          result.push({
+            bucket: `${from}T${String(hour).padStart(2, '0')}:00:00`,
+            total,
+            dayIntegral: cumulative,
+          });
+        }
+        return result;
+      }
+
+      const totals = new Map<string, number>();
+      for (const row of rowsForView) {
+        const day = row.timestamp.slice(0, 10);
+        totals.set(day, (totals.get(day) ?? 0) + row.reps);
+      }
+      const sortedDays = [...totals.keys()].sort((a, b) => a.localeCompare(b));
+      let cumulative = 0;
+      return sortedDays.map((day) => {
+        const total = totals.get(day) ?? 0;
+        cumulative += total;
+        return { bucket: day, total, dayIntegral: cumulative };
+      });
+    });
+
+    /**
+     * Raw view-filtered entries shaped for {@link StatsChartComponent}'s
+     * sets-stacking pass: it groups entries by bucket to colour the
+     * "with sets" portion separately. Routing exercise entries through
+     * here means a non-pushup tab gets its own stack rather than
+     * silently borrowing the pushup `[entries]`.
+     */
+    const viewChartEntries = computed<ChartFeedEntry[]>(() =>
+      viewFilteredRows().map((row) => ({
+        timestamp: row.timestamp,
+        reps: row.reps,
+        ...(row.sets ? { sets: row.sets } : {}),
+      }))
+    );
 
     /**
      * Per-category roll-up for the overview tab. Always operates on
@@ -736,6 +834,8 @@ export const AnalysisStore = signalStore(
     return {
       stats,
       chartSeries,
+      viewChartSeries,
+      viewChartEntries,
       granularity,
       rows,
       unifiedRows,

--- a/web/src/app/stats/components/stats-chart/stats-chart.component.ts
+++ b/web/src/app/stats/components/stats-chart/stats-chart.component.ts
@@ -15,11 +15,19 @@ import {
 } from '@angular/core';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
-import {
-  PushupRecord,
-  StatsGranularity,
-  StatsSeriesEntry,
-} from '@pu-stats/models';
+import { StatsGranularity, StatsSeriesEntry } from '@pu-stats/models';
+
+/**
+ * Minimum shape the chart reads off each entry for sets-stacking. Both
+ * the legacy {@link PushupRecord} and the analysis store's view-scoped
+ * unified feed satisfy this, so the input can ingest either without an
+ * intermediate adapter.
+ */
+export interface StatsChartEntry {
+  timestamp: string;
+  reps: number;
+  sets?: number[];
+}
 import {
   Chart,
   ChartConfiguration,
@@ -119,7 +127,7 @@ export class StatsChartComponent implements AfterViewInit {
   readonly from = input<string | null>(null);
   readonly to = input<string | null>(null);
   readonly dayChartMode = model<'24h' | '14h'>('14h');
-  readonly entries = input<PushupRecord[]>([]);
+  readonly entries = input<StatsChartEntry[]>([]);
   /**
    * Localised label naming the exercise (or group of exercises) the
    * series represents — appended to the title so users can tell at a
@@ -169,7 +177,7 @@ export class StatsChartComponent implements AfterViewInit {
 
   private renderChart(
     series: StatsSeriesEntry[],
-    entries: PushupRecord[] = []
+    entries: StatsChartEntry[] = []
   ): void {
     const element = this.chartCanvas()?.nativeElement;
     if (!element) return;

--- a/web/src/app/stats/shell/analysis-group-view.component.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.ts
@@ -32,12 +32,12 @@ import { kindDisplayName } from '../i18n/exercise-display-names';
   ],
   template: `
     <app-stats-chart
-      [series]="store.chartSeries()"
+      [series]="store.viewChartSeries()"
       [granularity]="store.granularity()"
       [rangeMode]="store.rangeMode()"
       [from]="store.from()"
       [to]="store.to()"
-      [entries]="store.rows()"
+      [entries]="store.viewChartEntries()"
       [dayChartMode]="store.resolvedDayChartMode()"
       (dayChartModeChange)="store.setDayChartMode($event)"
     />

--- a/web/src/app/stats/shell/analysis-group-view.component.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.ts
@@ -33,7 +33,7 @@ import { kindDisplayName } from '../i18n/exercise-display-names';
   template: `
     <app-stats-chart
       [series]="store.viewChartSeries()"
-      [granularity]="store.granularity()"
+      [granularity]="store.viewGranularity()"
       [rangeMode]="store.rangeMode()"
       [from]="store.from()"
       [to]="store.to()"

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -689,6 +689,19 @@ describe('AnalysisPageComponent', () => {
       expect(store.viewChartSeries()).toEqual([]);
     });
 
+    it('viewGranularity tracks from===to without waiting on the REST resource', () => {
+      // The REST-backed `granularity()` lags the resource during cold
+      // start / filter swaps; `viewGranularity()` must derive the mode
+      // from the page filter directly so the chart's axis stays in
+      // lockstep with `viewChartSeries()` bucketing.
+      const { store } = fixture.componentInstance;
+      expect(store.viewGranularity()).toBe('daily');
+      store.setRange('2026-02-12', '2026-02-12');
+      expect(store.viewGranularity()).toBe('hourly');
+      store.setRange('2026-02-09', '2026-02-15');
+      expect(store.viewGranularity()).toBe('daily');
+    });
+
     it('viewChartSeries switches to hourly buckets when the page filter is a single day', () => {
       // Single-day ranges flip the API to hourly granularity. The
       // view-scoped chart must mirror that bucketing on view-filtered
@@ -708,6 +721,21 @@ describe('AnalysisPageComponent', () => {
       expect(series[series.length - 1].dayIntegral).toBe(30);
     });
 
+    it('viewChartSeries collapses 00-07 into a single night bucket in 14h mode', () => {
+      // 14h mode mirrors `StatsApiService.toStatsResponse`: one night
+      // bucket "00-07" followed by hours 8..21 → 15 buckets total.
+      // CI runs in UTC, so the abs entry's hour (08:00 UTC) lands in
+      // the 08 slot, keeping the day's reps inside the 14h window.
+      const { store } = fixture.componentInstance;
+      store.setRange('2026-02-12', '2026-02-12');
+      store.setActiveView('abs');
+      store.setDayChartMode('14h');
+      const series = store.viewChartSeries();
+      expect(series).toHaveLength(15);
+      expect(series[0]).toMatchObject({ bucketLabel: '00-07' });
+      expect(series[series.length - 1].dayIntegral).toBe(30);
+    });
+
     it('viewChartEntries shapes view-filtered rows for the chart sets-stacking layer', () => {
       const { store } = fixture.componentInstance;
       store.setActiveView('abs');
@@ -715,6 +743,19 @@ describe('AnalysisPageComponent', () => {
       expect(entries).toEqual([
         { timestamp: '2026-02-12T08:00:00.000Z', reps: 30 },
       ]);
+    });
+
+    it('viewChartEntries preserves the sets array on entries that have one', () => {
+      // The chart's stacked-bar layer keys off `entry.sets[]` to colour
+      // the "with sets" portion separately. If the store dropped the
+      // array on the way through, every pushup tab would silently lose
+      // its purple "Mit Sets" segment.
+      const { store } = fixture.componentInstance;
+      store.setActiveView('pushup');
+      const entries = store.viewChartEntries();
+      expect(
+        entries.some((e) => Array.isArray(e.sets) && e.sets.length > 1)
+      ).toBe(true);
     });
 
     it('typeBreakdownDisplay localises kind-mode ids when activeView scopes to a non-pushup category', () => {

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -627,6 +627,96 @@ describe('AnalysisPageComponent', () => {
       expect(store.typeBreakdown()).toEqual([]);
     });
 
+    it('viewChartSeries aggregates pushups + exercises in overview mode', () => {
+      // Regression for the analysis-graph-tab bug: the chart used to
+      // bind to `store.chartSeries()` (pushup-only REST series) which
+      // ignored exercise entries and never re-aggregated per active
+      // view. The new view-scoped computed must include both source
+      // collections in overview mode.
+      const { store } = fixture.componentInstance;
+      const series = store.viewChartSeries();
+      const byBucket = new Map(series.map((s) => [s.bucket, s.total]));
+      // Feb 12: pushup id=4 (8) + abs sit-ups (30) = 38
+      expect(byBucket.get('2026-02-12')).toBe(38);
+      // Feb 13: pushup id=5 (25) + legs squats (40) = 65
+      expect(byBucket.get('2026-02-13')).toBe(65);
+      // dayIntegral on the last bucket totals everything in range
+      const last = series[series.length - 1];
+      expect(last.dayIntegral).toBe(163);
+    });
+
+    it('viewChartSeries narrows to the active category (abs)', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('abs');
+      const series = store.viewChartSeries();
+      expect(series).toEqual([
+        { bucket: '2026-02-12', total: 30, dayIntegral: 30 },
+      ]);
+    });
+
+    it('viewChartSeries narrows to the active category (legs)', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('legs');
+      const series = store.viewChartSeries();
+      expect(series).toEqual([
+        { bucket: '2026-02-13', total: 40, dayIntegral: 40 },
+      ]);
+    });
+
+    it('viewChartSeries scoped to pushup matches the legacy pushup-only daily totals', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('pushup');
+      const series = store.viewChartSeries();
+      // Seeded pushups: Feb 9 → 15 with one skipped day, totals
+      // [10,12,20,8,25,18] and cumulative dayIntegral [10,22,42,50,75,93].
+      expect(series.map((s) => s.bucket)).toEqual([
+        '2026-02-09',
+        '2026-02-10',
+        '2026-02-11',
+        '2026-02-12',
+        '2026-02-13',
+        '2026-02-15',
+      ]);
+      expect(series.map((s) => s.total)).toEqual([10, 12, 20, 8, 25, 18]);
+      expect(series.map((s) => s.dayIntegral)).toEqual([
+        10, 22, 42, 50, 75, 93,
+      ]);
+    });
+
+    it('viewChartSeries collapses to an empty array for a category with no entries', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('plank');
+      expect(store.viewChartSeries()).toEqual([]);
+    });
+
+    it('viewChartSeries switches to hourly buckets when the page filter is a single day', () => {
+      // Single-day ranges flip the API to hourly granularity. The
+      // view-scoped chart must mirror that bucketing on view-filtered
+      // rows so the per-category tab still renders a populated chart
+      // for that day. Exact hour placement depends on the runner's
+      // timezone (the seeded abs entry is in UTC), so we assert the
+      // shape and the total — both timezone-agnostic.
+      const { store } = fixture.componentInstance;
+      store.setRange('2026-02-12', '2026-02-12');
+      store.setActiveView('abs');
+      store.setDayChartMode('24h');
+      const series = store.viewChartSeries();
+      expect(series).toHaveLength(24);
+      // All 24 buckets sum to the single abs entry's reps.
+      expect(series.reduce((acc, s) => acc + s.total, 0)).toBe(30);
+      // Final cumulative dayIntegral equals the day's total.
+      expect(series[series.length - 1].dayIntegral).toBe(30);
+    });
+
+    it('viewChartEntries shapes view-filtered rows for the chart sets-stacking layer', () => {
+      const { store } = fixture.componentInstance;
+      store.setActiveView('abs');
+      const entries = store.viewChartEntries();
+      expect(entries).toEqual([
+        { timestamp: '2026-02-12T08:00:00.000Z', reps: 30 },
+      ]);
+    });
+
     it('typeBreakdownDisplay localises kind-mode ids when activeView scopes to a non-pushup category', () => {
       // Regression for codex P2: setActiveView('abs') without an
       // explicit kinds filter puts the store in kind-mode and emits


### PR DESCRIPTION
The chart on the analysis page was bound to `store.chartSeries()` /
`store.rows()`, both of which derive from the pushup-only REST resource
and ignore `activeView`. Switching to a non-pushup tab (Bauch, Beine, …)
left the same all-pushup graph showing, contradicting the KPIs below.

Add `viewChartSeries` and `viewChartEntries` to AnalysisStore that
re-aggregate `viewFilteredRows` per bucket — mirroring the daily/hourly
bucketing in `StatsApiService.toStatsResponse` — and rewire the group
view to consume them. Relax `StatsChartComponent.entries` to a
structural shape so it accepts both pushup records and the new unified
feed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charts now use view-scoped data so totals and stacked entries reflect your current filter and category.
  * Automatic switch between hourly and daily bucketing (including compact daytime/night grouping for single-day views).

* **Refactor**
  * Chart data processing and chart component inputs updated for more accurate aggregation and stacking.

* **Tests**
  * Extended test coverage validating aggregation, bucketing modes, and stacked-entry behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/331)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->