### PR TITLE
fix(daily-goal): override toolbar/quick-add goal with active training plan

### DIFF
--- a/web/src/app/core/app-data.facade.spec.ts
+++ b/web/src/app/core/app-data.facade.spec.ts
@@ -9,7 +9,8 @@ import {
 } from '@pu-stats/data-access';
 import { UserContextService } from '@pu-auth/auth';
 import { AdaptiveQuickAddService } from '@pu-stats/quick-add';
-import type { PushupRecord } from '@pu-stats/models';
+import type { PushupRecord, TrainingPlanDay } from '@pu-stats/models';
+import { TrainingPlanStore } from '../training-plans/training-plan.store';
 
 describe('AppDataFacade', () => {
   const userId = signal<string>('u1');
@@ -42,11 +43,21 @@ describe('AppDataFacade', () => {
   let liveConnected = signal(false);
   let liveEntries = signal<PushupRecord[]>([]);
 
+  // Default TrainingPlanStore: no active plan. Tests that exercise the
+  // plan-override path set `planTodayDay` and the mock derives `hasActivePlan`.
+  const planTodayDay = signal<TrainingPlanDay | null>(null);
+  const planHasActive = signal(false);
+  const trainingPlanStoreMock = {
+    hasActivePlan: planHasActive.asReadonly(),
+    todayDay: planTodayDay.asReadonly(),
+  };
+
   function setup(
     options: {
       dailyGoal?: number;
       todayTotal?: number;
       live?: { connected: boolean; entries: PushupRecord[] };
+      planTodayDay?: TrainingPlanDay | null;
     } = {}
   ): AppDataFacade {
     vitest.clearAllMocks();
@@ -73,6 +84,9 @@ describe('AppDataFacade', () => {
 
     liveConnected = signal(options.live?.connected ?? false);
     liveEntries = signal<PushupRecord[]>(options.live?.entries ?? []);
+    const planDay = options.planTodayDay ?? null;
+    planTodayDay.set(planDay);
+    planHasActive.set(planDay !== null);
 
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
@@ -95,6 +109,7 @@ describe('AppDataFacade', () => {
             updateTick: signal(0).asReadonly(),
           },
         },
+        { provide: TrainingPlanStore, useValue: trainingPlanStoreMock },
       ],
     });
     return TestBed.inject(AppDataFacade);
@@ -276,6 +291,9 @@ describe('AppDataFacade', () => {
       liveConnected = signal(true);
       liveEntries = signal<PushupRecord[]>([]);
 
+      planTodayDay.set(null);
+      planHasActive.set(false);
+
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
         providers: [
@@ -294,6 +312,7 @@ describe('AppDataFacade', () => {
               updateTick: signal(0).asReadonly(),
             },
           },
+          { provide: TrainingPlanStore, useValue: trainingPlanStoreMock },
         ],
       });
       const facade = TestBed.inject(AppDataFacade);
@@ -352,6 +371,75 @@ describe('AppDataFacade', () => {
       await flushResources();
 
       expect(facade.goalReached()).toBe(false);
+    });
+  });
+
+  describe('plan override (regression: toolbar pill stale after plan activation)', () => {
+    const mainDay: TrainingPlanDay = {
+      dayIndex: 1,
+      kind: 'main',
+      targetReps: 60,
+      description: 'Tag 1',
+    };
+    const restDay: TrainingPlanDay = {
+      dayIndex: 1,
+      kind: 'rest',
+      targetReps: 0,
+      description: 'Ruhetag',
+    };
+
+    it('Given an active plan with a non-rest day, Then dailyGoal returns the plan target (overrides user config)', async () => {
+      const facade = setup({ dailyGoal: 100, planTodayDay: mainDay });
+      await flushResources();
+
+      expect(facade.dailyGoal()).toBe(60);
+    });
+
+    it('Given an active plan with a non-rest day, Then remainingToGoal is computed against the plan target', async () => {
+      const facade = setup({
+        dailyGoal: 100,
+        todayTotal: 20,
+        planTodayDay: mainDay,
+      });
+      await flushResources();
+
+      expect(facade.remainingToGoal()).toBe(40);
+    });
+
+    it('Given an active plan with a non-rest day, Then goalReached fires when progress reaches the plan target, not the user goal', async () => {
+      const facade = setup({
+        dailyGoal: 100,
+        todayTotal: 60,
+        planTodayDay: mainDay,
+      });
+      await flushResources();
+
+      expect(facade.goalReached()).toBe(true);
+    });
+
+    it('Given an active plan on a rest day, Then dailyGoal falls back to the user-configured goal', async () => {
+      const facade = setup({ dailyGoal: 100, planTodayDay: restDay });
+      await flushResources();
+
+      expect(facade.dailyGoal()).toBe(100);
+    });
+
+    it('Given no active plan, Then dailyGoal still reflects the user-configured goal (no regression)', async () => {
+      const facade = setup({ dailyGoal: 100, planTodayDay: null });
+      await flushResources();
+
+      expect(facade.dailyGoal()).toBe(100);
+    });
+
+    it('When a plan is activated mid-session, Then dailyGoal reactively switches to the plan target without a reload', async () => {
+      const facade = setup({ dailyGoal: 100 });
+      await flushResources();
+      expect(facade.dailyGoal()).toBe(100);
+
+      planTodayDay.set(mainDay);
+      planHasActive.set(true);
+
+      expect(facade.dailyGoal()).toBe(60);
     });
   });
 });

--- a/web/src/app/core/app-data.facade.ts
+++ b/web/src/app/core/app-data.facade.ts
@@ -11,6 +11,7 @@ import { UserContextService } from '@pu-auth/auth';
 import { LiveDataStore, StatsApiService } from '@pu-stats/data-access';
 import { toBerlinIsoDate } from '@pu-stats/models';
 import { AdaptiveQuickAddService } from '@pu-stats/quick-add';
+import { TrainingPlanStore } from '../training-plans/training-plan.store';
 import { UserConfigStore } from './user-config.store';
 
 /**
@@ -28,6 +29,7 @@ export class AppDataFacade {
   private readonly statsApi = inject(StatsApiService);
   private readonly adaptiveQuickAdd = inject(AdaptiveQuickAddService);
   private readonly userConfig = inject(UserConfigStore);
+  private readonly trainingPlan = inject(TrainingPlanStore);
   private readonly live = inject(LiveDataStore);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
@@ -66,7 +68,29 @@ export class AppDataFacade {
     return this.adaptiveQuickAdd.compute(this.recentEntries());
   });
 
-  readonly dailyGoal = computed(() => this.userConfig.dailyGoal() || 100);
+  /**
+   * Today's prescribed plan reps when a plan is active and today is a
+   * non-rest day. Mirrors the dashboard's `planTodayTarget` so the
+   * toolbar pill and Quick-Add fill button reflect the plan target the
+   * moment a plan is activated, without waiting for a manual config edit.
+   */
+  private readonly planTodayTarget = computed(() => {
+    if (!this.trainingPlan.hasActivePlan()) return 0;
+    const day = this.trainingPlan.todayDay();
+    if (!day || day.kind === 'rest') return 0;
+    return day.targetReps;
+  });
+
+  /**
+   * Plan target if available, otherwise the user-configured goal. Kept
+   * without the `|| 100` fallback so `remainingToGoal` and `goalReached`
+   * can distinguish "no goal configured" from "goal of 100".
+   */
+  private readonly effectiveDailyGoal = computed(
+    () => this.planTodayTarget() || this.userConfig.dailyGoal()
+  );
+
+  readonly dailyGoal = computed(() => this.effectiveDailyGoal() || 100);
 
   readonly dailyProgressResource = resource({
     params: () => ({ userId: this.user.userIdSafe() }),
@@ -92,11 +116,11 @@ export class AppDataFacade {
   });
 
   readonly remainingToGoal = computed(() =>
-    Math.max(0, this.userConfig.dailyGoal() - this.todayProgress())
+    Math.max(0, this.effectiveDailyGoal() - this.todayProgress())
   );
 
   readonly goalReached = computed(() => {
-    const goal = this.userConfig.dailyGoal();
+    const goal = this.effectiveDailyGoal();
     return goal > 0 && this.todayProgress() >= goal;
   });
 


### PR DESCRIPTION
The dashboard's `dailyGoal` already used `planTodayTarget || userConfig.dailyGoal`,
but the toolbar pill, Quick-Add "fill to goal" button and goal-reached signal all
read from `AppDataFacade.dailyGoal`, which only consulted `UserConfigStore` and
therefore ignored the active plan. Activating a plan now propagates to all those
surfaces immediately, matching the dashboard behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily goals now intelligently integrate with active training plans, automatically adapting between plan targets and user-configured values
  * Goal calculations adjust dynamically for rest days and when plans become active mid-session

* **Tests**
  * Expanded test coverage for training plan integration and reactive goal behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/332)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->