### PR TITLE
feat(catalog): restructure exercise categories around movement patterns

### DIFF
--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -1,18 +1,54 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Centralised list of `measurement: 'reps'` exercises the
-    // `exerciseEntries` rule accepts. Keep in sync with the
-    // `measurement: 'reps'` entries in
-    // `libs/stats/src/lib/models/exercise.catalog.ts`. The same list
-    // backs the create and the update branch — adding a new reps
-    // exercise only requires touching this one helper plus the catalog.
+    // Centralised allowlists of catalog exercise ids per measurement
+    // type. Keep these in sync with `libs/stats/src/lib/models/exercise.catalog.ts` —
+    // the rule must list every id the catalog ships, otherwise users
+    // get permission-denied on save for a freshly added exercise.
+    //
+    // Per-exercise min/max bounds live in the catalog and are enforced
+    // client-side; the rule uses one broad bound per measurement type
+    // as a tamper-resistance backstop. A widened-but-not-infinite cap
+    // is intentional: catastrophic values (e.g. distanceM = 10^9) still
+    // get rejected here, but every legitimate catalog entry passes.
     function isRepsExerciseId(id) {
       return [
+        // Legacy `abs.*` / `legs.*` ids predate the movement-pattern
+        // restructure and live across `core` / `squat` / `hinge` / `lunge`.
         'abs.situps', 'abs.crunches', 'abs.legraises',
         'abs.russiantwist', 'abs.mountainclimbers',
         'legs.squats', 'legs.lunges', 'legs.glutebridge',
-        'legs.calfraises', 'legs.jumpsquats'
+        'legs.calfraises', 'legs.jumpsquats',
+        // core / squat / hinge / lunge — new reps exercises
+        'core.deadbug',
+        'squat.boxjump',
+        'hinge.singlelegRdl', 'hinge.goodmorning',
+        'lunge.stepup',
+        // pull — bodyweight pulling
+        'pull.pullups', 'pull.rows', 'pull.facepull',
+        // cardio reps-counted conditioning
+        'cardio.jumprope', 'cardio.burpees', 'cardio.jumpingjacks',
+        // mobility (only catcow is reps-counted; the others are time)
+        'mobility.catcow'
+      ].hasAny([id]);
+    }
+
+    function isTimeExerciseId(id) {
+      return [
+        'plank.standard',
+        'core.hollowhold',
+        'squat.wallsit',
+        'pull.deadhang',
+        'cardio.highknees',
+        'mobility.stretching', 'mobility.yoga', 'mobility.foamrolling',
+        'mobility.dynamicwarmup', 'mobility.hipopener'
+      ].hasAny([id]);
+    }
+
+    function isDistanceTimeExerciseId(id) {
+      return [
+        'cardio.running', 'cardio.walking', 'cardio.cycling',
+        'cardio.rowing', 'cardio.swimming'
       ].hasAny([id]);
     }
 
@@ -181,18 +217,23 @@ service cloud.firestore {
                       // Reps-measured exercises. Allowlist lives in
                       // `isRepsExerciseId()` at the top of this file so
                       // create + update share a single source of truth.
+                      // Cap (500) matches the widest catalog max for
+                      // reps exercises; per-exercise caps are enforced
+                      // client-side.
                       (isRepsExerciseId(request.resource.data.exerciseId)
                         && request.resource.data.reps is int
                         && request.resource.data.reps >= 1
-                        && request.resource.data.reps <= 500
+                        && request.resource.data.reps <= 10000
                         && !('durationSec' in request.resource.data.keys())
                         && !('distanceM' in request.resource.data.keys()))
                       ||
-                      // Time-measured exercises (plank). `sets` would
-                      // poison `applyDelta` because no per-set duration
-                      // breakdown is defined yet — block it at the rule
-                      // until a future phase introduces one.
-                      (request.resource.data.exerciseId == 'plank.standard'
+                      // Time-measured exercises (plank, hollow hold,
+                      // wall sit, dead hang, mobility holds, …). `sets`
+                      // would poison `applyDelta` because no per-set
+                      // duration breakdown is defined yet — block it at
+                      // the rule until a future phase introduces one.
+                      // Cap (7200 = 2 h) matches the widest catalog max.
+                      (isTimeExerciseId(request.resource.data.exerciseId)
                         && request.resource.data.durationSec is int
                         && request.resource.data.durationSec >= 1
                         && request.resource.data.durationSec <= 7200
@@ -200,13 +241,16 @@ service cloud.firestore {
                         && !('sets' in request.resource.data.keys())
                         && !('distanceM' in request.resource.data.keys()))
                       ||
-                      // Distance-time-measured exercises (cardio.running).
-                      // Both fields are required; `reps`/`sets` are blocked
-                      // for the same reason as plank.
-                      (request.resource.data.exerciseId == 'cardio.running'
+                      // Distance-time-measured exercises (cardio.running
+                      // and friends). Both fields are required; reps /
+                      // sets are blocked for the same reason as the
+                      // time branch. Distance cap (300 000 m = 300 km)
+                      // covers cycling; the per-exercise min/max
+                      // catalog bounds narrow it further client-side.
+                      (isDistanceTimeExerciseId(request.resource.data.exerciseId)
                         && request.resource.data.distanceM is int
-                        && request.resource.data.distanceM >= 100
-                        && request.resource.data.distanceM <= 50000
+                        && request.resource.data.distanceM >= 1
+                        && request.resource.data.distanceM <= 300000
                         && request.resource.data.durationSec is int
                         && request.resource.data.durationSec >= 1
                         && request.resource.data.durationSec <= 86400

--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -217,9 +217,10 @@ service cloud.firestore {
                       // Reps-measured exercises. Allowlist lives in
                       // `isRepsExerciseId()` at the top of this file so
                       // create + update share a single source of truth.
-                      // Cap (500) matches the widest catalog max for
-                      // reps exercises; per-exercise caps are enforced
-                      // client-side.
+                      // Cap (10 000) covers high-rep conditioning ids
+                      // like `cardio.jumprope`; per-exercise caps are
+                      // enforced client-side via the catalog
+                      // `min`/`max` plus the `applyDelta` trigger.
                       (isRepsExerciseId(request.resource.data.exerciseId)
                         && request.resource.data.reps is int
                         && request.resource.data.reps >= 1

--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -281,20 +281,20 @@ service cloud.firestore {
                     // pin to `resource.data.exerciseId`.
                     && (
                       // Reps-measured exercises: reject `durationSec`/
-                      // `distanceM` and validate reps when changed. Same
-                      // allowlist as create, sourced from
-                      // `isRepsExerciseId()` at the top of this file.
+                      // `distanceM` and validate reps when changed.
+                      // Caps mirror the create branch (single source of
+                      // truth via `isRepsExerciseId()` at the top).
                       (isRepsExerciseId(resource.data.exerciseId)
                         && !('durationSec' in request.resource.data.keys())
                         && !('distanceM' in request.resource.data.keys())
                         && (!('reps' in request.resource.data.diff(resource.data).affectedKeys())
                             || (request.resource.data.reps is int
                                 && request.resource.data.reps >= 1
-                                && request.resource.data.reps <= 500)))
+                                && request.resource.data.reps <= 10000)))
                       ||
-                      // Time-measured exercises (plank): reject `reps`,
-                      // `sets`, `distanceM`; validate durationSec when changed.
-                      (resource.data.exerciseId == 'plank.standard'
+                      // Time-measured exercises: reject `reps`, `sets`,
+                      // `distanceM`; validate durationSec when changed.
+                      (isTimeExerciseId(resource.data.exerciseId)
                         && !('reps' in request.resource.data.keys())
                         && !('sets' in request.resource.data.keys())
                         && !('distanceM' in request.resource.data.keys())
@@ -303,16 +303,15 @@ service cloud.firestore {
                                 && request.resource.data.durationSec >= 1
                                 && request.resource.data.durationSec <= 7200)))
                       ||
-                      // Distance-time-measured exercises (cardio.running):
-                      // reject `reps`/`sets`; validate distanceM and
-                      // durationSec when changed.
-                      (resource.data.exerciseId == 'cardio.running'
+                      // Distance-time-measured exercises: reject `reps`/
+                      // `sets`; validate distanceM + durationSec on change.
+                      (isDistanceTimeExerciseId(resource.data.exerciseId)
                         && !('reps' in request.resource.data.keys())
                         && !('sets' in request.resource.data.keys())
                         && (!('distanceM' in request.resource.data.diff(resource.data).affectedKeys())
                             || (request.resource.data.distanceM is int
-                                && request.resource.data.distanceM >= 100
-                                && request.resource.data.distanceM <= 50000))
+                                && request.resource.data.distanceM >= 1
+                                && request.resource.data.distanceM <= 300000))
                         && (!('durationSec' in request.resource.data.diff(resource.data).affectedKeys())
                             || (request.resource.data.durationSec is int
                                 && request.resource.data.durationSec >= 1

--- a/libs/stats/src/lib/models/exercise.catalog.spec.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.spec.ts
@@ -18,22 +18,30 @@ describe('EXERCISE_CATEGORIES', () => {
     }
   });
 
-  it('ships every movement-pattern category', () => {
+  it('ships the dialog-supported movement-pattern categories', () => {
     const ids = new Set(EXERCISE_CATEGORIES.map((c) => c.id));
+    // `carry` (distance) and `strength` (weight) stay declared in
+    // ExerciseCategoryId but are intentionally absent from
+    // EXERCISE_CATEGORIES until the training-entry dialog grows
+    // weight + distance form support — see catalog header comment.
     for (const id of [
       'push',
       'pull',
       'squat',
       'hinge',
       'lunge',
-      'carry',
       'core',
       'cardio',
       'mobility',
-      'strength',
     ]) {
       expect(ids.has(id)).toBe(true);
     }
+  });
+
+  it('omits weight/distance categories until dialog gains support', () => {
+    const ids = new Set(EXERCISE_CATEGORIES.map((c) => c.id));
+    expect(ids.has('carry')).toBe(false);
+    expect(ids.has('strength')).toBe(false);
   });
 });
 
@@ -101,14 +109,23 @@ describe('EXERCISE_CATALOG', () => {
     expect(running?.max).toBeGreaterThanOrEqual(50_000);
   });
 
-  it('ships pull/hinge/carry/strength exercises', () => {
+  it('ships pull/hinge/mobility exercises', () => {
     const ids = new Set(EXERCISE_CATALOG.map((d) => d.id));
     expect(ids.has('pull.pullups')).toBe(true);
     expect(ids.has('pull.rows')).toBe(true);
     expect(ids.has('hinge.singlelegRdl')).toBe(true);
-    expect(ids.has('carry.farmer')).toBe(true);
-    expect(ids.has('strength.deadlift')).toBe(true);
     expect(ids.has('mobility.stretching')).toBe(true);
+  });
+
+  it('does not yet ship distance- or weight-measured catalog entries', () => {
+    // The training-entry dialog only renders `reps` / `time` /
+    // `distance-time` form rows. Surfacing `distance` (carry) or
+    // `weight` (strength) catalog entries before the dialog gains
+    // those input shapes would route users into a save-error path.
+    for (const def of EXERCISE_CATALOG) {
+      expect(def.measurement).not.toBe('distance');
+      expect(def.measurement).not.toBe('weight');
+    }
   });
 
   it('attaches variants to compound exercises that benefit from them', () => {

--- a/libs/stats/src/lib/models/exercise.catalog.spec.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.spec.ts
@@ -17,6 +17,24 @@ describe('EXERCISE_CATEGORIES', () => {
       expect(cat.nameKey).toMatch(/^@@/);
     }
   });
+
+  it('ships every movement-pattern category', () => {
+    const ids = new Set(EXERCISE_CATEGORIES.map((c) => c.id));
+    for (const id of [
+      'push',
+      'pull',
+      'squat',
+      'hinge',
+      'lunge',
+      'carry',
+      'core',
+      'cardio',
+      'mobility',
+      'strength',
+    ]) {
+      expect(ids.has(id)).toBe(true);
+    }
+  });
 });
 
 describe('EXERCISE_CATALOG', () => {
@@ -44,32 +62,34 @@ describe('EXERCISE_CATALOG', () => {
     }
   });
 
-  it('includes the phase-0 sit-ups and squats exercises', () => {
+  it('keeps legacy core ids stable so existing Firestore docs resolve', () => {
     const ids = new Set(EXERCISE_CATALOG.map((d) => d.id));
+    // `abs.*` and `plank.*` ids predate the movement-pattern restructure
+    // (moved into the `core` category, ids untouched).
     expect(ids.has('abs.situps')).toBe(true);
-    expect(ids.has('legs.squats')).toBe(true);
+    expect(ids.has('abs.crunches')).toBe(true);
+    expect(ids.has('abs.legraises')).toBe(true);
+    expect(ids.has('abs.russiantwist')).toBe(true);
+    expect(ids.has('abs.mountainclimbers')).toBe(true);
+    expect(ids.has('plank.standard')).toBe(true);
   });
 
-  it('includes the additional abs and legs exercises', () => {
+  it('keeps legacy lower-body ids stable', () => {
     const ids = new Set(EXERCISE_CATALOG.map((d) => d.id));
-    for (const id of [
-      'abs.crunches',
-      'abs.legraises',
-      'abs.russiantwist',
-      'abs.mountainclimbers',
-      'legs.lunges',
-      'legs.glutebridge',
-      'legs.calfraises',
-      'legs.jumpsquats',
-    ]) {
-      expect(ids.has(id)).toBe(true);
-    }
+    // `legs.*` ids predate the squat/hinge/lunge split — kept stable,
+    // only categorisation moved.
+    expect(ids.has('legs.squats')).toBe(true);
+    expect(ids.has('legs.lunges')).toBe(true);
+    expect(ids.has('legs.glutebridge')).toBe(true);
+    expect(ids.has('legs.calfraises')).toBe(true);
+    expect(ids.has('legs.jumpsquats')).toBe(true);
   });
 
-  it('exposes plank.standard as the time-measurement entry point', () => {
+  it('exposes plank.standard as a time-measurement core exercise', () => {
     const plank = EXERCISE_CATALOG.find((d) => d.id === 'plank.standard');
     expect(plank?.measurement).toBe('time');
     expect(plank?.unit).toBe('s');
+    expect(plank?.categoryId).toBe('core');
   });
 
   it('exposes cardio.running as the first distance-time exercise', () => {
@@ -80,11 +100,38 @@ describe('EXERCISE_CATALOG', () => {
     expect(running?.min).toBeGreaterThan(0);
     expect(running?.max).toBeGreaterThanOrEqual(50_000);
   });
+
+  it('ships pull/hinge/carry/strength exercises', () => {
+    const ids = new Set(EXERCISE_CATALOG.map((d) => d.id));
+    expect(ids.has('pull.pullups')).toBe(true);
+    expect(ids.has('pull.rows')).toBe(true);
+    expect(ids.has('hinge.singlelegRdl')).toBe(true);
+    expect(ids.has('carry.farmer')).toBe(true);
+    expect(ids.has('strength.deadlift')).toBe(true);
+    expect(ids.has('mobility.stretching')).toBe(true);
+  });
+
+  it('attaches variants to compound exercises that benefit from them', () => {
+    const pullups = EXERCISE_CATALOG.find((d) => d.id === 'pull.pullups');
+    expect(pullups?.variants?.length).toBeGreaterThan(0);
+    const plank = EXERCISE_CATALOG.find((d) => d.id === 'plank.standard');
+    expect(plank?.variants?.length).toBeGreaterThan(0);
+    const lunges = EXERCISE_CATALOG.find((d) => d.id === 'legs.lunges');
+    expect(lunges?.variants?.length).toBeGreaterThan(0);
+  });
 });
 
 describe('findExerciseDefinition', () => {
-  it('returns a known catalog entry by id', () => {
-    expect(findExerciseDefinition('abs.situps')?.categoryId).toBe('abs');
+  it('resolves a legacy core id to the core category', () => {
+    expect(findExerciseDefinition('abs.situps')?.categoryId).toBe('core');
+  });
+
+  it('resolves a legacy lower-body id to its movement pattern', () => {
+    expect(findExerciseDefinition('legs.squats')?.categoryId).toBe('squat');
+    expect(findExerciseDefinition('legs.lunges')?.categoryId).toBe('lunge');
+    expect(findExerciseDefinition('legs.glutebridge')?.categoryId).toBe(
+      'hinge'
+    );
   });
 
   it('returns null for unknown ids', () => {
@@ -100,8 +147,11 @@ describe('findExerciseDefinition', () => {
 
 describe('findExerciseCategory', () => {
   it('returns a known category by id', () => {
-    expect(findExerciseCategory('abs')?.nameKey).toBe(
-      '@@exercise.category.abs'
+    expect(findExerciseCategory('core')?.nameKey).toBe(
+      '@@exercise.category.core'
+    );
+    expect(findExerciseCategory('squat')?.nameKey).toBe(
+      '@@exercise.category.squat'
     );
   });
 
@@ -113,10 +163,12 @@ describe('findExerciseCategory', () => {
 describe('exercisesByCategory', () => {
   it('groups every catalog entry under its category', () => {
     const map = exercisesByCategory();
-    const abs = map.get('abs') ?? [];
-    const legs = map.get('legs') ?? [];
-    expect(abs.map((d) => d.id)).toContain('abs.situps');
-    expect(legs.map((d) => d.id)).toContain('legs.squats');
+    const core = map.get('core') ?? [];
+    const squat = map.get('squat') ?? [];
+    const lunge = map.get('lunge') ?? [];
+    expect(core.map((d) => d.id)).toContain('abs.situps');
+    expect(squat.map((d) => d.id)).toContain('legs.squats');
+    expect(lunge.map((d) => d.id)).toContain('legs.lunges');
   });
 
   it('declares a bucket for every known category, even when empty', () => {

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -90,7 +90,6 @@ export const EXERCISE_CATEGORIES: ReadonlyArray<ExerciseCategoryInfo> = [
  * be reflected in `data-store/firestore.rules` and vice versa.
  */
 export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
-  // ─── core ────────────────────────────────────────────────────────────
   {
     // Legacy id `abs.situps` predates the movement-pattern restructure.
     // Kept as-is so existing Firestore docs continue to resolve; only
@@ -280,7 +279,6 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     ],
   },
 
-  // ─── squat (knee-dominant lower body) ────────────────────────────────
   {
     id: 'legs.squats',
     categoryId: 'squat',
@@ -376,7 +374,6 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     icon: 'directions_run',
   },
 
-  // ─── hinge (hip-dominant lower body) ─────────────────────────────────
   {
     id: 'legs.glutebridge',
     categoryId: 'hinge',
@@ -430,7 +427,6 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     icon: 'compress',
   },
 
-  // ─── lunge (single-leg / split-stance) ───────────────────────────────
   {
     id: 'legs.lunges',
     categoryId: 'lunge',
@@ -484,7 +480,6 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     icon: 'stairs',
   },
 
-  // ─── pull (vertical/horizontal pulling) ──────────────────────────────
   {
     id: 'pull.pullups',
     categoryId: 'pull',
@@ -585,14 +580,12 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     icon: 'rowing',
   },
 
-  // ─── carry (loaded carries) ──────────────────────────────────────────
   // Carry exercises are `distance`-measured and need a distance-only
   // form path the training dialog doesn't yet implement (today it only
   // renders `time` and `distance-time` form rows). They ship in a
   // follow-up PR alongside the dialog work + a Firestore rule branch
   // that bounds `distanceM` for the carry-specific ids.
 
-  // ─── cardio ──────────────────────────────────────────────────────────
   {
     id: 'cardio.running',
     categoryId: 'cardio',
@@ -684,7 +677,6 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     icon: 'directions_run',
   },
 
-  // ─── mobility ────────────────────────────────────────────────────────
   {
     id: 'mobility.stretching',
     categoryId: 'mobility',
@@ -746,7 +738,6 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     icon: 'accessibility_new',
   },
 
-  // ─── strength (weighted compound lifts) ──────────────────────────────
   // Strength exercises are `weight`-measured and require a `weightKg`
   // companion input the training dialog doesn't yet render. They ship
   // in a follow-up PR alongside the weighted-set form, the `weightKg`

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -49,12 +49,6 @@ export const EXERCISE_CATEGORIES: ReadonlyArray<ExerciseCategoryInfo> = [
     order: 50,
   },
   {
-    id: 'carry',
-    nameKey: '@@exercise.category.carry',
-    icon: 'luggage',
-    order: 60,
-  },
-  {
     id: 'core',
     nameKey: '@@exercise.category.core',
     icon: 'self_improvement',
@@ -72,12 +66,13 @@ export const EXERCISE_CATEGORIES: ReadonlyArray<ExerciseCategoryInfo> = [
     icon: 'accessibility_new',
     order: 90,
   },
-  {
-    id: 'strength',
-    nameKey: '@@exercise.category.strength',
-    icon: 'exercise',
-    order: 100,
-  },
+  // `carry` (distance) and `strength` (weight) are declared in
+  // ExerciseCategoryId for forward compatibility but stay out of the
+  // picker until the training-entry dialog grows weight + distance-only
+  // form fields and the Firestore rule learns the matching companion
+  // bounds. Today the dialog falls back to a reps payload for any
+  // measurement it doesn't recognise — surfacing those exercises now
+  // would put users in front of a save-error path.
 ];
 
 /**
@@ -591,36 +586,11 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
   },
 
   // ─── carry (loaded carries) ──────────────────────────────────────────
-  {
-    id: 'carry.farmer',
-    categoryId: 'carry',
-    measurement: 'distance',
-    min: 1,
-    max: 5000,
-    unit: 'm',
-    nameKey: '@@exercise.carry.farmer.name',
-    icon: 'luggage',
-  },
-  {
-    id: 'carry.suitcase',
-    categoryId: 'carry',
-    measurement: 'distance',
-    min: 1,
-    max: 5000,
-    unit: 'm',
-    nameKey: '@@exercise.carry.suitcase.name',
-    icon: 'luggage',
-  },
-  {
-    id: 'carry.overhead',
-    categoryId: 'carry',
-    measurement: 'distance',
-    min: 1,
-    max: 2000,
-    unit: 'm',
-    nameKey: '@@exercise.carry.overhead.name',
-    icon: 'luggage',
-  },
+  // Carry exercises are `distance`-measured and need a distance-only
+  // form path the training dialog doesn't yet implement (today it only
+  // renders `time` and `distance-time` form rows). They ship in a
+  // follow-up PR alongside the dialog work + a Firestore rule branch
+  // that bounds `distanceM` for the carry-specific ids.
 
   // ─── cardio ──────────────────────────────────────────────────────────
   {
@@ -777,66 +747,11 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
   },
 
   // ─── strength (weighted compound lifts) ──────────────────────────────
-  {
-    id: 'strength.benchpress',
-    categoryId: 'strength',
-    measurement: 'weight',
-    min: 1,
-    max: 50,
-    unit: 'reps',
-    nameKey: '@@exercise.strength.benchpress.name',
-    icon: 'exercise',
-  },
-  {
-    id: 'strength.overheadpress',
-    categoryId: 'strength',
-    measurement: 'weight',
-    min: 1,
-    max: 50,
-    unit: 'reps',
-    nameKey: '@@exercise.strength.overheadpress.name',
-    icon: 'exercise',
-  },
-  {
-    id: 'strength.deadlift',
-    categoryId: 'strength',
-    measurement: 'weight',
-    min: 1,
-    max: 50,
-    unit: 'reps',
-    nameKey: '@@exercise.strength.deadlift.name',
-    icon: 'exercise',
-  },
-  {
-    id: 'strength.barbellsquat',
-    categoryId: 'strength',
-    measurement: 'weight',
-    min: 1,
-    max: 50,
-    unit: 'reps',
-    nameKey: '@@exercise.strength.barbellsquat.name',
-    icon: 'exercise',
-  },
-  {
-    id: 'strength.barbellrow',
-    categoryId: 'strength',
-    measurement: 'weight',
-    min: 1,
-    max: 50,
-    unit: 'reps',
-    nameKey: '@@exercise.strength.barbellrow.name',
-    icon: 'exercise',
-  },
-  {
-    id: 'strength.kettlebellswing',
-    categoryId: 'strength',
-    measurement: 'weight',
-    min: 1,
-    max: 100,
-    unit: 'reps',
-    nameKey: '@@exercise.strength.kettlebellswing.name',
-    icon: 'exercise',
-  },
+  // Strength exercises are `weight`-measured and require a `weightKg`
+  // companion input the training dialog doesn't yet render. They ship
+  // in a follow-up PR alongside the weighted-set form, the `weightKg`
+  // companion in `exerciseEntries` Firestore rule, and the
+  // per-exercise stats trigger work to surface PRs in load × reps.
 ];
 
 const CATALOG_BY_ID: ReadonlyMap<string, ExerciseDefinition> = new Map(

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -5,148 +5,327 @@ import type {
 
 /**
  * Curated catalog of exercise categories shown in the dashboard and
- * filter UI. Order determines top-to-bottom layout on the dashboard.
+ * filter UI. Order determines top-to-bottom layout on the dashboard
+ * (lower = higher up).
  *
- * Phase 0 lists only the categories with at least one exercise in
- * {@link EXERCISE_CATALOG} below — additional categories (plank, cardio,
- * strength, mobility) are added incrementally with their own exercises.
+ * Categories follow the movement-pattern taxonomy documented on
+ * {@link import('./exercise.models').ExerciseCategoryId}.
+ *
+ * Existing user entries reference exercises by id, not by category, so
+ * recategorizing an exercise (e.g. moving `legs.squats` into the
+ * `squat` category) is a UI-only change — no Firestore migration is
+ * needed. Legacy entries in the `pushups` collection map to the `push`
+ * category via {@link import('./unified-entry.models').unifiedEntryCategoryId}.
  */
 export const EXERCISE_CATEGORIES: ReadonlyArray<ExerciseCategoryInfo> = [
   {
-    id: 'pushup',
-    nameKey: '@@exercise.category.pushup',
+    id: 'push',
+    nameKey: '@@exercise.category.push',
     icon: 'fitness_center',
     order: 10,
   },
   {
-    id: 'abs',
-    nameKey: '@@exercise.category.abs',
-    icon: 'self_improvement',
+    id: 'pull',
+    nameKey: '@@exercise.category.pull',
+    icon: 'rowing',
     order: 20,
   },
   {
-    id: 'legs',
-    nameKey: '@@exercise.category.legs',
-    icon: 'directions_run',
+    id: 'squat',
+    nameKey: '@@exercise.category.squat',
+    icon: 'airline_seat_legroom_reduced',
     order: 30,
   },
   {
-    id: 'plank',
-    nameKey: '@@exercise.category.plank',
-    icon: 'horizontal_rule',
+    id: 'hinge',
+    nameKey: '@@exercise.category.hinge',
+    icon: 'compress',
     order: 40,
+  },
+  {
+    id: 'lunge',
+    nameKey: '@@exercise.category.lunge',
+    icon: 'directions_walk',
+    order: 50,
+  },
+  {
+    id: 'carry',
+    nameKey: '@@exercise.category.carry',
+    icon: 'luggage',
+    order: 60,
+  },
+  {
+    id: 'core',
+    nameKey: '@@exercise.category.core',
+    icon: 'self_improvement',
+    order: 70,
   },
   {
     id: 'cardio',
     nameKey: '@@exercise.category.cardio',
     icon: 'directions_run',
-    order: 50,
+    order: 80,
+  },
+  {
+    id: 'mobility',
+    nameKey: '@@exercise.category.mobility',
+    icon: 'accessibility_new',
+    order: 90,
+  },
+  {
+    id: 'strength',
+    nameKey: '@@exercise.category.strength',
+    icon: 'exercise',
+    order: 100,
   },
 ];
 
 /**
- * Standard catalog of exercises available to every user. The pushup
- * catalog stays in `pushup-type.models.ts` for backwards compatibility
- * with existing Firestore docs in the `pushups` collection — see
- * roadmap.
+ * Standard catalog of exercises available to every user.
+ *
+ * Exercise IDs are stable — they're stored on every `ExerciseEntry`
+ * Firestore doc. Renaming an id requires a data migration. Recategorizing
+ * (changing `categoryId` only) does not.
+ *
+ * Pushup variants stay on `PushupRecord` in the legacy `pushups`
+ * collection — see `pushup-type.models.ts` and the Phase 7 migration
+ * note in `plans/multi-exercise-roadmap.md`.
  *
  * Caps mirror the `exerciseEntries` Firestore rule. Any change here MUST
  * be reflected in `data-store/firestore.rules` and vice versa.
  */
 export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
+  // ─── core ────────────────────────────────────────────────────────────
   {
+    // Legacy id `abs.situps` predates the movement-pattern restructure.
+    // Kept as-is so existing Firestore docs continue to resolve; only
+    // the `categoryId` moves them from `abs` → `core`.
     id: 'abs.situps',
-    categoryId: 'abs',
+    categoryId: 'core',
     measurement: 'reps',
     min: 1,
     max: 500,
     unit: 'reps',
     nameKey: '@@exercise.abs.situps.name',
     icon: 'self_improvement',
+    variants: [
+      {
+        id: 'standard',
+        nameKey: '@@exercise.variant.situps.standard',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'decline',
+        nameKey: '@@exercise.variant.situps.decline',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'weighted',
+        nameKey: '@@exercise.variant.situps.weighted',
+        difficulty: 'advanced',
+      },
+    ],
   },
   {
     id: 'abs.crunches',
-    categoryId: 'abs',
+    categoryId: 'core',
     measurement: 'reps',
     min: 1,
     max: 500,
     unit: 'reps',
     nameKey: '@@exercise.abs.crunches.name',
     icon: 'self_improvement',
+    variants: [
+      {
+        id: 'standard',
+        nameKey: '@@exercise.variant.crunches.standard',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'reverse',
+        nameKey: '@@exercise.variant.crunches.reverse',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'bicycle',
+        nameKey: '@@exercise.variant.crunches.bicycle',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'oblique',
+        nameKey: '@@exercise.variant.crunches.oblique',
+        difficulty: 'intermediate',
+      },
+    ],
   },
   {
     id: 'abs.legraises',
-    categoryId: 'abs',
+    categoryId: 'core',
     measurement: 'reps',
     min: 1,
     max: 500,
     unit: 'reps',
     nameKey: '@@exercise.abs.legraises.name',
     icon: 'self_improvement',
+    variants: [
+      {
+        id: 'lying',
+        nameKey: '@@exercise.variant.legraises.lying',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'hanging-knee',
+        nameKey: '@@exercise.variant.legraises.hanging-knee',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'hanging-straight',
+        nameKey: '@@exercise.variant.legraises.hanging-straight',
+        difficulty: 'advanced',
+      },
+    ],
   },
   {
     id: 'abs.russiantwist',
-    categoryId: 'abs',
+    categoryId: 'core',
     measurement: 'reps',
     min: 1,
     max: 500,
     unit: 'reps',
     nameKey: '@@exercise.abs.russiantwist.name',
     icon: 'self_improvement',
+    variants: [
+      {
+        id: 'bodyweight',
+        nameKey: '@@exercise.variant.russiantwist.bodyweight',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'weighted',
+        nameKey: '@@exercise.variant.russiantwist.weighted',
+        difficulty: 'intermediate',
+      },
+    ],
   },
   {
     id: 'abs.mountainclimbers',
-    categoryId: 'abs',
+    categoryId: 'core',
     measurement: 'reps',
     min: 1,
     max: 500,
     unit: 'reps',
     nameKey: '@@exercise.abs.mountainclimbers.name',
     icon: 'self_improvement',
+    variants: [
+      {
+        id: 'standard',
+        nameKey: '@@exercise.variant.mountainclimbers.standard',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'cross-body',
+        nameKey: '@@exercise.variant.mountainclimbers.cross-body',
+        difficulty: 'intermediate',
+      },
+    ],
   },
   {
+    id: 'core.deadbug',
+    categoryId: 'core',
+    measurement: 'reps',
+    min: 1,
+    max: 200,
+    unit: 'reps',
+    nameKey: '@@exercise.core.deadbug.name',
+    icon: 'self_improvement',
+  },
+  {
+    id: 'core.hollowhold',
+    categoryId: 'core',
+    measurement: 'time',
+    min: 1,
+    max: 1200,
+    unit: 's',
+    nameKey: '@@exercise.core.hollowhold.name',
+    icon: 'horizontal_rule',
+  },
+  {
+    // Legacy id `plank.standard` migrated into the `core` category as
+    // an isometric hold. The four plank variants live here so users see
+    // them under "Plank" inside the core picker.
+    id: 'plank.standard',
+    categoryId: 'core',
+    measurement: 'time',
+    min: 1,
+    max: 7200,
+    unit: 's',
+    nameKey: '@@exercise.plank.standard.name',
+    icon: 'horizontal_rule',
+    variants: [
+      {
+        id: 'standard',
+        nameKey: '@@exercise.variant.plank.standard',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'forearm',
+        nameKey: '@@exercise.variant.plank.forearm',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'side',
+        nameKey: '@@exercise.variant.plank.side',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'reverse',
+        nameKey: '@@exercise.variant.plank.reverse',
+        difficulty: 'intermediate',
+      },
+    ],
+  },
+
+  // ─── squat (knee-dominant lower body) ────────────────────────────────
+  {
     id: 'legs.squats',
-    categoryId: 'legs',
+    categoryId: 'squat',
     measurement: 'reps',
     min: 1,
     max: 500,
     unit: 'reps',
     nameKey: '@@exercise.legs.squats.name',
     icon: 'directions_run',
-  },
-  {
-    id: 'legs.lunges',
-    categoryId: 'legs',
-    measurement: 'reps',
-    min: 1,
-    max: 500,
-    unit: 'reps',
-    nameKey: '@@exercise.legs.lunges.name',
-    icon: 'directions_run',
-  },
-  {
-    id: 'legs.glutebridge',
-    categoryId: 'legs',
-    measurement: 'reps',
-    min: 1,
-    max: 500,
-    unit: 'reps',
-    nameKey: '@@exercise.legs.glutebridge.name',
-    icon: 'directions_run',
-  },
-  {
-    id: 'legs.calfraises',
-    categoryId: 'legs',
-    measurement: 'reps',
-    min: 1,
-    max: 500,
-    unit: 'reps',
-    nameKey: '@@exercise.legs.calfraises.name',
-    icon: 'directions_run',
+    variants: [
+      {
+        id: 'bodyweight',
+        nameKey: '@@exercise.variant.squats.bodyweight',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'sumo',
+        nameKey: '@@exercise.variant.squats.sumo',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'goblet',
+        nameKey: '@@exercise.variant.squats.goblet',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'bulgarian-split',
+        nameKey: '@@exercise.variant.squats.bulgarian-split',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'pistol',
+        nameKey: '@@exercise.variant.squats.pistol',
+        difficulty: 'advanced',
+      },
+    ],
   },
   {
     id: 'legs.jumpsquats',
-    categoryId: 'legs',
+    categoryId: 'squat',
     measurement: 'reps',
     min: 1,
     max: 500,
@@ -155,26 +334,296 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     icon: 'directions_run',
   },
   {
-    // Standard plank — the time-measurement entry point. Variants
-    // (forearm / side / hollow hold) ship with their own catalog ids
-    // once the variant picker grows the autocomplete-with-wiki path
-    // (see UI-3 Phase B in the roadmap).
-    id: 'plank.standard',
-    categoryId: 'plank',
-    measurement: 'time',
+    id: 'legs.calfraises',
+    categoryId: 'squat',
+    measurement: 'reps',
     min: 1,
-    max: 7200,
-    unit: 's',
-    nameKey: '@@exercise.plank.standard.name',
-    icon: 'horizontal_rule',
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.legs.calfraises.name',
+    icon: 'directions_run',
+    variants: [
+      {
+        id: 'standard',
+        nameKey: '@@exercise.variant.calfraises.standard',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'single-leg',
+        nameKey: '@@exercise.variant.calfraises.single-leg',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'seated',
+        nameKey: '@@exercise.variant.calfraises.seated',
+        difficulty: 'beginner',
+      },
+    ],
   },
   {
-    // First composite-measurement entry: a tracked run carries both
-    // distance and duration. `min`/`max` constrain `distanceM`
-    // (100 m sprint up to 50 km ultra); the required duration
-    // companion is bounded globally by COMPANION_BOUNDS in
-    // `exercise.models.ts` (1..86400 s) because no user data exists
-    // yet to establish a tighter per-exercise ceiling.
+    id: 'squat.wallsit',
+    categoryId: 'squat',
+    measurement: 'time',
+    min: 1,
+    max: 1200,
+    unit: 's',
+    nameKey: '@@exercise.squat.wallsit.name',
+    icon: 'airline_seat_legroom_reduced',
+  },
+  {
+    id: 'squat.boxjump',
+    categoryId: 'squat',
+    measurement: 'reps',
+    min: 1,
+    max: 300,
+    unit: 'reps',
+    nameKey: '@@exercise.squat.boxjump.name',
+    icon: 'directions_run',
+  },
+
+  // ─── hinge (hip-dominant lower body) ─────────────────────────────────
+  {
+    id: 'legs.glutebridge',
+    categoryId: 'hinge',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.legs.glutebridge.name',
+    icon: 'compress',
+    variants: [
+      {
+        id: 'standard',
+        nameKey: '@@exercise.variant.glutebridge.standard',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'single-leg',
+        nameKey: '@@exercise.variant.glutebridge.single-leg',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'hip-thrust',
+        nameKey: '@@exercise.variant.glutebridge.hip-thrust',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'march',
+        nameKey: '@@exercise.variant.glutebridge.march',
+        difficulty: 'beginner',
+      },
+    ],
+  },
+  {
+    id: 'hinge.singlelegRdl',
+    categoryId: 'hinge',
+    measurement: 'reps',
+    min: 1,
+    max: 200,
+    unit: 'reps',
+    nameKey: '@@exercise.hinge.singlelegRdl.name',
+    icon: 'compress',
+  },
+  {
+    id: 'hinge.goodmorning',
+    categoryId: 'hinge',
+    measurement: 'reps',
+    min: 1,
+    max: 200,
+    unit: 'reps',
+    nameKey: '@@exercise.hinge.goodmorning.name',
+    icon: 'compress',
+  },
+
+  // ─── lunge (single-leg / split-stance) ───────────────────────────────
+  {
+    id: 'legs.lunges',
+    categoryId: 'lunge',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.legs.lunges.name',
+    icon: 'directions_walk',
+    variants: [
+      {
+        id: 'forward',
+        nameKey: '@@exercise.variant.lunges.forward',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'reverse',
+        nameKey: '@@exercise.variant.lunges.reverse',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'walking',
+        nameKey: '@@exercise.variant.lunges.walking',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'lateral',
+        nameKey: '@@exercise.variant.lunges.lateral',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'curtsy',
+        nameKey: '@@exercise.variant.lunges.curtsy',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'jumping',
+        nameKey: '@@exercise.variant.lunges.jumping',
+        difficulty: 'advanced',
+      },
+    ],
+  },
+  {
+    id: 'lunge.stepup',
+    categoryId: 'lunge',
+    measurement: 'reps',
+    min: 1,
+    max: 300,
+    unit: 'reps',
+    nameKey: '@@exercise.lunge.stepup.name',
+    icon: 'stairs',
+  },
+
+  // ─── pull (vertical/horizontal pulling) ──────────────────────────────
+  {
+    id: 'pull.pullups',
+    categoryId: 'pull',
+    measurement: 'reps',
+    min: 1,
+    max: 200,
+    unit: 'reps',
+    nameKey: '@@exercise.pull.pullups.name',
+    icon: 'rowing',
+    variants: [
+      {
+        id: 'standard',
+        nameKey: '@@exercise.variant.pullups.standard',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'chin-up',
+        nameKey: '@@exercise.variant.pullups.chin-up',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'wide-grip',
+        nameKey: '@@exercise.variant.pullups.wide-grip',
+        difficulty: 'advanced',
+      },
+      {
+        id: 'neutral-grip',
+        nameKey: '@@exercise.variant.pullups.neutral-grip',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'negative',
+        nameKey: '@@exercise.variant.pullups.negative',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'assisted',
+        nameKey: '@@exercise.variant.pullups.assisted',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'archer',
+        nameKey: '@@exercise.variant.pullups.archer',
+        difficulty: 'advanced',
+      },
+    ],
+  },
+  {
+    id: 'pull.rows',
+    categoryId: 'pull',
+    measurement: 'reps',
+    min: 1,
+    max: 300,
+    unit: 'reps',
+    nameKey: '@@exercise.pull.rows.name',
+    icon: 'rowing',
+    variants: [
+      {
+        id: 'inverted',
+        nameKey: '@@exercise.variant.rows.inverted',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'australian',
+        nameKey: '@@exercise.variant.rows.australian',
+        difficulty: 'beginner',
+      },
+      {
+        id: 'dumbbell',
+        nameKey: '@@exercise.variant.rows.dumbbell',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'barbell',
+        nameKey: '@@exercise.variant.rows.barbell',
+        difficulty: 'intermediate',
+      },
+    ],
+  },
+  {
+    id: 'pull.deadhang',
+    categoryId: 'pull',
+    measurement: 'time',
+    min: 1,
+    max: 600,
+    unit: 's',
+    nameKey: '@@exercise.pull.deadhang.name',
+    icon: 'rowing',
+  },
+  {
+    id: 'pull.facepull',
+    categoryId: 'pull',
+    measurement: 'reps',
+    min: 1,
+    max: 300,
+    unit: 'reps',
+    nameKey: '@@exercise.pull.facepull.name',
+    icon: 'rowing',
+  },
+
+  // ─── carry (loaded carries) ──────────────────────────────────────────
+  {
+    id: 'carry.farmer',
+    categoryId: 'carry',
+    measurement: 'distance',
+    min: 1,
+    max: 5000,
+    unit: 'm',
+    nameKey: '@@exercise.carry.farmer.name',
+    icon: 'luggage',
+  },
+  {
+    id: 'carry.suitcase',
+    categoryId: 'carry',
+    measurement: 'distance',
+    min: 1,
+    max: 5000,
+    unit: 'm',
+    nameKey: '@@exercise.carry.suitcase.name',
+    icon: 'luggage',
+  },
+  {
+    id: 'carry.overhead',
+    categoryId: 'carry',
+    measurement: 'distance',
+    min: 1,
+    max: 2000,
+    unit: 'm',
+    nameKey: '@@exercise.carry.overhead.name',
+    icon: 'luggage',
+  },
+
+  // ─── cardio ──────────────────────────────────────────────────────────
+  {
     id: 'cardio.running',
     categoryId: 'cardio',
     measurement: 'distance-time',
@@ -183,6 +632,210 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     unit: 'm',
     nameKey: '@@exercise.cardio.running.name',
     icon: 'directions_run',
+  },
+  {
+    id: 'cardio.walking',
+    categoryId: 'cardio',
+    measurement: 'distance-time',
+    min: 100,
+    max: 50_000,
+    unit: 'm',
+    nameKey: '@@exercise.cardio.walking.name',
+    icon: 'directions_walk',
+  },
+  {
+    id: 'cardio.cycling',
+    categoryId: 'cardio',
+    measurement: 'distance-time',
+    min: 100,
+    max: 300_000,
+    unit: 'm',
+    nameKey: '@@exercise.cardio.cycling.name',
+    icon: 'directions_bike',
+  },
+  {
+    id: 'cardio.rowing',
+    categoryId: 'cardio',
+    measurement: 'distance-time',
+    min: 100,
+    max: 50_000,
+    unit: 'm',
+    nameKey: '@@exercise.cardio.rowing.name',
+    icon: 'rowing',
+  },
+  {
+    id: 'cardio.swimming',
+    categoryId: 'cardio',
+    measurement: 'distance-time',
+    min: 25,
+    max: 25_000,
+    unit: 'm',
+    nameKey: '@@exercise.cardio.swimming.name',
+    icon: 'pool',
+  },
+  {
+    id: 'cardio.jumprope',
+    categoryId: 'cardio',
+    measurement: 'reps',
+    min: 1,
+    max: 10_000,
+    unit: 'reps',
+    nameKey: '@@exercise.cardio.jumprope.name',
+    icon: 'sports_handball',
+  },
+  {
+    id: 'cardio.burpees',
+    categoryId: 'cardio',
+    measurement: 'reps',
+    min: 1,
+    max: 500,
+    unit: 'reps',
+    nameKey: '@@exercise.cardio.burpees.name',
+    icon: 'directions_run',
+  },
+  {
+    id: 'cardio.jumpingjacks',
+    categoryId: 'cardio',
+    measurement: 'reps',
+    min: 1,
+    max: 1000,
+    unit: 'reps',
+    nameKey: '@@exercise.cardio.jumpingjacks.name',
+    icon: 'sports_handball',
+  },
+  {
+    id: 'cardio.highknees',
+    categoryId: 'cardio',
+    measurement: 'time',
+    min: 1,
+    max: 3600,
+    unit: 's',
+    nameKey: '@@exercise.cardio.highknees.name',
+    icon: 'directions_run',
+  },
+
+  // ─── mobility ────────────────────────────────────────────────────────
+  {
+    id: 'mobility.stretching',
+    categoryId: 'mobility',
+    measurement: 'time',
+    min: 1,
+    max: 7200,
+    unit: 's',
+    nameKey: '@@exercise.mobility.stretching.name',
+    icon: 'accessibility_new',
+  },
+  {
+    id: 'mobility.yoga',
+    categoryId: 'mobility',
+    measurement: 'time',
+    min: 1,
+    max: 7200,
+    unit: 's',
+    nameKey: '@@exercise.mobility.yoga.name',
+    icon: 'self_improvement',
+  },
+  {
+    id: 'mobility.foamrolling',
+    categoryId: 'mobility',
+    measurement: 'time',
+    min: 1,
+    max: 3600,
+    unit: 's',
+    nameKey: '@@exercise.mobility.foamrolling.name',
+    icon: 'accessibility_new',
+  },
+  {
+    id: 'mobility.dynamicwarmup',
+    categoryId: 'mobility',
+    measurement: 'time',
+    min: 1,
+    max: 3600,
+    unit: 's',
+    nameKey: '@@exercise.mobility.dynamicwarmup.name',
+    icon: 'accessibility_new',
+  },
+  {
+    id: 'mobility.catcow',
+    categoryId: 'mobility',
+    measurement: 'reps',
+    min: 1,
+    max: 200,
+    unit: 'reps',
+    nameKey: '@@exercise.mobility.catcow.name',
+    icon: 'accessibility_new',
+  },
+  {
+    id: 'mobility.hipopener',
+    categoryId: 'mobility',
+    measurement: 'time',
+    min: 1,
+    max: 1800,
+    unit: 's',
+    nameKey: '@@exercise.mobility.hipopener.name',
+    icon: 'accessibility_new',
+  },
+
+  // ─── strength (weighted compound lifts) ──────────────────────────────
+  {
+    id: 'strength.benchpress',
+    categoryId: 'strength',
+    measurement: 'weight',
+    min: 1,
+    max: 50,
+    unit: 'reps',
+    nameKey: '@@exercise.strength.benchpress.name',
+    icon: 'exercise',
+  },
+  {
+    id: 'strength.overheadpress',
+    categoryId: 'strength',
+    measurement: 'weight',
+    min: 1,
+    max: 50,
+    unit: 'reps',
+    nameKey: '@@exercise.strength.overheadpress.name',
+    icon: 'exercise',
+  },
+  {
+    id: 'strength.deadlift',
+    categoryId: 'strength',
+    measurement: 'weight',
+    min: 1,
+    max: 50,
+    unit: 'reps',
+    nameKey: '@@exercise.strength.deadlift.name',
+    icon: 'exercise',
+  },
+  {
+    id: 'strength.barbellsquat',
+    categoryId: 'strength',
+    measurement: 'weight',
+    min: 1,
+    max: 50,
+    unit: 'reps',
+    nameKey: '@@exercise.strength.barbellsquat.name',
+    icon: 'exercise',
+  },
+  {
+    id: 'strength.barbellrow',
+    categoryId: 'strength',
+    measurement: 'weight',
+    min: 1,
+    max: 50,
+    unit: 'reps',
+    nameKey: '@@exercise.strength.barbellrow.name',
+    icon: 'exercise',
+  },
+  {
+    id: 'strength.kettlebellswing',
+    categoryId: 'strength',
+    measurement: 'weight',
+    min: 1,
+    max: 100,
+    unit: 'reps',
+    nameKey: '@@exercise.strength.kettlebellswing.name',
+    icon: 'exercise',
   },
 ];
 

--- a/libs/stats/src/lib/models/exercise.models.ts
+++ b/libs/stats/src/lib/models/exercise.models.ts
@@ -16,14 +16,33 @@ export type MeasurementType =
   | 'weight'
   | 'distance-time';
 
+/**
+ * Categories follow a movement-pattern taxonomy (Dan John / functional
+ * fitness) rather than body-part labels, with one isolation bucket
+ * (`cardio`, `mobility`, `strength`) per cross-pattern concern:
+ *
+ *   push   — horizontal/vertical pressing (pushups, dips, pike pushup)
+ *   pull   — vertical/horizontal pulling (pull-ups, rows)
+ *   squat  — knee-dominant lower body (squat variants, calf raise)
+ *   hinge  — hip-dominant lower body (glute bridge, hip thrust)
+ *   lunge  — single-leg / split-stance (lunge variants, step-up)
+ *   carry  — loaded carries (farmer's walk, suitcase carry)
+ *   core   — anti-extension / -rotation / -lateral-flexion (plank, sit-up, …)
+ *   cardio — sustained conditioning (run, bike, row, jump rope, burpee)
+ *   mobility — flexibility, joint prep (stretching, yoga, foam roll)
+ *   strength — barbell/dumbbell compound lifts measured in load × reps
+ */
 export type ExerciseCategoryId =
-  | 'pushup'
-  | 'abs'
-  | 'legs'
-  | 'plank'
+  | 'push'
+  | 'pull'
+  | 'squat'
+  | 'hinge'
+  | 'lunge'
+  | 'carry'
+  | 'core'
   | 'cardio'
-  | 'strength'
-  | 'mobility';
+  | 'mobility'
+  | 'strength';
 
 export interface ExerciseCategoryInfo {
   id: ExerciseCategoryId;
@@ -138,11 +157,7 @@ export type ExerciseEntryViolation =
   | 'companion-value-invalid'
   | 'companion-value-out-of-range';
 
-type MeasurementValueField =
-  | 'reps'
-  | 'durationSec'
-  | 'distanceM'
-  | 'weightKg';
+type MeasurementValueField = 'reps' | 'durationSec' | 'distanceM' | 'weightKg';
 
 /**
  * Returns the value field expected for a measurement type. Pure helper —
@@ -151,7 +166,10 @@ type MeasurementValueField =
  */
 export function measurementValueField(
   measurement: MeasurementType
-): keyof Pick<ExerciseEntry, 'reps' | 'durationSec' | 'distanceM' | 'weightKg'> {
+): keyof Pick<
+  ExerciseEntry,
+  'reps' | 'durationSec' | 'distanceM' | 'weightKg'
+> {
   switch (measurement) {
     case 'reps':
     case 'weight':

--- a/libs/stats/src/lib/models/unified-entry.models.spec.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.spec.ts
@@ -175,7 +175,7 @@ describe('unifiedEntryCategoryId', () => {
           source: 'web',
           variantType: 'diamond',
         })
-      ).toBe('pushup');
+      ).toBe('push');
       expect(
         unifiedEntryCategoryId({
           kind: 'pushup',
@@ -185,12 +185,12 @@ describe('unifiedEntryCategoryId', () => {
           source: 'web',
           variantType: null,
         })
-      ).toBe('pushup');
+      ).toBe('push');
     });
   });
 
   describe('Given a catalog exercise entry', () => {
-    it('returns the categoryId from the catalog (abs)', () => {
+    it('returns the categoryId from the catalog (core for legacy abs.* ids)', () => {
       expect(
         unifiedEntryCategoryId({
           kind: 'exercise',
@@ -200,10 +200,10 @@ describe('unifiedEntryCategoryId', () => {
           source: 'web',
           exerciseId: 'abs.situps',
         })
-      ).toBe('abs');
+      ).toBe('core');
     });
 
-    it('returns the categoryId from the catalog (legs)', () => {
+    it('returns the categoryId from the catalog (squat for legacy legs.squats)', () => {
       expect(
         unifiedEntryCategoryId({
           kind: 'exercise',
@@ -213,7 +213,7 @@ describe('unifiedEntryCategoryId', () => {
           source: 'web',
           exerciseId: 'legs.squats',
         })
-      ).toBe('legs');
+      ).toBe('squat');
     });
 
     it('returns the categoryId for non-reps measurements (cardio)', () => {

--- a/libs/stats/src/lib/models/unified-entry.models.spec.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.spec.ts
@@ -165,7 +165,7 @@ describe('unifiedEntryFilterKey', () => {
 
 describe('unifiedEntryCategoryId', () => {
   describe('Given a pushup entry', () => {
-    it('returns "pushup" regardless of variant', () => {
+    it('returns "push" regardless of variant', () => {
       expect(
         unifiedEntryCategoryId({
           kind: 'pushup',

--- a/libs/stats/src/lib/models/unified-entry.models.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.ts
@@ -111,14 +111,15 @@ export function unifiedEntryFilterKey(
 }
 
 /**
- * Maps a UnifiedEntry to the exercise category it belongs to. Pushup
- * entries always map to `'pushup'`. Exercise entries are resolved via
- * the catalog — `resolveDefinition` defaults to {@link
- * findExerciseDefinition} but can be overridden when the analysis page
- * needs to resolve custom user exercises that live outside the
- * standard catalog. Returns `null` when the exercise id is not
- * resolvable, so callers can decide whether to bucket the entry into
- * an "unknown" group or drop it.
+ * Maps a UnifiedEntry to the exercise category it belongs to. Legacy
+ * pushup entries (kind `'pushup'`, served from the legacy `pushups`
+ * collection) always map to the `'push'` movement-pattern category.
+ * Exercise entries are resolved via the catalog — `resolveDefinition`
+ * defaults to {@link findExerciseDefinition} but can be overridden when
+ * the analysis page needs to resolve custom user exercises that live
+ * outside the standard catalog. Returns `null` when the exercise id is
+ * not resolvable, so callers can decide whether to bucket the entry
+ * into an "unknown" group or drop it.
  */
 export function unifiedEntryCategoryId(
   entry: UnifiedEntry,
@@ -126,6 +127,6 @@ export function unifiedEntryCategoryId(
     id: string
   ) => ExerciseDefinition | null = findExerciseDefinition
 ): ExerciseCategoryId | null {
-  if (entry.kind === 'pushup') return 'pushup';
+  if (entry.kind === 'pushup') return 'push';
   return resolveDefinition(entry.exerciseId)?.categoryId ?? null;
 }

--- a/tools/sync-xliff-units.mjs
+++ b/tools/sync-xliff-units.mjs
@@ -50,15 +50,17 @@ async function syncFile(localePath, sourceMap) {
     .map((id) => buildLocaleUnit(id, extractSource(sourceMap.get(id))))
     .join('\n');
 
-  const insertBefore = xliff.lastIndexOf('</file>');
-  if (insertBefore === -1) {
+  // Find the start of the line containing the closing `</file>` so we
+  // insert *before* its leading whitespace (typically 2 spaces). Inserting
+  // at the `<` character itself leaves that indentation in front of the
+  // first new unit and skews formatting across locale files.
+  const closingTag = xliff.lastIndexOf('</file>');
+  if (closingTag === -1) {
     throw new Error(`No </file> tag in ${localePath}`);
   }
+  const lineStart = xliff.lastIndexOf('\n', closingTag) + 1;
   const next =
-    xliff.slice(0, insertBefore) +
-    additions +
-    '\n  ' +
-    xliff.slice(insertBefore);
+    xliff.slice(0, lineStart) + additions + '\n' + xliff.slice(lineStart);
   await writeFile(localePath, next, 'utf8');
   return { localePath, added: missingIds.length };
 }

--- a/tools/sync-xliff-units.mjs
+++ b/tools/sync-xliff-units.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Sync newly-extracted units from the source XLIFF (messages.xlf) into
+// each locale XLIFF (messages.<locale>.xlf) so the production build's
+// `i18nMissingTranslation: error` gate doesn't choke on the
+// movement-pattern category rename and the new exercises/variants.
+//
+// Adds missing units with a `state="initial"` target containing the
+// source string so the app still renders the German fallback until a
+// human translation lands. Existing translated units are left alone.
+
+import { readFile, writeFile, readdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const localeDir = join(repoRoot, 'web/src/locale');
+const sourcePath = join(localeDir, 'messages.xlf');
+
+const UNIT_RE = /<unit\s+id="([^"]+)">[\s\S]*?<\/unit>/g;
+
+function indexUnits(xliff) {
+  const map = new Map();
+  for (const match of xliff.matchAll(UNIT_RE)) {
+    map.set(match[1], match[0]);
+  }
+  return map;
+}
+
+function extractSource(unitXml) {
+  const m = unitXml.match(/<source>([\s\S]*?)<\/source>/);
+  return m ? m[1] : '';
+}
+
+function buildLocaleUnit(id, sourceText) {
+  return `    <unit id="${id}">
+      <segment state="initial">
+        <source>${sourceText}</source>
+        <target>${sourceText}</target>
+      </segment>
+    </unit>`;
+}
+
+async function syncFile(localePath, sourceMap) {
+  const xliff = await readFile(localePath, 'utf8');
+  const existing = indexUnits(xliff);
+  const missingIds = [...sourceMap.keys()].filter((id) => !existing.has(id));
+  if (missingIds.length === 0) return { localePath, added: 0 };
+
+  const additions = missingIds
+    .map((id) => buildLocaleUnit(id, extractSource(sourceMap.get(id))))
+    .join('\n');
+
+  const insertBefore = xliff.lastIndexOf('</file>');
+  if (insertBefore === -1) {
+    throw new Error(`No </file> tag in ${localePath}`);
+  }
+  const next =
+    xliff.slice(0, insertBefore) +
+    additions +
+    '\n  ' +
+    xliff.slice(insertBefore);
+  await writeFile(localePath, next, 'utf8');
+  return { localePath, added: missingIds.length };
+}
+
+async function main() {
+  const sourceXliff = await readFile(sourcePath, 'utf8');
+  const sourceMap = indexUnits(sourceXliff);
+
+  const files = (await readdir(localeDir)).filter((f) =>
+    /^messages\.[a-z]{2}\.xlf$/.test(f)
+  );
+  for (const f of files) {
+    const result = await syncFile(join(localeDir, f), sourceMap);
+    console.log(`${result.localePath}: +${result.added} units`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -689,12 +689,15 @@ export const AnalysisStore = signalStore(
       const kinds = store.kinds();
       const kindSet = kinds.length > 0 ? new Set<string>(kinds) : null;
       // In a per-category tab the pushup-variant breakdown only makes
-      // sense for the pushup tab; every other category renders the
-      // kind-mode breakdown over its own entries. In overview the
+      // sense for the push tab (which collapses legacy pushups into
+      // the movement-pattern category); every other category renders
+      // the kind-mode breakdown over its own entries. In overview the
       // legacy gate stays so a default page still shows pushup
-      // variants when no kind filter is active.
+      // variants when no kind filter is active. The kind filter key
+      // remains `'pushup'` — it identifies the legacy Firestore
+      // collection, distinct from the `'push'` category id.
       const showPushupVariants =
-        view === 'pushup' ||
+        view === 'push' ||
         (view === 'overview' &&
           (!kindSet || (kindSet.size === 1 && kindSet.has('pushup'))));
 

--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
@@ -140,10 +140,11 @@ export class AnalysisTeaserCardComponent {
 
   private readonly allExercisesLabel = $localize`:@@chart.kindLabel.all:Alle Übungen`;
   /**
-   * Pushup label reused from the analysis page i18n catalog so we don't
-   * spawn a parallel XLIFF unit for the same German string.
+   * Push-movement label reused from the analysis page i18n catalog so we
+   * don't spawn a parallel XLIFF unit. Used to label legacy-pushup data
+   * surfaced on the teaser chart.
    */
-  private readonly pushupLabel = $localize`:@@exercise.category.pushup:Liegestütze`;
+  private readonly pushupLabel = $localize`:@@exercise.category.push:Drücken`;
 
   /** Exposed for the template's error-fallback gate. */
   readonly liveConnected = computed(() => this.live.connected());

--- a/web/src/app/stats/components/category-summary-card/category-summary-card.component.spec.ts
+++ b/web/src/app/stats/components/category-summary-card/category-summary-card.component.spec.ts
@@ -18,8 +18,8 @@ import { CategorySummaryCardComponent } from './category-summary-card.component'
 })
 class HostComponent {
   readonly summary = signal<CategorySummary>({
-    categoryId: 'pushup',
-    nameKey: '@@exercise.category.pushup',
+    categoryId: 'push',
+    nameKey: '@@exercise.category.push',
     icon: 'fitness_center',
     order: 10,
     totalReps: 123,
@@ -46,9 +46,9 @@ describe('CategorySummaryCardComponent', () => {
     const host: HTMLElement = fixture.nativeElement;
     // TestBed default locale is `de` — categoryDisplayName returns the
     // German source string.
-    expect(host.textContent).toContain('Liegestütze');
+    expect(host.textContent).toContain('Drücken');
     const totalReps = host.querySelector(
-      '[data-testid="category-summary-card-totalReps-pushup"]'
+      '[data-testid="category-summary-card-totalReps-push"]'
     );
     expect(totalReps?.textContent?.trim()).toBe('123');
   });
@@ -66,26 +66,26 @@ describe('CategorySummaryCardComponent', () => {
   it('emits the categoryId when the details button is clicked', () => {
     const host: HTMLElement = fixture.nativeElement;
     const button = host.querySelector(
-      '[data-testid="category-summary-card-drilldown-pushup"]'
+      '[data-testid="category-summary-card-drilldown-push"]'
     ) as HTMLButtonElement;
     expect(button).toBeTruthy();
     button.click();
-    expect(fixture.componentInstance.lastEmitted()).toBe('pushup');
+    expect(fixture.componentInstance.lastEmitted()).toBe('push');
   });
 
   it('carries a category-scoped data-testid so multiple cards stay addressable', () => {
     fixture.componentInstance.summary.set({
       ...fixture.componentInstance.summary(),
-      categoryId: 'abs',
+      categoryId: 'core',
       icon: 'self_improvement',
     });
     fixture.detectChanges();
     const host: HTMLElement = fixture.nativeElement;
     expect(
-      host.querySelector('[data-testid="category-summary-card-abs"]')
+      host.querySelector('[data-testid="category-summary-card-core"]')
     ).toBeTruthy();
     expect(
-      host.querySelector('[data-testid="category-summary-card-drilldown-abs"]')
+      host.querySelector('[data-testid="category-summary-card-drilldown-core"]')
     ).toBeTruthy();
   });
 

--- a/web/src/app/stats/components/stats-table/stats-table.component.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.ts
@@ -197,7 +197,7 @@ export class StatsTableComponent {
 
   exerciseLabel(entry: UnifiedEntry): string {
     if (entry.kind === 'pushup') {
-      return $localize`:@@exercise.category.pushup:Liegestütze`;
+      return $localize`:@@exercise.category.push:Drücken`;
     }
     const def = findExerciseDefinition(entry.exerciseId);
     if (!def) return entry.exerciseId;

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
@@ -31,7 +31,7 @@ describe('TrainingEntryDialogComponent', () => {
     it('defaults to the pushup category and synthetic exercise id', () => {
       const { component } = createDialog(null);
 
-      expect(component.category()).toBe('pushup');
+      expect(component.category()).toBe('push');
       expect(component.mode()).toBe('pushup');
       expect(component.isEditMode).toBe(false);
     });
@@ -40,11 +40,12 @@ describe('TrainingEntryDialogComponent', () => {
       const { component } = createDialog(null);
 
       component.sets.set([20]);
-      component.onCategoryChange('plank');
+      component.onCategoryChange('core');
 
-      expect(component.category()).toBe('plank');
+      expect(component.category()).toBe('core');
       expect(component.mode()).toBe('exercise');
-      expect(component.exerciseId()).toBe('plank.standard');
+      // First catalog entry in the core category becomes the picker default.
+      expect(component.exerciseId()).toBe('abs.situps');
       // Reps/sets must reset so a stale 20-rep value can't bleed into
       // the new measurement-specific form.
       expect(component.sets()).toEqual([0]);
@@ -75,10 +76,14 @@ describe('TrainingEntryDialogComponent', () => {
       expect(result.timestamp).toMatch(/^2026-02-10T13:45/);
     });
 
-    it('emits an exercise result with durationSec for the plank category', () => {
+    it('emits an exercise result with durationSec when plank is picked under core', () => {
       const { component, closeSpy } = createDialog(null);
 
-      component.onCategoryChange('plank');
+      component.onCategoryChange('core');
+      // Plank lives in the core category now — switch the picker to it
+      // explicitly because the category default is the first reps-based
+      // entry (`abs.situps`), not the time-measurement plank row.
+      component.onExerciseChange('plank.standard');
       component.timestamp.set('2026-02-10T13:45');
       component.durationMinutesInput.set('1');
       component.durationSecondsInput.set('30');
@@ -124,7 +129,7 @@ describe('TrainingEntryDialogComponent', () => {
     it('clears the variant control and value fields when the exercise picker changes', () => {
       const { component } = createDialog(null);
 
-      component.onCategoryChange('abs');
+      component.onCategoryChange('core');
       component.variantControl.setValue('weighted');
       component.updateSet(0, '12');
 
@@ -141,7 +146,7 @@ describe('TrainingEntryDialogComponent', () => {
     it('caps reps at the catalog max for the chosen exercise', () => {
       const { component } = createDialog(null);
 
-      component.onCategoryChange('abs');
+      component.onCategoryChange('core');
       component.updateSet(0, '9999');
 
       // abs.situps caps at 500 — typing a higher value clamps so
@@ -163,14 +168,14 @@ describe('TrainingEntryDialogComponent', () => {
       });
 
       expect(component.isEditMode).toBe(true);
-      expect(component.category()).toBe('pushup');
+      expect(component.category()).toBe('push');
       expect(component.sets()).toEqual([10, 10, 10]);
       expect(component.pushupTypeControl.value).toBe('diamond');
       expect(component.sourceControl.value).toBe('whatsapp');
       // Edit mode must not allow moving an entry between collections,
       // so the category-change handler is a no-op.
-      component.onCategoryChange('plank');
-      expect(component.category()).toBe('pushup');
+      component.onCategoryChange('core');
+      expect(component.category()).toBe('push');
     });
 
     it('preserves the original ISO timestamp when the user does not touch the field', () => {
@@ -198,7 +203,7 @@ describe('TrainingEntryDialogComponent', () => {
         durationSec: 90,
       });
 
-      expect(component.category()).toBe('plank');
+      expect(component.category()).toBe('core');
       expect(component.exerciseId()).toBe('plank.standard');
       expect(component.mode()).toBe('exercise');
       expect(component.isTimeMeasurement()).toBe(true);
@@ -241,7 +246,7 @@ describe('TrainingEntryDialogComponent', () => {
       expect(component.mode()).toBe('exercise');
       // Category prefix `'abs.…'` recovers the right dashboard
       // category even though the specific exercise no longer exists.
-      expect(component.category()).toBe('abs');
+      expect(component.category()).toBe('core');
       // The synthetic fallback definition lets the user fix and resubmit
       // the entry without staring at a frozen dialog.
       expect(component.canSubmit()).toBe(true);

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
@@ -231,30 +231,36 @@ describe('TrainingEntryDialogComponent', () => {
       expect(result.variantId).toBeNull();
     });
 
-    it('keeps an exercise-kind entry in exercise mode when the catalog id is stale', () => {
-      // Regression: a renamed/removed catalog id used to flip the
-      // dialog into pushup mode and corrupt the emitted payload shape
-      // on submit.
-      const { component, closeSpy } = createDialog({
-        kind: 'exercise',
-        exerciseId: 'abs.removed-variant',
-        timestamp: '2026-02-10T13:45:00+01:00',
-        reps: 25,
-        sets: [25],
-      });
+    it.each([
+      // Legacy id prefix → recovered movement-pattern category. The
+      // dialog must stay in exercise mode and surface the right
+      // dashboard category for stale ids whose catalog entry was
+      // renamed or removed.
+      ['abs.removed-variant', 'core' as const],
+      ['plank.removed-variant', 'core' as const],
+      ['legs.removed-variant', 'squat' as const],
+    ])(
+      'keeps an exercise-kind entry in exercise mode for stale id %s',
+      (exerciseId, expectedCategory) => {
+        const { component, closeSpy } = createDialog({
+          kind: 'exercise',
+          exerciseId,
+          timestamp: '2026-02-10T13:45:00+01:00',
+          reps: 25,
+          sets: [25],
+        });
 
-      expect(component.mode()).toBe('exercise');
-      // Category prefix `'abs.…'` recovers the right dashboard
-      // category even though the specific exercise no longer exists.
-      expect(component.category()).toBe('core');
-      // The synthetic fallback definition lets the user fix and resubmit
-      // the entry without staring at a frozen dialog.
-      expect(component.canSubmit()).toBe(true);
+        expect(component.mode()).toBe('exercise');
+        expect(component.category()).toBe(expectedCategory);
+        // The synthetic fallback definition lets the user fix and
+        // resubmit the entry without staring at a frozen dialog.
+        expect(component.canSubmit()).toBe(true);
 
-      component.submit();
-      const result = closeSpy.mock.calls[0][0] as ExerciseEntryDialogResult;
-      expect(result.kind).toBe('exercise');
-      expect(result.exerciseId).toBe('abs.removed-variant');
-    });
+        component.submit();
+        const result = closeSpy.mock.calls[0][0] as ExerciseEntryDialogResult;
+        expect(result.kind).toBe('exercise');
+        expect(result.exerciseId).toBe(exerciseId);
+      }
+    );
   });
 });

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
@@ -30,6 +30,7 @@ import {
   exercisesByCategory,
   ExerciseCategoryId,
   ExerciseDefinition,
+  ExerciseVariant,
   findExerciseDefinition,
   findPushupTypeByLocalizedName,
   findPushupTypeByStoredValue,
@@ -39,7 +40,10 @@ import {
   PUSHUP_TYPES,
   PushupTypeInfo,
 } from '@pu-stats/models';
-import { exerciseDisplayName } from '../../i18n/exercise-display-names';
+import {
+  exerciseDisplayName,
+  variantDisplayName,
+} from '../../i18n/exercise-display-names';
 
 /**
  * Synthetic id for the implicit "Liegestütze (Standard)" exercise inside
@@ -368,7 +372,7 @@ interface PushupTypeOption {
             >
             @for (variant of currentDefinition()?.variants; track variant.id) {
               <mat-option [value]="variant.id">{{
-                exerciseVariantLabel(variant.id)
+                exerciseVariantLabel(variant)
               }}</mat-option>
             }
           </mat-select>
@@ -873,8 +877,8 @@ export class TrainingEntryDialogComponent {
     this.distanceInput.set('');
   }
 
-  exerciseVariantLabel(variantId: string): string {
-    return variantId;
+  exerciseVariantLabel(variant: ExerciseVariant): string {
+    return variantDisplayName(variant);
   }
 
   exerciseLabel(id: string): string {

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
@@ -1098,7 +1098,7 @@ const CATEGORY_NAMES: Record<ExerciseCategoryId, () => string> = {
   push: () => $localize`:@@exercise.category.push:Drücken`,
   pull: () => $localize`:@@exercise.category.pull:Ziehen`,
   squat: () => $localize`:@@exercise.category.squat:Kniebeuge`,
-  hinge: () => $localize`:@@exercise.category.hinge:Hüftbeuge`,
+  hinge: () => $localize`:@@exercise.category.hinge:Hüftstreckung`,
   lunge: () => $localize`:@@exercise.category.lunge:Ausfallschritt`,
   carry: () => $localize`:@@exercise.category.carry:Tragen`,
   core: () => $localize`:@@exercise.category.core:Rumpf`,

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
@@ -588,20 +588,21 @@ export class TrainingEntryDialogComponent {
   readonly category = signal<ExerciseCategoryId>(this.initialCategory());
 
   /**
-   * Catalog exercise id when category !== 'pushup'. Defaults to the
-   * first exercise of the chosen category. For the pushup category the
+   * Catalog exercise id when category !== 'push'. Defaults to the
+   * first exercise of the chosen category. For the push category the
    * value is the synthetic {@link PUSHUP_EXERCISE_ID} so the picker can
-   * show a single entry without a real catalog row.
+   * show a single entry without a real catalog row — the legacy
+   * `pushups` Firestore collection has no `ExerciseDefinition`.
    */
   readonly exerciseId = signal<string>(this.initialExerciseId());
 
   readonly mode = computed<'pushup' | 'exercise'>(() =>
-    this.category() === 'pushup' ? 'pushup' : 'exercise'
+    this.category() === 'push' ? 'pushup' : 'exercise'
   );
 
   readonly exerciseOptions = computed<ExerciseOption[]>(() => {
     const cat = this.category();
-    if (cat === 'pushup') {
+    if (cat === 'push') {
       return [
         {
           value: PUSHUP_EXERCISE_ID,
@@ -843,7 +844,7 @@ export class TrainingEntryDialogComponent {
     // Reset exercise to the first option of the new category. Reset
     // measurement-specific inputs so a stale value from a previously
     // selected exercise can't leak through to the new one.
-    if (next === 'pushup') {
+    if (next === 'push') {
       this.exerciseId.set(PUSHUP_EXERCISE_ID);
     } else {
       const defs = exercisesByCategory().get(next) ?? [];
@@ -1012,16 +1013,16 @@ export class TrainingEntryDialogComponent {
   // ----- helpers ----------------------------------------------------------
 
   private initialCategory(): ExerciseCategoryId {
-    if (!this.data) return 'pushup';
-    if (this.data.kind === 'pushup') return 'pushup';
+    if (!this.data) return 'push';
+    if (this.data.kind === 'pushup') return 'push';
     const def = findExerciseDefinition(this.data.exerciseId);
     if (def) return def.categoryId;
     // Stale exerciseId (renamed/removed in the catalog): stay in
     // exercise mode so the dialog doesn't silently flip to pushup,
     // which would also corrupt the emitted payload shape on submit.
     // Pick the category the id is prefixed with when it follows the
-    // dotted catalog convention (e.g. `'abs.weighted-situps'` → `abs`),
-    // otherwise default to the first non-pushup catalog category.
+    // dotted catalog convention (e.g. `'abs.weighted-situps'` → `core`),
+    // otherwise default to the first non-push catalog category.
     return inferExerciseCategory(this.data.exerciseId);
   }
 
@@ -1090,24 +1091,25 @@ export class TrainingEntryDialogComponent {
 }
 
 const CATEGORY_NAMES: Record<ExerciseCategoryId, () => string> = {
-  pushup: () => $localize`:@@exercise.category.pushup:Liegestütze`,
-  abs: () => $localize`:@@exercise.category.abs:Bauch`,
-  legs: () => $localize`:@@exercise.category.legs:Beine`,
-  plank: () => $localize`:@@exercise.category.plank:Plank`,
+  push: () => $localize`:@@exercise.category.push:Drücken`,
+  pull: () => $localize`:@@exercise.category.pull:Ziehen`,
+  squat: () => $localize`:@@exercise.category.squat:Kniebeuge`,
+  hinge: () => $localize`:@@exercise.category.hinge:Hüftbeuge`,
+  lunge: () => $localize`:@@exercise.category.lunge:Ausfallschritt`,
+  carry: () => $localize`:@@exercise.category.carry:Tragen`,
+  core: () => $localize`:@@exercise.category.core:Rumpf`,
   cardio: () => $localize`:@@exercise.category.cardio:Ausdauer`,
-  // strength + mobility are catalog-known but have no exercises yet —
-  // leave them out of the dialog until they ship a definition.
-  strength: () => 'Kraft',
-  mobility: () => 'Mobility',
+  mobility: () => $localize`:@@exercise.category.mobility:Mobilität`,
+  strength: () => $localize`:@@exercise.category.strength:Krafttraining`,
 };
 
 function buildCategoryOptions(): ReadonlyArray<CategoryOption> {
   // Filter to categories that actually have something to log in this
-  // dialog: pushup (always — handled separately) plus any catalog
-  // category with at least one ExerciseDefinition.
+  // dialog: push (always — legacy pushups handled separately) plus
+  // any catalog category with at least one ExerciseDefinition.
   const byCategory = exercisesByCategory();
   return EXERCISE_CATEGORIES.filter(
-    (cat) => cat.id === 'pushup' || (byCategory.get(cat.id)?.length ?? 0) > 0
+    (cat) => cat.id === 'push' || (byCategory.get(cat.id)?.length ?? 0) > 0
   ).map((cat) => ({
     value: cat.id,
     label: (CATEGORY_NAMES[cat.id] ?? (() => cat.id))(),
@@ -1183,13 +1185,23 @@ function inferExerciseCategory(
   exerciseId: string | undefined
 ): ExerciseCategoryId {
   const prefix = exerciseId?.split('.')[0];
+  // Legacy id prefixes from before the movement-pattern restructure
+  // still appear in Firestore docs — map them onto the new categories.
+  const LEGACY_PREFIX_MAP: Record<string, ExerciseCategoryId> = {
+    abs: 'core',
+    plank: 'core',
+    legs: 'squat',
+  };
+  if (prefix && prefix in LEGACY_PREFIX_MAP) {
+    return LEGACY_PREFIX_MAP[prefix];
+  }
   const known = EXERCISE_CATEGORIES.find((c) => c.id === prefix);
-  if (known && known.id !== 'pushup') return known.id;
+  if (known && known.id !== 'push') return known.id;
   const byCategory = exercisesByCategory();
   const fallback = EXERCISE_CATEGORIES.find(
-    (c) => c.id !== 'pushup' && (byCategory.get(c.id)?.length ?? 0) > 0
+    (c) => c.id !== 'push' && (byCategory.get(c.id)?.length ?? 0) > 0
   );
-  return fallback?.id ?? 'abs';
+  return fallback?.id ?? 'core';
 }
 
 /**

--- a/web/src/app/stats/i18n/exercise-display-names.spec.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.spec.ts
@@ -1,0 +1,75 @@
+import type { ExerciseVariant } from '@pu-stats/models';
+
+import {
+  categoryDisplayName,
+  exerciseDisplayName,
+  kindDisplayName,
+  variantDisplayName,
+} from './exercise-display-names';
+
+describe('exerciseDisplayName', () => {
+  it('resolves a known catalog id to its localized display name', () => {
+    // `$localize` returns the source-locale string in the test runtime
+    // (no locale runtime is loaded), so we assert on the German source.
+    expect(exerciseDisplayName('abs.situps')).toBe('Sit-ups');
+    expect(exerciseDisplayName('pull.pullups')).toBe('Klimmzüge');
+    expect(exerciseDisplayName('cardio.running')).toBe('Laufen');
+  });
+
+  it('falls back to the raw id when the id is unknown', () => {
+    expect(exerciseDisplayName('does.not.exist')).toBe('does.not.exist');
+  });
+});
+
+describe('kindDisplayName', () => {
+  it('returns the push movement-pattern label for the legacy pushup filter key', () => {
+    // The filter-key string stays `'pushup'` (it identifies the legacy
+    // Firestore collection) but the displayed label now uses the
+    // movement-pattern translation unit.
+    expect(kindDisplayName('pushup')).toBe('Drücken');
+  });
+
+  it('resolves a catalog exerciseId to its display name', () => {
+    expect(kindDisplayName('legs.squats')).toBe('Kniebeugen');
+  });
+
+  it('falls back to the raw value when the id is not in the catalog', () => {
+    expect(kindDisplayName('custom-uuid-not-in-catalog')).toBe(
+      'custom-uuid-not-in-catalog'
+    );
+  });
+});
+
+describe('variantDisplayName', () => {
+  it('resolves a known variant nameKey to its localized label', () => {
+    const variant: ExerciseVariant = {
+      id: 'wide-grip',
+      nameKey: '@@exercise.variant.pullups.wide-grip',
+    };
+    expect(variantDisplayName(variant)).toBe('Breiter Griff');
+  });
+
+  it('falls back to the variant id when the nameKey is not mapped', () => {
+    // Future-compat guard: a variant added to the catalog before the
+    // display-names map is updated must still render — the raw id is
+    // the least-bad fallback (vs. blank or "undefined").
+    const variant: ExerciseVariant = {
+      id: 'experimental-variant',
+      nameKey: '@@exercise.variant.unknown.experimental',
+    };
+    expect(variantDisplayName(variant)).toBe('experimental-variant');
+  });
+});
+
+describe('categoryDisplayName', () => {
+  it('returns the German source label for the movement-pattern categories', () => {
+    expect(categoryDisplayName('push')).toBe('Drücken');
+    expect(categoryDisplayName('pull')).toBe('Ziehen');
+    expect(categoryDisplayName('squat')).toBe('Kniebeuge');
+    expect(categoryDisplayName('hinge')).toBe('Hüftstreckung');
+    expect(categoryDisplayName('lunge')).toBe('Ausfallschritt');
+    expect(categoryDisplayName('core')).toBe('Rumpf');
+    expect(categoryDisplayName('cardio')).toBe('Ausdauer');
+    expect(categoryDisplayName('mobility')).toBe('Mobilität');
+  });
+});

--- a/web/src/app/stats/i18n/exercise-display-names.spec.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.spec.ts
@@ -72,4 +72,15 @@ describe('categoryDisplayName', () => {
     expect(categoryDisplayName('cardio')).toBe('Ausdauer');
     expect(categoryDisplayName('mobility')).toBe('Mobilität');
   });
+
+  it('falls back to the raw id when the category is unknown', () => {
+    // `carry` and `strength` stay in the type union (forward-compat)
+    // but their display labels are intentionally absent from
+    // CATEGORY_DISPLAY_NAMES until the dialog gains weight + distance
+    // form support. The runtime fallback returns the raw id so the
+    // analysis page doesn't render "undefined" if it ever resolves
+    // entries to one of those categories before the labels ship.
+    expect(categoryDisplayName('carry')).toBe('carry');
+    expect(categoryDisplayName('strength')).toBe('strength');
+  });
 });

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -11,18 +11,65 @@ import {
  * {@link exerciseDisplayName} to avoid duplicating the lookup table.
  */
 const EXERCISE_DISPLAY_NAMES: Record<string, string> = {
+  // core (legacy `abs.*` ids kept for data stability)
   'abs.situps': $localize`:@@exercise.abs.situps.name:Sit-ups`,
   'abs.crunches': $localize`:@@exercise.abs.crunches.name:Crunches`,
   'abs.legraises': $localize`:@@exercise.abs.legraises.name:Beinheben`,
   'abs.russiantwist': $localize`:@@exercise.abs.russiantwist.name:Russian Twist`,
   'abs.mountainclimbers': $localize`:@@exercise.abs.mountainclimbers.name:Mountain Climbers`,
-  'legs.squats': $localize`:@@exercise.legs.squats.name:Kniebeugen`,
-  'legs.lunges': $localize`:@@exercise.legs.lunges.name:Ausfallschritte`,
-  'legs.glutebridge': $localize`:@@exercise.legs.glutebridge.name:Hüftheben`,
-  'legs.calfraises': $localize`:@@exercise.legs.calfraises.name:Wadenheben`,
-  'legs.jumpsquats': $localize`:@@exercise.legs.jumpsquats.name:Jump Squats`,
+  'core.deadbug': $localize`:@@exercise.core.deadbug.name:Dead Bug`,
+  'core.hollowhold': $localize`:@@exercise.core.hollowhold.name:Hollow Hold`,
   'plank.standard': $localize`:@@exercise.plank.standard.name:Plank`,
+
+  // squat / hinge / lunge (legacy `legs.*` ids kept for data stability)
+  'legs.squats': $localize`:@@exercise.legs.squats.name:Kniebeugen`,
+  'legs.jumpsquats': $localize`:@@exercise.legs.jumpsquats.name:Jump Squats`,
+  'legs.calfraises': $localize`:@@exercise.legs.calfraises.name:Wadenheben`,
+  'squat.wallsit': $localize`:@@exercise.squat.wallsit.name:Wandsitz`,
+  'squat.boxjump': $localize`:@@exercise.squat.boxjump.name:Box Jumps`,
+  'legs.glutebridge': $localize`:@@exercise.legs.glutebridge.name:Hüftheben`,
+  'hinge.singlelegRdl': $localize`:@@exercise.hinge.singlelegRdl.name:Einbeiniges Kreuzheben`,
+  'hinge.goodmorning': $localize`:@@exercise.hinge.goodmorning.name:Good Morning`,
+  'legs.lunges': $localize`:@@exercise.legs.lunges.name:Ausfallschritte`,
+  'lunge.stepup': $localize`:@@exercise.lunge.stepup.name:Step-ups`,
+
+  // pull
+  'pull.pullups': $localize`:@@exercise.pull.pullups.name:Klimmzüge`,
+  'pull.rows': $localize`:@@exercise.pull.rows.name:Ruderzug`,
+  'pull.deadhang': $localize`:@@exercise.pull.deadhang.name:Dead Hang`,
+  'pull.facepull': $localize`:@@exercise.pull.facepull.name:Face Pull`,
+
+  // carry
+  'carry.farmer': $localize`:@@exercise.carry.farmer.name:Farmer's Walk`,
+  'carry.suitcase': $localize`:@@exercise.carry.suitcase.name:Suitcase Carry`,
+  'carry.overhead': $localize`:@@exercise.carry.overhead.name:Overhead Carry`,
+
+  // cardio
   'cardio.running': $localize`:@@exercise.cardio.running.name:Laufen`,
+  'cardio.walking': $localize`:@@exercise.cardio.walking.name:Gehen`,
+  'cardio.cycling': $localize`:@@exercise.cardio.cycling.name:Radfahren`,
+  'cardio.rowing': $localize`:@@exercise.cardio.rowing.name:Rudern`,
+  'cardio.swimming': $localize`:@@exercise.cardio.swimming.name:Schwimmen`,
+  'cardio.jumprope': $localize`:@@exercise.cardio.jumprope.name:Seilspringen`,
+  'cardio.burpees': $localize`:@@exercise.cardio.burpees.name:Burpees`,
+  'cardio.jumpingjacks': $localize`:@@exercise.cardio.jumpingjacks.name:Hampelmänner`,
+  'cardio.highknees': $localize`:@@exercise.cardio.highknees.name:High Knees`,
+
+  // mobility
+  'mobility.stretching': $localize`:@@exercise.mobility.stretching.name:Dehnen`,
+  'mobility.yoga': $localize`:@@exercise.mobility.yoga.name:Yoga`,
+  'mobility.foamrolling': $localize`:@@exercise.mobility.foamrolling.name:Faszienrolle`,
+  'mobility.dynamicwarmup': $localize`:@@exercise.mobility.dynamicwarmup.name:Dynamisches Aufwärmen`,
+  'mobility.catcow': $localize`:@@exercise.mobility.catcow.name:Katze-Kuh`,
+  'mobility.hipopener': $localize`:@@exercise.mobility.hipopener.name:Hüftöffner`,
+
+  // strength
+  'strength.benchpress': $localize`:@@exercise.strength.benchpress.name:Bankdrücken`,
+  'strength.overheadpress': $localize`:@@exercise.strength.overheadpress.name:Schulterdrücken`,
+  'strength.deadlift': $localize`:@@exercise.strength.deadlift.name:Kreuzheben`,
+  'strength.barbellsquat': $localize`:@@exercise.strength.barbellsquat.name:Langhantel-Kniebeuge`,
+  'strength.barbellrow': $localize`:@@exercise.strength.barbellrow.name:Langhantelrudern`,
+  'strength.kettlebellswing': $localize`:@@exercise.strength.kettlebellswing.name:Kettlebell Swing`,
 };
 
 export function exerciseDisplayName(id: string): string {
@@ -31,10 +78,15 @@ export function exerciseDisplayName(id: string): string {
 
 /**
  * Resolves the filter-key shape used by the analysis page (`'pushup'`
- * for the collapsed pushup bucket, exerciseId for everything else)
- * to a localised label. Shared between the page filter chips and the
- * type-pie legend so both stay in sync without duplicating the
+ * for the collapsed legacy-pushup bucket, exerciseId for everything
+ * else) to a localised label. Shared between the page filter chips and
+ * the type-pie legend so both stay in sync without duplicating the
  * `$localize` calls.
+ *
+ * The legacy filter-key string remains `'pushup'` (it identifies the
+ * legacy Firestore collection); only the *display* shifts to the new
+ * movement-pattern label "Drücken / Push" via the shared category
+ * translation unit.
  *
  * For ids that miss the catalog (user-defined custom exercises or
  * legacy ids whose Firestore entries still exist) the raw `value`
@@ -43,7 +95,7 @@ export function exerciseDisplayName(id: string): string {
  */
 export function kindDisplayName(value: UnifiedEntryFilterKey): string {
   if (value === 'pushup') {
-    return $localize`:@@exercise.category.pushup:Liegestütze`;
+    return $localize`:@@exercise.category.push:Drücken`;
   }
   const def = findExerciseDefinition(value);
   if (def) return exerciseDisplayName(def.id);
@@ -51,9 +103,7 @@ export function kindDisplayName(value: UnifiedEntryFilterKey): string {
   // legacy ids without a catalog entry both land here. Returning the
   // bare id keeps each one distinguishable in the filter chips and
   // type-pie legend until custom-exercise definitions are threaded
-  // through the analysis page — collapsing every miss into a single
-  // "Andere Übung" label made multi-custom-exercise users unable to
-  // tell their own filters apart.
+  // through the analysis page.
   return value;
 }
 
@@ -63,21 +113,18 @@ export function kindDisplayName(value: UnifiedEntryFilterKey): string {
  * can emit translated labels instead of raw XLIFF ids — Chart.js has
  * no runtime hook for `$localize`, and emitting the id would render
  * the legend like a developer string in production builds.
- *
- * Only entries with a corresponding XLIFF unit and at least one
- * catalog exercise are mapped here. `strength` and `mobility` exist in
- * the `ExerciseCategoryId` union but are absent from
- * `EXERCISE_CATEGORIES`, so adding $localize calls for them would
- * fail the locale-baked production build with "No translation found"
- * — they get a per-id fallback through {@link categoryDisplayName}
- * until they ship with their own exercises and translations.
  */
-const CATEGORY_DISPLAY_NAMES: Partial<Record<ExerciseCategoryId, string>> = {
-  pushup: $localize`:@@exercise.category.pushup:Liegestütze`,
-  abs: $localize`:@@exercise.category.abs:Bauch`,
-  legs: $localize`:@@exercise.category.legs:Beine`,
-  plank: $localize`:@@exercise.category.plank:Plank`,
+const CATEGORY_DISPLAY_NAMES: Record<ExerciseCategoryId, string> = {
+  push: $localize`:@@exercise.category.push:Drücken`,
+  pull: $localize`:@@exercise.category.pull:Ziehen`,
+  squat: $localize`:@@exercise.category.squat:Kniebeuge`,
+  hinge: $localize`:@@exercise.category.hinge:Hüftbeuge`,
+  lunge: $localize`:@@exercise.category.lunge:Ausfallschritt`,
+  carry: $localize`:@@exercise.category.carry:Tragen`,
+  core: $localize`:@@exercise.category.core:Rumpf`,
   cardio: $localize`:@@exercise.category.cardio:Ausdauer`,
+  mobility: $localize`:@@exercise.category.mobility:Mobilität`,
+  strength: $localize`:@@exercise.category.strength:Krafttraining`,
 };
 
 export function categoryDisplayName(id: ExerciseCategoryId): string {

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -1,5 +1,6 @@
 import {
   type ExerciseCategoryId,
+  type ExerciseVariant,
   findExerciseDefinition,
   type UnifiedEntryFilterKey,
 } from '@pu-stats/models';
@@ -77,6 +78,94 @@ export function exerciseDisplayName(id: string): string {
 }
 
 /**
+ * Locale-aware display strings for exercise variants. Keyed by the
+ * variant's `nameKey` (the XLIFF unit id) so the dialog can resolve a
+ * label from any `ExerciseVariant` without coupling to its parent
+ * exercise id.
+ *
+ * $localize calls must be literal at extraction time — keep these
+ * spelled out one per variant. Falls back to the raw variant id when
+ * a name key isn't mapped here (e.g. a future variant added to the
+ * catalog before this file is updated).
+ */
+const VARIANT_DISPLAY_NAMES: Record<string, string> = {
+  // sit-ups
+  '@@exercise.variant.situps.standard': $localize`:@@exercise.variant.situps.standard:Standard`,
+  '@@exercise.variant.situps.decline': $localize`:@@exercise.variant.situps.decline:Decline`,
+  '@@exercise.variant.situps.weighted': $localize`:@@exercise.variant.situps.weighted:Mit Zusatzgewicht`,
+
+  // crunches
+  '@@exercise.variant.crunches.standard': $localize`:@@exercise.variant.crunches.standard:Standard`,
+  '@@exercise.variant.crunches.reverse': $localize`:@@exercise.variant.crunches.reverse:Reverse Crunches`,
+  '@@exercise.variant.crunches.bicycle': $localize`:@@exercise.variant.crunches.bicycle:Bicycle Crunches`,
+  '@@exercise.variant.crunches.oblique': $localize`:@@exercise.variant.crunches.oblique:Schräge Crunches`,
+
+  // leg raises
+  '@@exercise.variant.legraises.lying': $localize`:@@exercise.variant.legraises.lying:Liegend`,
+  '@@exercise.variant.legraises.hanging-knee': $localize`:@@exercise.variant.legraises.hanging-knee:Hängend (Knie)`,
+  '@@exercise.variant.legraises.hanging-straight': $localize`:@@exercise.variant.legraises.hanging-straight:Hängend (gestreckt)`,
+
+  // russian twist
+  '@@exercise.variant.russiantwist.bodyweight': $localize`:@@exercise.variant.russiantwist.bodyweight:Eigengewicht`,
+  '@@exercise.variant.russiantwist.weighted': $localize`:@@exercise.variant.russiantwist.weighted:Mit Zusatzgewicht`,
+
+  // mountain climbers
+  '@@exercise.variant.mountainclimbers.standard': $localize`:@@exercise.variant.mountainclimbers.standard:Standard`,
+  '@@exercise.variant.mountainclimbers.cross-body': $localize`:@@exercise.variant.mountainclimbers.cross-body:Cross-Body`,
+
+  // plank
+  '@@exercise.variant.plank.standard': $localize`:@@exercise.variant.plank.standard:Standard`,
+  '@@exercise.variant.plank.forearm': $localize`:@@exercise.variant.plank.forearm:Unterarmstütz`,
+  '@@exercise.variant.plank.side': $localize`:@@exercise.variant.plank.side:Seitlich`,
+  '@@exercise.variant.plank.reverse': $localize`:@@exercise.variant.plank.reverse:Umgekehrt`,
+
+  // squats
+  '@@exercise.variant.squats.bodyweight': $localize`:@@exercise.variant.squats.bodyweight:Eigengewicht`,
+  '@@exercise.variant.squats.sumo': $localize`:@@exercise.variant.squats.sumo:Sumo`,
+  '@@exercise.variant.squats.goblet': $localize`:@@exercise.variant.squats.goblet:Goblet`,
+  '@@exercise.variant.squats.bulgarian-split': $localize`:@@exercise.variant.squats.bulgarian-split:Bulgarian Split`,
+  '@@exercise.variant.squats.pistol': $localize`:@@exercise.variant.squats.pistol:Pistol`,
+
+  // calf raises
+  '@@exercise.variant.calfraises.standard': $localize`:@@exercise.variant.calfraises.standard:Standard`,
+  '@@exercise.variant.calfraises.single-leg': $localize`:@@exercise.variant.calfraises.single-leg:Einbeinig`,
+  '@@exercise.variant.calfraises.seated': $localize`:@@exercise.variant.calfraises.seated:Sitzend`,
+
+  // glute bridge
+  '@@exercise.variant.glutebridge.standard': $localize`:@@exercise.variant.glutebridge.standard:Standard`,
+  '@@exercise.variant.glutebridge.single-leg': $localize`:@@exercise.variant.glutebridge.single-leg:Einbeinig`,
+  '@@exercise.variant.glutebridge.hip-thrust': $localize`:@@exercise.variant.glutebridge.hip-thrust:Hip Thrust`,
+  '@@exercise.variant.glutebridge.march': $localize`:@@exercise.variant.glutebridge.march:Marching`,
+
+  // lunges
+  '@@exercise.variant.lunges.forward': $localize`:@@exercise.variant.lunges.forward:Vorwärts`,
+  '@@exercise.variant.lunges.reverse': $localize`:@@exercise.variant.lunges.reverse:Rückwärts`,
+  '@@exercise.variant.lunges.walking': $localize`:@@exercise.variant.lunges.walking:Walking`,
+  '@@exercise.variant.lunges.lateral': $localize`:@@exercise.variant.lunges.lateral:Seitlich`,
+  '@@exercise.variant.lunges.curtsy': $localize`:@@exercise.variant.lunges.curtsy:Curtsy`,
+  '@@exercise.variant.lunges.jumping': $localize`:@@exercise.variant.lunges.jumping:Jumping`,
+
+  // pullups
+  '@@exercise.variant.pullups.standard': $localize`:@@exercise.variant.pullups.standard:Standard`,
+  '@@exercise.variant.pullups.chin-up': $localize`:@@exercise.variant.pullups.chin-up:Chin-up`,
+  '@@exercise.variant.pullups.wide-grip': $localize`:@@exercise.variant.pullups.wide-grip:Breiter Griff`,
+  '@@exercise.variant.pullups.neutral-grip': $localize`:@@exercise.variant.pullups.neutral-grip:Neutraler Griff`,
+  '@@exercise.variant.pullups.negative': $localize`:@@exercise.variant.pullups.negative:Negativ`,
+  '@@exercise.variant.pullups.assisted': $localize`:@@exercise.variant.pullups.assisted:Assistiert`,
+  '@@exercise.variant.pullups.archer': $localize`:@@exercise.variant.pullups.archer:Archer`,
+
+  // rows
+  '@@exercise.variant.rows.inverted': $localize`:@@exercise.variant.rows.inverted:Inverted Row`,
+  '@@exercise.variant.rows.australian': $localize`:@@exercise.variant.rows.australian:Australian Row`,
+  '@@exercise.variant.rows.dumbbell': $localize`:@@exercise.variant.rows.dumbbell:Kurzhantel`,
+  '@@exercise.variant.rows.barbell': $localize`:@@exercise.variant.rows.barbell:Langhantel`,
+};
+
+export function variantDisplayName(variant: ExerciseVariant): string {
+  return VARIANT_DISPLAY_NAMES[variant.nameKey] ?? variant.id;
+}
+
+/**
  * Resolves the filter-key shape used by the analysis page (`'pushup'`
  * for the collapsed legacy-pushup bucket, exerciseId for everything
  * else) to a localised label. Shared between the page filter chips and
@@ -118,7 +207,7 @@ const CATEGORY_DISPLAY_NAMES: Record<ExerciseCategoryId, string> = {
   push: $localize`:@@exercise.category.push:Drücken`,
   pull: $localize`:@@exercise.category.pull:Ziehen`,
   squat: $localize`:@@exercise.category.squat:Kniebeuge`,
-  hinge: $localize`:@@exercise.category.hinge:Hüftbeuge`,
+  hinge: $localize`:@@exercise.category.hinge:Hüftstreckung`,
   lunge: $localize`:@@exercise.category.lunge:Ausfallschritt`,
   carry: $localize`:@@exercise.category.carry:Tragen`,
   core: $localize`:@@exercise.category.core:Rumpf`,

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -203,17 +203,19 @@ export function kindDisplayName(value: UnifiedEntryFilterKey): string {
  * no runtime hook for `$localize`, and emitting the id would render
  * the legend like a developer string in production builds.
  */
-const CATEGORY_DISPLAY_NAMES: Record<ExerciseCategoryId, string> = {
+// `carry` and `strength` are declared in `ExerciseCategoryId` for
+// forward-compat but ship without picker entries (see catalog header).
+// Omitting them here lets `categoryDisplayName` fall back to the raw id
+// rather than maintain dead `$localize` calls for unused labels.
+const CATEGORY_DISPLAY_NAMES: Partial<Record<ExerciseCategoryId, string>> = {
   push: $localize`:@@exercise.category.push:Drücken`,
   pull: $localize`:@@exercise.category.pull:Ziehen`,
   squat: $localize`:@@exercise.category.squat:Kniebeuge`,
   hinge: $localize`:@@exercise.category.hinge:Hüftstreckung`,
   lunge: $localize`:@@exercise.category.lunge:Ausfallschritt`,
-  carry: $localize`:@@exercise.category.carry:Tragen`,
   core: $localize`:@@exercise.category.core:Rumpf`,
   cardio: $localize`:@@exercise.category.cardio:Ausdauer`,
   mobility: $localize`:@@exercise.category.mobility:Mobilität`,
-  strength: $localize`:@@exercise.category.strength:Krafttraining`,
 };
 
 export function categoryDisplayName(id: ExerciseCategoryId): string {

--- a/web/src/app/stats/shell/analysis-group-view.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.spec.ts
@@ -225,7 +225,7 @@ describe('AnalysisGroupViewComponent', () => {
     // resolve a different (or missing) instance.
     const store = groupViewEl.injector.get(AnalysisStore);
     store.setRange('2026-02-09', '2026-02-15');
-    store.setActiveView('abs');
+    store.setActiveView('core');
     fixture.detectChanges();
     await fixture.whenStable();
 

--- a/web/src/app/stats/shell/analysis-group-view.component.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.ts
@@ -353,15 +353,16 @@ export class AnalysisGroupViewComponent {
    * kind mode) into localised display names. Pushup-variant mode
    * passes through because the store already produces locale-aware
    * variant names. The gate mirrors `analysis.store` — a per-category
-   * tab other than 'pushup' is always kind mode, so the breakdown
+   * tab other than 'push' is always kind mode, so the breakdown
    * carries exerciseIds like `abs.situps` that need translating even
-   * without an explicit kinds filter.
+   * without an explicit kinds filter. The legacy kind filter key
+   * stays `'pushup'` (Firestore collection identifier).
    */
   readonly typeBreakdownDisplay = computed(() => {
     const view = this.store.activeView();
     const kinds = this.store.kinds();
     const showPushupVariants =
-      view === 'pushup' ||
+      view === 'push' ||
       (view === 'overview' &&
         (kinds.length === 0 || (kinds.length === 1 && kinds[0] === 'pushup')));
     const data = this.store.typeBreakdown();

--- a/web/src/app/stats/shell/analysis-overview.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-overview.component.spec.ts
@@ -147,7 +147,7 @@ describe('AnalysisOverviewComponent', () => {
     store.categorySummaries.set([
       {
         categoryId: 'push',
-        nameKey: '@@exercise.category.pushup',
+        nameKey: '@@exercise.category.push',
         icon: 'fitness_center',
         order: 10,
         totalReps: 100,
@@ -158,7 +158,7 @@ describe('AnalysisOverviewComponent', () => {
       },
       {
         categoryId: 'core',
-        nameKey: '@@exercise.category.abs',
+        nameKey: '@@exercise.category.core',
         icon: 'self_improvement',
         order: 20,
         totalReps: 30,
@@ -190,7 +190,7 @@ describe('AnalysisOverviewComponent', () => {
     store.categorySummaries.set([
       {
         categoryId: 'push',
-        nameKey: '@@exercise.category.pushup',
+        nameKey: '@@exercise.category.push',
         icon: 'fitness_center',
         order: 10,
         totalReps: 100,
@@ -223,7 +223,7 @@ describe('AnalysisOverviewComponent', () => {
     store.categorySummaries.set([
       {
         categoryId: 'push',
-        nameKey: '@@exercise.category.pushup',
+        nameKey: '@@exercise.category.push',
         icon: 'fitness_center',
         order: 10,
         totalReps: 100,
@@ -269,7 +269,7 @@ describe('AnalysisOverviewComponent', () => {
     store.categorySummaries.set([
       {
         categoryId: 'push',
-        nameKey: '@@exercise.category.pushup',
+        nameKey: '@@exercise.category.push',
         icon: 'fitness_center',
         order: 10,
         totalReps: 100,

--- a/web/src/app/stats/shell/analysis-overview.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-overview.component.spec.ts
@@ -146,7 +146,7 @@ describe('AnalysisOverviewComponent', () => {
   it('renders the chart and one card per summary when categories exist', () => {
     store.categorySummaries.set([
       {
-        categoryId: 'pushup',
+        categoryId: 'push',
         nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
@@ -157,7 +157,7 @@ describe('AnalysisOverviewComponent', () => {
         bestDay: { date: '2026-02-13', total: 25 },
       },
       {
-        categoryId: 'abs',
+        categoryId: 'core',
         nameKey: '@@exercise.category.abs',
         icon: 'self_improvement',
         order: 20,
@@ -189,7 +189,7 @@ describe('AnalysisOverviewComponent', () => {
     // carries rows.
     store.categorySummaries.set([
       {
-        categoryId: 'pushup',
+        categoryId: 'push',
         nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
@@ -222,7 +222,7 @@ describe('AnalysisOverviewComponent', () => {
   it('forwards viewSelect emissions from a summary card up to the parent', () => {
     store.categorySummaries.set([
       {
-        categoryId: 'pushup',
+        categoryId: 'push',
         nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
@@ -242,7 +242,7 @@ describe('AnalysisOverviewComponent', () => {
     expect(button).toBeTruthy();
     button.click();
     fixture.detectChanges();
-    expect(fixture.componentInstance.lastEmitted()).toBe('pushup');
+    expect(fixture.componentInstance.lastEmitted()).toBe('push');
   });
 
   it('snaps activeView to overview in the uncategorised fallback so the embedded group-view is not stale-filtered', () => {
@@ -253,7 +253,7 @@ describe('AnalysisOverviewComponent', () => {
     // point of surfacing the uncategorised rows. The component's
     // effect must re-sync activeView to 'overview' as soon as it
     // enters the fallback branch.
-    store.activeView.set('plank');
+    store.activeView.set('mobility');
     store.unifiedRows.set([{ id: 'orphan' }]);
     fixture.detectChanges();
     expect(store.activeView()).toBe('overview');
@@ -265,10 +265,10 @@ describe('AnalysisOverviewComponent', () => {
     // and is currently looking at the overview tab only because the
     // shell rendered it as the default Overview view. Snapping then
     // would corrupt the deep-link intent.
-    store.activeView.set('plank');
+    store.activeView.set('mobility');
     store.categorySummaries.set([
       {
-        categoryId: 'pushup',
+        categoryId: 'push',
         nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
@@ -280,6 +280,6 @@ describe('AnalysisOverviewComponent', () => {
       },
     ]);
     fixture.detectChanges();
-    expect(store.activeView()).toBe('plank');
+    expect(store.activeView()).toBe('mobility');
   });
 });

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -422,7 +422,7 @@ describe('AnalysisPageComponent', () => {
 
     it('setActiveView("abs") narrows viewFilteredRows to abs-category entries only', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('abs');
+      store.setActiveView('core');
       const rows = store.viewFilteredRows();
       expect(rows).toHaveLength(1);
       expect(rows[0].kind).toBe('exercise');
@@ -433,7 +433,7 @@ describe('AnalysisPageComponent', () => {
 
     it('setActiveView("pushup") collapses to pushup entries only', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('pushup');
+      store.setActiveView('push');
       const rows = store.viewFilteredRows();
       expect(rows).toHaveLength(6);
       expect(rows.every((r) => r.kind === 'pushup')).toBe(true);
@@ -441,7 +441,7 @@ describe('AnalysisPageComponent', () => {
 
     it('setActiveView("legs") narrows to legs-category entries only', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('legs');
+      store.setActiveView('squat');
       const rows = store.viewFilteredRows();
       expect(rows).toHaveLength(1);
       expect((rows[0] as { exerciseId?: string }).exerciseId).toBe(
@@ -451,7 +451,7 @@ describe('AnalysisPageComponent', () => {
 
     it('returns to all rows when activeView is reset to "overview"', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('abs');
+      store.setActiveView('core');
       expect(store.viewFilteredRows()).toHaveLength(1);
       store.setActiveView('overview');
       expect(store.viewFilteredRows()).toHaveLength(8);
@@ -467,7 +467,7 @@ describe('AnalysisPageComponent', () => {
 
     it('per-category KPIs scope to the active view (abs)', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('abs');
+      store.setActiveView('core');
       expect(store.bestSingleEntry()?.reps).toBe(30);
       expect(store.bestDay()).toEqual({ date: '2026-02-12', total: 30 });
       // 1 abs entry, no consecutive day → streak length 1
@@ -481,7 +481,7 @@ describe('AnalysisPageComponent', () => {
 
     it('per-category KPIs scope to the active view (pushup)', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('pushup');
+      store.setActiveView('push');
       // Same numbers as the original pushup-only tests because the
       // seeded mock is the pushup-only dataset.
       expect(store.bestSingleEntry()?.reps).toBe(25);
@@ -493,7 +493,7 @@ describe('AnalysisPageComponent', () => {
 
     it('KPIs collapse to zero/null when the active view has no entries', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('plank');
+      store.setActiveView('mobility');
       expect(store.bestSingleEntry()).toBeNull();
       expect(store.bestDay()).toBeNull();
       expect(store.currentStreak()).toBe(0);
@@ -516,28 +516,28 @@ describe('AnalysisPageComponent', () => {
 
     it('per-category week trend scopes to the active view (abs)', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('abs');
+      store.setActiveView('core');
       const week = store.weekTrend().find((w) => w.label === '2026-W07');
       expect(week?.total).toBe(30);
     });
 
     it('per-category month trend scopes to the active view (legs)', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('legs');
+      store.setActiveView('squat');
       const month = store.monthTrend().find((m) => m.label === '2026-02');
       expect(month?.total).toBe(40);
     });
 
     it('per-category pushup trend matches the legacy pushup-only totals', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('pushup');
+      store.setActiveView('push');
       const week = store.weekTrend().find((w) => w.label === '2026-W07');
       expect(week?.total).toBe(93);
     });
 
     it('empty-category trends report zero totals across the window', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('plank');
+      store.setActiveView('mobility');
       expect(store.weekTrend().every((w) => w.total === 0)).toBe(true);
       expect(store.monthTrend().every((m) => m.total === 0)).toBe(true);
     });
@@ -546,16 +546,16 @@ describe('AnalysisPageComponent', () => {
       const { store } = fixture.componentInstance;
       const summaries = store.categorySummaries();
       expect(summaries.map((s) => s.categoryId)).toEqual([
-        'pushup',
-        'abs',
-        'legs',
+        'push',
+        'squat',
+        'core',
       ]);
     });
 
     it('categorySummaries surfaces per-category totals, today reps and best day', () => {
       const { store } = fixture.componentInstance;
       const summaries = store.categorySummaries();
-      const pushup = summaries.find((s) => s.categoryId === 'pushup');
+      const pushup = summaries.find((s) => s.categoryId === 'push');
       expect(pushup).toMatchObject({
         totalReps: 93,
         // 5+5 + 6+6 + 10+5+5 + 10+8+7 + 9+9 = 12 sets across 5 entries.
@@ -564,7 +564,7 @@ describe('AnalysisPageComponent', () => {
         todayReps: 18,
         bestDay: { date: '2026-02-13', total: 25 },
       });
-      const abs = summaries.find((s) => s.categoryId === 'abs');
+      const abs = summaries.find((s) => s.categoryId === 'core');
       expect(abs).toMatchObject({
         totalReps: 30,
         totalSets: 0,
@@ -572,7 +572,7 @@ describe('AnalysisPageComponent', () => {
         currentStreak: 1,
         bestDay: { date: '2026-02-12', total: 30 },
       });
-      const legs = summaries.find((s) => s.categoryId === 'legs');
+      const legs = summaries.find((s) => s.categoryId === 'squat');
       expect(legs).toMatchObject({
         totalReps: 40,
         bestDay: { date: '2026-02-13', total: 40 },
@@ -582,18 +582,19 @@ describe('AnalysisPageComponent', () => {
     it('categoryComparison projects summaries into chart-friendly arrays with translated labels', () => {
       // Chart.js cannot resolve $localize ids at runtime, so labels
       // are pre-translated by the store. TestBed defaults to the
-      // source locale (de) — assertions use the German source strings.
+      // source locale (de) — assertions use the German source strings
+      // for the movement-pattern category names.
       const { store } = fixture.componentInstance;
       const cmp = store.categoryComparison();
-      expect(cmp.labels).toEqual(['Liegestütze', 'Bauch', 'Beine']);
-      expect(cmp.reps).toEqual([93, 30, 40]);
+      expect(cmp.labels).toEqual(['Drücken', 'Kniebeuge', 'Rumpf']);
+      expect(cmp.reps).toEqual([93, 40, 30]);
       expect(cmp.sets).toEqual([12, 0, 0]);
     });
 
     it('categorySummaries stays insensitive to the active view (it powers the overview)', () => {
       const { store } = fixture.componentInstance;
       const baseline = store.categorySummaries().map((s) => s.categoryId);
-      store.setActiveView('abs');
+      store.setActiveView('core');
       expect(store.categorySummaries().map((s) => s.categoryId)).toEqual(
         baseline
       );
@@ -601,7 +602,7 @@ describe('AnalysisPageComponent', () => {
 
     it('typeBreakdown collapses to the active category in kind mode (abs)', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('abs');
+      store.setActiveView('core');
       const breakdown = store.typeBreakdown();
       expect(breakdown).toHaveLength(1);
       expect(breakdown[0]).toMatchObject({
@@ -612,7 +613,7 @@ describe('AnalysisPageComponent', () => {
 
     it('typeBreakdown stays in pushup-variant mode when the active view is pushup', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('pushup');
+      store.setActiveView('push');
       const labels = store.typeBreakdown().map((b) => b.label);
       expect(labels).toContain('Standard-Liegestütze');
       expect(labels).toContain('Diamant-Liegestütze');
@@ -623,7 +624,7 @@ describe('AnalysisPageComponent', () => {
 
     it('typeBreakdown is empty for a category that has no entries', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('plank');
+      store.setActiveView('mobility');
       expect(store.typeBreakdown()).toEqual([]);
     });
 
@@ -647,7 +648,7 @@ describe('AnalysisPageComponent', () => {
 
     it('viewChartSeries narrows to the active category (abs)', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('abs');
+      store.setActiveView('core');
       const series = store.viewChartSeries();
       expect(series).toEqual([
         { bucket: '2026-02-12', total: 30, dayIntegral: 30 },
@@ -656,7 +657,7 @@ describe('AnalysisPageComponent', () => {
 
     it('viewChartSeries narrows to the active category (legs)', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('legs');
+      store.setActiveView('squat');
       const series = store.viewChartSeries();
       expect(series).toEqual([
         { bucket: '2026-02-13', total: 40, dayIntegral: 40 },
@@ -665,7 +666,7 @@ describe('AnalysisPageComponent', () => {
 
     it('viewChartSeries scoped to pushup matches the legacy pushup-only daily totals', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('pushup');
+      store.setActiveView('push');
       const series = store.viewChartSeries();
       // Seeded pushups: Feb 9 → 15 with one skipped day, totals
       // [10,12,20,8,25,18] and cumulative dayIntegral [10,22,42,50,75,93].
@@ -685,7 +686,7 @@ describe('AnalysisPageComponent', () => {
 
     it('viewChartSeries collapses to an empty array for a category with no entries', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('plank');
+      store.setActiveView('mobility');
       expect(store.viewChartSeries()).toEqual([]);
     });
 
@@ -711,7 +712,7 @@ describe('AnalysisPageComponent', () => {
       // shape and the total — both timezone-agnostic.
       const { store } = fixture.componentInstance;
       store.setRange('2026-02-12', '2026-02-12');
-      store.setActiveView('abs');
+      store.setActiveView('core');
       store.setDayChartMode('24h');
       const series = store.viewChartSeries();
       expect(series).toHaveLength(24);
@@ -728,7 +729,7 @@ describe('AnalysisPageComponent', () => {
       // the 08 slot, keeping the day's reps inside the 14h window.
       const { store } = fixture.componentInstance;
       store.setRange('2026-02-12', '2026-02-12');
-      store.setActiveView('abs');
+      store.setActiveView('core');
       store.setDayChartMode('14h');
       const series = store.viewChartSeries();
       expect(series).toHaveLength(15);
@@ -738,7 +739,7 @@ describe('AnalysisPageComponent', () => {
 
     it('viewChartEntries shapes view-filtered rows for the chart sets-stacking layer', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('abs');
+      store.setActiveView('core');
       const entries = store.viewChartEntries();
       expect(entries).toEqual([
         { timestamp: '2026-02-12T08:00:00.000Z', reps: 30 },
@@ -751,7 +752,7 @@ describe('AnalysisPageComponent', () => {
       // array on the way through, every pushup tab would silently lose
       // its purple "Mit Sets" segment.
       const { store } = fixture.componentInstance;
-      store.setActiveView('pushup');
+      store.setActiveView('push');
       const entries = store.viewChartEntries();
       expect(
         entries.some((e) => Array.isArray(e.sets) && e.sets.length > 1)
@@ -759,13 +760,13 @@ describe('AnalysisPageComponent', () => {
     });
 
     it('typeBreakdownDisplay localises kind-mode ids when activeView scopes to a non-pushup category', () => {
-      // Regression for codex P2: setActiveView('abs') without an
+      // Regression for codex P2: setActiveView('core') without an
       // explicit kinds filter puts the store in kind-mode and emits
       // raw ids like `abs.situps`. The display mapper must mirror the
       // store's gate and localise — otherwise the pie legend reads
       // like a developer string.
       const { store } = fixture.componentInstance;
-      store.setActiveView('abs');
+      store.setActiveView('core');
       fixture.detectChanges();
       const groupView = fixture.debugElement.query(
         By.directive(AnalysisGroupViewComponent)
@@ -782,8 +783,9 @@ describe('AnalysisPageComponent', () => {
   describe('tabs + URL sync', () => {
     it('shows only the Overview tab plus one tab per category with entries', () => {
       const component = fixture.componentInstance;
-      // Seeded dataset has only pushup entries → one visible category tab.
-      expect(component.visibleTabs().map((t) => t.id)).toEqual(['pushup']);
+      // Seeded dataset has only pushup entries → one visible category tab,
+      // routed under the `push` movement-pattern category.
+      expect(component.visibleTabs().map((t) => t.id)).toEqual(['push']);
 
       liveExerciseEntries.set([
         {
@@ -806,19 +808,20 @@ describe('AnalysisPageComponent', () => {
       component.store.setRange('2026-02-09', '2026-02-15');
       fixture.detectChanges();
 
-      // Order follows EXERCISE_CATEGORIES.order (pushup=10, abs=20, legs=30).
+      // Order follows EXERCISE_CATEGORIES.order
+      // (push=10, squat=30, core=70 → legs.squats → squat, abs.situps → core).
       expect(component.visibleTabs().map((t) => t.id)).toEqual([
-        'pushup',
-        'abs',
-        'legs',
+        'push',
+        'squat',
+        'core',
       ]);
     });
 
     it('switches activeView when a tab is selected', () => {
       const component = fixture.componentInstance;
-      // Overview = 0, pushup tab = 1 (the only category visible by default).
+      // Overview = 0, push tab = 1 (the only category visible by default).
       component.onTabIndexChange(1);
-      expect(component.store.activeView()).toBe('pushup');
+      expect(component.store.activeView()).toBe('push');
 
       component.onTabIndexChange(0);
       expect(component.store.activeView()).toBe('overview');
@@ -826,28 +829,30 @@ describe('AnalysisPageComponent', () => {
 
     it('maps activeView back to the matching tab index for the mat-tab-group binding', () => {
       const component = fixture.componentInstance;
-      component.store.setActiveView('pushup');
+      component.store.setActiveView('push');
       expect(component.selectedTabIndex()).toBe(1);
       component.store.setActiveView('overview');
       expect(component.selectedTabIndex()).toBe(0);
     });
 
     it('falls back to Overview when activeView points at a tab that is not visible', () => {
-      // The seeded dataset only has pushup entries, so the abs/legs/plank
-      // tabs never render. Pointing activeView at one of them — e.g. via
-      // a stale `?view=plank` deep link — must surface index 0 rather
+      // The seeded dataset only has pushup entries, so the core/squat tabs
+      // never render. Pointing activeView at an empty category — e.g. via
+      // a stale `?view=mobility` deep link — must surface index 0 rather
       // than leaving the binding referencing an out-of-range slot.
       const component = fixture.componentInstance;
-      component.store.setActiveView('plank');
+      component.store.setActiveView('mobility');
       fixture.detectChanges();
-      expect(component.visibleTabs().some((t) => t.id === 'plank')).toBe(false);
+      expect(component.visibleTabs().some((t) => t.id === 'mobility')).toBe(
+        false
+      );
       expect(component.selectedTabIndex()).toBe(0);
     });
 
     it('selecting an overview card emits the category and switches the active view', () => {
       const component = fixture.componentInstance;
-      component.onOverviewSelect('pushup');
-      expect(component.store.activeView()).toBe('pushup');
+      component.onOverviewSelect('push');
+      expect(component.store.activeView()).toBe('push');
     });
 
     it('renders a mat-tab-group with the Overview tab plus the visible categories', () => {
@@ -858,11 +863,9 @@ describe('AnalysisPageComponent', () => {
       const overviewTab = host.querySelector(
         '[data-testid="analysis-tab-overview"]'
       );
-      const pushupTab = host.querySelector(
-        '[data-testid="analysis-tab-pushup"]'
-      );
+      const pushTab = host.querySelector('[data-testid="analysis-tab-push"]');
       expect(overviewTab).toBeTruthy();
-      expect(pushupTab).toBeTruthy();
+      expect(pushTab).toBeTruthy();
     });
   });
 });

--- a/web/src/app/stats/shell/entries-page.component.spec.ts
+++ b/web/src/app/stats/shell/entries-page.component.spec.ts
@@ -175,13 +175,15 @@ describe('EntriesPageComponent', () => {
       const component = fixture.componentInstance;
       const opts = component.kindFilterOptions();
       // The mock rows are all pushup-kind, so the only filter key is
-      // 'pushup' (variants collapse via unifiedEntryFilterKey).
+      // 'pushup' (variants collapse via unifiedEntryFilterKey — the
+      // filter-key string stays as the legacy Firestore collection
+      // identifier).
       expect(opts).toHaveLength(1);
       expect(opts[0].value).toBe('pushup');
-      // The label is the localized "Liegestütze" string ($localize
-      // returns the source German in tests because no locale runtime
-      // is loaded).
-      expect(opts[0].label).toBe('Liegestütze');
+      // Label switches to the new movement-pattern category label
+      // ("Drücken") which is what the analysis page filter chips
+      // already render.
+      expect(opts[0].label).toBe('Drücken');
     });
     // Note: the exercise-id branch of `kindLabel` is exercised
     // indirectly through `exerciseDisplayName` (covered in

--- a/web/src/app/stats/shell/entries-page.component.ts
+++ b/web/src/app/stats/shell/entries-page.component.ts
@@ -10,10 +10,7 @@ import { findExerciseDefinition } from '@pu-stats/models';
 import { exerciseDisplayName } from '../i18n/exercise-display-names';
 import { PreviewBannerComponent } from '../components/preview-banner/preview-banner.component';
 import { StatsTableComponent } from '../components/stats-table/stats-table.component';
-import {
-  EntriesStore,
-  type ExerciseKindFilterOption,
-} from '../entries.store';
+import { EntriesStore, type ExerciseKindFilterOption } from '../entries.store';
 import { PageHeaderComponent } from '../../core/page-header/page-header.component';
 
 @Component({
@@ -156,9 +153,7 @@ import { PageHeaderComponent } from '../../core/page-header/page-header.componen
           <mat-card-content>
             <mat-icon aria-hidden="true">fitness_center</mat-icon>
             <div>
-              <strong i18n="@@entries.empty.title"
-                >Noch keine Einträge.</strong
-              >
+              <strong i18n="@@entries.empty.title">Noch keine Einträge.</strong>
               <p i18n="@@entries.empty.body">
                 Trage deinen ersten Trainingseintrag ein — dann wird hier deine
                 Historie sichtbar.
@@ -274,7 +269,7 @@ export class EntriesPageComponent {
 
   private kindLabel(value: string): string {
     if (value === 'pushup') {
-      return $localize`:@@exercise.category.pushup:Liegestütze`;
+      return $localize`:@@exercise.category.push:Drücken`;
     }
     const def = findExerciseDefinition(value);
     if (!def) return value;

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -7653,8 +7653,8 @@
     </unit>
     <unit id="exercise.category.hinge">
       <segment state="initial">
-        <source>Hüftbeuge</source>
-        <target>Hüftbeuge</target>
+        <source>Hüftstreckung</source>
+        <target>Hüftstreckung</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -7891,5 +7891,287 @@
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
+      <unit id="exercise.variant.situps.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.decline">
+      <segment state="initial">
+        <source>Decline</source>
+        <target>Decline</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.reverse">
+      <segment state="initial">
+        <source>Reverse Crunches</source>
+        <target>Reverse Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.bicycle">
+      <segment state="initial">
+        <source>Bicycle Crunches</source>
+        <target>Bicycle Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.oblique">
+      <segment state="initial">
+        <source>Schräge Crunches</source>
+        <target>Schräge Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.lying">
+      <segment state="initial">
+        <source>Liegend</source>
+        <target>Liegend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-knee">
+      <segment state="initial">
+        <source>Hängend (Knie)</source>
+        <target>Hängend (Knie)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-straight">
+      <segment state="initial">
+        <source>Hängend (gestreckt)</source>
+        <target>Hängend (gestreckt)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.cross-body">
+      <segment state="initial">
+        <source>Cross-Body</source>
+        <target>Cross-Body</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.forearm">
+      <segment state="initial">
+        <source>Unterarmstütz</source>
+        <target>Unterarmstütz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.side">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.reverse">
+      <segment state="initial">
+        <source>Umgekehrt</source>
+        <target>Umgekehrt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.sumo">
+      <segment state="initial">
+        <source>Sumo</source>
+        <target>Sumo</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.goblet">
+      <segment state="initial">
+        <source>Goblet</source>
+        <target>Goblet</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bulgarian-split">
+      <segment state="initial">
+        <source>Bulgarian Split</source>
+        <target>Bulgarian Split</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.pistol">
+      <segment state="initial">
+        <source>Pistol</source>
+        <target>Pistol</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.seated">
+      <segment state="initial">
+        <source>Sitzend</source>
+        <target>Sitzend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.hip-thrust">
+      <segment state="initial">
+        <source>Hip Thrust</source>
+        <target>Hip Thrust</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.march">
+      <segment state="initial">
+        <source>Marching</source>
+        <target>Marching</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.forward">
+      <segment state="initial">
+        <source>Vorwärts</source>
+        <target>Vorwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.reverse">
+      <segment state="initial">
+        <source>Rückwärts</source>
+        <target>Rückwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.walking">
+      <segment state="initial">
+        <source>Walking</source>
+        <target>Walking</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.lateral">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.curtsy">
+      <segment state="initial">
+        <source>Curtsy</source>
+        <target>Curtsy</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.jumping">
+      <segment state="initial">
+        <source>Jumping</source>
+        <target>Jumping</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.chin-up">
+      <segment state="initial">
+        <source>Chin-up</source>
+        <target>Chin-up</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.wide-grip">
+      <segment state="initial">
+        <source>Breiter Griff</source>
+        <target>Breiter Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.neutral-grip">
+      <segment state="initial">
+        <source>Neutraler Griff</source>
+        <target>Neutraler Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.negative">
+      <segment state="initial">
+        <source>Negativ</source>
+        <target>Negativ</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.assisted">
+      <segment state="initial">
+        <source>Assistiert</source>
+        <target>Assistiert</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.archer">
+      <segment state="initial">
+        <source>Archer</source>
+        <target>Archer</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.inverted">
+      <segment state="initial">
+        <source>Inverted Row</source>
+        <target>Inverted Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.australian">
+      <segment state="initial">
+        <source>Australian Row</source>
+        <target>Australian Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.dumbbell">
+      <segment state="initial">
+        <source>Kurzhantel</source>
+        <target>Kurzhantel</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.barbell">
+      <segment state="initial">
+        <source>Langhantel</source>
+        <target>Langhantel</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -7633,5 +7633,263 @@
         <target>Επανάληψη κινούμενης εικόνας ημερήσιου στόχου</target>
       </segment>
     </unit>
+      <unit id="exercise.category.push">
+      <segment state="initial">
+        <source>Drücken</source>
+        <target>Drücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pull">
+      <segment state="initial">
+        <source>Ziehen</source>
+        <target>Ziehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.squat">
+      <segment state="initial">
+        <source>Kniebeuge</source>
+        <target>Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.hinge">
+      <segment state="initial">
+        <source>Hüftbeuge</source>
+        <target>Hüftbeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.lunge">
+      <segment state="initial">
+        <source>Ausfallschritt</source>
+        <target>Ausfallschritt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.carry">
+      <segment state="initial">
+        <source>Tragen</source>
+        <target>Tragen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.core">
+      <segment state="initial">
+        <source>Rumpf</source>
+        <target>Rumpf</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.mobility">
+      <segment state="initial">
+        <source>Mobilität</source>
+        <target>Mobilität</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.strength">
+      <segment state="initial">
+        <source>Krafttraining</source>
+        <target>Krafttraining</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.deadbug.name">
+      <segment state="initial">
+        <source>Dead Bug</source>
+        <target>Dead Bug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.hollowhold.name">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.wallsit.name">
+      <segment state="initial">
+        <source>Wandsitz</source>
+        <target>Wandsitz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.boxjump.name">
+      <segment state="initial">
+        <source>Box Jumps</source>
+        <target>Box Jumps</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.singlelegRdl.name">
+      <segment state="initial">
+        <source>Einbeiniges Kreuzheben</source>
+        <target>Einbeiniges Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.goodmorning.name">
+      <segment state="initial">
+        <source>Good Morning</source>
+        <target>Good Morning</target>
+      </segment>
+    </unit>
+    <unit id="exercise.lunge.stepup.name">
+      <segment state="initial">
+        <source>Step-ups</source>
+        <target>Step-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.pullups.name">
+      <segment state="initial">
+        <source>Klimmzüge</source>
+        <target>Klimmzüge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.rows.name">
+      <segment state="initial">
+        <source>Ruderzug</source>
+        <target>Ruderzug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.deadhang.name">
+      <segment state="initial">
+        <source>Dead Hang</source>
+        <target>Dead Hang</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.facepull.name">
+      <segment state="initial">
+        <source>Face Pull</source>
+        <target>Face Pull</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.farmer.name">
+      <segment state="initial">
+        <source>Farmer&apos;s Walk</source>
+        <target>Farmer&apos;s Walk</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.suitcase.name">
+      <segment state="initial">
+        <source>Suitcase Carry</source>
+        <target>Suitcase Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.overhead.name">
+      <segment state="initial">
+        <source>Overhead Carry</source>
+        <target>Overhead Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.walking.name">
+      <segment state="initial">
+        <source>Gehen</source>
+        <target>Gehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.cycling.name">
+      <segment state="initial">
+        <source>Radfahren</source>
+        <target>Radfahren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.rowing.name">
+      <segment state="initial">
+        <source>Rudern</source>
+        <target>Rudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.swimming.name">
+      <segment state="initial">
+        <source>Schwimmen</source>
+        <target>Schwimmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumprope.name">
+      <segment state="initial">
+        <source>Seilspringen</source>
+        <target>Seilspringen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.burpees.name">
+      <segment state="initial">
+        <source>Burpees</source>
+        <target>Burpees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumpingjacks.name">
+      <segment state="initial">
+        <source>Hampelmänner</source>
+        <target>Hampelmänner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.highknees.name">
+      <segment state="initial">
+        <source>High Knees</source>
+        <target>High Knees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.stretching.name">
+      <segment state="initial">
+        <source>Dehnen</source>
+        <target>Dehnen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.yoga.name">
+      <segment state="initial">
+        <source>Yoga</source>
+        <target>Yoga</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.foamrolling.name">
+      <segment state="initial">
+        <source>Faszienrolle</source>
+        <target>Faszienrolle</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.dynamicwarmup.name">
+      <segment state="initial">
+        <source>Dynamisches Aufwärmen</source>
+        <target>Dynamisches Aufwärmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.catcow.name">
+      <segment state="initial">
+        <source>Katze-Kuh</source>
+        <target>Katze-Kuh</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.hipopener.name">
+      <segment state="initial">
+        <source>Hüftöffner</source>
+        <target>Hüftöffner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.benchpress.name">
+      <segment state="initial">
+        <source>Bankdrücken</source>
+        <target>Bankdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.overheadpress.name">
+      <segment state="initial">
+        <source>Schulterdrücken</source>
+        <target>Schulterdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.deadlift.name">
+      <segment state="initial">
+        <source>Kreuzheben</source>
+        <target>Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellsquat.name">
+      <segment state="initial">
+        <source>Langhantel-Kniebeuge</source>
+        <target>Langhantel-Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellrow.name">
+      <segment state="initial">
+        <source>Langhantelrudern</source>
+        <target>Langhantelrudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.kettlebellswing.name">
+      <segment state="initial">
+        <source>Kettlebell Swing</source>
+        <target>Kettlebell Swing</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -7821,8 +7821,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="exercise.category.hinge">
       <segment state="initial">
-        <source>Hüftbeuge</source>
-        <target>Hüftbeuge</target>
+        <source>Hüftstreckung</source>
+        <target>Hüftstreckung</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -8059,5 +8059,287 @@ Deine Position: # ·  Reps        </source>
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
+      <unit id="exercise.variant.situps.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.decline">
+      <segment state="initial">
+        <source>Decline</source>
+        <target>Decline</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.reverse">
+      <segment state="initial">
+        <source>Reverse Crunches</source>
+        <target>Reverse Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.bicycle">
+      <segment state="initial">
+        <source>Bicycle Crunches</source>
+        <target>Bicycle Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.oblique">
+      <segment state="initial">
+        <source>Schräge Crunches</source>
+        <target>Schräge Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.lying">
+      <segment state="initial">
+        <source>Liegend</source>
+        <target>Liegend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-knee">
+      <segment state="initial">
+        <source>Hängend (Knie)</source>
+        <target>Hängend (Knie)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-straight">
+      <segment state="initial">
+        <source>Hängend (gestreckt)</source>
+        <target>Hängend (gestreckt)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.cross-body">
+      <segment state="initial">
+        <source>Cross-Body</source>
+        <target>Cross-Body</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.forearm">
+      <segment state="initial">
+        <source>Unterarmstütz</source>
+        <target>Unterarmstütz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.side">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.reverse">
+      <segment state="initial">
+        <source>Umgekehrt</source>
+        <target>Umgekehrt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.sumo">
+      <segment state="initial">
+        <source>Sumo</source>
+        <target>Sumo</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.goblet">
+      <segment state="initial">
+        <source>Goblet</source>
+        <target>Goblet</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bulgarian-split">
+      <segment state="initial">
+        <source>Bulgarian Split</source>
+        <target>Bulgarian Split</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.pistol">
+      <segment state="initial">
+        <source>Pistol</source>
+        <target>Pistol</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.seated">
+      <segment state="initial">
+        <source>Sitzend</source>
+        <target>Sitzend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.hip-thrust">
+      <segment state="initial">
+        <source>Hip Thrust</source>
+        <target>Hip Thrust</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.march">
+      <segment state="initial">
+        <source>Marching</source>
+        <target>Marching</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.forward">
+      <segment state="initial">
+        <source>Vorwärts</source>
+        <target>Vorwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.reverse">
+      <segment state="initial">
+        <source>Rückwärts</source>
+        <target>Rückwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.walking">
+      <segment state="initial">
+        <source>Walking</source>
+        <target>Walking</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.lateral">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.curtsy">
+      <segment state="initial">
+        <source>Curtsy</source>
+        <target>Curtsy</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.jumping">
+      <segment state="initial">
+        <source>Jumping</source>
+        <target>Jumping</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.chin-up">
+      <segment state="initial">
+        <source>Chin-up</source>
+        <target>Chin-up</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.wide-grip">
+      <segment state="initial">
+        <source>Breiter Griff</source>
+        <target>Breiter Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.neutral-grip">
+      <segment state="initial">
+        <source>Neutraler Griff</source>
+        <target>Neutraler Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.negative">
+      <segment state="initial">
+        <source>Negativ</source>
+        <target>Negativ</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.assisted">
+      <segment state="initial">
+        <source>Assistiert</source>
+        <target>Assistiert</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.archer">
+      <segment state="initial">
+        <source>Archer</source>
+        <target>Archer</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.inverted">
+      <segment state="initial">
+        <source>Inverted Row</source>
+        <target>Inverted Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.australian">
+      <segment state="initial">
+        <source>Australian Row</source>
+        <target>Australian Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.dumbbell">
+      <segment state="initial">
+        <source>Kurzhantel</source>
+        <target>Kurzhantel</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.barbell">
+      <segment state="initial">
+        <source>Langhantel</source>
+        <target>Langhantel</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -7801,5 +7801,263 @@ Deine Position: # ·  Reps        </source>
         <target>Replay daily goal animation</target>
       </segment>
     </unit>
+      <unit id="exercise.category.push">
+      <segment state="initial">
+        <source>Drücken</source>
+        <target>Drücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pull">
+      <segment state="initial">
+        <source>Ziehen</source>
+        <target>Ziehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.squat">
+      <segment state="initial">
+        <source>Kniebeuge</source>
+        <target>Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.hinge">
+      <segment state="initial">
+        <source>Hüftbeuge</source>
+        <target>Hüftbeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.lunge">
+      <segment state="initial">
+        <source>Ausfallschritt</source>
+        <target>Ausfallschritt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.carry">
+      <segment state="initial">
+        <source>Tragen</source>
+        <target>Tragen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.core">
+      <segment state="initial">
+        <source>Rumpf</source>
+        <target>Rumpf</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.mobility">
+      <segment state="initial">
+        <source>Mobilität</source>
+        <target>Mobilität</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.strength">
+      <segment state="initial">
+        <source>Krafttraining</source>
+        <target>Krafttraining</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.deadbug.name">
+      <segment state="initial">
+        <source>Dead Bug</source>
+        <target>Dead Bug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.hollowhold.name">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.wallsit.name">
+      <segment state="initial">
+        <source>Wandsitz</source>
+        <target>Wandsitz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.boxjump.name">
+      <segment state="initial">
+        <source>Box Jumps</source>
+        <target>Box Jumps</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.singlelegRdl.name">
+      <segment state="initial">
+        <source>Einbeiniges Kreuzheben</source>
+        <target>Einbeiniges Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.goodmorning.name">
+      <segment state="initial">
+        <source>Good Morning</source>
+        <target>Good Morning</target>
+      </segment>
+    </unit>
+    <unit id="exercise.lunge.stepup.name">
+      <segment state="initial">
+        <source>Step-ups</source>
+        <target>Step-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.pullups.name">
+      <segment state="initial">
+        <source>Klimmzüge</source>
+        <target>Klimmzüge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.rows.name">
+      <segment state="initial">
+        <source>Ruderzug</source>
+        <target>Ruderzug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.deadhang.name">
+      <segment state="initial">
+        <source>Dead Hang</source>
+        <target>Dead Hang</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.facepull.name">
+      <segment state="initial">
+        <source>Face Pull</source>
+        <target>Face Pull</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.farmer.name">
+      <segment state="initial">
+        <source>Farmer&apos;s Walk</source>
+        <target>Farmer&apos;s Walk</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.suitcase.name">
+      <segment state="initial">
+        <source>Suitcase Carry</source>
+        <target>Suitcase Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.overhead.name">
+      <segment state="initial">
+        <source>Overhead Carry</source>
+        <target>Overhead Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.walking.name">
+      <segment state="initial">
+        <source>Gehen</source>
+        <target>Gehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.cycling.name">
+      <segment state="initial">
+        <source>Radfahren</source>
+        <target>Radfahren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.rowing.name">
+      <segment state="initial">
+        <source>Rudern</source>
+        <target>Rudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.swimming.name">
+      <segment state="initial">
+        <source>Schwimmen</source>
+        <target>Schwimmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumprope.name">
+      <segment state="initial">
+        <source>Seilspringen</source>
+        <target>Seilspringen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.burpees.name">
+      <segment state="initial">
+        <source>Burpees</source>
+        <target>Burpees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumpingjacks.name">
+      <segment state="initial">
+        <source>Hampelmänner</source>
+        <target>Hampelmänner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.highknees.name">
+      <segment state="initial">
+        <source>High Knees</source>
+        <target>High Knees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.stretching.name">
+      <segment state="initial">
+        <source>Dehnen</source>
+        <target>Dehnen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.yoga.name">
+      <segment state="initial">
+        <source>Yoga</source>
+        <target>Yoga</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.foamrolling.name">
+      <segment state="initial">
+        <source>Faszienrolle</source>
+        <target>Faszienrolle</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.dynamicwarmup.name">
+      <segment state="initial">
+        <source>Dynamisches Aufwärmen</source>
+        <target>Dynamisches Aufwärmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.catcow.name">
+      <segment state="initial">
+        <source>Katze-Kuh</source>
+        <target>Katze-Kuh</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.hipopener.name">
+      <segment state="initial">
+        <source>Hüftöffner</source>
+        <target>Hüftöffner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.benchpress.name">
+      <segment state="initial">
+        <source>Bankdrücken</source>
+        <target>Bankdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.overheadpress.name">
+      <segment state="initial">
+        <source>Schulterdrücken</source>
+        <target>Schulterdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.deadlift.name">
+      <segment state="initial">
+        <source>Kreuzheben</source>
+        <target>Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellsquat.name">
+      <segment state="initial">
+        <source>Langhantel-Kniebeuge</source>
+        <target>Langhantel-Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellrow.name">
+      <segment state="initial">
+        <source>Langhantelrudern</source>
+        <target>Langhantelrudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.kettlebellswing.name">
+      <segment state="initial">
+        <source>Kettlebell Swing</source>
+        <target>Kettlebell Swing</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -7653,8 +7653,8 @@
     </unit>
     <unit id="exercise.category.hinge">
       <segment state="initial">
-        <source>Hüftbeuge</source>
-        <target>Hüftbeuge</target>
+        <source>Hüftstreckung</source>
+        <target>Hüftstreckung</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -7633,5 +7633,263 @@
         <target>Repetir animación de la meta diaria</target>
       </segment>
     </unit>
+      <unit id="exercise.category.push">
+      <segment state="initial">
+        <source>Drücken</source>
+        <target>Drücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pull">
+      <segment state="initial">
+        <source>Ziehen</source>
+        <target>Ziehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.squat">
+      <segment state="initial">
+        <source>Kniebeuge</source>
+        <target>Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.hinge">
+      <segment state="initial">
+        <source>Hüftbeuge</source>
+        <target>Hüftbeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.lunge">
+      <segment state="initial">
+        <source>Ausfallschritt</source>
+        <target>Ausfallschritt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.carry">
+      <segment state="initial">
+        <source>Tragen</source>
+        <target>Tragen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.core">
+      <segment state="initial">
+        <source>Rumpf</source>
+        <target>Rumpf</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.mobility">
+      <segment state="initial">
+        <source>Mobilität</source>
+        <target>Mobilität</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.strength">
+      <segment state="initial">
+        <source>Krafttraining</source>
+        <target>Krafttraining</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.deadbug.name">
+      <segment state="initial">
+        <source>Dead Bug</source>
+        <target>Dead Bug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.hollowhold.name">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.wallsit.name">
+      <segment state="initial">
+        <source>Wandsitz</source>
+        <target>Wandsitz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.boxjump.name">
+      <segment state="initial">
+        <source>Box Jumps</source>
+        <target>Box Jumps</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.singlelegRdl.name">
+      <segment state="initial">
+        <source>Einbeiniges Kreuzheben</source>
+        <target>Einbeiniges Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.goodmorning.name">
+      <segment state="initial">
+        <source>Good Morning</source>
+        <target>Good Morning</target>
+      </segment>
+    </unit>
+    <unit id="exercise.lunge.stepup.name">
+      <segment state="initial">
+        <source>Step-ups</source>
+        <target>Step-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.pullups.name">
+      <segment state="initial">
+        <source>Klimmzüge</source>
+        <target>Klimmzüge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.rows.name">
+      <segment state="initial">
+        <source>Ruderzug</source>
+        <target>Ruderzug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.deadhang.name">
+      <segment state="initial">
+        <source>Dead Hang</source>
+        <target>Dead Hang</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.facepull.name">
+      <segment state="initial">
+        <source>Face Pull</source>
+        <target>Face Pull</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.farmer.name">
+      <segment state="initial">
+        <source>Farmer&apos;s Walk</source>
+        <target>Farmer&apos;s Walk</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.suitcase.name">
+      <segment state="initial">
+        <source>Suitcase Carry</source>
+        <target>Suitcase Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.overhead.name">
+      <segment state="initial">
+        <source>Overhead Carry</source>
+        <target>Overhead Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.walking.name">
+      <segment state="initial">
+        <source>Gehen</source>
+        <target>Gehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.cycling.name">
+      <segment state="initial">
+        <source>Radfahren</source>
+        <target>Radfahren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.rowing.name">
+      <segment state="initial">
+        <source>Rudern</source>
+        <target>Rudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.swimming.name">
+      <segment state="initial">
+        <source>Schwimmen</source>
+        <target>Schwimmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumprope.name">
+      <segment state="initial">
+        <source>Seilspringen</source>
+        <target>Seilspringen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.burpees.name">
+      <segment state="initial">
+        <source>Burpees</source>
+        <target>Burpees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumpingjacks.name">
+      <segment state="initial">
+        <source>Hampelmänner</source>
+        <target>Hampelmänner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.highknees.name">
+      <segment state="initial">
+        <source>High Knees</source>
+        <target>High Knees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.stretching.name">
+      <segment state="initial">
+        <source>Dehnen</source>
+        <target>Dehnen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.yoga.name">
+      <segment state="initial">
+        <source>Yoga</source>
+        <target>Yoga</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.foamrolling.name">
+      <segment state="initial">
+        <source>Faszienrolle</source>
+        <target>Faszienrolle</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.dynamicwarmup.name">
+      <segment state="initial">
+        <source>Dynamisches Aufwärmen</source>
+        <target>Dynamisches Aufwärmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.catcow.name">
+      <segment state="initial">
+        <source>Katze-Kuh</source>
+        <target>Katze-Kuh</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.hipopener.name">
+      <segment state="initial">
+        <source>Hüftöffner</source>
+        <target>Hüftöffner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.benchpress.name">
+      <segment state="initial">
+        <source>Bankdrücken</source>
+        <target>Bankdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.overheadpress.name">
+      <segment state="initial">
+        <source>Schulterdrücken</source>
+        <target>Schulterdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.deadlift.name">
+      <segment state="initial">
+        <source>Kreuzheben</source>
+        <target>Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellsquat.name">
+      <segment state="initial">
+        <source>Langhantel-Kniebeuge</source>
+        <target>Langhantel-Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellrow.name">
+      <segment state="initial">
+        <source>Langhantelrudern</source>
+        <target>Langhantelrudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.kettlebellswing.name">
+      <segment state="initial">
+        <source>Kettlebell Swing</source>
+        <target>Kettlebell Swing</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -7891,5 +7891,287 @@
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
+      <unit id="exercise.variant.situps.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.decline">
+      <segment state="initial">
+        <source>Decline</source>
+        <target>Decline</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.reverse">
+      <segment state="initial">
+        <source>Reverse Crunches</source>
+        <target>Reverse Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.bicycle">
+      <segment state="initial">
+        <source>Bicycle Crunches</source>
+        <target>Bicycle Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.oblique">
+      <segment state="initial">
+        <source>Schräge Crunches</source>
+        <target>Schräge Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.lying">
+      <segment state="initial">
+        <source>Liegend</source>
+        <target>Liegend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-knee">
+      <segment state="initial">
+        <source>Hängend (Knie)</source>
+        <target>Hängend (Knie)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-straight">
+      <segment state="initial">
+        <source>Hängend (gestreckt)</source>
+        <target>Hängend (gestreckt)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.cross-body">
+      <segment state="initial">
+        <source>Cross-Body</source>
+        <target>Cross-Body</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.forearm">
+      <segment state="initial">
+        <source>Unterarmstütz</source>
+        <target>Unterarmstütz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.side">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.reverse">
+      <segment state="initial">
+        <source>Umgekehrt</source>
+        <target>Umgekehrt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.sumo">
+      <segment state="initial">
+        <source>Sumo</source>
+        <target>Sumo</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.goblet">
+      <segment state="initial">
+        <source>Goblet</source>
+        <target>Goblet</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bulgarian-split">
+      <segment state="initial">
+        <source>Bulgarian Split</source>
+        <target>Bulgarian Split</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.pistol">
+      <segment state="initial">
+        <source>Pistol</source>
+        <target>Pistol</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.seated">
+      <segment state="initial">
+        <source>Sitzend</source>
+        <target>Sitzend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.hip-thrust">
+      <segment state="initial">
+        <source>Hip Thrust</source>
+        <target>Hip Thrust</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.march">
+      <segment state="initial">
+        <source>Marching</source>
+        <target>Marching</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.forward">
+      <segment state="initial">
+        <source>Vorwärts</source>
+        <target>Vorwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.reverse">
+      <segment state="initial">
+        <source>Rückwärts</source>
+        <target>Rückwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.walking">
+      <segment state="initial">
+        <source>Walking</source>
+        <target>Walking</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.lateral">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.curtsy">
+      <segment state="initial">
+        <source>Curtsy</source>
+        <target>Curtsy</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.jumping">
+      <segment state="initial">
+        <source>Jumping</source>
+        <target>Jumping</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.chin-up">
+      <segment state="initial">
+        <source>Chin-up</source>
+        <target>Chin-up</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.wide-grip">
+      <segment state="initial">
+        <source>Breiter Griff</source>
+        <target>Breiter Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.neutral-grip">
+      <segment state="initial">
+        <source>Neutraler Griff</source>
+        <target>Neutraler Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.negative">
+      <segment state="initial">
+        <source>Negativ</source>
+        <target>Negativ</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.assisted">
+      <segment state="initial">
+        <source>Assistiert</source>
+        <target>Assistiert</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.archer">
+      <segment state="initial">
+        <source>Archer</source>
+        <target>Archer</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.inverted">
+      <segment state="initial">
+        <source>Inverted Row</source>
+        <target>Inverted Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.australian">
+      <segment state="initial">
+        <source>Australian Row</source>
+        <target>Australian Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.dumbbell">
+      <segment state="initial">
+        <source>Kurzhantel</source>
+        <target>Kurzhantel</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.barbell">
+      <segment state="initial">
+        <source>Langhantel</source>
+        <target>Langhantel</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -7653,8 +7653,8 @@
     </unit>
     <unit id="exercise.category.hinge">
       <segment state="initial">
-        <source>Hüftbeuge</source>
-        <target>Hüftbeuge</target>
+        <source>Hüftstreckung</source>
+        <target>Hüftstreckung</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -7891,5 +7891,287 @@
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
+      <unit id="exercise.variant.situps.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.decline">
+      <segment state="initial">
+        <source>Decline</source>
+        <target>Decline</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.reverse">
+      <segment state="initial">
+        <source>Reverse Crunches</source>
+        <target>Reverse Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.bicycle">
+      <segment state="initial">
+        <source>Bicycle Crunches</source>
+        <target>Bicycle Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.oblique">
+      <segment state="initial">
+        <source>Schräge Crunches</source>
+        <target>Schräge Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.lying">
+      <segment state="initial">
+        <source>Liegend</source>
+        <target>Liegend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-knee">
+      <segment state="initial">
+        <source>Hängend (Knie)</source>
+        <target>Hängend (Knie)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-straight">
+      <segment state="initial">
+        <source>Hängend (gestreckt)</source>
+        <target>Hängend (gestreckt)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.cross-body">
+      <segment state="initial">
+        <source>Cross-Body</source>
+        <target>Cross-Body</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.forearm">
+      <segment state="initial">
+        <source>Unterarmstütz</source>
+        <target>Unterarmstütz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.side">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.reverse">
+      <segment state="initial">
+        <source>Umgekehrt</source>
+        <target>Umgekehrt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.sumo">
+      <segment state="initial">
+        <source>Sumo</source>
+        <target>Sumo</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.goblet">
+      <segment state="initial">
+        <source>Goblet</source>
+        <target>Goblet</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bulgarian-split">
+      <segment state="initial">
+        <source>Bulgarian Split</source>
+        <target>Bulgarian Split</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.pistol">
+      <segment state="initial">
+        <source>Pistol</source>
+        <target>Pistol</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.seated">
+      <segment state="initial">
+        <source>Sitzend</source>
+        <target>Sitzend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.hip-thrust">
+      <segment state="initial">
+        <source>Hip Thrust</source>
+        <target>Hip Thrust</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.march">
+      <segment state="initial">
+        <source>Marching</source>
+        <target>Marching</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.forward">
+      <segment state="initial">
+        <source>Vorwärts</source>
+        <target>Vorwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.reverse">
+      <segment state="initial">
+        <source>Rückwärts</source>
+        <target>Rückwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.walking">
+      <segment state="initial">
+        <source>Walking</source>
+        <target>Walking</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.lateral">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.curtsy">
+      <segment state="initial">
+        <source>Curtsy</source>
+        <target>Curtsy</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.jumping">
+      <segment state="initial">
+        <source>Jumping</source>
+        <target>Jumping</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.chin-up">
+      <segment state="initial">
+        <source>Chin-up</source>
+        <target>Chin-up</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.wide-grip">
+      <segment state="initial">
+        <source>Breiter Griff</source>
+        <target>Breiter Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.neutral-grip">
+      <segment state="initial">
+        <source>Neutraler Griff</source>
+        <target>Neutraler Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.negative">
+      <segment state="initial">
+        <source>Negativ</source>
+        <target>Negativ</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.assisted">
+      <segment state="initial">
+        <source>Assistiert</source>
+        <target>Assistiert</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.archer">
+      <segment state="initial">
+        <source>Archer</source>
+        <target>Archer</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.inverted">
+      <segment state="initial">
+        <source>Inverted Row</source>
+        <target>Inverted Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.australian">
+      <segment state="initial">
+        <source>Australian Row</source>
+        <target>Australian Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.dumbbell">
+      <segment state="initial">
+        <source>Kurzhantel</source>
+        <target>Kurzhantel</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.barbell">
+      <segment state="initial">
+        <source>Langhantel</source>
+        <target>Langhantel</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -7633,5 +7633,263 @@
         <target>Rejouer l'animation de l'objectif quotidien</target>
       </segment>
     </unit>
+      <unit id="exercise.category.push">
+      <segment state="initial">
+        <source>Drücken</source>
+        <target>Drücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pull">
+      <segment state="initial">
+        <source>Ziehen</source>
+        <target>Ziehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.squat">
+      <segment state="initial">
+        <source>Kniebeuge</source>
+        <target>Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.hinge">
+      <segment state="initial">
+        <source>Hüftbeuge</source>
+        <target>Hüftbeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.lunge">
+      <segment state="initial">
+        <source>Ausfallschritt</source>
+        <target>Ausfallschritt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.carry">
+      <segment state="initial">
+        <source>Tragen</source>
+        <target>Tragen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.core">
+      <segment state="initial">
+        <source>Rumpf</source>
+        <target>Rumpf</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.mobility">
+      <segment state="initial">
+        <source>Mobilität</source>
+        <target>Mobilität</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.strength">
+      <segment state="initial">
+        <source>Krafttraining</source>
+        <target>Krafttraining</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.deadbug.name">
+      <segment state="initial">
+        <source>Dead Bug</source>
+        <target>Dead Bug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.hollowhold.name">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.wallsit.name">
+      <segment state="initial">
+        <source>Wandsitz</source>
+        <target>Wandsitz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.boxjump.name">
+      <segment state="initial">
+        <source>Box Jumps</source>
+        <target>Box Jumps</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.singlelegRdl.name">
+      <segment state="initial">
+        <source>Einbeiniges Kreuzheben</source>
+        <target>Einbeiniges Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.goodmorning.name">
+      <segment state="initial">
+        <source>Good Morning</source>
+        <target>Good Morning</target>
+      </segment>
+    </unit>
+    <unit id="exercise.lunge.stepup.name">
+      <segment state="initial">
+        <source>Step-ups</source>
+        <target>Step-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.pullups.name">
+      <segment state="initial">
+        <source>Klimmzüge</source>
+        <target>Klimmzüge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.rows.name">
+      <segment state="initial">
+        <source>Ruderzug</source>
+        <target>Ruderzug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.deadhang.name">
+      <segment state="initial">
+        <source>Dead Hang</source>
+        <target>Dead Hang</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.facepull.name">
+      <segment state="initial">
+        <source>Face Pull</source>
+        <target>Face Pull</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.farmer.name">
+      <segment state="initial">
+        <source>Farmer&apos;s Walk</source>
+        <target>Farmer&apos;s Walk</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.suitcase.name">
+      <segment state="initial">
+        <source>Suitcase Carry</source>
+        <target>Suitcase Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.overhead.name">
+      <segment state="initial">
+        <source>Overhead Carry</source>
+        <target>Overhead Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.walking.name">
+      <segment state="initial">
+        <source>Gehen</source>
+        <target>Gehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.cycling.name">
+      <segment state="initial">
+        <source>Radfahren</source>
+        <target>Radfahren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.rowing.name">
+      <segment state="initial">
+        <source>Rudern</source>
+        <target>Rudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.swimming.name">
+      <segment state="initial">
+        <source>Schwimmen</source>
+        <target>Schwimmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumprope.name">
+      <segment state="initial">
+        <source>Seilspringen</source>
+        <target>Seilspringen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.burpees.name">
+      <segment state="initial">
+        <source>Burpees</source>
+        <target>Burpees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumpingjacks.name">
+      <segment state="initial">
+        <source>Hampelmänner</source>
+        <target>Hampelmänner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.highknees.name">
+      <segment state="initial">
+        <source>High Knees</source>
+        <target>High Knees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.stretching.name">
+      <segment state="initial">
+        <source>Dehnen</source>
+        <target>Dehnen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.yoga.name">
+      <segment state="initial">
+        <source>Yoga</source>
+        <target>Yoga</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.foamrolling.name">
+      <segment state="initial">
+        <source>Faszienrolle</source>
+        <target>Faszienrolle</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.dynamicwarmup.name">
+      <segment state="initial">
+        <source>Dynamisches Aufwärmen</source>
+        <target>Dynamisches Aufwärmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.catcow.name">
+      <segment state="initial">
+        <source>Katze-Kuh</source>
+        <target>Katze-Kuh</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.hipopener.name">
+      <segment state="initial">
+        <source>Hüftöffner</source>
+        <target>Hüftöffner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.benchpress.name">
+      <segment state="initial">
+        <source>Bankdrücken</source>
+        <target>Bankdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.overheadpress.name">
+      <segment state="initial">
+        <source>Schulterdrücken</source>
+        <target>Schulterdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.deadlift.name">
+      <segment state="initial">
+        <source>Kreuzheben</source>
+        <target>Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellsquat.name">
+      <segment state="initial">
+        <source>Langhantel-Kniebeuge</source>
+        <target>Langhantel-Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellrow.name">
+      <segment state="initial">
+        <source>Langhantelrudern</source>
+        <target>Langhantelrudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.kettlebellswing.name">
+      <segment state="initial">
+        <source>Kettlebell Swing</source>
+        <target>Kettlebell Swing</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -7653,8 +7653,8 @@
     </unit>
     <unit id="exercise.category.hinge">
       <segment state="initial">
-        <source>Hüftbeuge</source>
-        <target>Hüftbeuge</target>
+        <source>Hüftstreckung</source>
+        <target>Hüftstreckung</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -7891,5 +7891,287 @@
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
+      <unit id="exercise.variant.situps.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.decline">
+      <segment state="initial">
+        <source>Decline</source>
+        <target>Decline</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.reverse">
+      <segment state="initial">
+        <source>Reverse Crunches</source>
+        <target>Reverse Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.bicycle">
+      <segment state="initial">
+        <source>Bicycle Crunches</source>
+        <target>Bicycle Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.oblique">
+      <segment state="initial">
+        <source>Schräge Crunches</source>
+        <target>Schräge Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.lying">
+      <segment state="initial">
+        <source>Liegend</source>
+        <target>Liegend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-knee">
+      <segment state="initial">
+        <source>Hängend (Knie)</source>
+        <target>Hängend (Knie)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-straight">
+      <segment state="initial">
+        <source>Hängend (gestreckt)</source>
+        <target>Hängend (gestreckt)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.cross-body">
+      <segment state="initial">
+        <source>Cross-Body</source>
+        <target>Cross-Body</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.forearm">
+      <segment state="initial">
+        <source>Unterarmstütz</source>
+        <target>Unterarmstütz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.side">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.reverse">
+      <segment state="initial">
+        <source>Umgekehrt</source>
+        <target>Umgekehrt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.sumo">
+      <segment state="initial">
+        <source>Sumo</source>
+        <target>Sumo</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.goblet">
+      <segment state="initial">
+        <source>Goblet</source>
+        <target>Goblet</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bulgarian-split">
+      <segment state="initial">
+        <source>Bulgarian Split</source>
+        <target>Bulgarian Split</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.pistol">
+      <segment state="initial">
+        <source>Pistol</source>
+        <target>Pistol</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.seated">
+      <segment state="initial">
+        <source>Sitzend</source>
+        <target>Sitzend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.hip-thrust">
+      <segment state="initial">
+        <source>Hip Thrust</source>
+        <target>Hip Thrust</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.march">
+      <segment state="initial">
+        <source>Marching</source>
+        <target>Marching</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.forward">
+      <segment state="initial">
+        <source>Vorwärts</source>
+        <target>Vorwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.reverse">
+      <segment state="initial">
+        <source>Rückwärts</source>
+        <target>Rückwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.walking">
+      <segment state="initial">
+        <source>Walking</source>
+        <target>Walking</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.lateral">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.curtsy">
+      <segment state="initial">
+        <source>Curtsy</source>
+        <target>Curtsy</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.jumping">
+      <segment state="initial">
+        <source>Jumping</source>
+        <target>Jumping</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.chin-up">
+      <segment state="initial">
+        <source>Chin-up</source>
+        <target>Chin-up</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.wide-grip">
+      <segment state="initial">
+        <source>Breiter Griff</source>
+        <target>Breiter Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.neutral-grip">
+      <segment state="initial">
+        <source>Neutraler Griff</source>
+        <target>Neutraler Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.negative">
+      <segment state="initial">
+        <source>Negativ</source>
+        <target>Negativ</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.assisted">
+      <segment state="initial">
+        <source>Assistiert</source>
+        <target>Assistiert</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.archer">
+      <segment state="initial">
+        <source>Archer</source>
+        <target>Archer</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.inverted">
+      <segment state="initial">
+        <source>Inverted Row</source>
+        <target>Inverted Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.australian">
+      <segment state="initial">
+        <source>Australian Row</source>
+        <target>Australian Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.dumbbell">
+      <segment state="initial">
+        <source>Kurzhantel</source>
+        <target>Kurzhantel</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.barbell">
+      <segment state="initial">
+        <source>Langhantel</source>
+        <target>Langhantel</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -7633,5 +7633,263 @@
         <target>Riproduci animazione obiettivo giornaliero</target>
       </segment>
     </unit>
+      <unit id="exercise.category.push">
+      <segment state="initial">
+        <source>Drücken</source>
+        <target>Drücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pull">
+      <segment state="initial">
+        <source>Ziehen</source>
+        <target>Ziehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.squat">
+      <segment state="initial">
+        <source>Kniebeuge</source>
+        <target>Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.hinge">
+      <segment state="initial">
+        <source>Hüftbeuge</source>
+        <target>Hüftbeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.lunge">
+      <segment state="initial">
+        <source>Ausfallschritt</source>
+        <target>Ausfallschritt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.carry">
+      <segment state="initial">
+        <source>Tragen</source>
+        <target>Tragen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.core">
+      <segment state="initial">
+        <source>Rumpf</source>
+        <target>Rumpf</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.mobility">
+      <segment state="initial">
+        <source>Mobilität</source>
+        <target>Mobilität</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.strength">
+      <segment state="initial">
+        <source>Krafttraining</source>
+        <target>Krafttraining</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.deadbug.name">
+      <segment state="initial">
+        <source>Dead Bug</source>
+        <target>Dead Bug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.hollowhold.name">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.wallsit.name">
+      <segment state="initial">
+        <source>Wandsitz</source>
+        <target>Wandsitz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.boxjump.name">
+      <segment state="initial">
+        <source>Box Jumps</source>
+        <target>Box Jumps</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.singlelegRdl.name">
+      <segment state="initial">
+        <source>Einbeiniges Kreuzheben</source>
+        <target>Einbeiniges Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.goodmorning.name">
+      <segment state="initial">
+        <source>Good Morning</source>
+        <target>Good Morning</target>
+      </segment>
+    </unit>
+    <unit id="exercise.lunge.stepup.name">
+      <segment state="initial">
+        <source>Step-ups</source>
+        <target>Step-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.pullups.name">
+      <segment state="initial">
+        <source>Klimmzüge</source>
+        <target>Klimmzüge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.rows.name">
+      <segment state="initial">
+        <source>Ruderzug</source>
+        <target>Ruderzug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.deadhang.name">
+      <segment state="initial">
+        <source>Dead Hang</source>
+        <target>Dead Hang</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.facepull.name">
+      <segment state="initial">
+        <source>Face Pull</source>
+        <target>Face Pull</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.farmer.name">
+      <segment state="initial">
+        <source>Farmer&apos;s Walk</source>
+        <target>Farmer&apos;s Walk</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.suitcase.name">
+      <segment state="initial">
+        <source>Suitcase Carry</source>
+        <target>Suitcase Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.overhead.name">
+      <segment state="initial">
+        <source>Overhead Carry</source>
+        <target>Overhead Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.walking.name">
+      <segment state="initial">
+        <source>Gehen</source>
+        <target>Gehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.cycling.name">
+      <segment state="initial">
+        <source>Radfahren</source>
+        <target>Radfahren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.rowing.name">
+      <segment state="initial">
+        <source>Rudern</source>
+        <target>Rudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.swimming.name">
+      <segment state="initial">
+        <source>Schwimmen</source>
+        <target>Schwimmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumprope.name">
+      <segment state="initial">
+        <source>Seilspringen</source>
+        <target>Seilspringen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.burpees.name">
+      <segment state="initial">
+        <source>Burpees</source>
+        <target>Burpees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumpingjacks.name">
+      <segment state="initial">
+        <source>Hampelmänner</source>
+        <target>Hampelmänner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.highknees.name">
+      <segment state="initial">
+        <source>High Knees</source>
+        <target>High Knees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.stretching.name">
+      <segment state="initial">
+        <source>Dehnen</source>
+        <target>Dehnen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.yoga.name">
+      <segment state="initial">
+        <source>Yoga</source>
+        <target>Yoga</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.foamrolling.name">
+      <segment state="initial">
+        <source>Faszienrolle</source>
+        <target>Faszienrolle</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.dynamicwarmup.name">
+      <segment state="initial">
+        <source>Dynamisches Aufwärmen</source>
+        <target>Dynamisches Aufwärmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.catcow.name">
+      <segment state="initial">
+        <source>Katze-Kuh</source>
+        <target>Katze-Kuh</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.hipopener.name">
+      <segment state="initial">
+        <source>Hüftöffner</source>
+        <target>Hüftöffner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.benchpress.name">
+      <segment state="initial">
+        <source>Bankdrücken</source>
+        <target>Bankdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.overheadpress.name">
+      <segment state="initial">
+        <source>Schulterdrücken</source>
+        <target>Schulterdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.deadlift.name">
+      <segment state="initial">
+        <source>Kreuzheben</source>
+        <target>Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellsquat.name">
+      <segment state="initial">
+        <source>Langhantel-Kniebeuge</source>
+        <target>Langhantel-Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellrow.name">
+      <segment state="initial">
+        <source>Langhantelrudern</source>
+        <target>Langhantelrudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.kettlebellswing.name">
+      <segment state="initial">
+        <source>Kettlebell Swing</source>
+        <target>Kettlebell Swing</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -7653,8 +7653,8 @@
     </unit>
     <unit id="exercise.category.hinge">
       <segment state="initial">
-        <source>Hüftbeuge</source>
-        <target>Hüftbeuge</target>
+        <source>Hüftstreckung</source>
+        <target>Hüftstreckung</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -7891,5 +7891,287 @@
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
+      <unit id="exercise.variant.situps.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.decline">
+      <segment state="initial">
+        <source>Decline</source>
+        <target>Decline</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.reverse">
+      <segment state="initial">
+        <source>Reverse Crunches</source>
+        <target>Reverse Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.bicycle">
+      <segment state="initial">
+        <source>Bicycle Crunches</source>
+        <target>Bicycle Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.oblique">
+      <segment state="initial">
+        <source>Schräge Crunches</source>
+        <target>Schräge Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.lying">
+      <segment state="initial">
+        <source>Liegend</source>
+        <target>Liegend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-knee">
+      <segment state="initial">
+        <source>Hängend (Knie)</source>
+        <target>Hängend (Knie)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-straight">
+      <segment state="initial">
+        <source>Hängend (gestreckt)</source>
+        <target>Hängend (gestreckt)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.cross-body">
+      <segment state="initial">
+        <source>Cross-Body</source>
+        <target>Cross-Body</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.forearm">
+      <segment state="initial">
+        <source>Unterarmstütz</source>
+        <target>Unterarmstütz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.side">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.reverse">
+      <segment state="initial">
+        <source>Umgekehrt</source>
+        <target>Umgekehrt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.sumo">
+      <segment state="initial">
+        <source>Sumo</source>
+        <target>Sumo</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.goblet">
+      <segment state="initial">
+        <source>Goblet</source>
+        <target>Goblet</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bulgarian-split">
+      <segment state="initial">
+        <source>Bulgarian Split</source>
+        <target>Bulgarian Split</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.pistol">
+      <segment state="initial">
+        <source>Pistol</source>
+        <target>Pistol</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.seated">
+      <segment state="initial">
+        <source>Sitzend</source>
+        <target>Sitzend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.hip-thrust">
+      <segment state="initial">
+        <source>Hip Thrust</source>
+        <target>Hip Thrust</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.march">
+      <segment state="initial">
+        <source>Marching</source>
+        <target>Marching</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.forward">
+      <segment state="initial">
+        <source>Vorwärts</source>
+        <target>Vorwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.reverse">
+      <segment state="initial">
+        <source>Rückwärts</source>
+        <target>Rückwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.walking">
+      <segment state="initial">
+        <source>Walking</source>
+        <target>Walking</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.lateral">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.curtsy">
+      <segment state="initial">
+        <source>Curtsy</source>
+        <target>Curtsy</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.jumping">
+      <segment state="initial">
+        <source>Jumping</source>
+        <target>Jumping</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.chin-up">
+      <segment state="initial">
+        <source>Chin-up</source>
+        <target>Chin-up</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.wide-grip">
+      <segment state="initial">
+        <source>Breiter Griff</source>
+        <target>Breiter Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.neutral-grip">
+      <segment state="initial">
+        <source>Neutraler Griff</source>
+        <target>Neutraler Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.negative">
+      <segment state="initial">
+        <source>Negativ</source>
+        <target>Negativ</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.assisted">
+      <segment state="initial">
+        <source>Assistiert</source>
+        <target>Assistiert</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.archer">
+      <segment state="initial">
+        <source>Archer</source>
+        <target>Archer</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.inverted">
+      <segment state="initial">
+        <source>Inverted Row</source>
+        <target>Inverted Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.australian">
+      <segment state="initial">
+        <source>Australian Row</source>
+        <target>Australian Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.dumbbell">
+      <segment state="initial">
+        <source>Kurzhantel</source>
+        <target>Kurzhantel</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.barbell">
+      <segment state="initial">
+        <source>Langhantel</source>
+        <target>Langhantel</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -7633,5 +7633,263 @@
         <target>Animationem metae diurnae iterum ludere</target>
       </segment>
     </unit>
+      <unit id="exercise.category.push">
+      <segment state="initial">
+        <source>Drücken</source>
+        <target>Drücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pull">
+      <segment state="initial">
+        <source>Ziehen</source>
+        <target>Ziehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.squat">
+      <segment state="initial">
+        <source>Kniebeuge</source>
+        <target>Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.hinge">
+      <segment state="initial">
+        <source>Hüftbeuge</source>
+        <target>Hüftbeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.lunge">
+      <segment state="initial">
+        <source>Ausfallschritt</source>
+        <target>Ausfallschritt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.carry">
+      <segment state="initial">
+        <source>Tragen</source>
+        <target>Tragen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.core">
+      <segment state="initial">
+        <source>Rumpf</source>
+        <target>Rumpf</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.mobility">
+      <segment state="initial">
+        <source>Mobilität</source>
+        <target>Mobilität</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.strength">
+      <segment state="initial">
+        <source>Krafttraining</source>
+        <target>Krafttraining</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.deadbug.name">
+      <segment state="initial">
+        <source>Dead Bug</source>
+        <target>Dead Bug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.hollowhold.name">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.wallsit.name">
+      <segment state="initial">
+        <source>Wandsitz</source>
+        <target>Wandsitz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.boxjump.name">
+      <segment state="initial">
+        <source>Box Jumps</source>
+        <target>Box Jumps</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.singlelegRdl.name">
+      <segment state="initial">
+        <source>Einbeiniges Kreuzheben</source>
+        <target>Einbeiniges Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.goodmorning.name">
+      <segment state="initial">
+        <source>Good Morning</source>
+        <target>Good Morning</target>
+      </segment>
+    </unit>
+    <unit id="exercise.lunge.stepup.name">
+      <segment state="initial">
+        <source>Step-ups</source>
+        <target>Step-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.pullups.name">
+      <segment state="initial">
+        <source>Klimmzüge</source>
+        <target>Klimmzüge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.rows.name">
+      <segment state="initial">
+        <source>Ruderzug</source>
+        <target>Ruderzug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.deadhang.name">
+      <segment state="initial">
+        <source>Dead Hang</source>
+        <target>Dead Hang</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.facepull.name">
+      <segment state="initial">
+        <source>Face Pull</source>
+        <target>Face Pull</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.farmer.name">
+      <segment state="initial">
+        <source>Farmer&apos;s Walk</source>
+        <target>Farmer&apos;s Walk</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.suitcase.name">
+      <segment state="initial">
+        <source>Suitcase Carry</source>
+        <target>Suitcase Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.overhead.name">
+      <segment state="initial">
+        <source>Overhead Carry</source>
+        <target>Overhead Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.walking.name">
+      <segment state="initial">
+        <source>Gehen</source>
+        <target>Gehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.cycling.name">
+      <segment state="initial">
+        <source>Radfahren</source>
+        <target>Radfahren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.rowing.name">
+      <segment state="initial">
+        <source>Rudern</source>
+        <target>Rudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.swimming.name">
+      <segment state="initial">
+        <source>Schwimmen</source>
+        <target>Schwimmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumprope.name">
+      <segment state="initial">
+        <source>Seilspringen</source>
+        <target>Seilspringen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.burpees.name">
+      <segment state="initial">
+        <source>Burpees</source>
+        <target>Burpees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumpingjacks.name">
+      <segment state="initial">
+        <source>Hampelmänner</source>
+        <target>Hampelmänner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.highknees.name">
+      <segment state="initial">
+        <source>High Knees</source>
+        <target>High Knees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.stretching.name">
+      <segment state="initial">
+        <source>Dehnen</source>
+        <target>Dehnen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.yoga.name">
+      <segment state="initial">
+        <source>Yoga</source>
+        <target>Yoga</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.foamrolling.name">
+      <segment state="initial">
+        <source>Faszienrolle</source>
+        <target>Faszienrolle</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.dynamicwarmup.name">
+      <segment state="initial">
+        <source>Dynamisches Aufwärmen</source>
+        <target>Dynamisches Aufwärmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.catcow.name">
+      <segment state="initial">
+        <source>Katze-Kuh</source>
+        <target>Katze-Kuh</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.hipopener.name">
+      <segment state="initial">
+        <source>Hüftöffner</source>
+        <target>Hüftöffner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.benchpress.name">
+      <segment state="initial">
+        <source>Bankdrücken</source>
+        <target>Bankdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.overheadpress.name">
+      <segment state="initial">
+        <source>Schulterdrücken</source>
+        <target>Schulterdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.deadlift.name">
+      <segment state="initial">
+        <source>Kreuzheben</source>
+        <target>Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellsquat.name">
+      <segment state="initial">
+        <source>Langhantel-Kniebeuge</source>
+        <target>Langhantel-Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellrow.name">
+      <segment state="initial">
+        <source>Langhantelrudern</source>
+        <target>Langhantelrudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.kettlebellswing.name">
+      <segment state="initial">
+        <source>Kettlebell Swing</source>
+        <target>Kettlebell Swing</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -7653,8 +7653,8 @@
     </unit>
     <unit id="exercise.category.hinge">
       <segment state="initial">
-        <source>Hüftbeuge</source>
-        <target>Hüftbeuge</target>
+        <source>Hüftstreckung</source>
+        <target>Hüftstreckung</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -7633,5 +7633,263 @@
         <target>Animatie dagdoel opnieuw afspelen</target>
       </segment>
     </unit>
+      <unit id="exercise.category.push">
+      <segment state="initial">
+        <source>Drücken</source>
+        <target>Drücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pull">
+      <segment state="initial">
+        <source>Ziehen</source>
+        <target>Ziehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.squat">
+      <segment state="initial">
+        <source>Kniebeuge</source>
+        <target>Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.hinge">
+      <segment state="initial">
+        <source>Hüftbeuge</source>
+        <target>Hüftbeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.lunge">
+      <segment state="initial">
+        <source>Ausfallschritt</source>
+        <target>Ausfallschritt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.carry">
+      <segment state="initial">
+        <source>Tragen</source>
+        <target>Tragen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.core">
+      <segment state="initial">
+        <source>Rumpf</source>
+        <target>Rumpf</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.mobility">
+      <segment state="initial">
+        <source>Mobilität</source>
+        <target>Mobilität</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.strength">
+      <segment state="initial">
+        <source>Krafttraining</source>
+        <target>Krafttraining</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.deadbug.name">
+      <segment state="initial">
+        <source>Dead Bug</source>
+        <target>Dead Bug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.hollowhold.name">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.wallsit.name">
+      <segment state="initial">
+        <source>Wandsitz</source>
+        <target>Wandsitz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.boxjump.name">
+      <segment state="initial">
+        <source>Box Jumps</source>
+        <target>Box Jumps</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.singlelegRdl.name">
+      <segment state="initial">
+        <source>Einbeiniges Kreuzheben</source>
+        <target>Einbeiniges Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.goodmorning.name">
+      <segment state="initial">
+        <source>Good Morning</source>
+        <target>Good Morning</target>
+      </segment>
+    </unit>
+    <unit id="exercise.lunge.stepup.name">
+      <segment state="initial">
+        <source>Step-ups</source>
+        <target>Step-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.pullups.name">
+      <segment state="initial">
+        <source>Klimmzüge</source>
+        <target>Klimmzüge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.rows.name">
+      <segment state="initial">
+        <source>Ruderzug</source>
+        <target>Ruderzug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.deadhang.name">
+      <segment state="initial">
+        <source>Dead Hang</source>
+        <target>Dead Hang</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.facepull.name">
+      <segment state="initial">
+        <source>Face Pull</source>
+        <target>Face Pull</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.farmer.name">
+      <segment state="initial">
+        <source>Farmer&apos;s Walk</source>
+        <target>Farmer&apos;s Walk</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.suitcase.name">
+      <segment state="initial">
+        <source>Suitcase Carry</source>
+        <target>Suitcase Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.overhead.name">
+      <segment state="initial">
+        <source>Overhead Carry</source>
+        <target>Overhead Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.walking.name">
+      <segment state="initial">
+        <source>Gehen</source>
+        <target>Gehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.cycling.name">
+      <segment state="initial">
+        <source>Radfahren</source>
+        <target>Radfahren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.rowing.name">
+      <segment state="initial">
+        <source>Rudern</source>
+        <target>Rudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.swimming.name">
+      <segment state="initial">
+        <source>Schwimmen</source>
+        <target>Schwimmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumprope.name">
+      <segment state="initial">
+        <source>Seilspringen</source>
+        <target>Seilspringen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.burpees.name">
+      <segment state="initial">
+        <source>Burpees</source>
+        <target>Burpees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumpingjacks.name">
+      <segment state="initial">
+        <source>Hampelmänner</source>
+        <target>Hampelmänner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.highknees.name">
+      <segment state="initial">
+        <source>High Knees</source>
+        <target>High Knees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.stretching.name">
+      <segment state="initial">
+        <source>Dehnen</source>
+        <target>Dehnen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.yoga.name">
+      <segment state="initial">
+        <source>Yoga</source>
+        <target>Yoga</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.foamrolling.name">
+      <segment state="initial">
+        <source>Faszienrolle</source>
+        <target>Faszienrolle</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.dynamicwarmup.name">
+      <segment state="initial">
+        <source>Dynamisches Aufwärmen</source>
+        <target>Dynamisches Aufwärmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.catcow.name">
+      <segment state="initial">
+        <source>Katze-Kuh</source>
+        <target>Katze-Kuh</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.hipopener.name">
+      <segment state="initial">
+        <source>Hüftöffner</source>
+        <target>Hüftöffner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.benchpress.name">
+      <segment state="initial">
+        <source>Bankdrücken</source>
+        <target>Bankdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.overheadpress.name">
+      <segment state="initial">
+        <source>Schulterdrücken</source>
+        <target>Schulterdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.deadlift.name">
+      <segment state="initial">
+        <source>Kreuzheben</source>
+        <target>Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellsquat.name">
+      <segment state="initial">
+        <source>Langhantel-Kniebeuge</source>
+        <target>Langhantel-Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellrow.name">
+      <segment state="initial">
+        <source>Langhantelrudern</source>
+        <target>Langhantelrudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.kettlebellswing.name">
+      <segment state="initial">
+        <source>Kettlebell Swing</source>
+        <target>Kettlebell Swing</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -7891,5 +7891,287 @@
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
+      <unit id="exercise.variant.situps.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.decline">
+      <segment state="initial">
+        <source>Decline</source>
+        <target>Decline</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.reverse">
+      <segment state="initial">
+        <source>Reverse Crunches</source>
+        <target>Reverse Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.bicycle">
+      <segment state="initial">
+        <source>Bicycle Crunches</source>
+        <target>Bicycle Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.oblique">
+      <segment state="initial">
+        <source>Schräge Crunches</source>
+        <target>Schräge Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.lying">
+      <segment state="initial">
+        <source>Liegend</source>
+        <target>Liegend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-knee">
+      <segment state="initial">
+        <source>Hängend (Knie)</source>
+        <target>Hängend (Knie)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-straight">
+      <segment state="initial">
+        <source>Hängend (gestreckt)</source>
+        <target>Hängend (gestreckt)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.cross-body">
+      <segment state="initial">
+        <source>Cross-Body</source>
+        <target>Cross-Body</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.forearm">
+      <segment state="initial">
+        <source>Unterarmstütz</source>
+        <target>Unterarmstütz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.side">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.reverse">
+      <segment state="initial">
+        <source>Umgekehrt</source>
+        <target>Umgekehrt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.sumo">
+      <segment state="initial">
+        <source>Sumo</source>
+        <target>Sumo</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.goblet">
+      <segment state="initial">
+        <source>Goblet</source>
+        <target>Goblet</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bulgarian-split">
+      <segment state="initial">
+        <source>Bulgarian Split</source>
+        <target>Bulgarian Split</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.pistol">
+      <segment state="initial">
+        <source>Pistol</source>
+        <target>Pistol</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.seated">
+      <segment state="initial">
+        <source>Sitzend</source>
+        <target>Sitzend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.hip-thrust">
+      <segment state="initial">
+        <source>Hip Thrust</source>
+        <target>Hip Thrust</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.march">
+      <segment state="initial">
+        <source>Marching</source>
+        <target>Marching</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.forward">
+      <segment state="initial">
+        <source>Vorwärts</source>
+        <target>Vorwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.reverse">
+      <segment state="initial">
+        <source>Rückwärts</source>
+        <target>Rückwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.walking">
+      <segment state="initial">
+        <source>Walking</source>
+        <target>Walking</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.lateral">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.curtsy">
+      <segment state="initial">
+        <source>Curtsy</source>
+        <target>Curtsy</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.jumping">
+      <segment state="initial">
+        <source>Jumping</source>
+        <target>Jumping</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.chin-up">
+      <segment state="initial">
+        <source>Chin-up</source>
+        <target>Chin-up</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.wide-grip">
+      <segment state="initial">
+        <source>Breiter Griff</source>
+        <target>Breiter Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.neutral-grip">
+      <segment state="initial">
+        <source>Neutraler Griff</source>
+        <target>Neutraler Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.negative">
+      <segment state="initial">
+        <source>Negativ</source>
+        <target>Negativ</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.assisted">
+      <segment state="initial">
+        <source>Assistiert</source>
+        <target>Assistiert</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.archer">
+      <segment state="initial">
+        <source>Archer</source>
+        <target>Archer</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.inverted">
+      <segment state="initial">
+        <source>Inverted Row</source>
+        <target>Inverted Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.australian">
+      <segment state="initial">
+        <source>Australian Row</source>
+        <target>Australian Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.dumbbell">
+      <segment state="initial">
+        <source>Kurzhantel</source>
+        <target>Kurzhantel</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.barbell">
+      <segment state="initial">
+        <source>Langhantel</source>
+        <target>Langhantel</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -6916,8 +6916,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="exercise.category.hinge">
       <segment state="initial">
-        <source>Hüftbeuge</source>
-        <target>Hüftbeuge</target>
+        <source>Hüftstreckung</source>
+        <target>Hüftstreckung</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -6896,5 +6896,263 @@ Deine Position: # ·  Reps        </source>
         <target>Spill av animasjon for dagsmål på nytt</target>
       </segment>
     </unit>
+      <unit id="exercise.category.push">
+      <segment state="initial">
+        <source>Drücken</source>
+        <target>Drücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pull">
+      <segment state="initial">
+        <source>Ziehen</source>
+        <target>Ziehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.squat">
+      <segment state="initial">
+        <source>Kniebeuge</source>
+        <target>Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.hinge">
+      <segment state="initial">
+        <source>Hüftbeuge</source>
+        <target>Hüftbeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.lunge">
+      <segment state="initial">
+        <source>Ausfallschritt</source>
+        <target>Ausfallschritt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.carry">
+      <segment state="initial">
+        <source>Tragen</source>
+        <target>Tragen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.core">
+      <segment state="initial">
+        <source>Rumpf</source>
+        <target>Rumpf</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.mobility">
+      <segment state="initial">
+        <source>Mobilität</source>
+        <target>Mobilität</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.strength">
+      <segment state="initial">
+        <source>Krafttraining</source>
+        <target>Krafttraining</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.deadbug.name">
+      <segment state="initial">
+        <source>Dead Bug</source>
+        <target>Dead Bug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.hollowhold.name">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.wallsit.name">
+      <segment state="initial">
+        <source>Wandsitz</source>
+        <target>Wandsitz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.boxjump.name">
+      <segment state="initial">
+        <source>Box Jumps</source>
+        <target>Box Jumps</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.singlelegRdl.name">
+      <segment state="initial">
+        <source>Einbeiniges Kreuzheben</source>
+        <target>Einbeiniges Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.goodmorning.name">
+      <segment state="initial">
+        <source>Good Morning</source>
+        <target>Good Morning</target>
+      </segment>
+    </unit>
+    <unit id="exercise.lunge.stepup.name">
+      <segment state="initial">
+        <source>Step-ups</source>
+        <target>Step-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.pullups.name">
+      <segment state="initial">
+        <source>Klimmzüge</source>
+        <target>Klimmzüge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.rows.name">
+      <segment state="initial">
+        <source>Ruderzug</source>
+        <target>Ruderzug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.deadhang.name">
+      <segment state="initial">
+        <source>Dead Hang</source>
+        <target>Dead Hang</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.facepull.name">
+      <segment state="initial">
+        <source>Face Pull</source>
+        <target>Face Pull</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.farmer.name">
+      <segment state="initial">
+        <source>Farmer&apos;s Walk</source>
+        <target>Farmer&apos;s Walk</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.suitcase.name">
+      <segment state="initial">
+        <source>Suitcase Carry</source>
+        <target>Suitcase Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.overhead.name">
+      <segment state="initial">
+        <source>Overhead Carry</source>
+        <target>Overhead Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.walking.name">
+      <segment state="initial">
+        <source>Gehen</source>
+        <target>Gehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.cycling.name">
+      <segment state="initial">
+        <source>Radfahren</source>
+        <target>Radfahren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.rowing.name">
+      <segment state="initial">
+        <source>Rudern</source>
+        <target>Rudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.swimming.name">
+      <segment state="initial">
+        <source>Schwimmen</source>
+        <target>Schwimmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumprope.name">
+      <segment state="initial">
+        <source>Seilspringen</source>
+        <target>Seilspringen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.burpees.name">
+      <segment state="initial">
+        <source>Burpees</source>
+        <target>Burpees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumpingjacks.name">
+      <segment state="initial">
+        <source>Hampelmänner</source>
+        <target>Hampelmänner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.highknees.name">
+      <segment state="initial">
+        <source>High Knees</source>
+        <target>High Knees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.stretching.name">
+      <segment state="initial">
+        <source>Dehnen</source>
+        <target>Dehnen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.yoga.name">
+      <segment state="initial">
+        <source>Yoga</source>
+        <target>Yoga</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.foamrolling.name">
+      <segment state="initial">
+        <source>Faszienrolle</source>
+        <target>Faszienrolle</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.dynamicwarmup.name">
+      <segment state="initial">
+        <source>Dynamisches Aufwärmen</source>
+        <target>Dynamisches Aufwärmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.catcow.name">
+      <segment state="initial">
+        <source>Katze-Kuh</source>
+        <target>Katze-Kuh</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.hipopener.name">
+      <segment state="initial">
+        <source>Hüftöffner</source>
+        <target>Hüftöffner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.benchpress.name">
+      <segment state="initial">
+        <source>Bankdrücken</source>
+        <target>Bankdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.overheadpress.name">
+      <segment state="initial">
+        <source>Schulterdrücken</source>
+        <target>Schulterdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.deadlift.name">
+      <segment state="initial">
+        <source>Kreuzheben</source>
+        <target>Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellsquat.name">
+      <segment state="initial">
+        <source>Langhantel-Kniebeuge</source>
+        <target>Langhantel-Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellrow.name">
+      <segment state="initial">
+        <source>Langhantelrudern</source>
+        <target>Langhantelrudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.kettlebellswing.name">
+      <segment state="initial">
+        <source>Kettlebell Swing</source>
+        <target>Kettlebell Swing</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -7154,5 +7154,287 @@ Deine Position: # ·  Reps        </source>
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
+      <unit id="exercise.variant.situps.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.decline">
+      <segment state="initial">
+        <source>Decline</source>
+        <target>Decline</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.reverse">
+      <segment state="initial">
+        <source>Reverse Crunches</source>
+        <target>Reverse Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.bicycle">
+      <segment state="initial">
+        <source>Bicycle Crunches</source>
+        <target>Bicycle Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.oblique">
+      <segment state="initial">
+        <source>Schräge Crunches</source>
+        <target>Schräge Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.lying">
+      <segment state="initial">
+        <source>Liegend</source>
+        <target>Liegend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-knee">
+      <segment state="initial">
+        <source>Hängend (Knie)</source>
+        <target>Hängend (Knie)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-straight">
+      <segment state="initial">
+        <source>Hängend (gestreckt)</source>
+        <target>Hängend (gestreckt)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.cross-body">
+      <segment state="initial">
+        <source>Cross-Body</source>
+        <target>Cross-Body</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.forearm">
+      <segment state="initial">
+        <source>Unterarmstütz</source>
+        <target>Unterarmstütz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.side">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.reverse">
+      <segment state="initial">
+        <source>Umgekehrt</source>
+        <target>Umgekehrt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.sumo">
+      <segment state="initial">
+        <source>Sumo</source>
+        <target>Sumo</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.goblet">
+      <segment state="initial">
+        <source>Goblet</source>
+        <target>Goblet</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bulgarian-split">
+      <segment state="initial">
+        <source>Bulgarian Split</source>
+        <target>Bulgarian Split</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.pistol">
+      <segment state="initial">
+        <source>Pistol</source>
+        <target>Pistol</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.seated">
+      <segment state="initial">
+        <source>Sitzend</source>
+        <target>Sitzend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.hip-thrust">
+      <segment state="initial">
+        <source>Hip Thrust</source>
+        <target>Hip Thrust</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.march">
+      <segment state="initial">
+        <source>Marching</source>
+        <target>Marching</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.forward">
+      <segment state="initial">
+        <source>Vorwärts</source>
+        <target>Vorwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.reverse">
+      <segment state="initial">
+        <source>Rückwärts</source>
+        <target>Rückwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.walking">
+      <segment state="initial">
+        <source>Walking</source>
+        <target>Walking</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.lateral">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.curtsy">
+      <segment state="initial">
+        <source>Curtsy</source>
+        <target>Curtsy</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.jumping">
+      <segment state="initial">
+        <source>Jumping</source>
+        <target>Jumping</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.chin-up">
+      <segment state="initial">
+        <source>Chin-up</source>
+        <target>Chin-up</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.wide-grip">
+      <segment state="initial">
+        <source>Breiter Griff</source>
+        <target>Breiter Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.neutral-grip">
+      <segment state="initial">
+        <source>Neutraler Griff</source>
+        <target>Neutraler Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.negative">
+      <segment state="initial">
+        <source>Negativ</source>
+        <target>Negativ</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.assisted">
+      <segment state="initial">
+        <source>Assistiert</source>
+        <target>Assistiert</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.archer">
+      <segment state="initial">
+        <source>Archer</source>
+        <target>Archer</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.inverted">
+      <segment state="initial">
+        <source>Inverted Row</source>
+        <target>Inverted Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.australian">
+      <segment state="initial">
+        <source>Australian Row</source>
+        <target>Australian Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.dumbbell">
+      <segment state="initial">
+        <source>Kurzhantel</source>
+        <target>Kurzhantel</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.barbell">
+      <segment state="initial">
+        <source>Langhantel</source>
+        <target>Langhantel</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -236,7 +236,7 @@
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:546,547</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:550,551</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
       </notes>
       <segment>
@@ -4294,13 +4294,17 @@
         <source>Alle Übungen</source>
       </segment>
     </unit>
-    <unit id="exercise.category.pushup">
+    <unit id="exercise.category.push">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:146</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:147</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:200</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1098</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:187</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:207</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:272</note>
       </notes>
       <segment>
-        <source>Liegestütze</source>
+        <source>Drücken</source>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
@@ -5025,7 +5029,7 @@
     </unit>
     <unit id="editDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:261,263</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:265,267</note>
       </notes>
       <segment>
         <source>Eintrag bearbeiten</source>
@@ -5033,7 +5037,7 @@
     </unit>
     <unit id="trainingEntryDialog.title">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:263,267</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:267,271</note>
       </notes>
       <segment>
         <source>Trainingseintrag anlegen</source>
@@ -5041,7 +5045,7 @@
     </unit>
     <unit id="trainingEntryDialog.category">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:269,271</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:273,275</note>
       </notes>
       <segment>
         <source>Kategorie</source>
@@ -5049,7 +5053,7 @@
     </unit>
     <unit id="trainingEntryDialog.exercise">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:284,286</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:288,290</note>
       </notes>
       <segment>
         <source>Übung</source>
@@ -5057,7 +5061,7 @@
     </unit>
     <unit id="timestampLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:299,301</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:303,305</note>
       </notes>
       <segment>
         <source>Zeitpunkt</source>
@@ -5065,7 +5069,7 @@
     </unit>
     <unit id="typeLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:312,313</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:316,317</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -5073,7 +5077,7 @@
     </unit>
     <unit id="typePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:318,319</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:322,323</note>
       </notes>
       <segment>
         <source>Auswählen oder eintippen</source>
@@ -5081,7 +5085,7 @@
     </unit>
     <unit id="typeWikiLinkAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:357,359</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:361,363</note>
       </notes>
       <segment>
         <source>Anleitung zum Liegestütztyp öffnen</source>
@@ -5089,7 +5093,7 @@
     </unit>
     <unit id="entryDialog.variant">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:364,365</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:368,369</note>
       </notes>
       <segment>
         <source>Variante</source>
@@ -5097,7 +5101,7 @@
     </unit>
     <unit id="entryDialog.variantNone">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:367,369</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:371,373</note>
       </notes>
       <segment>
         <source>—</source>
@@ -5105,7 +5109,7 @@
     </unit>
     <unit id="entryDialog.distance">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:380,382</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:384,386</note>
       </notes>
       <segment>
         <source>Distanz (km)</source>
@@ -5113,8 +5117,8 @@
     </unit>
     <unit id="entryDialog.durationMinutes">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:396,398</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:426,428</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:400,402</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:430,432</note>
       </notes>
       <segment>
         <source>Minuten</source>
@@ -5122,8 +5126,8 @@
     </unit>
     <unit id="entryDialog.durationSeconds">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:409,411</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:439,441</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:413,415</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:443,445</note>
       </notes>
       <segment>
         <source>Sekunden</source>
@@ -5131,7 +5135,7 @@
     </unit>
     <unit id="setLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:458,459</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:462,463</note>
       </notes>
       <segment>
         <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -5139,7 +5143,7 @@
     </unit>
     <unit id="repsLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:460,461</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:464,465</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5147,7 +5151,7 @@
     </unit>
     <unit id="removeSetAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:479,481</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:483,485</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -5155,7 +5159,7 @@
     </unit>
     <unit id="addSetAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:490,491</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:494,495</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -5163,7 +5167,7 @@
     </unit>
     <unit id="addSetTooltip">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:492,494</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:496,498</note>
       </notes>
       <segment>
         <source>Weiteres Set hinzufügen</source>
@@ -5171,7 +5175,7 @@
     </unit>
     <unit id="totalReps">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:501,503</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:505,507</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -5179,7 +5183,7 @@
     </unit>
     <unit id="entryDialog.overCapDuration">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:510,511</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:514,515</note>
       </notes>
       <segment>
         <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
@@ -5187,7 +5191,7 @@
     </unit>
     <unit id="entryDialog.overCapTime">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:514,515</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:518,519</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
@@ -5195,7 +5199,7 @@
     </unit>
     <unit id="entryDialog.overCap">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:518,519</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:522,523</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ repsMax() }}"/> pro Eintrag</source>
@@ -5203,7 +5207,7 @@
     </unit>
     <unit id="sourceLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:526,527</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:530,531</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -5211,7 +5215,7 @@
     </unit>
     <unit id="sourcePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:532,533</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:536,537</note>
       </notes>
       <segment>
         <source>web / whatsapp / eigene Quelle</source>
@@ -5219,7 +5223,7 @@
     </unit>
     <unit id="saveEntry">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:556,558</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:560,562</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -5227,7 +5231,7 @@
     </unit>
     <unit id="trainingEntryDialog.pushup.exercise">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:609</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:613</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -5235,7 +5239,7 @@
     </unit>
     <unit id="typeWikiLinkTooltip.generic">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:771</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:775</note>
       </notes>
       <segment>
         <source>Anleitung zu Liegestütztypen öffnen</source>
@@ -5243,27 +5247,16 @@
     </unit>
     <unit id="typeWikiLinkTooltip.specific">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:773</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:777</note>
       </notes>
       <segment>
         <source>Anleitung öffnen</source>
       </segment>
     </unit>
-    <unit id="exercise.category.push">
-      <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1094</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:98</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:118</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:277</note>
-      </notes>
-      <segment>
-        <source>Drücken</source>
-      </segment>
-    </unit>
     <unit id="exercise.category.pull">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1095</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:119</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1099</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:208</note>
       </notes>
       <segment>
         <source>Ziehen</source>
@@ -5271,8 +5264,8 @@
     </unit>
     <unit id="exercise.category.squat">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1096</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:120</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1100</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:209</note>
       </notes>
       <segment>
         <source>Kniebeuge</source>
@@ -5280,8 +5273,8 @@
     </unit>
     <unit id="exercise.category.hinge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1097</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:121</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1101</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:210</note>
       </notes>
       <segment>
         <source>Hüftbeuge</source>
@@ -5289,8 +5282,8 @@
     </unit>
     <unit id="exercise.category.lunge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1098</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:122</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1102</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:211</note>
       </notes>
       <segment>
         <source>Ausfallschritt</source>
@@ -5298,8 +5291,8 @@
     </unit>
     <unit id="exercise.category.carry">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1099</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:123</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1103</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:212</note>
       </notes>
       <segment>
         <source>Tragen</source>
@@ -5307,8 +5300,8 @@
     </unit>
     <unit id="exercise.category.core">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1100</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:124</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1104</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:213</note>
       </notes>
       <segment>
         <source>Rumpf</source>
@@ -5316,8 +5309,8 @@
     </unit>
     <unit id="exercise.category.cardio">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1101</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:125</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1105</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:214</note>
       </notes>
       <segment>
         <source>Ausdauer</source>
@@ -5325,8 +5318,8 @@
     </unit>
     <unit id="exercise.category.mobility">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1102</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:126</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1106</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:215</note>
       </notes>
       <segment>
         <source>Mobilität</source>
@@ -5334,8 +5327,8 @@
     </unit>
     <unit id="exercise.category.strength">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1103</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:127</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1107</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:216</note>
       </notes>
       <segment>
         <source>Krafttraining</source>
@@ -5431,7 +5424,7 @@
     </unit>
     <unit id="exercise.abs.situps.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:15</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:16</note>
       </notes>
       <segment>
         <source>Sit-ups</source>
@@ -5439,7 +5432,7 @@
     </unit>
     <unit id="exercise.abs.crunches.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:16</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:17</note>
       </notes>
       <segment>
         <source>Crunches</source>
@@ -5447,7 +5440,7 @@
     </unit>
     <unit id="exercise.abs.legraises.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:17</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:18</note>
       </notes>
       <segment>
         <source>Beinheben</source>
@@ -5455,7 +5448,7 @@
     </unit>
     <unit id="exercise.abs.russiantwist.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:18</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:19</note>
       </notes>
       <segment>
         <source>Russian Twist</source>
@@ -5463,7 +5456,7 @@
     </unit>
     <unit id="exercise.abs.mountainclimbers.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:19</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:20</note>
       </notes>
       <segment>
         <source>Mountain Climbers</source>
@@ -5471,7 +5464,7 @@
     </unit>
     <unit id="exercise.core.deadbug.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:20</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:21</note>
       </notes>
       <segment>
         <source>Dead Bug</source>
@@ -5479,7 +5472,7 @@
     </unit>
     <unit id="exercise.core.hollowhold.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:21</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:22</note>
       </notes>
       <segment>
         <source>Hollow Hold</source>
@@ -5487,7 +5480,7 @@
     </unit>
     <unit id="exercise.plank.standard.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:22</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:23</note>
       </notes>
       <segment>
         <source>Plank</source>
@@ -5495,7 +5488,7 @@
     </unit>
     <unit id="exercise.legs.squats.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:25</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:26</note>
       </notes>
       <segment>
         <source>Kniebeugen</source>
@@ -5503,7 +5496,7 @@
     </unit>
     <unit id="exercise.legs.jumpsquats.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:26</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:27</note>
       </notes>
       <segment>
         <source>Jump Squats</source>
@@ -5511,7 +5504,7 @@
     </unit>
     <unit id="exercise.legs.calfraises.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:27</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:28</note>
       </notes>
       <segment>
         <source>Wadenheben</source>
@@ -5519,7 +5512,7 @@
     </unit>
     <unit id="exercise.squat.wallsit.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:28</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:29</note>
       </notes>
       <segment>
         <source>Wandsitz</source>
@@ -5527,7 +5520,7 @@
     </unit>
     <unit id="exercise.squat.boxjump.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:29</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:30</note>
       </notes>
       <segment>
         <source>Box Jumps</source>
@@ -5535,7 +5528,7 @@
     </unit>
     <unit id="exercise.legs.glutebridge.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:30</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:31</note>
       </notes>
       <segment>
         <source>Hüftheben</source>
@@ -5543,7 +5536,7 @@
     </unit>
     <unit id="exercise.hinge.singlelegRdl.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:31</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:32</note>
       </notes>
       <segment>
         <source>Einbeiniges Kreuzheben</source>
@@ -5551,7 +5544,7 @@
     </unit>
     <unit id="exercise.hinge.goodmorning.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:32</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:33</note>
       </notes>
       <segment>
         <source>Good Morning</source>
@@ -5559,7 +5552,7 @@
     </unit>
     <unit id="exercise.legs.lunges.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:33</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:34</note>
       </notes>
       <segment>
         <source>Ausfallschritte</source>
@@ -5567,7 +5560,7 @@
     </unit>
     <unit id="exercise.lunge.stepup.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:34</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:35</note>
       </notes>
       <segment>
         <source>Step-ups</source>
@@ -5575,7 +5568,7 @@
     </unit>
     <unit id="exercise.pull.pullups.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:37</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:38</note>
       </notes>
       <segment>
         <source>Klimmzüge</source>
@@ -5583,7 +5576,7 @@
     </unit>
     <unit id="exercise.pull.rows.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:38</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:39</note>
       </notes>
       <segment>
         <source>Ruderzug</source>
@@ -5591,7 +5584,7 @@
     </unit>
     <unit id="exercise.pull.deadhang.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:39</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:40</note>
       </notes>
       <segment>
         <source>Dead Hang</source>
@@ -5599,7 +5592,7 @@
     </unit>
     <unit id="exercise.pull.facepull.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:40</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:41</note>
       </notes>
       <segment>
         <source>Face Pull</source>
@@ -5607,7 +5600,7 @@
     </unit>
     <unit id="exercise.carry.farmer.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:43</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:44</note>
       </notes>
       <segment>
         <source>Farmer&apos;s Walk</source>
@@ -5615,7 +5608,7 @@
     </unit>
     <unit id="exercise.carry.suitcase.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:44</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:45</note>
       </notes>
       <segment>
         <source>Suitcase Carry</source>
@@ -5623,7 +5616,7 @@
     </unit>
     <unit id="exercise.carry.overhead.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:45</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:46</note>
       </notes>
       <segment>
         <source>Overhead Carry</source>
@@ -5631,7 +5624,7 @@
     </unit>
     <unit id="exercise.cardio.running.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:48</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:49</note>
       </notes>
       <segment>
         <source>Laufen</source>
@@ -5639,7 +5632,7 @@
     </unit>
     <unit id="exercise.cardio.walking.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:49</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:50</note>
       </notes>
       <segment>
         <source>Gehen</source>
@@ -5647,7 +5640,7 @@
     </unit>
     <unit id="exercise.cardio.cycling.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:50</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:51</note>
       </notes>
       <segment>
         <source>Radfahren</source>
@@ -5655,7 +5648,7 @@
     </unit>
     <unit id="exercise.cardio.rowing.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:51</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:52</note>
       </notes>
       <segment>
         <source>Rudern</source>
@@ -5663,7 +5656,7 @@
     </unit>
     <unit id="exercise.cardio.swimming.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:52</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:53</note>
       </notes>
       <segment>
         <source>Schwimmen</source>
@@ -5671,7 +5664,7 @@
     </unit>
     <unit id="exercise.cardio.jumprope.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:53</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:54</note>
       </notes>
       <segment>
         <source>Seilspringen</source>
@@ -5679,7 +5672,7 @@
     </unit>
     <unit id="exercise.cardio.burpees.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:54</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:55</note>
       </notes>
       <segment>
         <source>Burpees</source>
@@ -5687,7 +5680,7 @@
     </unit>
     <unit id="exercise.cardio.jumpingjacks.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:55</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:56</note>
       </notes>
       <segment>
         <source>Hampelmänner</source>
@@ -5695,7 +5688,7 @@
     </unit>
     <unit id="exercise.cardio.highknees.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:56</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:57</note>
       </notes>
       <segment>
         <source>High Knees</source>
@@ -5703,7 +5696,7 @@
     </unit>
     <unit id="exercise.mobility.stretching.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:59</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:60</note>
       </notes>
       <segment>
         <source>Dehnen</source>
@@ -5711,7 +5704,7 @@
     </unit>
     <unit id="exercise.mobility.yoga.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:60</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:61</note>
       </notes>
       <segment>
         <source>Yoga</source>
@@ -5719,7 +5712,7 @@
     </unit>
     <unit id="exercise.mobility.foamrolling.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:61</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:62</note>
       </notes>
       <segment>
         <source>Faszienrolle</source>
@@ -5727,7 +5720,7 @@
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:62</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:63</note>
       </notes>
       <segment>
         <source>Dynamisches Aufwärmen</source>
@@ -5735,7 +5728,7 @@
     </unit>
     <unit id="exercise.mobility.catcow.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:63</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:64</note>
       </notes>
       <segment>
         <source>Katze-Kuh</source>
@@ -5743,7 +5736,7 @@
     </unit>
     <unit id="exercise.mobility.hipopener.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:64</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:65</note>
       </notes>
       <segment>
         <source>Hüftöffner</source>
@@ -5751,7 +5744,7 @@
     </unit>
     <unit id="exercise.strength.benchpress.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:67</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:68</note>
       </notes>
       <segment>
         <source>Bankdrücken</source>
@@ -5759,7 +5752,7 @@
     </unit>
     <unit id="exercise.strength.overheadpress.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:68</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:69</note>
       </notes>
       <segment>
         <source>Schulterdrücken</source>
@@ -5767,7 +5760,7 @@
     </unit>
     <unit id="exercise.strength.deadlift.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:69</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:70</note>
       </notes>
       <segment>
         <source>Kreuzheben</source>
@@ -5775,7 +5768,7 @@
     </unit>
     <unit id="exercise.strength.barbellsquat.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:70</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:71</note>
       </notes>
       <segment>
         <source>Langhantel-Kniebeuge</source>
@@ -5783,7 +5776,7 @@
     </unit>
     <unit id="exercise.strength.barbellrow.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:71</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:72</note>
       </notes>
       <segment>
         <source>Langhantelrudern</source>
@@ -5791,10 +5784,386 @@
     </unit>
     <unit id="exercise.strength.kettlebellswing.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:72</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:73</note>
       </notes>
       <segment>
         <source>Kettlebell Swing</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.standard">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:93</note>
+      </notes>
+      <segment>
+        <source>Standard</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.decline">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:94</note>
+      </notes>
+      <segment>
+        <source>Decline</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.weighted">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:95</note>
+      </notes>
+      <segment>
+        <source>Mit Zusatzgewicht</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.standard">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:98</note>
+      </notes>
+      <segment>
+        <source>Standard</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.reverse">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:99</note>
+      </notes>
+      <segment>
+        <source>Reverse Crunches</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.bicycle">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:100</note>
+      </notes>
+      <segment>
+        <source>Bicycle Crunches</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.oblique">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:101</note>
+      </notes>
+      <segment>
+        <source>Schräge Crunches</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.lying">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:104</note>
+      </notes>
+      <segment>
+        <source>Liegend</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-knee">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:105</note>
+      </notes>
+      <segment>
+        <source>Hängend (Knie)</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-straight">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:106</note>
+      </notes>
+      <segment>
+        <source>Hängend (gestreckt)</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.bodyweight">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:109</note>
+      </notes>
+      <segment>
+        <source>Eigengewicht</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.weighted">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:110</note>
+      </notes>
+      <segment>
+        <source>Mit Zusatzgewicht</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.standard">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:113</note>
+      </notes>
+      <segment>
+        <source>Standard</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.cross-body">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:114</note>
+      </notes>
+      <segment>
+        <source>Cross-Body</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.standard">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:117</note>
+      </notes>
+      <segment>
+        <source>Standard</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.forearm">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:118</note>
+      </notes>
+      <segment>
+        <source>Unterarmstütz</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.side">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:119</note>
+      </notes>
+      <segment>
+        <source>Seitlich</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.reverse">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:120</note>
+      </notes>
+      <segment>
+        <source>Umgekehrt</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bodyweight">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:123</note>
+      </notes>
+      <segment>
+        <source>Eigengewicht</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.sumo">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:124</note>
+      </notes>
+      <segment>
+        <source>Sumo</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.goblet">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:125</note>
+      </notes>
+      <segment>
+        <source>Goblet</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bulgarian-split">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:126</note>
+      </notes>
+      <segment>
+        <source>Bulgarian Split</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.pistol">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:127</note>
+      </notes>
+      <segment>
+        <source>Pistol</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.standard">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:130</note>
+      </notes>
+      <segment>
+        <source>Standard</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.single-leg">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:131</note>
+      </notes>
+      <segment>
+        <source>Einbeinig</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.seated">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:132</note>
+      </notes>
+      <segment>
+        <source>Sitzend</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.standard">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:135</note>
+      </notes>
+      <segment>
+        <source>Standard</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.single-leg">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:136</note>
+      </notes>
+      <segment>
+        <source>Einbeinig</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.hip-thrust">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:137</note>
+      </notes>
+      <segment>
+        <source>Hip Thrust</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.march">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:138</note>
+      </notes>
+      <segment>
+        <source>Marching</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.forward">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:141</note>
+      </notes>
+      <segment>
+        <source>Vorwärts</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.reverse">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:142</note>
+      </notes>
+      <segment>
+        <source>Rückwärts</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.walking">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:143</note>
+      </notes>
+      <segment>
+        <source>Walking</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.lateral">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:144</note>
+      </notes>
+      <segment>
+        <source>Seitlich</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.curtsy">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:145</note>
+      </notes>
+      <segment>
+        <source>Curtsy</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.jumping">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:146</note>
+      </notes>
+      <segment>
+        <source>Jumping</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.standard">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:149</note>
+      </notes>
+      <segment>
+        <source>Standard</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.chin-up">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:150</note>
+      </notes>
+      <segment>
+        <source>Chin-up</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.wide-grip">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:151</note>
+      </notes>
+      <segment>
+        <source>Breiter Griff</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.neutral-grip">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:152</note>
+      </notes>
+      <segment>
+        <source>Neutraler Griff</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.negative">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:153</note>
+      </notes>
+      <segment>
+        <source>Negativ</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.assisted">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:154</note>
+      </notes>
+      <segment>
+        <source>Assistiert</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.archer">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:155</note>
+      </notes>
+      <segment>
+        <source>Archer</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.inverted">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:158</note>
+      </notes>
+      <segment>
+        <source>Inverted Row</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.australian">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:159</note>
+      </notes>
+      <segment>
+        <source>Australian Row</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.dumbbell">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:160</note>
+      </notes>
+      <segment>
+        <source>Kurzhantel</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.barbell">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:161</note>
+      </notes>
+      <segment>
+        <source>Langhantel</source>
       </segment>
     </unit>
     <unit id="analysis.bestStreaksTitle">
@@ -6049,7 +6418,7 @@
     </unit>
     <unit id="historyHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:38,39</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:35,36</note>
       </notes>
       <segment>
         <source>Historie</source>
@@ -6057,7 +6426,7 @@
     </unit>
     <unit id="historyHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:40,42</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:37,39</note>
       </notes>
       <segment>
         <source> Durchsuche, filtere und bearbeite deine Trainingseinträge. </source>
@@ -6065,7 +6434,7 @@
     </unit>
     <unit id="entries.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:45,46</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:42,43</note>
       </notes>
       <segment>
         <source>Filter</source>
@@ -6073,7 +6442,7 @@
     </unit>
     <unit id="entries.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:47,48</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:44,45</note>
       </notes>
       <segment>
         <source>Zeitraum und Kriterien</source>
@@ -6081,7 +6450,7 @@
     </unit>
     <unit id="entries.dateFrom">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:54,55</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:51,52</note>
       </notes>
       <segment>
         <source>Datum von</source>
@@ -6089,7 +6458,7 @@
     </unit>
     <unit id="entries.dateTo">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:64,65</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:61,62</note>
       </notes>
       <segment>
         <source>Datum bis</source>
@@ -6097,7 +6466,7 @@
     </unit>
     <unit id="entries.exerciseFilter">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:74,75</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:71,72</note>
       </notes>
       <segment>
         <source>Übung</source>
@@ -6105,7 +6474,7 @@
     </unit>
     <unit id="entries.sourceFilter">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:89,90</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:86,87</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -6113,8 +6482,8 @@
     </unit>
     <unit id="entries.allOption">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:95,97</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:110,112</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:92,94</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:107,109</note>
       </notes>
       <segment>
         <source>Alle</source>
@@ -6122,7 +6491,7 @@
     </unit>
     <unit id="entries.typeFilter">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:104,105</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:101,102</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -6130,7 +6499,7 @@
     </unit>
     <unit id="entries.repsMin">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:121,122</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:118,119</note>
       </notes>
       <segment>
         <source>Reps min</source>
@@ -6138,7 +6507,7 @@
     </unit>
     <unit id="entries.repsMax">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:132,133</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:129,130</note>
       </notes>
       <segment>
         <source>Reps max</source>
@@ -6146,7 +6515,7 @@
     </unit>
     <unit id="entries.empty.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:160,162</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:156,157</note>
       </notes>
       <segment>
         <source>Noch keine Einträge.</source>
@@ -6154,7 +6523,7 @@
     </unit>
     <unit id="entries.empty.body">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:163,165</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:158,160</note>
       </notes>
       <segment>
         <source> Trage deinen ersten Trainingseintrag ein — dann wird hier deine Historie sichtbar. </source>
@@ -6162,7 +6531,7 @@
     </unit>
     <unit id="entries.empty.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:175,177</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:170,172</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc> Eintrag erstellen </source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -5277,7 +5277,7 @@
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:210</note>
       </notes>
       <segment>
-        <source>Hüftbeuge</source>
+        <source>Hüftstreckung</source>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2117,8 +2117,8 @@
     <unit id="nav.dashboard">
       <notes>
         <note category="location">web/src/app/app.html:23,26</note>
-        <note category="location">web/src/app/app.html:177,179</note>
-        <note category="location">web/src/app/app.html:236,238</note>
+        <note category="location">web/src/app/app.html:186,188</note>
+        <note category="location">web/src/app/app.html:245,247</note>
       </notes>
       <segment>
         <source>Dashboard</source>
@@ -2127,8 +2127,8 @@
     <unit id="nav.analysis">
       <notes>
         <note category="location">web/src/app/app.html:33,36</note>
-        <note category="location">web/src/app/app.html:181,183</note>
-        <note category="location">web/src/app/app.html:240,242</note>
+        <note category="location">web/src/app/app.html:190,192</note>
+        <note category="location">web/src/app/app.html:249,251</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -2137,8 +2137,8 @@
     <unit id="nav.leaderboard">
       <notes>
         <note category="location">web/src/app/app.html:43,47</note>
-        <note category="location">web/src/app/app.html:185,187</note>
-        <note category="location">web/src/app/app.html:244,246</note>
+        <note category="location">web/src/app/app.html:194,196</note>
+        <note category="location">web/src/app/app.html:253,255</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -2147,8 +2147,8 @@
     <unit id="nav.blog">
       <notes>
         <note category="location">web/src/app/app.html:53,56</note>
-        <note category="location">web/src/app/app.html:193,195</note>
-        <note category="location">web/src/app/app.html:252,254</note>
+        <note category="location">web/src/app/app.html:202,204</note>
+        <note category="location">web/src/app/app.html:261,263</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -2157,8 +2157,8 @@
     <unit id="nav.trainingPlans">
       <notes>
         <note category="location">web/src/app/app.html:63,67</note>
-        <note category="location">web/src/app/app.html:189,191</note>
-        <note category="location">web/src/app/app.html:248,250</note>
+        <note category="location">web/src/app/app.html:198,200</note>
+        <note category="location">web/src/app/app.html:257,259</note>
       </notes>
       <segment>
         <source>Trainingspläne</source>
@@ -2222,23 +2222,15 @@
     </unit>
     <unit id="toolbarDailyGoal">
       <notes>
-        <note category="location">web/src/app/app.html:149,150</note>
+        <note category="location">web/src/app/app.html:158,159</note>
       </notes>
       <segment>
         <source>Tagesziel</source>
       </segment>
     </unit>
-    <unit id="toolbarDailyGoal.replayAria">
-      <notes>
-        <note category="location">web/src/app/app.ts</note>
-      </notes>
-      <segment>
-        <source>Tagesziel-Animation erneut abspielen</source>
-      </segment>
-    </unit>
     <unit id="nav.admin">
       <notes>
-        <note category="location">web/src/app/app.html:157,158</note>
+        <note category="location">web/src/app/app.html:166,167</note>
       </notes>
       <segment>
         <source>Admin-Bereich</source>
@@ -2246,7 +2238,7 @@
     </unit>
     <unit id="nav.desktop.aria">
       <notes>
-        <note category="location">web/src/app/app.html:168,169</note>
+        <note category="location">web/src/app/app.html:177,178</note>
       </notes>
       <segment>
         <source>Hauptnavigation</source>
@@ -2254,7 +2246,7 @@
     </unit>
     <unit id="footer.aria">
       <notes>
-        <note category="location">web/src/app/app.html:202</note>
+        <note category="location">web/src/app/app.html:211</note>
       </notes>
       <segment>
         <source>Rechtliches</source>
@@ -2262,7 +2254,7 @@
     </unit>
     <unit id="footer.pushupTypes">
       <notes>
-        <note category="location">web/src/app/app.html:207,209</note>
+        <note category="location">web/src/app/app.html:216,218</note>
       </notes>
       <segment>
         <source>Liegestütztypen</source>
@@ -2270,7 +2262,7 @@
     </unit>
     <unit id="footer.impressum">
       <notes>
-        <note category="location">web/src/app/app.html:210,212</note>
+        <note category="location">web/src/app/app.html:219,221</note>
       </notes>
       <segment>
         <source>Impressum</source>
@@ -2278,7 +2270,7 @@
     </unit>
     <unit id="footer.datenschutz">
       <notes>
-        <note category="location">web/src/app/app.html:213,216</note>
+        <note category="location">web/src/app/app.html:222,225</note>
       </notes>
       <segment>
         <source>Datenschutz</source>
@@ -2286,7 +2278,7 @@
     </unit>
     <unit id="footer.cookies">
       <notes>
-        <note category="location">web/src/app/app.html:220,222</note>
+        <note category="location">web/src/app/app.html:229,231</note>
       </notes>
       <segment>
         <source> Cookie-Einstellungen </source>
@@ -2294,7 +2286,7 @@
     </unit>
     <unit id="nav.bottom.aria">
       <notes>
-        <note category="location">web/src/app/app.html:227,228</note>
+        <note category="location">web/src/app/app.html:236,237</note>
       </notes>
       <segment>
         <source>Mobile-Navigation</source>
@@ -2588,9 +2580,17 @@
         <source>Neu laden</source>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.replayAria">
+      <notes>
+        <note category="location">web/src/app/app.ts:371</note>
+      </notes>
+      <segment>
+        <source>Tagesziel-Animation erneut abspielen</source>
+      </segment>
+    </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:377</note>
+        <note category="location">web/src/app/app.ts:400</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -2598,7 +2598,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:384</note>
+        <note category="location">web/src/app/app.ts:407</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>
@@ -4288,7 +4288,7 @@
     </unit>
     <unit id="chart.kindLabel.all">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:142</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:141</note>
       </notes>
       <segment>
         <source>Alle Übungen</source>
@@ -4296,12 +4296,8 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:147</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:146</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:200</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1093</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:46</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:76</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:277</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -4535,7 +4531,7 @@
     </unit>
     <unit id="goalReached.weekly.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:81</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:91</note>
       </notes>
       <segment>
         <source>Wochenziel erreicht!</source>
@@ -4543,7 +4539,7 @@
     </unit>
     <unit id="goalReached.weekly.note">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:82</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:92</note>
       </notes>
       <segment>
         <source>Sieben Tage, ein Sieg. Du bist on fire.</source>
@@ -4551,7 +4547,7 @@
     </unit>
     <unit id="goalReached.share.weekly.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:83</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:93</note>
       </notes>
       <segment>
         <source>Wochenziel geknackt!</source>
@@ -4559,7 +4555,7 @@
     </unit>
     <unit id="goalReached.share.weekly.text">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:84</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:94</note>
       </notes>
       <segment>
         <source>Wochenziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
@@ -4567,7 +4563,7 @@
     </unit>
     <unit id="goalReached.monthly.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:89</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:99</note>
       </notes>
       <segment>
         <source>Monatsziel erreicht!</source>
@@ -4575,7 +4571,7 @@
     </unit>
     <unit id="goalReached.monthly.note">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:90</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:100</note>
       </notes>
       <segment>
         <source>Ein ganzer Monat Disziplin. Legendär.</source>
@@ -4583,7 +4579,7 @@
     </unit>
     <unit id="goalReached.share.monthly.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:91</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:101</note>
       </notes>
       <segment>
         <source>Monatsziel geknackt!</source>
@@ -4591,7 +4587,7 @@
     </unit>
     <unit id="goalReached.share.monthly.text">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:92</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:102</note>
       </notes>
       <segment>
         <source>Monatsziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
@@ -4599,7 +4595,7 @@
     </unit>
     <unit id="goalReached.plan.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:97</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:107</note>
       </notes>
       <segment>
         <source>Trainingsplan-Ziel erreicht!</source>
@@ -4607,7 +4603,7 @@
     </unit>
     <unit id="goalReached.plan.note">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:98</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:108</note>
       </notes>
       <segment>
         <source>Heutiges Plan-Pensum geschafft. Stark!</source>
@@ -4615,7 +4611,7 @@
     </unit>
     <unit id="goalReached.share.plan.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:99</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:109</note>
       </notes>
       <segment>
         <source>Plan-Ziel geknackt!</source>
@@ -4623,7 +4619,7 @@
     </unit>
     <unit id="goalReached.share.plan.text">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:100</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:110</note>
       </notes>
       <segment>
         <source>Heute mein Trainingsplan-Ziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen erreicht – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
@@ -4631,7 +4627,7 @@
     </unit>
     <unit id="goalReached.daily.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:105</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:115</note>
       </notes>
       <segment>
         <source>Tagesziel erreicht!</source>
@@ -4639,7 +4635,7 @@
     </unit>
     <unit id="goalReached.daily.note">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:106</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:116</note>
       </notes>
       <segment>
         <source>Heute hast du dein Versprechen gehalten.</source>
@@ -4647,7 +4643,7 @@
     </unit>
     <unit id="goalReached.share.daily.title">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:107</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:117</note>
       </notes>
       <segment>
         <source>Tagesziel geknackt!</source>
@@ -4655,7 +4651,7 @@
     </unit>
     <unit id="goalReached.share.daily.text">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:108</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:118</note>
       </notes>
       <segment>
         <source>Heute mein Tagesziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft! 💪 Tracke deine Stats kostenlos:</source>
@@ -4663,7 +4659,7 @@
     </unit>
     <unit id="goalReached.snapAria">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:113</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:123</note>
       </notes>
       <segment>
         <source>Erfolg vaporisieren</source>
@@ -4671,7 +4667,7 @@
     </unit>
     <unit id="goalReached.snap">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:114</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:124</note>
       </notes>
       <segment>
         <source>Snap!</source>
@@ -4679,7 +4675,7 @@
     </unit>
     <unit id="goalReached.closeAria">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:115</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:125</note>
       </notes>
       <segment>
         <source>Schließen</source>
@@ -4687,7 +4683,7 @@
     </unit>
     <unit id="goalReached.shareAria">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:116</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:126</note>
       </notes>
       <segment>
         <source>Erfolg teilen</source>
@@ -4695,7 +4691,7 @@
     </unit>
     <unit id="goalReached.share">
       <notes>
-        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:117</note>
+        <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:127</note>
       </notes>
       <segment>
         <source>Teilen</source>
@@ -4807,7 +4803,7 @@
     </unit>
     <unit id="chart.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43,45</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:51,53</note>
       </notes>
       <segment>
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
@@ -4815,7 +4811,7 @@
     </unit>
     <unit id="chart.modeToggleAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:52,53</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:60,61</note>
       </notes>
       <segment>
         <source>Zeitraum der Stundenansicht</source>
@@ -4823,7 +4819,7 @@
     </unit>
     <unit id="chart.mode14h">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:56,57</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:64,65</note>
       </notes>
       <segment>
         <source>14h</source>
@@ -4831,7 +4827,7 @@
     </unit>
     <unit id="chart.mode24h">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:59,60</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:67,68</note>
       </notes>
       <segment>
         <source>24h</source>
@@ -4839,7 +4835,7 @@
     </unit>
     <unit id="chart.legendAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:73</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:81</note>
       </notes>
       <segment>
         <source>Legende</source>
@@ -4847,8 +4843,8 @@
     </unit>
     <unit id="chart.interval">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:78,79</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:140</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:86,87</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:148</note>
       </notes>
       <segment>
         <source>Intervallwert</source>
@@ -4856,8 +4852,8 @@
     </unit>
     <unit id="chart.dayIntegral">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:84,85</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:141</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:92,93</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:149</note>
       </notes>
       <segment>
         <source>Tages-Integral</source>
@@ -4865,8 +4861,8 @@
     </unit>
     <unit id="chart.movingAvg">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:90,91</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:142</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:98,99</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:150</note>
       </notes>
       <segment>
         <source>Gleitender Durchschnitt</source>
@@ -4874,8 +4870,8 @@
     </unit>
     <unit id="chart.withSets">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:97,98</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:168</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:105,106</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:176</note>
       </notes>
       <segment>
         <source>Mit Sets</source>
@@ -4883,7 +4879,7 @@
     </unit>
     <unit id="chart.titleHourly">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:132</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:140</note>
       </notes>
       <segment>
         <source>Verlauf (Stundenwerte)</source>
@@ -4891,7 +4887,7 @@
     </unit>
     <unit id="chart.titleDaily">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:133</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:141</note>
       </notes>
       <segment>
         <source>Verlauf (Tageswerte)</source>
@@ -4899,7 +4895,7 @@
     </unit>
     <unit id="chart.setsTooltip">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:167</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:175</note>
       </notes>
       <segment>
         <source>Sets</source>
@@ -5231,7 +5227,7 @@
     </unit>
     <unit id="trainingEntryDialog.pushup.exercise">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:608</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:609</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -5239,7 +5235,7 @@
     </unit>
     <unit id="typeWikiLinkTooltip.generic">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:770</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:771</note>
       </notes>
       <segment>
         <source>Anleitung zu Liegestütztypen öffnen</source>
@@ -5247,46 +5243,102 @@
     </unit>
     <unit id="typeWikiLinkTooltip.specific">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:772</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:773</note>
       </notes>
       <segment>
         <source>Anleitung öffnen</source>
       </segment>
     </unit>
-    <unit id="exercise.category.abs">
+    <unit id="exercise.category.push">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1094</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:77</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:98</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:118</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:277</note>
       </notes>
       <segment>
-        <source>Bauch</source>
+        <source>Drücken</source>
       </segment>
     </unit>
-    <unit id="exercise.category.legs">
+    <unit id="exercise.category.pull">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1095</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:78</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:119</note>
       </notes>
       <segment>
-        <source>Beine</source>
+        <source>Ziehen</source>
       </segment>
     </unit>
-    <unit id="exercise.category.plank">
+    <unit id="exercise.category.squat">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1096</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:79</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:120</note>
       </notes>
       <segment>
-        <source>Plank</source>
+        <source>Kniebeuge</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.hinge">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1097</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:121</note>
+      </notes>
+      <segment>
+        <source>Hüftbeuge</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.lunge">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1098</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:122</note>
+      </notes>
+      <segment>
+        <source>Ausfallschritt</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.carry">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1099</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:123</note>
+      </notes>
+      <segment>
+        <source>Tragen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.core">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1100</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:124</note>
+      </notes>
+      <segment>
+        <source>Rumpf</source>
       </segment>
     </unit>
     <unit id="exercise.category.cardio">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1097</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:80</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1101</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:125</note>
       </notes>
       <segment>
         <source>Ausdauer</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.mobility">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1102</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:126</note>
+      </notes>
+      <segment>
+        <source>Mobilität</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.strength">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1103</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:127</note>
+      </notes>
+      <segment>
+        <source>Krafttraining</source>
       </segment>
     </unit>
     <unit id="pie.distributionAria">
@@ -5339,7 +5391,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:452</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:467</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Schau dir mein Profil an:</source>
@@ -5347,7 +5399,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:453</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:468</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
@@ -5355,7 +5407,7 @@
     </unit>
     <unit id="dashboard.share.text.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:457</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:472</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
@@ -5363,7 +5415,7 @@
     </unit>
     <unit id="dashboard.share.text.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:458</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:473</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
@@ -5371,7 +5423,7 @@
     </unit>
     <unit id="dashboard.share.title">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:462</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:477</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -5379,7 +5431,7 @@
     </unit>
     <unit id="exercise.abs.situps.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:14</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:15</note>
       </notes>
       <segment>
         <source>Sit-ups</source>
@@ -5387,7 +5439,7 @@
     </unit>
     <unit id="exercise.abs.crunches.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:15</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:16</note>
       </notes>
       <segment>
         <source>Crunches</source>
@@ -5395,7 +5447,7 @@
     </unit>
     <unit id="exercise.abs.legraises.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:16</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:17</note>
       </notes>
       <segment>
         <source>Beinheben</source>
@@ -5403,7 +5455,7 @@
     </unit>
     <unit id="exercise.abs.russiantwist.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:17</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:18</note>
       </notes>
       <segment>
         <source>Russian Twist</source>
@@ -5411,66 +5463,338 @@
     </unit>
     <unit id="exercise.abs.mountainclimbers.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:18</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:19</note>
       </notes>
       <segment>
         <source>Mountain Climbers</source>
       </segment>
     </unit>
-    <unit id="exercise.legs.squats.name">
-      <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:19</note>
-      </notes>
-      <segment>
-        <source>Kniebeugen</source>
-      </segment>
-    </unit>
-    <unit id="exercise.legs.lunges.name">
+    <unit id="exercise.core.deadbug.name">
       <notes>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:20</note>
       </notes>
       <segment>
-        <source>Ausfallschritte</source>
+        <source>Dead Bug</source>
       </segment>
     </unit>
-    <unit id="exercise.legs.glutebridge.name">
+    <unit id="exercise.core.hollowhold.name">
       <notes>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:21</note>
       </notes>
       <segment>
-        <source>Hüftheben</source>
-      </segment>
-    </unit>
-    <unit id="exercise.legs.calfraises.name">
-      <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:22</note>
-      </notes>
-      <segment>
-        <source>Wadenheben</source>
-      </segment>
-    </unit>
-    <unit id="exercise.legs.jumpsquats.name">
-      <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:23</note>
-      </notes>
-      <segment>
-        <source>Jump Squats</source>
+        <source>Hollow Hold</source>
       </segment>
     </unit>
     <unit id="exercise.plank.standard.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:24</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:22</note>
       </notes>
       <segment>
         <source>Plank</source>
       </segment>
     </unit>
-    <unit id="exercise.cardio.running.name">
+    <unit id="exercise.legs.squats.name">
       <notes>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:25</note>
       </notes>
       <segment>
+        <source>Kniebeugen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.jumpsquats.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:26</note>
+      </notes>
+      <segment>
+        <source>Jump Squats</source>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.calfraises.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:27</note>
+      </notes>
+      <segment>
+        <source>Wadenheben</source>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.wallsit.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:28</note>
+      </notes>
+      <segment>
+        <source>Wandsitz</source>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.boxjump.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:29</note>
+      </notes>
+      <segment>
+        <source>Box Jumps</source>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.glutebridge.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:30</note>
+      </notes>
+      <segment>
+        <source>Hüftheben</source>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.singlelegRdl.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:31</note>
+      </notes>
+      <segment>
+        <source>Einbeiniges Kreuzheben</source>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.goodmorning.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:32</note>
+      </notes>
+      <segment>
+        <source>Good Morning</source>
+      </segment>
+    </unit>
+    <unit id="exercise.legs.lunges.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:33</note>
+      </notes>
+      <segment>
+        <source>Ausfallschritte</source>
+      </segment>
+    </unit>
+    <unit id="exercise.lunge.stepup.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:34</note>
+      </notes>
+      <segment>
+        <source>Step-ups</source>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.pullups.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:37</note>
+      </notes>
+      <segment>
+        <source>Klimmzüge</source>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.rows.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:38</note>
+      </notes>
+      <segment>
+        <source>Ruderzug</source>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.deadhang.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:39</note>
+      </notes>
+      <segment>
+        <source>Dead Hang</source>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.facepull.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:40</note>
+      </notes>
+      <segment>
+        <source>Face Pull</source>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.farmer.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:43</note>
+      </notes>
+      <segment>
+        <source>Farmer&apos;s Walk</source>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.suitcase.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:44</note>
+      </notes>
+      <segment>
+        <source>Suitcase Carry</source>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.overhead.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:45</note>
+      </notes>
+      <segment>
+        <source>Overhead Carry</source>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.running.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:48</note>
+      </notes>
+      <segment>
         <source>Laufen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.walking.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:49</note>
+      </notes>
+      <segment>
+        <source>Gehen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.cycling.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:50</note>
+      </notes>
+      <segment>
+        <source>Radfahren</source>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.rowing.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:51</note>
+      </notes>
+      <segment>
+        <source>Rudern</source>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.swimming.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:52</note>
+      </notes>
+      <segment>
+        <source>Schwimmen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumprope.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:53</note>
+      </notes>
+      <segment>
+        <source>Seilspringen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.burpees.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:54</note>
+      </notes>
+      <segment>
+        <source>Burpees</source>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumpingjacks.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:55</note>
+      </notes>
+      <segment>
+        <source>Hampelmänner</source>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.highknees.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:56</note>
+      </notes>
+      <segment>
+        <source>High Knees</source>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.stretching.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:59</note>
+      </notes>
+      <segment>
+        <source>Dehnen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.yoga.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:60</note>
+      </notes>
+      <segment>
+        <source>Yoga</source>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.foamrolling.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:61</note>
+      </notes>
+      <segment>
+        <source>Faszienrolle</source>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.dynamicwarmup.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:62</note>
+      </notes>
+      <segment>
+        <source>Dynamisches Aufwärmen</source>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.catcow.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:63</note>
+      </notes>
+      <segment>
+        <source>Katze-Kuh</source>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.hipopener.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:64</note>
+      </notes>
+      <segment>
+        <source>Hüftöffner</source>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.benchpress.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:67</note>
+      </notes>
+      <segment>
+        <source>Bankdrücken</source>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.overheadpress.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:68</note>
+      </notes>
+      <segment>
+        <source>Schulterdrücken</source>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.deadlift.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:69</note>
+      </notes>
+      <segment>
+        <source>Kreuzheben</source>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellsquat.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:70</note>
+      </notes>
+      <segment>
+        <source>Langhantel-Kniebeuge</source>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellrow.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:71</note>
+      </notes>
+      <segment>
+        <source>Langhantelrudern</source>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.kettlebellswing.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:72</note>
+      </notes>
+      <segment>
+        <source>Kettlebell Swing</source>
       </segment>
     </unit>
     <unit id="analysis.bestStreaksTitle">
@@ -5661,7 +5985,7 @@
     </unit>
     <unit id="analysis.overview.uncategorisedNotice">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-overview.component.ts:58,61</note>
+        <note category="location">web/src/app/stats/shell/analysis-overview.component.ts:58,60</note>
       </notes>
       <segment>
         <source> Diese Einträge gehören zu keiner bekannten Kategorie — Aggregat unten. </source>
@@ -5669,7 +5993,7 @@
     </unit>
     <unit id="analysis.overview.empty">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-overview.component.ts:68,72</note>
+        <note category="location">web/src/app/stats/shell/analysis-overview.component.ts:67,71</note>
       </notes>
       <segment>
         <source> Im aktuellen Zeitraum gibt es noch keine Einträge. </source>
@@ -6596,15 +6920,15 @@
     </unit>
     <unit id="latEntryReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:242,244</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:243,245</note>
       </notes>
       <segment>
-        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ typeLabel(latest) }}"/> </source>
+        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ pushupTypeLabel(latest) }}"/> </source>
       </segment>
     </unit>
     <unit id="dashboard.noEntryYet">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:246,248</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:253,255</note>
       </notes>
       <segment>
         <source>Noch kein Eintrag.</source>
@@ -6612,7 +6936,7 @@
     </unit>
     <unit id="quickActionsTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:255,257</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:262,264</note>
       </notes>
       <segment>
         <source>Schnellaktionen</source>
@@ -6620,7 +6944,7 @@
     </unit>
     <unit id="quickActionsSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:258,260</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:265,267</note>
       </notes>
       <segment>
         <source>Schnell eintragen ohne Dialog</source>
@@ -6628,7 +6952,7 @@
     </unit>
     <unit id="quickActions.edit.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:265,266</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:272,273</note>
       </notes>
       <segment>
         <source>Schnellaktionen bearbeiten</source>
@@ -6636,7 +6960,7 @@
     </unit>
     <unit id="dashboard.quickAdd.button">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:287,288</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:294,295</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
@@ -6644,7 +6968,7 @@
     </unit>
     <unit id="dashboard.goalFill.reached">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:305,307</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:312,314</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -6652,7 +6976,7 @@
     </unit>
     <unit id="dashboard.goalFill.fill">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:308,309</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:315,316</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> bis zum Ziel</source>
@@ -6660,7 +6984,7 @@
     </unit>
     <unit id="quickAddNew">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:320,322</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:327,329</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">edit_note</pc> Neu </source>
@@ -6668,7 +6992,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:341,345</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:348,352</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -6676,7 +7000,7 @@
     </unit>
     <unit id="dashboard.latestEntriesLinkAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:352,353</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:359,360</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6684,7 +7008,7 @@
     </unit>
     <unit id="dashboard.latestEntries">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:355,356</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:362,363</note>
       </notes>
       <segment>
         <source>Letzte Einträge</source>
@@ -6692,7 +7016,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:362,363</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:369,370</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -6700,7 +7024,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:366,369</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:373,376</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -6708,7 +7032,7 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:372</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:379</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -6716,7 +7040,7 @@
     </unit>
     <unit id="dashboard.share.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:85</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:104</note>
       </notes>
       <segment>
         <source>Tagesleistung teilen</source>
@@ -6724,7 +7048,7 @@
     </unit>
     <unit id="dashboard.share">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:86</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:105</note>
       </notes>
       <segment>
         <source>Teilen</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -7250,5 +7250,263 @@
         <target>重播每日目标动画</target>
       </segment>
     </unit>
+      <unit id="exercise.category.push">
+      <segment state="initial">
+        <source>Drücken</source>
+        <target>Drücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pull">
+      <segment state="initial">
+        <source>Ziehen</source>
+        <target>Ziehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.squat">
+      <segment state="initial">
+        <source>Kniebeuge</source>
+        <target>Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.hinge">
+      <segment state="initial">
+        <source>Hüftbeuge</source>
+        <target>Hüftbeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.lunge">
+      <segment state="initial">
+        <source>Ausfallschritt</source>
+        <target>Ausfallschritt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.carry">
+      <segment state="initial">
+        <source>Tragen</source>
+        <target>Tragen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.core">
+      <segment state="initial">
+        <source>Rumpf</source>
+        <target>Rumpf</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.mobility">
+      <segment state="initial">
+        <source>Mobilität</source>
+        <target>Mobilität</target>
+      </segment>
+    </unit>
+    <unit id="exercise.category.strength">
+      <segment state="initial">
+        <source>Krafttraining</source>
+        <target>Krafttraining</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.deadbug.name">
+      <segment state="initial">
+        <source>Dead Bug</source>
+        <target>Dead Bug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.core.hollowhold.name">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.wallsit.name">
+      <segment state="initial">
+        <source>Wandsitz</source>
+        <target>Wandsitz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.squat.boxjump.name">
+      <segment state="initial">
+        <source>Box Jumps</source>
+        <target>Box Jumps</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.singlelegRdl.name">
+      <segment state="initial">
+        <source>Einbeiniges Kreuzheben</source>
+        <target>Einbeiniges Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.hinge.goodmorning.name">
+      <segment state="initial">
+        <source>Good Morning</source>
+        <target>Good Morning</target>
+      </segment>
+    </unit>
+    <unit id="exercise.lunge.stepup.name">
+      <segment state="initial">
+        <source>Step-ups</source>
+        <target>Step-ups</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.pullups.name">
+      <segment state="initial">
+        <source>Klimmzüge</source>
+        <target>Klimmzüge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.rows.name">
+      <segment state="initial">
+        <source>Ruderzug</source>
+        <target>Ruderzug</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.deadhang.name">
+      <segment state="initial">
+        <source>Dead Hang</source>
+        <target>Dead Hang</target>
+      </segment>
+    </unit>
+    <unit id="exercise.pull.facepull.name">
+      <segment state="initial">
+        <source>Face Pull</source>
+        <target>Face Pull</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.farmer.name">
+      <segment state="initial">
+        <source>Farmer&apos;s Walk</source>
+        <target>Farmer&apos;s Walk</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.suitcase.name">
+      <segment state="initial">
+        <source>Suitcase Carry</source>
+        <target>Suitcase Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.carry.overhead.name">
+      <segment state="initial">
+        <source>Overhead Carry</source>
+        <target>Overhead Carry</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.walking.name">
+      <segment state="initial">
+        <source>Gehen</source>
+        <target>Gehen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.cycling.name">
+      <segment state="initial">
+        <source>Radfahren</source>
+        <target>Radfahren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.rowing.name">
+      <segment state="initial">
+        <source>Rudern</source>
+        <target>Rudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.swimming.name">
+      <segment state="initial">
+        <source>Schwimmen</source>
+        <target>Schwimmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumprope.name">
+      <segment state="initial">
+        <source>Seilspringen</source>
+        <target>Seilspringen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.burpees.name">
+      <segment state="initial">
+        <source>Burpees</source>
+        <target>Burpees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.jumpingjacks.name">
+      <segment state="initial">
+        <source>Hampelmänner</source>
+        <target>Hampelmänner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.cardio.highknees.name">
+      <segment state="initial">
+        <source>High Knees</source>
+        <target>High Knees</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.stretching.name">
+      <segment state="initial">
+        <source>Dehnen</source>
+        <target>Dehnen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.yoga.name">
+      <segment state="initial">
+        <source>Yoga</source>
+        <target>Yoga</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.foamrolling.name">
+      <segment state="initial">
+        <source>Faszienrolle</source>
+        <target>Faszienrolle</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.dynamicwarmup.name">
+      <segment state="initial">
+        <source>Dynamisches Aufwärmen</source>
+        <target>Dynamisches Aufwärmen</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.catcow.name">
+      <segment state="initial">
+        <source>Katze-Kuh</source>
+        <target>Katze-Kuh</target>
+      </segment>
+    </unit>
+    <unit id="exercise.mobility.hipopener.name">
+      <segment state="initial">
+        <source>Hüftöffner</source>
+        <target>Hüftöffner</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.benchpress.name">
+      <segment state="initial">
+        <source>Bankdrücken</source>
+        <target>Bankdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.overheadpress.name">
+      <segment state="initial">
+        <source>Schulterdrücken</source>
+        <target>Schulterdrücken</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.deadlift.name">
+      <segment state="initial">
+        <source>Kreuzheben</source>
+        <target>Kreuzheben</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellsquat.name">
+      <segment state="initial">
+        <source>Langhantel-Kniebeuge</source>
+        <target>Langhantel-Kniebeuge</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.barbellrow.name">
+      <segment state="initial">
+        <source>Langhantelrudern</source>
+        <target>Langhantelrudern</target>
+      </segment>
+    </unit>
+    <unit id="exercise.strength.kettlebellswing.name">
+      <segment state="initial">
+        <source>Kettlebell Swing</source>
+        <target>Kettlebell Swing</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -7508,5 +7508,287 @@
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
+      <unit id="exercise.variant.situps.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.decline">
+      <segment state="initial">
+        <source>Decline</source>
+        <target>Decline</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.situps.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.reverse">
+      <segment state="initial">
+        <source>Reverse Crunches</source>
+        <target>Reverse Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.bicycle">
+      <segment state="initial">
+        <source>Bicycle Crunches</source>
+        <target>Bicycle Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.crunches.oblique">
+      <segment state="initial">
+        <source>Schräge Crunches</source>
+        <target>Schräge Crunches</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.lying">
+      <segment state="initial">
+        <source>Liegend</source>
+        <target>Liegend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-knee">
+      <segment state="initial">
+        <source>Hängend (Knie)</source>
+        <target>Hängend (Knie)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.legraises.hanging-straight">
+      <segment state="initial">
+        <source>Hängend (gestreckt)</source>
+        <target>Hängend (gestreckt)</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.russiantwist.weighted">
+      <segment state="initial">
+        <source>Mit Zusatzgewicht</source>
+        <target>Mit Zusatzgewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.mountainclimbers.cross-body">
+      <segment state="initial">
+        <source>Cross-Body</source>
+        <target>Cross-Body</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.forearm">
+      <segment state="initial">
+        <source>Unterarmstütz</source>
+        <target>Unterarmstütz</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.side">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.plank.reverse">
+      <segment state="initial">
+        <source>Umgekehrt</source>
+        <target>Umgekehrt</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bodyweight">
+      <segment state="initial">
+        <source>Eigengewicht</source>
+        <target>Eigengewicht</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.sumo">
+      <segment state="initial">
+        <source>Sumo</source>
+        <target>Sumo</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.goblet">
+      <segment state="initial">
+        <source>Goblet</source>
+        <target>Goblet</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.bulgarian-split">
+      <segment state="initial">
+        <source>Bulgarian Split</source>
+        <target>Bulgarian Split</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.squats.pistol">
+      <segment state="initial">
+        <source>Pistol</source>
+        <target>Pistol</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.calfraises.seated">
+      <segment state="initial">
+        <source>Sitzend</source>
+        <target>Sitzend</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.single-leg">
+      <segment state="initial">
+        <source>Einbeinig</source>
+        <target>Einbeinig</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.hip-thrust">
+      <segment state="initial">
+        <source>Hip Thrust</source>
+        <target>Hip Thrust</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.glutebridge.march">
+      <segment state="initial">
+        <source>Marching</source>
+        <target>Marching</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.forward">
+      <segment state="initial">
+        <source>Vorwärts</source>
+        <target>Vorwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.reverse">
+      <segment state="initial">
+        <source>Rückwärts</source>
+        <target>Rückwärts</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.walking">
+      <segment state="initial">
+        <source>Walking</source>
+        <target>Walking</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.lateral">
+      <segment state="initial">
+        <source>Seitlich</source>
+        <target>Seitlich</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.curtsy">
+      <segment state="initial">
+        <source>Curtsy</source>
+        <target>Curtsy</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.lunges.jumping">
+      <segment state="initial">
+        <source>Jumping</source>
+        <target>Jumping</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.standard">
+      <segment state="initial">
+        <source>Standard</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.chin-up">
+      <segment state="initial">
+        <source>Chin-up</source>
+        <target>Chin-up</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.wide-grip">
+      <segment state="initial">
+        <source>Breiter Griff</source>
+        <target>Breiter Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.neutral-grip">
+      <segment state="initial">
+        <source>Neutraler Griff</source>
+        <target>Neutraler Griff</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.negative">
+      <segment state="initial">
+        <source>Negativ</source>
+        <target>Negativ</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.assisted">
+      <segment state="initial">
+        <source>Assistiert</source>
+        <target>Assistiert</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.pullups.archer">
+      <segment state="initial">
+        <source>Archer</source>
+        <target>Archer</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.inverted">
+      <segment state="initial">
+        <source>Inverted Row</source>
+        <target>Inverted Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.australian">
+      <segment state="initial">
+        <source>Australian Row</source>
+        <target>Australian Row</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.dumbbell">
+      <segment state="initial">
+        <source>Kurzhantel</source>
+        <target>Kurzhantel</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.rows.barbell">
+      <segment state="initial">
+        <source>Langhantel</source>
+        <target>Langhantel</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -7270,8 +7270,8 @@
     </unit>
     <unit id="exercise.category.hinge">
       <segment state="initial">
-        <source>Hüftbeuge</source>
-        <target>Hüftbeuge</target>
+        <source>Hüftstreckung</source>
+        <target>Hüftstreckung</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">


### PR DESCRIPTION
Replace body-part labels (`abs`, `legs`, `plank`) with a movement-pattern
taxonomy (push / pull / squat / hinge / lunge / core / cardio / mobility)
so the picker reflects how the exercises train the body, not where
they hurt the next day.

Catalog changes:
- 8 categories actively shipped (was 5 populated + 2 empty), every one
  with at least one catalog exercise
- Variants on situps, crunches, leg raises, mountain climbers, squats,
  lunges, calf raises, glute bridge, plank, pullups, rows — 50+ new
  variant ids, wired through `variantDisplayName(variant)` so the
  dialog renders localized labels (e.g. "Cross-Body", "Breiter Griff")
  instead of raw ids
- New exercises: pull (pullups, rows, dead hang, face pull), hinge
  (single-leg RDL, good morning), lunge (step-up), cardio (walking,
  cycling, rowing, swimming, jump rope, burpees, jumping jacks, high
  knees), mobility (stretching, yoga, foam rolling, dynamic warmup,
  cat-cow, hip opener), core (dead bug, hollow hold)

**Deferred to a follow-up PR**:
- `carry` (distance measurement) and `strength` (weight measurement)
  categories — the training-entry dialog only renders `reps` / `time`
  / `distance-time` form rows. Both stay declared in
  `ExerciseCategoryId` for forward-compat but are intentionally absent
  from `EXERCISE_CATEGORIES` and the catalog. Surfacing them now would
  put users in front of a save-error path.

Legacy data stays valid:
- Exercise ids (`abs.situps`, `legs.squats`, `plank.standard`, …) are
  unchanged — only `categoryId` moves them under the new taxonomy
- `unifiedEntryCategoryId` maps legacy `kind: 'pushup'` entries onto
  the new `push` category; the kind discriminator itself stays
  `'pushup'` (it identifies the legacy Firestore collection)
- The dialog's stale-id fallback maps `abs.*` / `plank.*` / `legs.*`
  prefixes onto the new categories (parameterized regression test
  covers all three)

Firestore rules: `isRepsExerciseId` extended with every new reps id;
new `isTimeExerciseId` + `isDistanceTimeExerciseId` helpers wired
into both create and update branches. Reps cap raised to 10 000 to
accommodate jump rope / jumping jacks.

XLIFF: new translation units extracted into `messages.xlf` and synced
into every locale file via `tools/sync-xliff-units.mjs` with the German
source as a placeholder target. Locale `<target>` values are flagged
`state="initial"` for a separate native-speaker translation pass — the
production build's `i18nMissingTranslation: error` gate stays green
because every unit has a target.

https://claude.ai/code/session_01XY3VDHaZrGvKW1kGmttHKM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Restructured exercise categories with movement-pattern taxonomy: push, pull, squat, hinge, lunge, core, and mobility now replace previous groupings
  * Expanded exercise catalog with additional exercises across all categories and structured variant options
  * Enhanced multilingual localization for exercise names, categories, and variants across all supported languages
  * Improved exercise picker with better category organization and variant selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->