### PR TITLE
fix(goal-dialog): fire celebration when plan target is the daily goal

### DIFF
--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -188,12 +188,16 @@ describe('App (testing-library)', () => {
   });
 
   describe('toolbar goal-pill replay', () => {
-    function makeNotifierMock(): { reopen: ReturnType<typeof vitest.fn> } {
-      return { reopen: vitest.fn() };
+    function makeNotifierMock(): {
+      reopen: ReturnType<typeof vitest.fn>;
+      reopenPrimaryGoal: ReturnType<typeof vitest.fn>;
+    } {
+      return { reopen: vitest.fn(), reopenPrimaryGoal: vitest.fn() };
     }
 
     function commonProviders(notifierMock: {
       reopen: ReturnType<typeof vitest.fn>;
+      reopenPrimaryGoal: ReturnType<typeof vitest.fn>;
     }) {
       return [
         provideRouter([]),
@@ -254,8 +258,8 @@ describe('App (testing-library)', () => {
       await user.click(screen.getByTestId('toolbar-goal-pill'));
 
       // Then
-      expect(notifierMock.reopen).toHaveBeenCalledTimes(1);
-      expect(notifierMock.reopen).toHaveBeenCalledWith('daily');
+      expect(notifierMock.reopenPrimaryGoal).toHaveBeenCalledTimes(1);
+      expect(notifierMock.reopen).not.toHaveBeenCalled();
     });
 
     it('given the daily goal has NOT been reached, when the pill is clicked, then the notifier stays quiet', async () => {
@@ -285,6 +289,7 @@ describe('App (testing-library)', () => {
       await user.click(screen.getByTestId('toolbar-goal-pill'));
 
       // Then
+      expect(notifierMock.reopenPrimaryGoal).not.toHaveBeenCalled();
       expect(notifierMock.reopen).not.toHaveBeenCalled();
     });
 
@@ -381,8 +386,8 @@ describe('App (testing-library)', () => {
       );
 
       // Then
-      expect(notifierMock.reopen).toHaveBeenCalledTimes(1);
-      expect(notifierMock.reopen).toHaveBeenCalledWith('daily');
+      expect(notifierMock.reopenPrimaryGoal).toHaveBeenCalledTimes(1);
+      expect(notifierMock.reopen).not.toHaveBeenCalled();
     });
 
     it('replays the celebration when Space is pressed and suppresses the default page-scroll', async () => {
@@ -417,8 +422,8 @@ describe('App (testing-library)', () => {
       pill?.dispatchEvent(spaceEvent);
 
       // Then
-      expect(notifierMock.reopen).toHaveBeenCalledTimes(1);
-      expect(notifierMock.reopen).toHaveBeenCalledWith('daily');
+      expect(notifierMock.reopenPrimaryGoal).toHaveBeenCalledTimes(1);
+      expect(notifierMock.reopen).not.toHaveBeenCalled();
       expect(spaceEvent.defaultPrevented).toBe(true);
     });
 
@@ -456,6 +461,7 @@ describe('App (testing-library)', () => {
       );
 
       // Then
+      expect(notifierMock.reopenPrimaryGoal).not.toHaveBeenCalled();
       expect(notifierMock.reopen).not.toHaveBeenCalled();
     });
   });

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -349,12 +349,13 @@ export class App {
 
   /**
    * Toolbar "Tagesziel" pill click — when today's goal has already been
-   * reached, replay the snap-celebration dialog on demand. No-op while the
-   * pill is still counting up to the goal.
+   * reached, replay the snap-celebration dialog on demand. The notifier
+   * picks the right dialog kind (plan vs. daily) to match what the pill
+   * is showing. No-op while the pill is still counting up to the goal.
    */
   handleGoalPillClick(): void {
     if (!this.goalReached()) return;
-    this._goalReachedNotifier.reopen('daily');
+    this._goalReachedNotifier.reopenPrimaryGoal();
   }
 
   // Angular's strictTemplates mode types `$event` for `(keydown.*)` key-

--- a/web/src/app/core/goal-reached-notification.service.spec.ts
+++ b/web/src/app/core/goal-reached-notification.service.spec.ts
@@ -818,12 +818,11 @@ describe('GoalReachedNotificationService', () => {
   });
 
   describe('Given an active plan but no configured daily goal', () => {
-    it('Then the plan dialog stays silent (the daily-loading-state guard)', async () => {
-      // Given — no `dailyGoal` set in the user config (resource resolves to 0).
-      // The notification service can't distinguish "still loading" from
-      // "user never configured one", so plan-goal celebrations are gated
-      // on a non-zero configured daily goal. Locks the documented behaviour
-      // referenced in the planGoal comment block.
+    it('Then it opens the plan dialog when the plan target is reached', async () => {
+      // Given — only a plan is active (no dailyGoal configured). The toolbar
+      // pill labels the plan target as the "Tagesziel", so reaching it must
+      // celebrate via the plan-specific dialog (regression for #332 + #330:
+      // before this fix the dialog never fired at all in this scenario).
       setup({
         planTodayDay: {
           dayIndex: 1,
@@ -843,12 +842,165 @@ describe('GoalReachedNotificationService', () => {
       // When
       await flushAll();
 
-      // Then
+      // Then — plan dialog fires with the plan target.
       const planCall = dialogOpenSpy.mock.calls.find((call) => {
         const c = call[1] as { data?: { kind?: string } } | undefined;
         return c?.data?.kind === 'plan';
       });
-      expect(planCall).toBeUndefined();
+      expect(planCall).toBeDefined();
+      const [, planConfig] = planCall!;
+      expect(planConfig?.data).toMatchObject({
+        kind: 'plan',
+        total: 30,
+        goal: 30,
+      });
+      // And — no daily dialog (no configured daily goal to celebrate).
+      const dailyCall = dialogOpenSpy.mock.calls.find((call) => {
+        const c = call[1] as { data?: { kind?: string } } | undefined;
+        return c?.data?.kind === 'daily';
+      });
+      expect(dailyCall).toBeUndefined();
+    });
+
+    it('Then it stays silent while the plan target has not yet been reached', async () => {
+      // Given — only a plan is active, total below plan target.
+      setup({
+        planTodayDay: {
+          dayIndex: 1,
+          kind: 'main',
+          targetReps: 30,
+          description: '',
+        },
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 10,
+          } as PushupRecord,
+        ],
+      });
+
+      // When
+      await flushAll();
+
+      // Then
+      expect(dialogOpenSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Given the toolbar pill replays the primary goal', () => {
+    it('Then reopenPrimaryGoal() reopens the plan dialog when only a plan is active', async () => {
+      // Given — auto-fire opens the plan dialog once.
+      const service = setup({
+        planTodayDay: {
+          dayIndex: 1,
+          kind: 'main',
+          targetReps: 30,
+          description: '',
+        },
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 30,
+          } as PushupRecord,
+        ],
+      });
+      await flushAll();
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      dialogOpenSpy.mockClear();
+
+      // When
+      service.reopenPrimaryGoal();
+      await flushAll();
+
+      // Then
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      const [, config] = dialogOpenSpy.mock.calls[0];
+      expect(config?.data).toMatchObject({
+        kind: 'plan',
+        total: 30,
+        goal: 30,
+      });
+    });
+
+    it('Then reopenPrimaryGoal() reopens the daily dialog when daily is configured', async () => {
+      // Given
+      const service = setup({
+        dailyGoal: 10,
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 12,
+          } as PushupRecord,
+        ],
+      });
+      await flushAll();
+      dialogOpenSpy.mockClear();
+
+      // When
+      service.reopenPrimaryGoal();
+      await flushAll();
+
+      // Then
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      const [, config] = dialogOpenSpy.mock.calls[0];
+      expect(config?.data).toMatchObject({ kind: 'daily' });
+    });
+
+    it("Then reopenPrimaryGoal() prefers the plan dialog when both daily and plan have been crossed (matches the pill's plan-target label)", async () => {
+      // Given — daily=10, plan=50, total=50. Both auto-fire during setup.
+      const service = setup({
+        dailyGoal: 10,
+        planTodayDay: {
+          dayIndex: 1,
+          kind: 'main',
+          targetReps: 50,
+          description: '',
+        },
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 50,
+          } as PushupRecord,
+        ],
+      });
+      await flushAll();
+      dialogOpenSpy.mockClear();
+
+      // When
+      service.reopenPrimaryGoal();
+      await flushAll();
+
+      // Then — plan dialog wins (the toolbar pill shows the plan target).
+      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+      const [, config] = dialogOpenSpy.mock.calls[0];
+      expect(config?.data).toMatchObject({ kind: 'plan' });
+    });
+
+    it('Then reopenPrimaryGoal() no-ops when neither goal has been reached', async () => {
+      // Given
+      const service = setup({
+        dailyGoal: 100,
+        entries: [
+          {
+            _id: '1',
+            timestamp: '2026-04-22T08:00:00',
+            reps: 5,
+          } as PushupRecord,
+        ],
+      });
+      await flushAll();
+      dialogOpenSpy.mockClear();
+
+      // When
+      service.reopenPrimaryGoal();
+      await flushAll();
+
+      // Then
+      expect(dialogOpenSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/web/src/app/core/goal-reached-notification.service.ts
+++ b/web/src/app/core/goal-reached-notification.service.ts
@@ -112,23 +112,26 @@ export class GoalReachedNotificationService {
   });
 
   /**
-   * Plan-goal threshold: only fires when the plan target would actually
-   * be a stretch above the configured daily goal. When plan target ≤
-   * daily goal, the regular daily celebration already covers the
-   * milestone, so suppress the plan dialog to avoid a near-duplicate.
+   * Plan-goal threshold. Fires whenever the plan's daily target is
+   * reached, with one exception: when a configured daily goal already
+   * covers the plan target (daily ≥ plan), the daily celebration is
+   * enough and we suppress the plan dialog to avoid a near-duplicate.
    *
-   * Requires a configured daily goal (`> 0`) to disambiguate the
-   * `userConfig` resource's initial loading state (which returns `0`)
-   * from a real "daily goal less than plan" comparison. Users without
-   * a configured daily goal don't get this celebration — the regular
-   * daily one only fires once they configure a goal anyway.
+   * Users with only a plan (no configured daily goal) get the plan
+   * dialog as their primary celebration — the toolbar pill labels the
+   * plan target as the "Tagesziel", so reaching it deserves a snap.
+   *
+   * Gated on `userConfig.loaded()` so the resource's initial loading
+   * state (where `dailyGoal()` is `0` before the first emission) can't
+   * be mistaken for a user who genuinely has no configured daily goal.
    */
   private readonly planGoal = computed(() => {
     const planTarget = this.planTodayTarget();
     if (planTarget <= 0) return 0;
+    if (!this.userConfig.loaded()) return 0;
     const daily = this.userConfig.dailyGoal();
-    if (daily <= 0) return 0;
-    return planTarget > daily ? planTarget : 0;
+    if (daily > 0 && daily >= planTarget) return 0;
+    return planTarget;
   });
 
   private readonly specs: readonly GoalSpec[] = [
@@ -290,6 +293,26 @@ export class GoalReachedNotificationService {
     const maxParticleCount =
       SNAP_QUALITY_PARTICLES[this.userConfig.snapQuality()];
     void this.openDialog(kind, { total, goal, maxParticleCount });
+  }
+
+  /**
+   * Replay the celebration matching the toolbar "Tagesziel" pill. The
+   * pill displays the plan target when a plan is active (effective
+   * daily-goal semantics in `AppDataFacade`), so prefer 'plan' when
+   * it's the relevant dialog and fall back to 'daily' otherwise. No-op
+   * when neither has been reached.
+   */
+  reopenPrimaryGoal(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    for (const kind of ['plan', 'daily'] as const) {
+      const spec = this.specs.find((s) => s.kind === kind);
+      if (!spec) continue;
+      const goal = spec.goal();
+      if (goal <= 0) continue;
+      if (spec.total() < goal) continue;
+      this.reopen(kind);
+      return;
+    }
   }
 }
 

--- a/web/src/app/core/user-config.store.ts
+++ b/web/src/app/core/user-config.store.ts
@@ -46,6 +46,13 @@ export const UserConfigStore = signalStore(
     config: computed<UserConfig | null>(
       () => store.configResource.value() ?? null
     ),
+    /**
+     * True once the config resource has emitted at least once (either a
+     * real config doc or `null` for unauthenticated users). Lets callers
+     * distinguish "still loading" from "user never configured a daily
+     * goal" — both expose `dailyGoal() === 0` otherwise.
+     */
+    loaded: computed(() => store.configResource.value() !== undefined),
     dailyGoal: computed(() => store.configResource.value()?.dailyGoal ?? 0),
     weeklyGoal: computed(() => store.configResource.value()?.weeklyGoal ?? 0),
     monthlyGoal: computed(() => store.configResource.value()?.monthlyGoal ?? 0),


### PR DESCRIPTION
When a training plan is active without a separately configured daily
goal, the toolbar pill ("Tagesziel") shows the plan target as the
effective daily goal, but neither the daily nor the plan
goal-reached dialog fired on hitting it.

Root cause: `planGoal` required `userConfig.dailyGoal() > 0` to
disambiguate the resource's initial loading state from a real "no
daily configured" config. Replace that proxy with an explicit
`UserConfigStore.loaded` signal and let `planGoal` fire whenever the
plan target is reached (suppressed only when a configured daily goal
already covers it).

Toolbar pill replay now goes through a new
`GoalReachedNotificationService.reopenPrimaryGoal()` that picks 'plan'
or 'daily' to match what the pill is showing. Without this the pill
silently no-opped when only a plan was active (`reopen('daily')`
short-circuited on the zero daily goal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a primary-goal replay action that prefers the plan celebration when applicable.

* **Bug Fixes**
  * Fixed toolbar goal-pill replay to invoke the correct primary celebration and avoid duplicate triggers.

* **Improvements**
  * Plan celebration now respects configured daily goals; when none is set, plan targets can trigger celebrations.
  * Configuration loading now exposes a "loaded" state to distinguish loading vs no-config.

* **Tests**
  * Updated and expanded tests to cover replay behavior and plan/daily precedence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/334)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->