### PR TITLE
fix(analysis): aggregate time/distance entries by primary measurement value

### DIFF
--- a/libs/stats/src/lib/models/unified-entry.models.spec.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.spec.ts
@@ -3,6 +3,8 @@ import {
   pushupRecordToUnified,
   unifiedEntryCategoryId,
   unifiedEntryFilterKey,
+  unifiedEntryMeasurement,
+  unifiedEntryPrimaryValue,
 } from './unified-entry.models';
 import type { ExerciseDefinition, ExerciseEntry } from './exercise.models';
 import type { PushupRecord } from './pushup.models';
@@ -274,6 +276,198 @@ describe('unifiedEntryCategoryId', () => {
           resolver
         )
       ).toBe('mobility');
+    });
+  });
+});
+
+describe('unifiedEntryMeasurement', () => {
+  it('returns "reps" for any pushup entry', () => {
+    expect(
+      unifiedEntryMeasurement({
+        kind: 'pushup',
+        _id: 'p',
+        timestamp: 't',
+        reps: 1,
+        source: 'web',
+        variantType: null,
+      })
+    ).toBe('reps');
+  });
+
+  it('resolves the catalog measurement for known exercise ids', () => {
+    expect(
+      unifiedEntryMeasurement({
+        kind: 'exercise',
+        _id: 'e',
+        timestamp: 't',
+        reps: 0,
+        source: 'web',
+        exerciseId: 'plank.standard',
+        durationSec: 60,
+      })
+    ).toBe('time');
+
+    expect(
+      unifiedEntryMeasurement({
+        kind: 'exercise',
+        _id: 'e',
+        timestamp: 't',
+        reps: 30,
+        source: 'web',
+        exerciseId: 'abs.situps',
+      })
+    ).toBe('reps');
+  });
+
+  it('returns null when the exerciseId is not in the catalog', () => {
+    expect(
+      unifiedEntryMeasurement({
+        kind: 'exercise',
+        _id: 'e',
+        timestamp: 't',
+        reps: 1,
+        source: 'web',
+        exerciseId: 'custom-uuid',
+      })
+    ).toBeNull();
+  });
+});
+
+describe('unifiedEntryPrimaryValue', () => {
+  describe('Given a reps-measured entry (pushup or catalog rep exercise)', () => {
+    it('returns the reps count for pushups', () => {
+      expect(
+        unifiedEntryPrimaryValue({
+          kind: 'pushup',
+          _id: 'p',
+          timestamp: 't',
+          reps: 25,
+          source: 'web',
+          variantType: 'standard',
+        })
+      ).toBe(25);
+    });
+
+    it('returns the reps count for rep-measured catalog exercises', () => {
+      expect(
+        unifiedEntryPrimaryValue({
+          kind: 'exercise',
+          _id: 'e',
+          timestamp: 't',
+          reps: 30,
+          source: 'web',
+          exerciseId: 'abs.situps',
+        })
+      ).toBe(30);
+    });
+  });
+
+  describe('Given a time-measured entry (plank, hollow hold, …)', () => {
+    it('returns durationSec so the chart sees a non-zero contribution', () => {
+      // Regression: time-measured entries used to surface as `reps = 0`
+      // in the analysis chart, hiding planks/hollow holds from the
+      // graph entirely. The primary value must come off `durationSec`.
+      expect(
+        unifiedEntryPrimaryValue({
+          kind: 'exercise',
+          _id: 'e',
+          timestamp: 't',
+          reps: 0,
+          source: 'web',
+          exerciseId: 'plank.standard',
+          durationSec: 90,
+        })
+      ).toBe(90);
+    });
+
+    it('falls back to 0 when durationSec is missing', () => {
+      expect(
+        unifiedEntryPrimaryValue({
+          kind: 'exercise',
+          _id: 'e',
+          timestamp: 't',
+          reps: 0,
+          source: 'web',
+          exerciseId: 'plank.standard',
+        })
+      ).toBe(0);
+    });
+  });
+
+  describe('Given a distance-measured entry', () => {
+    it('returns distanceM for distance-time exercises like a tracked run', () => {
+      expect(
+        unifiedEntryPrimaryValue({
+          kind: 'exercise',
+          _id: 'e',
+          timestamp: 't',
+          reps: 0,
+          source: 'web',
+          exerciseId: 'cardio.running',
+          distanceM: 5000,
+          durationSec: 1650,
+        })
+      ).toBe(5000);
+    });
+  });
+
+  describe('Given an unknown exercise id (custom user exercise not resolved)', () => {
+    it('falls back to the first populated numeric field so the entry still contributes', () => {
+      expect(
+        unifiedEntryPrimaryValue({
+          kind: 'exercise',
+          _id: 'e',
+          timestamp: 't',
+          reps: 0,
+          source: 'web',
+          exerciseId: 'custom-uuid',
+          durationSec: 120,
+        })
+      ).toBe(120);
+    });
+
+    it('returns 0 when no numeric field is populated', () => {
+      expect(
+        unifiedEntryPrimaryValue({
+          kind: 'exercise',
+          _id: 'e',
+          timestamp: 't',
+          reps: 0,
+          source: 'web',
+          exerciseId: 'custom-uuid',
+        })
+      ).toBe(0);
+    });
+  });
+
+  describe('Given a custom resolver', () => {
+    it('uses the resolver to pick the right value field for custom exercises', () => {
+      const customDef: ExerciseDefinition = {
+        id: 'custom-uuid',
+        categoryId: 'core',
+        ownerId: 'u1',
+        measurement: 'time',
+        min: 1,
+        max: 1200,
+        unit: 's',
+        customName: 'Custom plank',
+      };
+      const resolver = (id: string) =>
+        id === 'custom-uuid' ? customDef : null;
+      expect(
+        unifiedEntryPrimaryValue(
+          {
+            kind: 'exercise',
+            _id: 'e',
+            timestamp: 't',
+            reps: 0,
+            source: 'web',
+            exerciseId: 'custom-uuid',
+            durationSec: 75,
+          },
+          resolver
+        )
+      ).toBe(75);
     });
   });
 });

--- a/libs/stats/src/lib/models/unified-entry.models.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.ts
@@ -165,11 +165,15 @@ export function unifiedEntryMeasurement(
  * `typeBreakdown` referred to as "until per-measurement charts land").
  *
  * Unknown exerciseIds (custom user exercises whose catalog entry the
- * caller didn't resolve) fall back to the first populated numeric
- * field so they still contribute a visible bar rather than vanishing.
- * Mixed-unit aggregation in a category that contains both reps and
- * time exercises is intentional for now — drilling into a single
- * measurement is a separate UX concern.
+ * caller didn't resolve) fall back to the first populated
+ * volume-meaningful field in the order `reps` → `durationSec` →
+ * `distanceM` so they still contribute a visible bar rather than
+ * vanishing. `weightKg` is intentionally excluded: it expresses load
+ * per rep rather than a volume, and summing it across entries has no
+ * sensible meaning for a chart bar height. Mixed-unit aggregation in
+ * a category that contains both reps and time exercises is intentional
+ * for now — drilling into a single measurement is a separate UX
+ * concern.
  */
 export function unifiedEntryPrimaryValue(
   entry: UnifiedEntry,

--- a/libs/stats/src/lib/models/unified-entry.models.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.ts
@@ -19,6 +19,7 @@ import type {
   ExerciseCategoryId,
   ExerciseDefinition,
   ExerciseEntry,
+  MeasurementType,
 } from './exercise.models';
 import type { PushupRecord } from './pushup.models';
 
@@ -129,4 +130,65 @@ export function unifiedEntryCategoryId(
 ): ExerciseCategoryId | null {
   if (entry.kind === 'pushup') return 'push';
   return resolveDefinition(entry.exerciseId)?.categoryId ?? null;
+}
+
+/**
+ * Returns the measurement type for an entry — the dimension its primary
+ * value lives on. Pushup entries are always `'reps'`. Exercise entries
+ * resolve through the catalog; an unknown `exerciseId` yields `null` so
+ * callers can decide whether to drop the row or fall back to a default.
+ */
+export function unifiedEntryMeasurement(
+  entry: UnifiedEntry,
+  resolveDefinition: (
+    id: string
+  ) => ExerciseDefinition | null = findExerciseDefinition
+): MeasurementType | null {
+  if (entry.kind === 'pushup') return 'reps';
+  return resolveDefinition(entry.exerciseId)?.measurement ?? null;
+}
+
+/**
+ * Volume value for time-bucket aggregations (analysis chart, week/month
+ * trends). The chart bar height per day/hour is `sum(primaryValue)`
+ * across the bucket's entries — so each entry must contribute on the
+ * dimension its measurement type lives on:
+ *
+ *   - `reps` / `weight` → `reps`
+ *   - `time`            → `durationSec`
+ *   - `distance` / `distance-time` → `distanceM`
+ *
+ * The legacy implementation summed `reps` unconditionally, which made
+ * planks, hollow holds and timed cardio surface as zero-height bars
+ * even when the user had logged them — that's the bug this helper
+ * fixes (and what the historical TODO in `analysis.store.ts`
+ * `typeBreakdown` referred to as "until per-measurement charts land").
+ *
+ * Unknown exerciseIds (custom user exercises whose catalog entry the
+ * caller didn't resolve) fall back to the first populated numeric
+ * field so they still contribute a visible bar rather than vanishing.
+ * Mixed-unit aggregation in a category that contains both reps and
+ * time exercises is intentional for now — drilling into a single
+ * measurement is a separate UX concern.
+ */
+export function unifiedEntryPrimaryValue(
+  entry: UnifiedEntry,
+  resolveDefinition: (
+    id: string
+  ) => ExerciseDefinition | null = findExerciseDefinition
+): number {
+  if (entry.kind === 'pushup') return entry.reps;
+  const measurement = resolveDefinition(entry.exerciseId)?.measurement;
+  switch (measurement) {
+    case 'reps':
+    case 'weight':
+      return entry.reps;
+    case 'time':
+      return entry.durationSec ?? 0;
+    case 'distance':
+    case 'distance-time':
+      return entry.distanceM ?? 0;
+    default:
+      return entry.reps || entry.durationSec || entry.distanceM || 0;
+  }
 }

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -33,6 +33,7 @@ import {
   unifiedEntryCategoryId,
   UnifiedEntryFilterKey,
   unifiedEntryFilterKey,
+  unifiedEntryPrimaryValue,
   UserStats,
 } from '@pu-stats/models';
 import { categoryDisplayName } from './i18n/exercise-display-names';
@@ -409,7 +410,8 @@ export const AnalysisStore = signalStore(
         const hourTotals = Array.from({ length: 24 }, () => 0);
         for (const row of rowsForView) {
           const hour = new Date(row.timestamp).getHours();
-          if (hour >= 0 && hour <= 23) hourTotals[hour] += row.reps;
+          if (hour >= 0 && hour <= 23)
+            hourTotals[hour] += unifiedEntryPrimaryValue(row);
         }
         let cumulative = 0;
         if (resolvedDayChartMode() === '24h') {
@@ -448,7 +450,7 @@ export const AnalysisStore = signalStore(
       const totals = new Map<string, number>();
       for (const row of rowsForView) {
         const day = row.timestamp.slice(0, 10);
-        totals.set(day, (totals.get(day) ?? 0) + row.reps);
+        totals.set(day, (totals.get(day) ?? 0) + unifiedEntryPrimaryValue(row));
       }
       const sortedDays = [...totals.keys()].sort((a, b) => a.localeCompare(b));
       let cumulative = 0;
@@ -465,11 +467,19 @@ export const AnalysisStore = signalStore(
      * "with sets" portion separately. Routing exercise entries through
      * here means a non-pushup tab gets its own stack rather than
      * silently borrowing the pushup `[entries]`.
+     *
+     * `reps` carries the entry's primary measurement value (so time /
+     * distance entries contribute their `durationSec` / `distanceM`)
+     * rather than the literal rep count — otherwise the chart's
+     * stacked-bar layer would render time-measured rows as zero even
+     * though {@link viewChartSeries} now sums them correctly. Sets are
+     * a reps/weight concept, so time-measured rows still fall into the
+     * "no sets" portion of the stack.
      */
     const viewChartEntries = computed<ChartFeedEntry[]>(() =>
       viewFilteredRows().map((row) => ({
         timestamp: row.timestamp,
-        reps: row.reps,
+        reps: unifiedEntryPrimaryValue(row),
         ...(row.sets ? { sets: row.sets } : {}),
       }))
     );
@@ -624,7 +634,7 @@ export const AnalysisStore = signalStore(
         const key = `${isoWeekYear(date)}-W${String(isoWeek(date)).padStart(2, '0')}`;
         const entry = byWeek.get(key);
         if (!entry) continue;
-        entry.total += row.reps;
+        entry.total += unifiedEntryPrimaryValue(row);
         entry.entryCount += 1;
         entry.setsCount += row.sets?.length ?? 0;
       }
@@ -668,7 +678,7 @@ export const AnalysisStore = signalStore(
         const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
         const entry = byMonth.get(key);
         if (!entry) continue;
-        entry.total += row.reps;
+        entry.total += unifiedEntryPrimaryValue(row);
         entry.entryCount += 1;
         entry.setsCount += row.sets?.length ?? 0;
       }

--- a/web/src/app/stats/shell/analysis-group-view.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.spec.ts
@@ -202,6 +202,70 @@ describe('AnalysisGroupViewComponent', () => {
     expect(headerToggle?.tagName.toLowerCase()).toBe('mat-button-toggle-group');
   });
 
+  it('viewChartSeries includes durationSec for time-measured exercises (regression: planks rendered as zero-height bars)', async () => {
+    // Regression: time-measured exercises (`plank.standard`,
+    // `core.hollowhold`, …) store their primary value on
+    // `durationSec`, not `reps`. The chart aggregation used to sum
+    // `row.reps` unconditionally, which made these entries surface as
+    // zero on the analysis graph — the user-visible bug.
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'plank.standard',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        durationSec: 60,
+        source: 'web',
+      } as ExerciseEntry,
+      {
+        _id: 'e2',
+        userId: 'u1',
+        exerciseId: 'plank.standard',
+        timestamp: '2026-02-12T09:00:00.000Z',
+        durationSec: 90,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('core');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const series = store.viewChartSeries();
+    const totals = Object.fromEntries(series.map((s) => [s.bucket, s.total]));
+    expect(totals['2026-02-10']).toBe(60);
+    expect(totals['2026-02-12']).toBe(90);
+  });
+
+  it('viewChartEntries surfaces durationSec on `reps` for time-measured rows so the stacked-bar layer also sees the volume', async () => {
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'plank.standard',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        durationSec: 75,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('core');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const entries = store.viewChartEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].reps).toBe(75);
+  });
+
   it('typeBreakdownDisplay localises bare exerciseIds in kind mode', async () => {
     // Regression: in kind mode (a non-pushup active view, or a kinds
     // filter that excludes pushups) the store emits raw catalog ids


### PR DESCRIPTION
Time-measured exercises (planks, hollow holds, …) and distance-measured
exercises store their primary value on `durationSec` / `distanceM`, not
`reps`. The analysis chart and week/month trends summed `row.reps`
unconditionally, so these entries surfaced as zero-height bars on the
graph even when the user had logged them.

Introduce `unifiedEntryPrimaryValue` that resolves the catalog
measurement type and returns the right field per entry, then wire it
through the four analysis-store aggregations (hourly + daily chart
series, chart entries feed for sets-stacking, week trend, month trend).
Unknown exerciseIds fall back to the first populated numeric field so
custom user exercises still contribute a visible bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charts and analysis now use a unified primary measurement per entry so time, distance, rep, and custom exercises contribute correctly.

* **Bug Fixes**
  * Fixed zero or missing bars for time- and distance-based activities; unknown/custom exercises now surface via sensible fallback values.

* **Tests**
  * Added regression tests ensuring time-measured entries (e.g., planks) and other measurement types appear correctly in charts and totals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/335)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->