### PR TITLE
feat(app): make ngsw update toast sticky + top-anchored

### DIFF
--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -876,6 +876,56 @@ describe('App (testing-library)', () => {
       expect(reloadCall?.[0]).toBe('Neue Version verfügbar');
     });
 
+    // Regression: a 20s auto-dismiss + bottom anchor meant the prompt was
+    // easy to miss (mobile bottom-nav clipped it; tabbing away wiped it).
+    // The update toast must now be sticky and top-anchored so the user can
+    // always act on it, with a distinct panelClass for styling.
+    it('opens the update snackbar sticky at top-center with the sw-update panelClass', async () => {
+      const swUpdate = makeSwUpdateMock();
+      const openSpy = vitest
+        .spyOn(MatSnackBar.prototype, 'open')
+        .mockReturnValue({
+          onAction: () => of(undefined),
+          afterDismissed: () => of({ dismissedByAction: false }),
+        } as unknown as ReturnType<MatSnackBar['open']>);
+
+      await render(App, {
+        providers: [
+          provideRouter([]),
+          { provide: PLATFORM_ID, useValue: 'browser' },
+          {
+            provide: UserContextService,
+            useValue: {
+              userNameSafe: userNameSignal.asReadonly(),
+              userIdSafe: () => 'u1',
+              isAdmin: () => false,
+              isGuest: () => false,
+            },
+          },
+          { provide: AuthStore, useValue: authMock },
+          { provide: AuthService, useValue: authServiceMock },
+          { provide: Auth, useValue: firebaseAuthMock },
+          { provide: UserConfigApiService, useValue: userConfigApiMock },
+          { provide: StatsApiService, useValue: statsApiMock },
+          { provide: AdsStore, useValue: adsStoreMock },
+          { provide: VAPID_PUBLIC_KEY, useValue: 'test-vapid-key' },
+          { provide: SwUpdate, useValue: swUpdate },
+        ],
+      });
+
+      swUpdate.emit({ type: 'VERSION_READY' });
+
+      const reloadCall = openSpy.mock.calls.find(
+        ([, action]) => action === 'Neu laden'
+      );
+      expect(reloadCall).toBeTruthy();
+      const config = reloadCall?.[2];
+      expect(config?.duration).toBeUndefined();
+      expect(config?.horizontalPosition).toBe('center');
+      expect(config?.verticalPosition).toBe('top');
+      expect(config?.panelClass).toBe('sw-update-snackbar');
+    });
+
     // Regression: a non-actionable "downloading in background" toast used to
     // fire on VERSION_DETECTED, visually replacing the actionable reload toast
     // and leaving users with no way to apply the update.

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -300,13 +300,19 @@ export class App {
         .subscribe((event) => {
           if (event.type !== 'VERSION_READY') return;
 
+          // Sticky (no `duration`) + top-center: the prompt sits at eye level
+          // and stays put until the user clicks "Neu laden". An auto-dismiss
+          // timer made the toast easy to miss (especially when the mobile
+          // bottom-nav cropped the bottom-anchored variant). Distinct
+          // panelClass lets `styles.scss` give it its own surface colour so
+          // it doesn't get mistaken for a routine info toast.
           const ref = this.snackBar.open(
             $localize`:@@sw.update.available:Neue Version verfügbar`,
             $localize`:@@sw.update.reload:Neu laden`,
             {
-              duration: 20_000,
               horizontalPosition: 'center',
-              verticalPosition: 'bottom',
+              verticalPosition: 'top',
+              panelClass: 'sw-update-snackbar',
             }
           );
 

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -210,6 +210,27 @@ mat-card-header + mat-card-footer {
   font-weight: 600;
 }
 
+// ngsw update available — top-anchored, primary container so it reads as an
+// actionable system prompt distinct from the early-access notice. Clears the
+// 64px sticky toolbar like the early-access toast.
+.sw-update-snackbar {
+  margin-top: 72px;
+}
+
+.sw-update-snackbar .mdc-snackbar__surface {
+  background: var(--mat-sys-primary-container, #d0e4ff) !important;
+  color: var(--mat-sys-on-primary-container, #001c38) !important;
+}
+
+.sw-update-snackbar .mdc-snackbar__label {
+  color: var(--mat-sys-on-primary-container, #001c38) !important;
+}
+
+.sw-update-snackbar .mat-mdc-button {
+  color: var(--mat-sys-on-primary-container, #001c38) !important;
+  font-weight: 600;
+}
+
 // Goal-reached celebration dialog: the .goal-card paints its own gold-gradient
 // frame on a ::before pseudo, and the @wolsok/thanos snap animation rasterises
 // the card into a particle canvas that flows beyond the dialog bounds.


### PR DESCRIPTION
## Summary

- The actionable `VERSION_READY` snackbar was firing, but a 20 s auto-dismiss + bottom anchor made it effectively invisible: on mobile the fixed `.bottom-nav` clipped it, and tabbing away wiped the prompt before the user could click **Neu laden**.
- Pin the update toast at `top-center`, drop the duration so it stays until the user activates it, and give it a `sw-update-snackbar` panelClass painted in the primary container colour so it reads as a system prompt distinct from the early-access notice.
- Scope filter unchanged: still only opens for ngsw `VERSION_READY` events — the separate push SW at `/{locale}/push/` is not wired through `SwUpdate` and cannot trigger this toast.

## Test plan

- [x] `pnpm nx test web` (new regression spec asserts position / sticky / panelClass; existing VERSION_READY / VERSION_DETECTED / activateUpdate / 10-min poll specs still pass)
- [x] `pnpm nx lint web`
- [x] `pnpm nx run web:build -c production` (prerender succeeds, i18n IDs `@@sw.update.available` / `@@sw.update.reload` already present in all 10 XLF files)
- [ ] Smoke after merge: deploy a new build, confirm the toast appears at top-center and persists until **Neu laden** is clicked.

https://claude.ai/code/session_01AVRZ1at1iaFdNGX4XRhtCM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVRZ1at1iaFdNGX4XRhtCM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Service worker update notifications now remain permanently displayed at the top-center of the screen. The improved positioning and persistent visibility ensure users are always aware when a new version is available and can review updates at their convenience without the notification disappearing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/336)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->