### PR TITLE
feat(catalog): separate pushup category from generic push movement

### DIFF
--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -24,6 +24,9 @@ service cloud.firestore {
         'squat.boxjump',
         'hinge.singlelegRdl', 'hinge.goodmorning',
         'lunge.stepup',
+        // push — non-pushup pressing (pushup variants stay on the
+        // legacy `pushups` collection with their own rule above)
+        'push.dips', 'push.benchdips',
         // pull — bodyweight pulling
         'pull.pullups', 'pull.rows', 'pull.facepull',
         // cardio reps-counted conditioning
@@ -38,6 +41,7 @@ service cloud.firestore {
         'plank.standard',
         'core.hollowhold',
         'squat.wallsit',
+        'push.handstandhold',
         'pull.deadhang',
         'cardio.highknees',
         'mobility.stretching', 'mobility.yoga', 'mobility.foamrolling',

--- a/libs/stats/src/lib/models/exercise.catalog.spec.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.spec.ts
@@ -20,11 +20,15 @@ describe('EXERCISE_CATEGORIES', () => {
 
   it('ships the dialog-supported movement-pattern categories', () => {
     const ids = new Set(EXERCISE_CATEGORIES.map((c) => c.id));
+    // `pushup` is kept as a dedicated bucket separate from `push`
+    // because the app is called "PushUps" — Liegestütze are the
+    // headline workout and deserve their own dashboard card.
     // `carry` (distance) and `strength` (weight) stay declared in
     // ExerciseCategoryId but are intentionally absent from
     // EXERCISE_CATEGORIES until the training-entry dialog grows
     // weight + distance form support — see catalog header comment.
     for (const id of [
+      'pushup',
       'push',
       'pull',
       'squat',
@@ -109,12 +113,30 @@ describe('EXERCISE_CATALOG', () => {
     expect(running?.max).toBeGreaterThanOrEqual(50_000);
   });
 
-  it('ships pull/hinge/mobility exercises', () => {
+  it('ships push (non-pushup) / pull / hinge / mobility exercises', () => {
     const ids = new Set(EXERCISE_CATALOG.map((d) => d.id));
+    expect(ids.has('push.dips')).toBe(true);
+    expect(ids.has('push.benchdips')).toBe(true);
+    expect(ids.has('push.handstandhold')).toBe(true);
     expect(ids.has('pull.pullups')).toBe(true);
     expect(ids.has('pull.rows')).toBe(true);
     expect(ids.has('hinge.singlelegRdl')).toBe(true);
     expect(ids.has('mobility.stretching')).toBe(true);
+  });
+
+  it('keeps pushup variants out of the new push category', () => {
+    // Liegestütze stay on the legacy `pushups` Firestore collection
+    // via `PushupRecord`; the `push` catalog category is reserved for
+    // non-pushup pressing movements (dips, handstand). The catalog
+    // must not double-list any pushup variant under push.dips* or
+    // similar.
+    const pushIds = EXERCISE_CATALOG.filter((d) => d.categoryId === 'push').map(
+      (d) => d.id
+    );
+    for (const id of pushIds) {
+      expect(id.startsWith('push.')).toBe(true);
+      expect(id).not.toMatch(/pushup/i);
+    }
   });
 
   it('does not yet ship distance- or weight-measured catalog entries', () => {

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -14,14 +14,23 @@ import type {
  * Existing user entries reference exercises by id, not by category, so
  * recategorizing an exercise (e.g. moving `legs.squats` into the
  * `squat` category) is a UI-only change — no Firestore migration is
- * needed. Legacy entries in the `pushups` collection map to the `push`
- * category via {@link import('./unified-entry.models').unifiedEntryCategoryId}.
+ * needed. Legacy entries in the `pushups` collection map to the
+ * `pushup` category via
+ * {@link import('./unified-entry.models').unifiedEntryCategoryId}, so
+ * Liegestütze keep their dedicated bucket separate from the generic
+ * `push` movement-pattern category.
  */
 export const EXERCISE_CATEGORIES: ReadonlyArray<ExerciseCategoryInfo> = [
   {
+    id: 'pushup',
+    nameKey: '@@exercise.category.pushup',
+    icon: 'fitness_center',
+    order: 5,
+  },
+  {
     id: 'push',
     nameKey: '@@exercise.category.push',
-    icon: 'fitness_center',
+    icon: 'open_with',
     order: 10,
   },
   {
@@ -478,6 +487,54 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     unit: 'reps',
     nameKey: '@@exercise.lunge.stepup.name',
     icon: 'stairs',
+  },
+
+  {
+    id: 'push.dips',
+    categoryId: 'push',
+    measurement: 'reps',
+    min: 1,
+    max: 200,
+    unit: 'reps',
+    nameKey: '@@exercise.push.dips.name',
+    icon: 'open_with',
+    variants: [
+      {
+        id: 'parallel',
+        nameKey: '@@exercise.variant.dips.parallel',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'straight-bar',
+        nameKey: '@@exercise.variant.dips.straight-bar',
+        difficulty: 'intermediate',
+      },
+      {
+        id: 'ring',
+        nameKey: '@@exercise.variant.dips.ring',
+        difficulty: 'advanced',
+      },
+    ],
+  },
+  {
+    id: 'push.benchdips',
+    categoryId: 'push',
+    measurement: 'reps',
+    min: 1,
+    max: 300,
+    unit: 'reps',
+    nameKey: '@@exercise.push.benchdips.name',
+    icon: 'open_with',
+  },
+  {
+    id: 'push.handstandhold',
+    categoryId: 'push',
+    measurement: 'time',
+    min: 1,
+    max: 600,
+    unit: 's',
+    nameKey: '@@exercise.push.handstandhold.name',
+    icon: 'open_with',
   },
 
   {

--- a/libs/stats/src/lib/models/exercise.models.ts
+++ b/libs/stats/src/lib/models/exercise.models.ts
@@ -21,7 +21,8 @@ export type MeasurementType =
  * fitness) rather than body-part labels, with one isolation bucket
  * (`cardio`, `mobility`, `strength`) per cross-pattern concern:
  *
- *   push   — horizontal/vertical pressing (pushups, dips, pike pushup)
+ *   pushup — bodyweight pushup variants (legacy `pushups` collection)
+ *   push   — other horizontal/vertical pressing (dips, handstand hold)
  *   pull   — vertical/horizontal pulling (pull-ups, rows)
  *   squat  — knee-dominant lower body (squat variants, calf raise)
  *   hinge  — hip-dominant lower body (glute bridge, hip thrust)
@@ -31,8 +32,14 @@ export type MeasurementType =
  *   cardio — sustained conditioning (run, bike, row, jump rope, burpee)
  *   mobility — flexibility, joint prep (stretching, yoga, foam roll)
  *   strength — barbell/dumbbell compound lifts measured in load × reps
+ *
+ * `pushup` is kept as a separate category from `push` because the app
+ * is called "PushUps" — pushup variants are the headline workout and
+ * deserve their own bucket on the dashboard. Other pressing movements
+ * (dips, handstand) live in `push`.
  */
 export type ExerciseCategoryId =
+  | 'pushup'
   | 'push'
   | 'pull'
   | 'squat'

--- a/libs/stats/src/lib/models/unified-entry.models.spec.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.spec.ts
@@ -165,7 +165,7 @@ describe('unifiedEntryFilterKey', () => {
 
 describe('unifiedEntryCategoryId', () => {
   describe('Given a pushup entry', () => {
-    it('returns "push" regardless of variant', () => {
+    it('returns "pushup" regardless of variant', () => {
       expect(
         unifiedEntryCategoryId({
           kind: 'pushup',
@@ -175,7 +175,7 @@ describe('unifiedEntryCategoryId', () => {
           source: 'web',
           variantType: 'diamond',
         })
-      ).toBe('push');
+      ).toBe('pushup');
       expect(
         unifiedEntryCategoryId({
           kind: 'pushup',
@@ -185,7 +185,7 @@ describe('unifiedEntryCategoryId', () => {
           source: 'web',
           variantType: null,
         })
-      ).toBe('push');
+      ).toBe('pushup');
     });
   });
 

--- a/libs/stats/src/lib/models/unified-entry.models.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.ts
@@ -113,13 +113,16 @@ export function unifiedEntryFilterKey(
 /**
  * Maps a UnifiedEntry to the exercise category it belongs to. Legacy
  * pushup entries (kind `'pushup'`, served from the legacy `pushups`
- * collection) always map to the `'push'` movement-pattern category.
- * Exercise entries are resolved via the catalog — `resolveDefinition`
- * defaults to {@link findExerciseDefinition} but can be overridden when
- * the analysis page needs to resolve custom user exercises that live
- * outside the standard catalog. Returns `null` when the exercise id is
- * not resolvable, so callers can decide whether to bucket the entry
- * into an "unknown" group or drop it.
+ * collection) always map to the dedicated `'pushup'` category so
+ * Liegestütze keep their own dashboard bucket — the generic `push`
+ * movement-pattern category is reserved for non-pushup pressing
+ * movements (dips, handstand). Exercise entries are resolved via the
+ * catalog — `resolveDefinition` defaults to
+ * {@link findExerciseDefinition} but can be overridden when the
+ * analysis page needs to resolve custom user exercises that live
+ * outside the standard catalog. Returns `null` when the exercise id
+ * is not resolvable, so callers can decide whether to bucket the
+ * entry into an "unknown" group or drop it.
  */
 export function unifiedEntryCategoryId(
   entry: UnifiedEntry,
@@ -127,6 +130,6 @@ export function unifiedEntryCategoryId(
     id: string
   ) => ExerciseDefinition | null = findExerciseDefinition
 ): ExerciseCategoryId | null {
-  if (entry.kind === 'pushup') return 'push';
+  if (entry.kind === 'pushup') return 'pushup';
   return resolveDefinition(entry.exerciseId)?.categoryId ?? null;
 }

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -689,15 +689,14 @@ export const AnalysisStore = signalStore(
       const kinds = store.kinds();
       const kindSet = kinds.length > 0 ? new Set<string>(kinds) : null;
       // In a per-category tab the pushup-variant breakdown only makes
-      // sense for the push tab (which collapses legacy pushups into
-      // the movement-pattern category); every other category renders
-      // the kind-mode breakdown over its own entries. In overview the
-      // legacy gate stays so a default page still shows pushup
-      // variants when no kind filter is active. The kind filter key
-      // remains `'pushup'` — it identifies the legacy Firestore
-      // collection, distinct from the `'push'` category id.
+      // sense for the dedicated `pushup` tab (Liegestütze); every
+      // other category — including the generic `push` movement-pattern
+      // bucket (dips, handstand) — renders the kind-mode breakdown
+      // over its own entries. In overview the legacy gate stays so a
+      // default page still shows pushup variants when no kind filter
+      // is active.
       const showPushupVariants =
-        view === 'push' ||
+        view === 'pushup' ||
         (view === 'overview' &&
           (!kindSet || (kindSet.size === 1 && kindSet.has('pushup'))));
 

--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
@@ -140,11 +140,11 @@ export class AnalysisTeaserCardComponent {
 
   private readonly allExercisesLabel = $localize`:@@chart.kindLabel.all:Alle Übungen`;
   /**
-   * Push-movement label reused from the analysis page i18n catalog so we
-   * don't spawn a parallel XLIFF unit. Used to label legacy-pushup data
-   * surfaced on the teaser chart.
+   * Pushup label reused from the analysis page i18n catalog so we
+   * don't spawn a parallel XLIFF unit. Used to label legacy-pushup
+   * data surfaced on the teaser chart.
    */
-  private readonly pushupLabel = $localize`:@@exercise.category.push:Drücken`;
+  private readonly pushupLabel = $localize`:@@exercise.category.pushup:Liegestütze`;
 
   /** Exposed for the template's error-fallback gate. */
   readonly liveConnected = computed(() => this.live.connected());

--- a/web/src/app/stats/components/category-summary-card/category-summary-card.component.spec.ts
+++ b/web/src/app/stats/components/category-summary-card/category-summary-card.component.spec.ts
@@ -18,8 +18,8 @@ import { CategorySummaryCardComponent } from './category-summary-card.component'
 })
 class HostComponent {
   readonly summary = signal<CategorySummary>({
-    categoryId: 'push',
-    nameKey: '@@exercise.category.push',
+    categoryId: 'pushup',
+    nameKey: '@@exercise.category.pushup',
     icon: 'fitness_center',
     order: 10,
     totalReps: 123,
@@ -46,9 +46,9 @@ describe('CategorySummaryCardComponent', () => {
     const host: HTMLElement = fixture.nativeElement;
     // TestBed default locale is `de` — categoryDisplayName returns the
     // German source string.
-    expect(host.textContent).toContain('Drücken');
+    expect(host.textContent).toContain('Liegestütze');
     const totalReps = host.querySelector(
-      '[data-testid="category-summary-card-totalReps-push"]'
+      '[data-testid="category-summary-card-totalReps-pushup"]'
     );
     expect(totalReps?.textContent?.trim()).toBe('123');
   });
@@ -66,11 +66,11 @@ describe('CategorySummaryCardComponent', () => {
   it('emits the categoryId when the details button is clicked', () => {
     const host: HTMLElement = fixture.nativeElement;
     const button = host.querySelector(
-      '[data-testid="category-summary-card-drilldown-push"]'
+      '[data-testid="category-summary-card-drilldown-pushup"]'
     ) as HTMLButtonElement;
     expect(button).toBeTruthy();
     button.click();
-    expect(fixture.componentInstance.lastEmitted()).toBe('push');
+    expect(fixture.componentInstance.lastEmitted()).toBe('pushup');
   });
 
   it('carries a category-scoped data-testid so multiple cards stay addressable', () => {

--- a/web/src/app/stats/components/stats-table/stats-table.component.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.ts
@@ -197,7 +197,7 @@ export class StatsTableComponent {
 
   exerciseLabel(entry: UnifiedEntry): string {
     if (entry.kind === 'pushup') {
-      return $localize`:@@exercise.category.push:Drücken`;
+      return $localize`:@@exercise.category.pushup:Liegestütze`;
     }
     const def = findExerciseDefinition(entry.exerciseId);
     if (!def) return entry.exerciseId;

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
@@ -31,7 +31,7 @@ describe('TrainingEntryDialogComponent', () => {
     it('defaults to the pushup category and synthetic exercise id', () => {
       const { component } = createDialog(null);
 
-      expect(component.category()).toBe('push');
+      expect(component.category()).toBe('pushup');
       expect(component.mode()).toBe('pushup');
       expect(component.isEditMode).toBe(false);
     });
@@ -168,14 +168,14 @@ describe('TrainingEntryDialogComponent', () => {
       });
 
       expect(component.isEditMode).toBe(true);
-      expect(component.category()).toBe('push');
+      expect(component.category()).toBe('pushup');
       expect(component.sets()).toEqual([10, 10, 10]);
       expect(component.pushupTypeControl.value).toBe('diamond');
       expect(component.sourceControl.value).toBe('whatsapp');
       // Edit mode must not allow moving an entry between collections,
       // so the category-change handler is a no-op.
       component.onCategoryChange('core');
-      expect(component.category()).toBe('push');
+      expect(component.category()).toBe('pushup');
     });
 
     it('preserves the original ISO timestamp when the user does not touch the field', () => {

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
@@ -592,21 +592,23 @@ export class TrainingEntryDialogComponent {
   readonly category = signal<ExerciseCategoryId>(this.initialCategory());
 
   /**
-   * Catalog exercise id when category !== 'push'. Defaults to the
-   * first exercise of the chosen category. For the push category the
-   * value is the synthetic {@link PUSHUP_EXERCISE_ID} so the picker can
-   * show a single entry without a real catalog row — the legacy
-   * `pushups` Firestore collection has no `ExerciseDefinition`.
+   * Catalog exercise id when category !== 'pushup'. Defaults to the
+   * first exercise of the chosen category. For the `pushup` category
+   * (Liegestütze) the value is the synthetic {@link PUSHUP_EXERCISE_ID}
+   * so the picker can show a single entry without a real catalog row —
+   * the legacy `pushups` Firestore collection has no
+   * `ExerciseDefinition`. Other push exercises (dips, handstand) live
+   * in the separate `push` category as normal catalog entries.
    */
   readonly exerciseId = signal<string>(this.initialExerciseId());
 
   readonly mode = computed<'pushup' | 'exercise'>(() =>
-    this.category() === 'push' ? 'pushup' : 'exercise'
+    this.category() === 'pushup' ? 'pushup' : 'exercise'
   );
 
   readonly exerciseOptions = computed<ExerciseOption[]>(() => {
     const cat = this.category();
-    if (cat === 'push') {
+    if (cat === 'pushup') {
       return [
         {
           value: PUSHUP_EXERCISE_ID,
@@ -848,7 +850,7 @@ export class TrainingEntryDialogComponent {
     // Reset exercise to the first option of the new category. Reset
     // measurement-specific inputs so a stale value from a previously
     // selected exercise can't leak through to the new one.
-    if (next === 'push') {
+    if (next === 'pushup') {
       this.exerciseId.set(PUSHUP_EXERCISE_ID);
     } else {
       const defs = exercisesByCategory().get(next) ?? [];
@@ -1017,8 +1019,8 @@ export class TrainingEntryDialogComponent {
   // ----- helpers ----------------------------------------------------------
 
   private initialCategory(): ExerciseCategoryId {
-    if (!this.data) return 'push';
-    if (this.data.kind === 'pushup') return 'push';
+    if (!this.data) return 'pushup';
+    if (this.data.kind === 'pushup') return 'pushup';
     const def = findExerciseDefinition(this.data.exerciseId);
     if (def) return def.categoryId;
     // Stale exerciseId (renamed/removed in the catalog): stay in
@@ -1095,6 +1097,7 @@ export class TrainingEntryDialogComponent {
 }
 
 const CATEGORY_NAMES: Record<ExerciseCategoryId, () => string> = {
+  pushup: () => $localize`:@@exercise.category.pushup:Liegestütze`,
   push: () => $localize`:@@exercise.category.push:Drücken`,
   pull: () => $localize`:@@exercise.category.pull:Ziehen`,
   squat: () => $localize`:@@exercise.category.squat:Kniebeuge`,
@@ -1113,7 +1116,7 @@ function buildCategoryOptions(): ReadonlyArray<CategoryOption> {
   // any catalog category with at least one ExerciseDefinition.
   const byCategory = exercisesByCategory();
   return EXERCISE_CATEGORIES.filter(
-    (cat) => cat.id === 'push' || (byCategory.get(cat.id)?.length ?? 0) > 0
+    (cat) => cat.id === 'pushup' || (byCategory.get(cat.id)?.length ?? 0) > 0
   ).map((cat) => ({
     value: cat.id,
     label: (CATEGORY_NAMES[cat.id] ?? (() => cat.id))(),
@@ -1200,10 +1203,10 @@ function inferExerciseCategory(
     return LEGACY_PREFIX_MAP[prefix];
   }
   const known = EXERCISE_CATEGORIES.find((c) => c.id === prefix);
-  if (known && known.id !== 'push') return known.id;
+  if (known && known.id !== 'pushup') return known.id;
   const byCategory = exercisesByCategory();
   const fallback = EXERCISE_CATEGORIES.find(
-    (c) => c.id !== 'push' && (byCategory.get(c.id)?.length ?? 0) > 0
+    (c) => c.id !== 'pushup' && (byCategory.get(c.id)?.length ?? 0) > 0
   );
   return fallback?.id ?? 'core';
 }

--- a/web/src/app/stats/i18n/exercise-display-names.spec.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.spec.ts
@@ -22,11 +22,11 @@ describe('exerciseDisplayName', () => {
 });
 
 describe('kindDisplayName', () => {
-  it('returns the push movement-pattern label for the legacy pushup filter key', () => {
-    // The filter-key string stays `'pushup'` (it identifies the legacy
-    // Firestore collection) but the displayed label now uses the
-    // movement-pattern translation unit.
-    expect(kindDisplayName('pushup')).toBe('Drücken');
+  it('returns the Liegestütze label for the legacy pushup filter key', () => {
+    // Pushup variants keep their own dedicated bucket separate from
+    // the generic `push` movement-pattern category, so the legacy
+    // filter key `'pushup'` resolves to "Liegestütze".
+    expect(kindDisplayName('pushup')).toBe('Liegestütze');
   });
 
   it('resolves a catalog exerciseId to its display name', () => {
@@ -63,6 +63,7 @@ describe('variantDisplayName', () => {
 
 describe('categoryDisplayName', () => {
   it('returns the German source label for the movement-pattern categories', () => {
+    expect(categoryDisplayName('pushup')).toBe('Liegestütze');
     expect(categoryDisplayName('push')).toBe('Drücken');
     expect(categoryDisplayName('pull')).toBe('Ziehen');
     expect(categoryDisplayName('squat')).toBe('Kniebeuge');

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -34,6 +34,12 @@ const EXERCISE_DISPLAY_NAMES: Record<string, string> = {
   'legs.lunges': $localize`:@@exercise.legs.lunges.name:Ausfallschritte`,
   'lunge.stepup': $localize`:@@exercise.lunge.stepup.name:Step-ups`,
 
+  // push (non-pushup pressing movements — pushup variants live on the
+  // legacy `pushups` collection, not in this map)
+  'push.dips': $localize`:@@exercise.push.dips.name:Dips`,
+  'push.benchdips': $localize`:@@exercise.push.benchdips.name:Bankdips`,
+  'push.handstandhold': $localize`:@@exercise.push.handstandhold.name:Handstand-Hold`,
+
   // pull
   'pull.pullups': $localize`:@@exercise.pull.pullups.name:Klimmzüge`,
   'pull.rows': $localize`:@@exercise.pull.rows.name:Ruderzug`,
@@ -159,6 +165,11 @@ const VARIANT_DISPLAY_NAMES: Record<string, string> = {
   '@@exercise.variant.rows.australian': $localize`:@@exercise.variant.rows.australian:Australian Row`,
   '@@exercise.variant.rows.dumbbell': $localize`:@@exercise.variant.rows.dumbbell:Kurzhantel`,
   '@@exercise.variant.rows.barbell': $localize`:@@exercise.variant.rows.barbell:Langhantel`,
+
+  // dips
+  '@@exercise.variant.dips.parallel': $localize`:@@exercise.variant.dips.parallel:Barren`,
+  '@@exercise.variant.dips.straight-bar': $localize`:@@exercise.variant.dips.straight-bar:Stange`,
+  '@@exercise.variant.dips.ring': $localize`:@@exercise.variant.dips.ring:Ringe`,
 };
 
 export function variantDisplayName(variant: ExerciseVariant): string {
@@ -172,10 +183,9 @@ export function variantDisplayName(variant: ExerciseVariant): string {
  * the type-pie legend so both stay in sync without duplicating the
  * `$localize` calls.
  *
- * The legacy filter-key string remains `'pushup'` (it identifies the
- * legacy Firestore collection); only the *display* shifts to the new
- * movement-pattern label "Drücken / Push" via the shared category
- * translation unit.
+ * Legacy pushup entries (Liegestütze) keep their own bucket separate
+ * from the generic `push` movement-pattern category (dips, handstand),
+ * so this branch resolves to the Liegestütze label.
  *
  * For ids that miss the catalog (user-defined custom exercises or
  * legacy ids whose Firestore entries still exist) the raw `value`
@@ -184,7 +194,7 @@ export function variantDisplayName(variant: ExerciseVariant): string {
  */
 export function kindDisplayName(value: UnifiedEntryFilterKey): string {
   if (value === 'pushup') {
-    return $localize`:@@exercise.category.push:Drücken`;
+    return $localize`:@@exercise.category.pushup:Liegestütze`;
   }
   const def = findExerciseDefinition(value);
   if (def) return exerciseDisplayName(def.id);
@@ -208,6 +218,7 @@ export function kindDisplayName(value: UnifiedEntryFilterKey): string {
 // Omitting them here lets `categoryDisplayName` fall back to the raw id
 // rather than maintain dead `$localize` calls for unused labels.
 const CATEGORY_DISPLAY_NAMES: Partial<Record<ExerciseCategoryId, string>> = {
+  pushup: $localize`:@@exercise.category.pushup:Liegestütze`,
   push: $localize`:@@exercise.category.push:Drücken`,
   pull: $localize`:@@exercise.category.pull:Ziehen`,
   squat: $localize`:@@exercise.category.squat:Kniebeuge`,

--- a/web/src/app/stats/shell/analysis-group-view.component.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.ts
@@ -353,16 +353,15 @@ export class AnalysisGroupViewComponent {
    * kind mode) into localised display names. Pushup-variant mode
    * passes through because the store already produces locale-aware
    * variant names. The gate mirrors `analysis.store` — a per-category
-   * tab other than 'push' is always kind mode, so the breakdown
-   * carries exerciseIds like `abs.situps` that need translating even
-   * without an explicit kinds filter. The legacy kind filter key
-   * stays `'pushup'` (Firestore collection identifier).
+   * tab other than `pushup` (Liegestütze) is always kind mode, so the
+   * breakdown carries exerciseIds like `abs.situps` that need
+   * translating even without an explicit kinds filter.
    */
   readonly typeBreakdownDisplay = computed(() => {
     const view = this.store.activeView();
     const kinds = this.store.kinds();
     const showPushupVariants =
-      view === 'push' ||
+      view === 'pushup' ||
       (view === 'overview' &&
         (kinds.length === 0 || (kinds.length === 1 && kinds[0] === 'pushup')));
     const data = this.store.typeBreakdown();

--- a/web/src/app/stats/shell/analysis-overview.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-overview.component.spec.ts
@@ -146,8 +146,8 @@ describe('AnalysisOverviewComponent', () => {
   it('renders the chart and one card per summary when categories exist', () => {
     store.categorySummaries.set([
       {
-        categoryId: 'push',
-        nameKey: '@@exercise.category.push',
+        categoryId: 'pushup',
+        nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
         totalReps: 100,
@@ -189,8 +189,8 @@ describe('AnalysisOverviewComponent', () => {
     // carries rows.
     store.categorySummaries.set([
       {
-        categoryId: 'push',
-        nameKey: '@@exercise.category.push',
+        categoryId: 'pushup',
+        nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
         totalReps: 100,
@@ -222,8 +222,8 @@ describe('AnalysisOverviewComponent', () => {
   it('forwards viewSelect emissions from a summary card up to the parent', () => {
     store.categorySummaries.set([
       {
-        categoryId: 'push',
-        nameKey: '@@exercise.category.push',
+        categoryId: 'pushup',
+        nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
         totalReps: 100,
@@ -242,7 +242,7 @@ describe('AnalysisOverviewComponent', () => {
     expect(button).toBeTruthy();
     button.click();
     fixture.detectChanges();
-    expect(fixture.componentInstance.lastEmitted()).toBe('push');
+    expect(fixture.componentInstance.lastEmitted()).toBe('pushup');
   });
 
   it('snaps activeView to overview in the uncategorised fallback so the embedded group-view is not stale-filtered', () => {
@@ -268,8 +268,8 @@ describe('AnalysisOverviewComponent', () => {
     store.activeView.set('mobility');
     store.categorySummaries.set([
       {
-        categoryId: 'push',
-        nameKey: '@@exercise.category.push',
+        categoryId: 'pushup',
+        nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
         totalReps: 100,

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -433,7 +433,7 @@ describe('AnalysisPageComponent', () => {
 
     it('setActiveView("pushup") collapses to pushup entries only', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('push');
+      store.setActiveView('pushup');
       const rows = store.viewFilteredRows();
       expect(rows).toHaveLength(6);
       expect(rows.every((r) => r.kind === 'pushup')).toBe(true);
@@ -481,7 +481,7 @@ describe('AnalysisPageComponent', () => {
 
     it('per-category KPIs scope to the active view (pushup)', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('push');
+      store.setActiveView('pushup');
       // Same numbers as the original pushup-only tests because the
       // seeded mock is the pushup-only dataset.
       expect(store.bestSingleEntry()?.reps).toBe(25);
@@ -530,7 +530,7 @@ describe('AnalysisPageComponent', () => {
 
     it('per-category pushup trend matches the legacy pushup-only totals', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('push');
+      store.setActiveView('pushup');
       const week = store.weekTrend().find((w) => w.label === '2026-W07');
       expect(week?.total).toBe(93);
     });
@@ -546,7 +546,7 @@ describe('AnalysisPageComponent', () => {
       const { store } = fixture.componentInstance;
       const summaries = store.categorySummaries();
       expect(summaries.map((s) => s.categoryId)).toEqual([
-        'push',
+        'pushup',
         'squat',
         'core',
       ]);
@@ -555,7 +555,7 @@ describe('AnalysisPageComponent', () => {
     it('categorySummaries surfaces per-category totals, today reps and best day', () => {
       const { store } = fixture.componentInstance;
       const summaries = store.categorySummaries();
-      const pushup = summaries.find((s) => s.categoryId === 'push');
+      const pushup = summaries.find((s) => s.categoryId === 'pushup');
       expect(pushup).toMatchObject({
         totalReps: 93,
         // 5+5 + 6+6 + 10+5+5 + 10+8+7 + 9+9 = 12 sets across 5 entries.
@@ -586,7 +586,7 @@ describe('AnalysisPageComponent', () => {
       // for the movement-pattern category names.
       const { store } = fixture.componentInstance;
       const cmp = store.categoryComparison();
-      expect(cmp.labels).toEqual(['Drücken', 'Kniebeuge', 'Rumpf']);
+      expect(cmp.labels).toEqual(['Liegestütze', 'Kniebeuge', 'Rumpf']);
       expect(cmp.reps).toEqual([93, 40, 30]);
       expect(cmp.sets).toEqual([12, 0, 0]);
     });
@@ -613,7 +613,7 @@ describe('AnalysisPageComponent', () => {
 
     it('typeBreakdown stays in pushup-variant mode when the active view is pushup', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('push');
+      store.setActiveView('pushup');
       const labels = store.typeBreakdown().map((b) => b.label);
       expect(labels).toContain('Standard-Liegestütze');
       expect(labels).toContain('Diamant-Liegestütze');
@@ -666,7 +666,7 @@ describe('AnalysisPageComponent', () => {
 
     it('viewChartSeries scoped to pushup matches the legacy pushup-only daily totals', () => {
       const { store } = fixture.componentInstance;
-      store.setActiveView('push');
+      store.setActiveView('pushup');
       const series = store.viewChartSeries();
       // Seeded pushups: Feb 9 → 15 with one skipped day, totals
       // [10,12,20,8,25,18] and cumulative dayIntegral [10,22,42,50,75,93].
@@ -752,7 +752,7 @@ describe('AnalysisPageComponent', () => {
       // array on the way through, every pushup tab would silently lose
       // its purple "Mit Sets" segment.
       const { store } = fixture.componentInstance;
-      store.setActiveView('push');
+      store.setActiveView('pushup');
       const entries = store.viewChartEntries();
       expect(
         entries.some((e) => Array.isArray(e.sets) && e.sets.length > 1)
@@ -785,7 +785,7 @@ describe('AnalysisPageComponent', () => {
       const component = fixture.componentInstance;
       // Seeded dataset has only pushup entries → one visible category tab,
       // routed under the `push` movement-pattern category.
-      expect(component.visibleTabs().map((t) => t.id)).toEqual(['push']);
+      expect(component.visibleTabs().map((t) => t.id)).toEqual(['pushup']);
 
       liveExerciseEntries.set([
         {
@@ -809,9 +809,9 @@ describe('AnalysisPageComponent', () => {
       fixture.detectChanges();
 
       // Order follows EXERCISE_CATEGORIES.order
-      // (push=10, squat=30, core=70 → legs.squats → squat, abs.situps → core).
+      // (pushup=5, squat=30, core=70 → legs.squats → squat, abs.situps → core).
       expect(component.visibleTabs().map((t) => t.id)).toEqual([
-        'push',
+        'pushup',
         'squat',
         'core',
       ]);
@@ -821,7 +821,7 @@ describe('AnalysisPageComponent', () => {
       const component = fixture.componentInstance;
       // Overview = 0, push tab = 1 (the only category visible by default).
       component.onTabIndexChange(1);
-      expect(component.store.activeView()).toBe('push');
+      expect(component.store.activeView()).toBe('pushup');
 
       component.onTabIndexChange(0);
       expect(component.store.activeView()).toBe('overview');
@@ -829,7 +829,7 @@ describe('AnalysisPageComponent', () => {
 
     it('maps activeView back to the matching tab index for the mat-tab-group binding', () => {
       const component = fixture.componentInstance;
-      component.store.setActiveView('push');
+      component.store.setActiveView('pushup');
       expect(component.selectedTabIndex()).toBe(1);
       component.store.setActiveView('overview');
       expect(component.selectedTabIndex()).toBe(0);
@@ -851,8 +851,8 @@ describe('AnalysisPageComponent', () => {
 
     it('selecting an overview card emits the category and switches the active view', () => {
       const component = fixture.componentInstance;
-      component.onOverviewSelect('push');
-      expect(component.store.activeView()).toBe('push');
+      component.onOverviewSelect('pushup');
+      expect(component.store.activeView()).toBe('pushup');
     });
 
     it('renders a mat-tab-group with the Overview tab plus the visible categories', () => {
@@ -863,9 +863,11 @@ describe('AnalysisPageComponent', () => {
       const overviewTab = host.querySelector(
         '[data-testid="analysis-tab-overview"]'
       );
-      const pushTab = host.querySelector('[data-testid="analysis-tab-push"]');
+      const pushupTab = host.querySelector(
+        '[data-testid="analysis-tab-pushup"]'
+      );
       expect(overviewTab).toBeTruthy();
-      expect(pushTab).toBeTruthy();
+      expect(pushupTab).toBeTruthy();
     });
   });
 });

--- a/web/src/app/stats/shell/entries-page.component.spec.ts
+++ b/web/src/app/stats/shell/entries-page.component.spec.ts
@@ -183,7 +183,7 @@ describe('EntriesPageComponent', () => {
       // Label switches to the new movement-pattern category label
       // ("Drücken") which is what the analysis page filter chips
       // already render.
-      expect(opts[0].label).toBe('Drücken');
+      expect(opts[0].label).toBe('Liegestütze');
     });
     // Note: the exercise-id branch of `kindLabel` is exercised
     // indirectly through `exerciseDisplayName` (covered in

--- a/web/src/app/stats/shell/entries-page.component.ts
+++ b/web/src/app/stats/shell/entries-page.component.ts
@@ -269,7 +269,7 @@ export class EntriesPageComponent {
 
   private kindLabel(value: string): string {
     if (value === 'pushup') {
-      return $localize`:@@exercise.category.push:Drücken`;
+      return $localize`:@@exercise.category.pushup:Liegestütze`;
     }
     const def = findExerciseDefinition(value);
     if (!def) return value;

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -8173,5 +8173,41 @@
         <target>Langhantel</target>
       </segment>
     </unit>
+    <unit id="exercise.push.dips.name">
+      <segment state="initial">
+        <source>Dips</source>
+        <target>Dips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.benchdips.name">
+      <segment state="initial">
+        <source>Bankdips</source>
+        <target>Bankdips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.handstandhold.name">
+      <segment state="initial">
+        <source>Handstand-Hold</source>
+        <target>Handstand-Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.parallel">
+      <segment state="initial">
+        <source>Barren</source>
+        <target>Barren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.straight-bar">
+      <segment state="initial">
+        <source>Stange</source>
+        <target>Stange</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.ring">
+      <segment state="initial">
+        <source>Ringe</source>
+        <target>Ringe</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -8341,5 +8341,41 @@ Deine Position: # ·  Reps        </source>
         <target>Langhantel</target>
       </segment>
     </unit>
+    <unit id="exercise.push.dips.name">
+      <segment state="initial">
+        <source>Dips</source>
+        <target>Dips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.benchdips.name">
+      <segment state="initial">
+        <source>Bankdips</source>
+        <target>Bankdips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.handstandhold.name">
+      <segment state="initial">
+        <source>Handstand-Hold</source>
+        <target>Handstand-Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.parallel">
+      <segment state="initial">
+        <source>Barren</source>
+        <target>Barren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.straight-bar">
+      <segment state="initial">
+        <source>Stange</source>
+        <target>Stange</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.ring">
+      <segment state="initial">
+        <source>Ringe</source>
+        <target>Ringe</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -8173,5 +8173,41 @@
         <target>Langhantel</target>
       </segment>
     </unit>
+    <unit id="exercise.push.dips.name">
+      <segment state="initial">
+        <source>Dips</source>
+        <target>Dips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.benchdips.name">
+      <segment state="initial">
+        <source>Bankdips</source>
+        <target>Bankdips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.handstandhold.name">
+      <segment state="initial">
+        <source>Handstand-Hold</source>
+        <target>Handstand-Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.parallel">
+      <segment state="initial">
+        <source>Barren</source>
+        <target>Barren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.straight-bar">
+      <segment state="initial">
+        <source>Stange</source>
+        <target>Stange</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.ring">
+      <segment state="initial">
+        <source>Ringe</source>
+        <target>Ringe</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -8173,5 +8173,41 @@
         <target>Langhantel</target>
       </segment>
     </unit>
+    <unit id="exercise.push.dips.name">
+      <segment state="initial">
+        <source>Dips</source>
+        <target>Dips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.benchdips.name">
+      <segment state="initial">
+        <source>Bankdips</source>
+        <target>Bankdips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.handstandhold.name">
+      <segment state="initial">
+        <source>Handstand-Hold</source>
+        <target>Handstand-Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.parallel">
+      <segment state="initial">
+        <source>Barren</source>
+        <target>Barren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.straight-bar">
+      <segment state="initial">
+        <source>Stange</source>
+        <target>Stange</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.ring">
+      <segment state="initial">
+        <source>Ringe</source>
+        <target>Ringe</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -8173,5 +8173,41 @@
         <target>Langhantel</target>
       </segment>
     </unit>
+    <unit id="exercise.push.dips.name">
+      <segment state="initial">
+        <source>Dips</source>
+        <target>Dips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.benchdips.name">
+      <segment state="initial">
+        <source>Bankdips</source>
+        <target>Bankdips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.handstandhold.name">
+      <segment state="initial">
+        <source>Handstand-Hold</source>
+        <target>Handstand-Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.parallel">
+      <segment state="initial">
+        <source>Barren</source>
+        <target>Barren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.straight-bar">
+      <segment state="initial">
+        <source>Stange</source>
+        <target>Stange</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.ring">
+      <segment state="initial">
+        <source>Ringe</source>
+        <target>Ringe</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -8173,5 +8173,41 @@
         <target>Langhantel</target>
       </segment>
     </unit>
+    <unit id="exercise.push.dips.name">
+      <segment state="initial">
+        <source>Dips</source>
+        <target>Dips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.benchdips.name">
+      <segment state="initial">
+        <source>Bankdips</source>
+        <target>Bankdips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.handstandhold.name">
+      <segment state="initial">
+        <source>Handstand-Hold</source>
+        <target>Handstand-Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.parallel">
+      <segment state="initial">
+        <source>Barren</source>
+        <target>Barren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.straight-bar">
+      <segment state="initial">
+        <source>Stange</source>
+        <target>Stange</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.ring">
+      <segment state="initial">
+        <source>Ringe</source>
+        <target>Ringe</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -8173,5 +8173,41 @@
         <target>Langhantel</target>
       </segment>
     </unit>
+    <unit id="exercise.push.dips.name">
+      <segment state="initial">
+        <source>Dips</source>
+        <target>Dips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.benchdips.name">
+      <segment state="initial">
+        <source>Bankdips</source>
+        <target>Bankdips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.handstandhold.name">
+      <segment state="initial">
+        <source>Handstand-Hold</source>
+        <target>Handstand-Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.parallel">
+      <segment state="initial">
+        <source>Barren</source>
+        <target>Barren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.straight-bar">
+      <segment state="initial">
+        <source>Stange</source>
+        <target>Stange</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.ring">
+      <segment state="initial">
+        <source>Ringe</source>
+        <target>Ringe</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -7436,5 +7436,41 @@ Deine Position: # ·  Reps        </source>
         <target>Langhantel</target>
       </segment>
     </unit>
+    <unit id="exercise.push.dips.name">
+      <segment state="initial">
+        <source>Dips</source>
+        <target>Dips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.benchdips.name">
+      <segment state="initial">
+        <source>Bankdips</source>
+        <target>Bankdips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.handstandhold.name">
+      <segment state="initial">
+        <source>Handstand-Hold</source>
+        <target>Handstand-Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.parallel">
+      <segment state="initial">
+        <source>Barren</source>
+        <target>Barren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.straight-bar">
+      <segment state="initial">
+        <source>Stange</source>
+        <target>Stange</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.ring">
+      <segment state="initial">
+        <source>Ringe</source>
+        <target>Ringe</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4294,17 +4294,17 @@
         <source>Alle Übungen</source>
       </segment>
     </unit>
-    <unit id="exercise.category.push">
+    <unit id="exercise.category.pushup">
       <notes>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:147</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:200</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1098</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:187</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:207</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1100</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:197</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:272</note>
       </notes>
       <segment>
-        <source>Drücken</source>
+        <source>Liegestütze</source>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
@@ -5231,7 +5231,7 @@
     </unit>
     <unit id="trainingEntryDialog.pushup.exercise">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:613</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:615</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -5239,7 +5239,7 @@
     </unit>
     <unit id="typeWikiLinkTooltip.generic">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:775</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:777</note>
       </notes>
       <segment>
         <source>Anleitung zu Liegestütztypen öffnen</source>
@@ -5247,16 +5247,25 @@
     </unit>
     <unit id="typeWikiLinkTooltip.specific">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:777</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:779</note>
       </notes>
       <segment>
         <source>Anleitung öffnen</source>
       </segment>
     </unit>
+    <unit id="exercise.category.push">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1101</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:222</note>
+      </notes>
+      <segment>
+        <source>Drücken</source>
+      </segment>
+    </unit>
     <unit id="exercise.category.pull">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1099</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:208</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1102</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:223</note>
       </notes>
       <segment>
         <source>Ziehen</source>
@@ -5264,8 +5273,8 @@
     </unit>
     <unit id="exercise.category.squat">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1100</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:209</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1103</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:224</note>
       </notes>
       <segment>
         <source>Kniebeuge</source>
@@ -5273,8 +5282,8 @@
     </unit>
     <unit id="exercise.category.hinge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1101</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:210</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1104</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:225</note>
       </notes>
       <segment>
         <source>Hüftstreckung</source>
@@ -5282,8 +5291,8 @@
     </unit>
     <unit id="exercise.category.lunge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1102</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:211</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1105</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:226</note>
       </notes>
       <segment>
         <source>Ausfallschritt</source>
@@ -5291,8 +5300,7 @@
     </unit>
     <unit id="exercise.category.carry">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1103</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:212</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1106</note>
       </notes>
       <segment>
         <source>Tragen</source>
@@ -5300,8 +5308,8 @@
     </unit>
     <unit id="exercise.category.core">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1104</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:213</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1107</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:227</note>
       </notes>
       <segment>
         <source>Rumpf</source>
@@ -5309,8 +5317,8 @@
     </unit>
     <unit id="exercise.category.cardio">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1105</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:214</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1108</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:228</note>
       </notes>
       <segment>
         <source>Ausdauer</source>
@@ -5318,8 +5326,8 @@
     </unit>
     <unit id="exercise.category.mobility">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1106</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:215</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1109</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:229</note>
       </notes>
       <segment>
         <source>Mobilität</source>
@@ -5327,8 +5335,7 @@
     </unit>
     <unit id="exercise.category.strength">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1107</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:216</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1110</note>
       </notes>
       <segment>
         <source>Krafttraining</source>
@@ -5566,9 +5573,33 @@
         <source>Step-ups</source>
       </segment>
     </unit>
+    <unit id="exercise.push.dips.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:39</note>
+      </notes>
+      <segment>
+        <source>Dips</source>
+      </segment>
+    </unit>
+    <unit id="exercise.push.benchdips.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:40</note>
+      </notes>
+      <segment>
+        <source>Bankdips</source>
+      </segment>
+    </unit>
+    <unit id="exercise.push.handstandhold.name">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:41</note>
+      </notes>
+      <segment>
+        <source>Handstand-Hold</source>
+      </segment>
+    </unit>
     <unit id="exercise.pull.pullups.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:38</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:44</note>
       </notes>
       <segment>
         <source>Klimmzüge</source>
@@ -5576,7 +5607,7 @@
     </unit>
     <unit id="exercise.pull.rows.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:39</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:45</note>
       </notes>
       <segment>
         <source>Ruderzug</source>
@@ -5584,7 +5615,7 @@
     </unit>
     <unit id="exercise.pull.deadhang.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:40</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:46</note>
       </notes>
       <segment>
         <source>Dead Hang</source>
@@ -5592,7 +5623,7 @@
     </unit>
     <unit id="exercise.pull.facepull.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:41</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:47</note>
       </notes>
       <segment>
         <source>Face Pull</source>
@@ -5600,7 +5631,7 @@
     </unit>
     <unit id="exercise.carry.farmer.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:44</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:50</note>
       </notes>
       <segment>
         <source>Farmer&apos;s Walk</source>
@@ -5608,7 +5639,7 @@
     </unit>
     <unit id="exercise.carry.suitcase.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:45</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:51</note>
       </notes>
       <segment>
         <source>Suitcase Carry</source>
@@ -5616,7 +5647,7 @@
     </unit>
     <unit id="exercise.carry.overhead.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:46</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:52</note>
       </notes>
       <segment>
         <source>Overhead Carry</source>
@@ -5624,7 +5655,7 @@
     </unit>
     <unit id="exercise.cardio.running.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:49</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:55</note>
       </notes>
       <segment>
         <source>Laufen</source>
@@ -5632,7 +5663,7 @@
     </unit>
     <unit id="exercise.cardio.walking.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:50</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:56</note>
       </notes>
       <segment>
         <source>Gehen</source>
@@ -5640,7 +5671,7 @@
     </unit>
     <unit id="exercise.cardio.cycling.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:51</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:57</note>
       </notes>
       <segment>
         <source>Radfahren</source>
@@ -5648,7 +5679,7 @@
     </unit>
     <unit id="exercise.cardio.rowing.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:52</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:58</note>
       </notes>
       <segment>
         <source>Rudern</source>
@@ -5656,7 +5687,7 @@
     </unit>
     <unit id="exercise.cardio.swimming.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:53</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:59</note>
       </notes>
       <segment>
         <source>Schwimmen</source>
@@ -5664,7 +5695,7 @@
     </unit>
     <unit id="exercise.cardio.jumprope.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:54</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:60</note>
       </notes>
       <segment>
         <source>Seilspringen</source>
@@ -5672,7 +5703,7 @@
     </unit>
     <unit id="exercise.cardio.burpees.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:55</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:61</note>
       </notes>
       <segment>
         <source>Burpees</source>
@@ -5680,7 +5711,7 @@
     </unit>
     <unit id="exercise.cardio.jumpingjacks.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:56</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:62</note>
       </notes>
       <segment>
         <source>Hampelmänner</source>
@@ -5688,7 +5719,7 @@
     </unit>
     <unit id="exercise.cardio.highknees.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:57</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:63</note>
       </notes>
       <segment>
         <source>High Knees</source>
@@ -5696,7 +5727,7 @@
     </unit>
     <unit id="exercise.mobility.stretching.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:60</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:66</note>
       </notes>
       <segment>
         <source>Dehnen</source>
@@ -5704,7 +5735,7 @@
     </unit>
     <unit id="exercise.mobility.yoga.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:61</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:67</note>
       </notes>
       <segment>
         <source>Yoga</source>
@@ -5712,7 +5743,7 @@
     </unit>
     <unit id="exercise.mobility.foamrolling.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:62</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:68</note>
       </notes>
       <segment>
         <source>Faszienrolle</source>
@@ -5720,7 +5751,7 @@
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:63</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:69</note>
       </notes>
       <segment>
         <source>Dynamisches Aufwärmen</source>
@@ -5728,7 +5759,7 @@
     </unit>
     <unit id="exercise.mobility.catcow.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:64</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:70</note>
       </notes>
       <segment>
         <source>Katze-Kuh</source>
@@ -5736,7 +5767,7 @@
     </unit>
     <unit id="exercise.mobility.hipopener.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:65</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:71</note>
       </notes>
       <segment>
         <source>Hüftöffner</source>
@@ -5744,7 +5775,7 @@
     </unit>
     <unit id="exercise.strength.benchpress.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:68</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:74</note>
       </notes>
       <segment>
         <source>Bankdrücken</source>
@@ -5752,7 +5783,7 @@
     </unit>
     <unit id="exercise.strength.overheadpress.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:69</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:75</note>
       </notes>
       <segment>
         <source>Schulterdrücken</source>
@@ -5760,7 +5791,7 @@
     </unit>
     <unit id="exercise.strength.deadlift.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:70</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:76</note>
       </notes>
       <segment>
         <source>Kreuzheben</source>
@@ -5768,7 +5799,7 @@
     </unit>
     <unit id="exercise.strength.barbellsquat.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:71</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:77</note>
       </notes>
       <segment>
         <source>Langhantel-Kniebeuge</source>
@@ -5776,7 +5807,7 @@
     </unit>
     <unit id="exercise.strength.barbellrow.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:72</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:78</note>
       </notes>
       <segment>
         <source>Langhantelrudern</source>
@@ -5784,7 +5815,7 @@
     </unit>
     <unit id="exercise.strength.kettlebellswing.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:73</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:79</note>
       </notes>
       <segment>
         <source>Kettlebell Swing</source>
@@ -5792,7 +5823,7 @@
     </unit>
     <unit id="exercise.variant.situps.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:93</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:99</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -5800,7 +5831,7 @@
     </unit>
     <unit id="exercise.variant.situps.decline">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:94</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:100</note>
       </notes>
       <segment>
         <source>Decline</source>
@@ -5808,7 +5839,7 @@
     </unit>
     <unit id="exercise.variant.situps.weighted">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:95</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:101</note>
       </notes>
       <segment>
         <source>Mit Zusatzgewicht</source>
@@ -5816,7 +5847,7 @@
     </unit>
     <unit id="exercise.variant.crunches.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:98</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:104</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -5824,7 +5855,7 @@
     </unit>
     <unit id="exercise.variant.crunches.reverse">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:99</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:105</note>
       </notes>
       <segment>
         <source>Reverse Crunches</source>
@@ -5832,7 +5863,7 @@
     </unit>
     <unit id="exercise.variant.crunches.bicycle">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:100</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:106</note>
       </notes>
       <segment>
         <source>Bicycle Crunches</source>
@@ -5840,7 +5871,7 @@
     </unit>
     <unit id="exercise.variant.crunches.oblique">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:101</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:107</note>
       </notes>
       <segment>
         <source>Schräge Crunches</source>
@@ -5848,7 +5879,7 @@
     </unit>
     <unit id="exercise.variant.legraises.lying">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:104</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:110</note>
       </notes>
       <segment>
         <source>Liegend</source>
@@ -5856,7 +5887,7 @@
     </unit>
     <unit id="exercise.variant.legraises.hanging-knee">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:105</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:111</note>
       </notes>
       <segment>
         <source>Hängend (Knie)</source>
@@ -5864,7 +5895,7 @@
     </unit>
     <unit id="exercise.variant.legraises.hanging-straight">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:106</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:112</note>
       </notes>
       <segment>
         <source>Hängend (gestreckt)</source>
@@ -5872,7 +5903,7 @@
     </unit>
     <unit id="exercise.variant.russiantwist.bodyweight">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:109</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:115</note>
       </notes>
       <segment>
         <source>Eigengewicht</source>
@@ -5880,7 +5911,7 @@
     </unit>
     <unit id="exercise.variant.russiantwist.weighted">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:110</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:116</note>
       </notes>
       <segment>
         <source>Mit Zusatzgewicht</source>
@@ -5888,7 +5919,7 @@
     </unit>
     <unit id="exercise.variant.mountainclimbers.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:113</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:119</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -5896,7 +5927,7 @@
     </unit>
     <unit id="exercise.variant.mountainclimbers.cross-body">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:114</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:120</note>
       </notes>
       <segment>
         <source>Cross-Body</source>
@@ -5904,7 +5935,7 @@
     </unit>
     <unit id="exercise.variant.plank.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:117</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:123</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -5912,7 +5943,7 @@
     </unit>
     <unit id="exercise.variant.plank.forearm">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:118</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:124</note>
       </notes>
       <segment>
         <source>Unterarmstütz</source>
@@ -5920,7 +5951,7 @@
     </unit>
     <unit id="exercise.variant.plank.side">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:119</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:125</note>
       </notes>
       <segment>
         <source>Seitlich</source>
@@ -5928,7 +5959,7 @@
     </unit>
     <unit id="exercise.variant.plank.reverse">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:120</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:126</note>
       </notes>
       <segment>
         <source>Umgekehrt</source>
@@ -5936,7 +5967,7 @@
     </unit>
     <unit id="exercise.variant.squats.bodyweight">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:123</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:129</note>
       </notes>
       <segment>
         <source>Eigengewicht</source>
@@ -5944,7 +5975,7 @@
     </unit>
     <unit id="exercise.variant.squats.sumo">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:124</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:130</note>
       </notes>
       <segment>
         <source>Sumo</source>
@@ -5952,7 +5983,7 @@
     </unit>
     <unit id="exercise.variant.squats.goblet">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:125</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:131</note>
       </notes>
       <segment>
         <source>Goblet</source>
@@ -5960,7 +5991,7 @@
     </unit>
     <unit id="exercise.variant.squats.bulgarian-split">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:126</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:132</note>
       </notes>
       <segment>
         <source>Bulgarian Split</source>
@@ -5968,7 +5999,7 @@
     </unit>
     <unit id="exercise.variant.squats.pistol">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:127</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:133</note>
       </notes>
       <segment>
         <source>Pistol</source>
@@ -5976,7 +6007,7 @@
     </unit>
     <unit id="exercise.variant.calfraises.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:130</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:136</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -5984,7 +6015,7 @@
     </unit>
     <unit id="exercise.variant.calfraises.single-leg">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:131</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:137</note>
       </notes>
       <segment>
         <source>Einbeinig</source>
@@ -5992,7 +6023,7 @@
     </unit>
     <unit id="exercise.variant.calfraises.seated">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:132</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:138</note>
       </notes>
       <segment>
         <source>Sitzend</source>
@@ -6000,7 +6031,7 @@
     </unit>
     <unit id="exercise.variant.glutebridge.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:135</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:141</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -6008,7 +6039,7 @@
     </unit>
     <unit id="exercise.variant.glutebridge.single-leg">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:136</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:142</note>
       </notes>
       <segment>
         <source>Einbeinig</source>
@@ -6016,7 +6047,7 @@
     </unit>
     <unit id="exercise.variant.glutebridge.hip-thrust">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:137</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:143</note>
       </notes>
       <segment>
         <source>Hip Thrust</source>
@@ -6024,7 +6055,7 @@
     </unit>
     <unit id="exercise.variant.glutebridge.march">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:138</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:144</note>
       </notes>
       <segment>
         <source>Marching</source>
@@ -6032,7 +6063,7 @@
     </unit>
     <unit id="exercise.variant.lunges.forward">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:141</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:147</note>
       </notes>
       <segment>
         <source>Vorwärts</source>
@@ -6040,7 +6071,7 @@
     </unit>
     <unit id="exercise.variant.lunges.reverse">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:142</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:148</note>
       </notes>
       <segment>
         <source>Rückwärts</source>
@@ -6048,7 +6079,7 @@
     </unit>
     <unit id="exercise.variant.lunges.walking">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:143</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:149</note>
       </notes>
       <segment>
         <source>Walking</source>
@@ -6056,7 +6087,7 @@
     </unit>
     <unit id="exercise.variant.lunges.lateral">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:144</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:150</note>
       </notes>
       <segment>
         <source>Seitlich</source>
@@ -6064,7 +6095,7 @@
     </unit>
     <unit id="exercise.variant.lunges.curtsy">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:145</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:151</note>
       </notes>
       <segment>
         <source>Curtsy</source>
@@ -6072,7 +6103,7 @@
     </unit>
     <unit id="exercise.variant.lunges.jumping">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:146</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:152</note>
       </notes>
       <segment>
         <source>Jumping</source>
@@ -6080,7 +6111,7 @@
     </unit>
     <unit id="exercise.variant.pullups.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:149</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:155</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -6088,7 +6119,7 @@
     </unit>
     <unit id="exercise.variant.pullups.chin-up">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:150</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:156</note>
       </notes>
       <segment>
         <source>Chin-up</source>
@@ -6096,7 +6127,7 @@
     </unit>
     <unit id="exercise.variant.pullups.wide-grip">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:151</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:157</note>
       </notes>
       <segment>
         <source>Breiter Griff</source>
@@ -6104,7 +6135,7 @@
     </unit>
     <unit id="exercise.variant.pullups.neutral-grip">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:152</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:158</note>
       </notes>
       <segment>
         <source>Neutraler Griff</source>
@@ -6112,7 +6143,7 @@
     </unit>
     <unit id="exercise.variant.pullups.negative">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:153</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:159</note>
       </notes>
       <segment>
         <source>Negativ</source>
@@ -6120,7 +6151,7 @@
     </unit>
     <unit id="exercise.variant.pullups.assisted">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:154</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:160</note>
       </notes>
       <segment>
         <source>Assistiert</source>
@@ -6128,7 +6159,7 @@
     </unit>
     <unit id="exercise.variant.pullups.archer">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:155</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:161</note>
       </notes>
       <segment>
         <source>Archer</source>
@@ -6136,7 +6167,7 @@
     </unit>
     <unit id="exercise.variant.rows.inverted">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:158</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:164</note>
       </notes>
       <segment>
         <source>Inverted Row</source>
@@ -6144,7 +6175,7 @@
     </unit>
     <unit id="exercise.variant.rows.australian">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:159</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:165</note>
       </notes>
       <segment>
         <source>Australian Row</source>
@@ -6152,7 +6183,7 @@
     </unit>
     <unit id="exercise.variant.rows.dumbbell">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:160</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:166</note>
       </notes>
       <segment>
         <source>Kurzhantel</source>
@@ -6160,10 +6191,34 @@
     </unit>
     <unit id="exercise.variant.rows.barbell">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:161</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:167</note>
       </notes>
       <segment>
         <source>Langhantel</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.parallel">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:170</note>
+      </notes>
+      <segment>
+        <source>Barren</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.straight-bar">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:171</note>
+      </notes>
+      <segment>
+        <source>Stange</source>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.ring">
+      <notes>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:172</note>
+      </notes>
+      <segment>
+        <source>Ringe</source>
       </segment>
     </unit>
     <unit id="analysis.bestStreaksTitle">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -7790,5 +7790,41 @@
         <target>Langhantel</target>
       </segment>
     </unit>
+    <unit id="exercise.push.dips.name">
+      <segment state="initial">
+        <source>Dips</source>
+        <target>Dips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.benchdips.name">
+      <segment state="initial">
+        <source>Bankdips</source>
+        <target>Bankdips</target>
+      </segment>
+    </unit>
+    <unit id="exercise.push.handstandhold.name">
+      <segment state="initial">
+        <source>Handstand-Hold</source>
+        <target>Handstand-Hold</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.parallel">
+      <segment state="initial">
+        <source>Barren</source>
+        <target>Barren</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.straight-bar">
+      <segment state="initial">
+        <source>Stange</source>
+        <target>Stange</target>
+      </segment>
+    </unit>
+    <unit id="exercise.variant.dips.ring">
+      <segment state="initial">
+        <source>Ringe</source>
+        <target>Ringe</target>
+      </segment>
+    </unit>
   </file>
 </xliff>


### PR DESCRIPTION
The app is called PushUps, so Liegestütze deserve their own headline
dashboard bucket rather than collapsing into a generic "Drücken"
category alongside dips and handstands.

## Summary

- Restore `pushup` as a dedicated `ExerciseCategoryId` (order 5,
  first in the picker), reserved for the 13 legacy pushup variants
  stored on the `pushups` Firestore collection.
- Keep `push` (order 10) as the movement-pattern bucket for other
  pressing movements that aren't pushup variants.
- Add three starter exercises under `push`:
  - `push.dips` — reps, with parallel / straight-bar / ring variants
  - `push.benchdips` — reps
  - `push.handstandhold` — time

## Wire-up

- `unifiedEntryCategoryId` maps legacy `kind: 'pushup'` entries onto
  the dedicated `pushup` category again (not the generic `push`).
- Dialog mode discriminator and `CATEGORY_NAMES` restored to use
  `'pushup'` for the legacy-Liegestütze form path.
- `kindDisplayName('pushup')` resolves to "Liegestütze"; the new
  `push` category surfaces as "Drücken" with its own catalog
  exercises. Analysis store / group view / stats table / entries
  page / teaser card labels follow the same split.

## Firestore rules

`isRepsExerciseId` extended with `push.dips` and `push.benchdips`;
`isTimeExerciseId` adds `push.handstandhold`. Legacy pushup variants
stay on the existing `pushups` collection rule, untouched.

## XLIFF

Source unit `exercise.category.pushup` restored to active use; new
units for the three `push.*` exercises + the three dips variants
synced into every locale file as German placeholders
(`tools/sync-xliff-units.mjs`).

## Test plan

- [x] `pnpm nx test stats-models` (363 tests passing)
- [x] `pnpm nx test web` (53 test files passing)
- [x] `pnpm nx run-many --target=lint` (0 errors)
- [x] `pnpm nx run web:build --configuration=production` (succeeds incl. prerender)

https://claude.ai/code/session_01XY3VDHaZrGvKW1kGmttHKM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY3VDHaZrGvKW1kGmttHKM)_