### PR TITLE
fix(analysis): keep tab row from widening the page beyond max-width

### DIFF
--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -362,33 +362,19 @@ describe('AnalysisPageComponent', () => {
     // viewport so mat-tab-header switches to its scrollable/paginated
     // mode instead.
     //
-    // jsdom doesn't compute `grid-template-columns` from stylesheets
-    // (returns ''), so we walk the document's adopted/style-sheets and
-    // assert the raw cssText for `.page-wrap` carries the constraint.
-    fixture.detectChanges();
-    const rules: string[] = [];
-    for (const sheet of Array.from(document.styleSheets)) {
-      let cssRules: CSSRuleList;
-      try {
-        cssRules = sheet.cssRules;
-      } catch {
-        continue;
-      }
-      for (const rule of Array.from(cssRules)) {
-        rules.push(rule.cssText);
-      }
-    }
-    const pageWrapRule = rules.find(
-      (r) => r.includes('.page-wrap') && r.includes('grid-template-columns')
+    // We assert against Angular's compiled component styles
+    // (`ɵcmp.styles`) rather than walking `document.styleSheets` — the
+    // codebase already uses this pattern (see
+    // analysis-teaser-card.component.spec.ts) and it's resilient to
+    // jsdom CSSOM quirks.
+    const cmpDef = (
+      AnalysisPageComponent as unknown as { ɵcmp: { styles: string[] } }
+    ).ɵcmp;
+    const styles = (cmpDef?.styles ?? []).join(' ');
+    expect(styles).toMatch(
+      /\.page-wrap[^}]*grid-template-columns:\s*minmax\(\s*0(px)?\s*,\s*1fr\s*\)/
     );
-    expect(pageWrapRule).toBeDefined();
-    expect(pageWrapRule).toMatch(/minmax\(\s*0(px)?\s*,\s*1fr\s*\)/);
-
-    const tabsRule = rules.find(
-      (r) => r.includes('.analysis-tabs') && r.includes('min-width')
-    );
-    expect(tabsRule).toBeDefined();
-    expect(tabsRule).toMatch(/min-width:\s*0/);
+    expect(styles).toMatch(/\.analysis-tabs[^}]*min-width:\s*0/);
   });
 
   it('includes avgSetsPerEntry in week and month trend', () => {

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -353,6 +353,44 @@ describe('AnalysisPageComponent', () => {
     expect(computed.top).toMatch(/var\(--desktop-nav-height/);
   });
 
+  it('constrains the page-wrap grid track so the tab row cannot widen the page', () => {
+    // Regression: without an explicit `minmax(0, 1fr)` track, the grid
+    // child mat-tab-group's intrinsic width (all tab labels side-by-side)
+    // overflows max-width: 1200px and Material's tab-header pagination
+    // never engages — making the entire Analyse page horizontally
+    // scrollable. The track constraint lets the tab-group shrink to the
+    // viewport so mat-tab-header switches to its scrollable/paginated
+    // mode instead.
+    //
+    // jsdom doesn't compute `grid-template-columns` from stylesheets
+    // (returns ''), so we walk the document's adopted/style-sheets and
+    // assert the raw cssText for `.page-wrap` carries the constraint.
+    fixture.detectChanges();
+    const rules: string[] = [];
+    for (const sheet of Array.from(document.styleSheets)) {
+      let cssRules: CSSRuleList;
+      try {
+        cssRules = sheet.cssRules;
+      } catch {
+        continue;
+      }
+      for (const rule of Array.from(cssRules)) {
+        rules.push(rule.cssText);
+      }
+    }
+    const pageWrapRule = rules.find(
+      (r) => r.includes('.page-wrap') && r.includes('grid-template-columns')
+    );
+    expect(pageWrapRule).toBeDefined();
+    expect(pageWrapRule).toMatch(/minmax\(\s*0(px)?\s*,\s*1fr\s*\)/);
+
+    const tabsRule = rules.find(
+      (r) => r.includes('.analysis-tabs') && r.includes('min-width')
+    );
+    expect(tabsRule).toBeDefined();
+    expect(tabsRule).toMatch(/min-width:\s*0/);
+  });
+
   it('includes avgSetsPerEntry in week and month trend', () => {
     const { store } = fixture.componentInstance;
     const week = store.weekTrend();

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -148,6 +148,11 @@ interface VisibleTab {
       margin: 0 auto;
       padding: 16px;
       display: grid;
+      /* minmax(0, 1fr) lets grid children shrink below their intrinsic
+         width — without it, mat-tab-header's full row of tab labels
+         widens the page past max-width and Material's auto-pagination
+         never engages. */
+      grid-template-columns: minmax(0, 1fr);
       gap: 16px;
     }
 
@@ -217,6 +222,7 @@ interface VisibleTab {
 
     .analysis-tabs {
       width: 100%;
+      min-width: 0;
     }
     .analysis-tabs ::ng-deep .mat-mdc-tab-label-container {
       border-bottom: 1px solid rgba(148, 163, 184, 0.2);


### PR DESCRIPTION
## Summary

The Analyse page was getting horizontally scrollable on smaller viewports because `.page-wrap` used `display: grid` with no explicit column track. The implicit `auto` track sizes to its content's intrinsic width, and grid items (like flex items) have no implicit `min-width: 0`. With 10 tabs (Overview + 9 categories), `mat-tab-header`'s intrinsic width exceeded the 1200px cap and widened the entire page — which also prevented Material's tab-header auto-pagination/scrolling from engaging.

## Fix

- Pin the grid track on `.page-wrap` to `minmax(0, 1fr)` so it can shrink below intrinsic content width.
- Belt-and-braces `min-width: 0` on `.analysis-tabs` so its own flex children also shrink and Material's scrollable header takes over instead of overflowing.

## Test plan

- [x] `pnpm nx test web` — all 736 tests pass, including a new regression test that walks `document.styleSheets` and asserts `.page-wrap` carries the `minmax(0, 1fr)` track constraint (jsdom doesn't compute `grid-template-columns` via `getComputedStyle`).
- [x] `pnpm nx lint web` — clean (warnings only, pre-existing).
- [x] `pnpm nx run web:build -c production` — succeeds, prerender intact.
- [ ] Manual check: open `/analysis` with all categories visible at common breakpoints and confirm the tab strip scrolls/paginates instead of forcing horizontal page scroll.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAWAqXGqQQq839AG25xYes)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed responsive layout sizing on the analysis page so tab headers and content no longer force the page wider than intended.

* **Tests**
  * Added unit tests to verify layout constraints and responsive CSS behavior, ensuring the analysis page can shrink correctly within its container.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/338)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->