### PR TITLE
test(app): use NEVER for sw-update onAction stub in config-only spec

### DIFF
--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -6,7 +6,7 @@ import { provideRouter } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { SwUpdate } from '@angular/service-worker';
-import { of, Subject } from 'rxjs';
+import { NEVER, of, Subject } from 'rxjs';
 import { StatsApiService, UserConfigApiService } from '@pu-stats/data-access';
 import { Auth } from '@angular/fire/auth';
 import { AuthService, AuthStore, UserContextService } from '@pu-auth/auth';
@@ -888,10 +888,14 @@ describe('App (testing-library)', () => {
     // always act on it, with a distinct panelClass for styling.
     it('opens the update snackbar sticky at top-center with the sw-update panelClass', async () => {
       const swUpdate = makeSwUpdateMock();
+      // `NEVER` (not `of(undefined)`) so the action observable never emits —
+      // an immediate emission would synchronously fire the VERSION_READY
+      // handler's `activateUpdate()` + `window.location.reload()` side
+      // effects during this config-only assertion (jsdom can't navigate).
       const openSpy = vitest
         .spyOn(MatSnackBar.prototype, 'open')
         .mockReturnValue({
-          onAction: () => of(undefined),
+          onAction: () => NEVER,
           afterDismissed: () => of({ dismissedByAction: false }),
         } as unknown as ReturnType<MatSnackBar['open']>);
 


### PR DESCRIPTION
## Summary

Follow-up to #336 addressing the unresolved Copilot review comment on `web/src/app/app.spec.ts:888`.

The new `"opens the update snackbar sticky at top-center…"` regression spec mocks `MatSnackBar.open()` with `onAction: () => of(undefined)`. `of(undefined)` emits synchronously the moment `App` subscribes, which fires the VERSION_READY handler's `activateUpdate()` + `window.location.reload()` chain inside a spec that only asserts the snackbar config. Today the reload is deferred to a microtask the test never awaits, so it passes — but the side effect is a latent footgun that would surface as a jsdom navigation error the moment the handler's `async` ordering changes.

Swap the stub to `NEVER` so the action stream genuinely never emits. The activate/reload contract is still covered by the dedicated `"activates the waiting worker before reloading on Neu laden click"` spec, which drives `onActionSubject.next()` explicitly and stubs `window.location.reload`.

## Test plan

- [x] `pnpm nx test web` — all specs pass, including the touched regression test
- [ ] Auto-merge (squash) once required checks (lint-test-build, e2e, build_and_preview, CodeQL) go green

https://claude.ai/code/session_01AVRZ1at1iaFdNGX4XRhtCM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVRZ1at1iaFdNGX4XRhtCM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite for service worker update notifications to better validate update handler behavior across different snackbar interaction scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/339)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->