### PR TITLE
fix(training-plans): keep deep-linked day visible below sticky toolbar

### DIFF
--- a/web/src/app/training-plans/training-plan-detail.component.spec.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.spec.ts
@@ -407,6 +407,37 @@ describe('TrainingPlanDetailComponent', () => {
       HTMLElement.prototype.scrollIntoView = original;
     });
 
+    it('offsets day-row anchors below the sticky toolbar so deep-linked days are not hidden', async () => {
+      // Regression: navigating from the dashboard banner with `?day=N`
+      // scrolls the matching `.day-row` to the top of the scroll
+      // container, but the sticky `mat-toolbar.top-nav` (≈64px tall)
+      // would otherwise overlap the row. `scroll-margin-top` shifts the
+      // scroll resting position down so the row is fully visible.
+      const { fixture } = await render(TrainingPlanDetailComponent, {
+        providers: [
+          provideRouter([]),
+          { provide: ActivatedRoute, useValue: makeRouteMock('recruit-6w') },
+          { provide: TrainingPlanStore, useValue: makeStoreMock() },
+          {
+            provide: AuthStore,
+            useValue: makeAuthStoreMock({
+              isAuthenticated: true,
+              authResolved: true,
+            }),
+          },
+        ],
+      });
+      fixture.detectChanges();
+
+      const dayRow = (fixture.nativeElement as HTMLElement).querySelector(
+        '.day-row'
+      );
+      expect(dayRow).not.toBeNull();
+      const computed = window.getComputedStyle(dayRow as Element);
+      const offset = parseFloat(computed.scrollMarginTop);
+      expect(offset).toBeGreaterThanOrEqual(64);
+    });
+
     it('does not scroll when ?day is missing', async () => {
       const original = HTMLElement.prototype.scrollIntoView;
       const scrollIntoView = vitest.fn();

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -483,6 +483,7 @@ interface DayRow {
         padding: 10px 12px;
         border-radius: 8px;
         background: rgba(0, 0, 0, 0.04);
+        scroll-margin-top: 80px;
       }
       .day-body {
         min-width: 0;


### PR DESCRIPTION
Navigating from the dashboard's active-plan banner with ?day=N scrolls
the matching .day-row to the top of the scroll container, but the sticky
mat-toolbar.top-nav overlapped it. Adding scroll-margin-top: 80px matches
the convention already used by the settings page and wiki pushup-types
page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where navigating to specific training plan sections could hide content behind the sticky toolbar. Sections now display with proper spacing from the top when scrolled into view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/340)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->