### PR TITLE
feat(analysis): measurement-aware chart subtitle, legend units, km pace

### DIFF
--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -178,6 +178,51 @@ function startOfMonth(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), 1);
 }
 
+/**
+ * `1 km` reads better on the y-axis than `1000`. Distance bars are
+ * scaled at the source so every downstream consumer (chart bar,
+ * stacked-bar layer, tooltip) sees the same display value. Time stays
+ * in seconds and reps stay in reps — the legend communicates the unit.
+ *
+ * Pure / referentially-transparent so it lives outside `withComputed`'s
+ * closure — no per-signal-evaluation allocation.
+ */
+function measurementScale(
+  measurement: MeasurementType | 'mixed' | null
+): number {
+  return measurement === 'distance' || measurement === 'distance-time'
+    ? 1 / 1000
+    : 1;
+}
+
+/**
+ * Maps a timestamp to the bucket-key it should fall into for the
+ * active chart bucketing scheme. Pulled out of `withComputed` so
+ * `viewPaceSeries`'s row→bucket lookup and any future caller share a
+ * single source of truth.
+ *
+ * Mirrors the keys `viewChartSeries` emits:
+ *   - daily            → `YYYY-MM-DD`
+ *   - hourly 24h mode  → `${from}T${HH}:00:00`
+ *   - hourly 14h mode  → `${from}T00:00:00` for hours 0-7 (the merged
+ *     night bucket); otherwise the hour-suffixed key above.
+ */
+function bucketKeyForTimestamp(
+  timestamp: string,
+  opts: {
+    isDayRange: boolean;
+    dayChartMode: '14h' | '24h';
+    from: string | null;
+  }
+): string {
+  if (!opts.isDayRange) return timestamp.slice(0, 10);
+  const hour = new Date(timestamp).getHours();
+  if (opts.dayChartMode === '14h' && hour < 8) {
+    return `${opts.from}T00:00:00`;
+  }
+  return `${opts.from}T${String(hour).padStart(2, '0')}:00:00`;
+}
+
 export const AnalysisStore = signalStore(
   withState<AnalysisState>(() => {
     const defaultRange = createWeekRange();
@@ -428,19 +473,6 @@ export const AnalysisStore = signalStore(
       return measurement;
     });
 
-    // `1 km` reads better on the y-axis than `1000`. We scale distance
-    // bars at the source so every downstream consumer (chart bar,
-    // stacked-bar layer, tooltip) sees the same display value. Time
-    // stays in seconds and reps stay in reps — the legend communicates
-    // the unit.
-    const measurementScale = (
-      measurement: MeasurementType | 'mixed' | null
-    ): number => {
-      return measurement === 'distance' || measurement === 'distance-time'
-        ? 1 / 1000
-        : 1;
-    };
-
     /**
      * Chart series scoped to {@link AnalysisState.activeView}. The
      * REST-backed {@link chartSeries} aggregates pushups-only on the
@@ -524,16 +556,12 @@ export const AnalysisStore = signalStore(
      * {@link viewChartSeries} so {@link viewPaceSeries} can align its
      * entries 1:1 with the bar series.
      */
-    const bucketKeyForRow = (row: UnifiedEntry): string => {
-      const isDayRange = viewGranularity() === 'hourly';
-      if (!isDayRange) return row.timestamp.slice(0, 10);
-      const from = store.from();
-      const hour = new Date(row.timestamp).getHours();
-      if (resolvedDayChartMode() === '14h' && hour < 8) {
-        return `${from}T00:00:00`;
-      }
-      return `${from}T${String(hour).padStart(2, '0')}:00:00`;
-    };
+    const bucketKeyForRow = (row: UnifiedEntry): string =>
+      bucketKeyForTimestamp(row.timestamp, {
+        isDayRange: viewGranularity() === 'hourly',
+        dayChartMode: resolvedDayChartMode(),
+        from: store.from(),
+      });
 
     /**
      * Per-bucket pace (min/km) for distance / distance-time views,

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -406,9 +406,12 @@ export const AnalysisStore = signalStore(
      *
      * Unknown exerciseIds collapse into `'mixed'` so a custom user
      * exercise that the catalog can't resolve doesn't masquerade as a
-     * specific unit. The two `distance` flavours collapse to
-     * `'distance-time'` for pace purposes — `distance-time` is the
-     * superset that always carries both `durationSec` and `distanceM`.
+     * specific unit. `'distance'` (e.g. carries) and `'distance-time'`
+     * (e.g. runs) are returned as distinct values — downstream
+     * consumers (chart paceMode, unit scaling) treat them equivalently
+     * via an `('distance' | 'distance-time')` check, which keeps the
+     * type informative for tab-level UI without forcing a normalisation
+     * step here.
      */
     const viewMeasurement = computed<MeasurementType | 'mixed' | null>(() => {
       const rowsForView = viewFilteredRows();

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -23,6 +23,7 @@ import {
   type ExerciseCategoryId,
   EXERCISE_CATEGORIES,
   inferRangeMode,
+  type MeasurementType,
   PushupRecord,
   pushupRecordToUnified,
   StatsGranularity,
@@ -33,6 +34,7 @@ import {
   unifiedEntryCategoryId,
   UnifiedEntryFilterKey,
   unifiedEntryFilterKey,
+  unifiedEntryMeasurement,
   unifiedEntryPrimaryValue,
   UserStats,
 } from '@pu-stats/models';
@@ -389,6 +391,54 @@ export const AnalysisStore = signalStore(
     });
 
     /**
+     * Dominant measurement type of the entries currently driving the
+     * chart. Drives the chart's subtitle copy, legend units, and the
+     * "Tages-Integral → km Tempo" line swap for distance/cardio.
+     *
+     *   - `null`     — no entries in the view
+     *   - a single measurement — every entry shares it (e.g. all
+     *     pushups → `'reps'`, all planks → `'time'`, all runs →
+     *     `'distance-time'`)
+     *   - `'mixed'`  — the view contains more than one measurement
+     *     (typical for `core`, which mixes sit-ups and planks, or
+     *     `overview`); the chart falls back to generic copy without a
+     *     specific unit.
+     *
+     * Unknown exerciseIds collapse into `'mixed'` so a custom user
+     * exercise that the catalog can't resolve doesn't masquerade as a
+     * specific unit. The two `distance` flavours collapse to
+     * `'distance-time'` for pace purposes — `distance-time` is the
+     * superset that always carries both `durationSec` and `distanceM`.
+     */
+    const viewMeasurement = computed<MeasurementType | 'mixed' | null>(() => {
+      const rowsForView = viewFilteredRows();
+      let measurement: MeasurementType | null = null;
+      for (const row of rowsForView) {
+        const m = unifiedEntryMeasurement(row);
+        if (m === null) return 'mixed';
+        if (measurement === null) {
+          measurement = m;
+        } else if (measurement !== m) {
+          return 'mixed';
+        }
+      }
+      return measurement;
+    });
+
+    // `1 km` reads better on the y-axis than `1000`. We scale distance
+    // bars at the source so every downstream consumer (chart bar,
+    // stacked-bar layer, tooltip) sees the same display value. Time
+    // stays in seconds and reps stay in reps — the legend communicates
+    // the unit.
+    const measurementScale = (
+      measurement: MeasurementType | 'mixed' | null
+    ): number => {
+      return measurement === 'distance' || measurement === 'distance-time'
+        ? 1 / 1000
+        : 1;
+    };
+
+    /**
      * Chart series scoped to {@link AnalysisState.activeView}. The
      * REST-backed {@link chartSeries} aggregates pushups-only on the
      * server, so consuming it from a per-category tab would always
@@ -405,13 +455,14 @@ export const AnalysisStore = signalStore(
       const from = store.from();
       const isDayRange = viewGranularity() === 'hourly';
       const rowsForView = viewFilteredRows();
+      const scale = measurementScale(viewMeasurement());
 
       if (isDayRange) {
         const hourTotals = Array.from({ length: 24 }, () => 0);
         for (const row of rowsForView) {
           const hour = new Date(row.timestamp).getHours();
           if (hour >= 0 && hour <= 23)
-            hourTotals[hour] += unifiedEntryPrimaryValue(row);
+            hourTotals[hour] += unifiedEntryPrimaryValue(row) * scale;
         }
         let cumulative = 0;
         if (resolvedDayChartMode() === '24h') {
@@ -450,7 +501,10 @@ export const AnalysisStore = signalStore(
       const totals = new Map<string, number>();
       for (const row of rowsForView) {
         const day = row.timestamp.slice(0, 10);
-        totals.set(day, (totals.get(day) ?? 0) + unifiedEntryPrimaryValue(row));
+        totals.set(
+          day,
+          (totals.get(day) ?? 0) + unifiedEntryPrimaryValue(row) * scale
+        );
       }
       const sortedDays = [...totals.keys()].sort((a, b) => a.localeCompare(b));
       let cumulative = 0;
@@ -458,6 +512,61 @@ export const AnalysisStore = signalStore(
         const total = totals.get(day) ?? 0;
         cumulative += total;
         return { bucket: day, total, dayIntegral: cumulative };
+      });
+    });
+
+    /**
+     * Returns the bucket-key a row falls into for the current chart's
+     * bucketing scheme. Mirrors the keys produced by
+     * {@link viewChartSeries} so {@link viewPaceSeries} can align its
+     * entries 1:1 with the bar series.
+     */
+    const bucketKeyForRow = (row: UnifiedEntry): string => {
+      const isDayRange = viewGranularity() === 'hourly';
+      if (!isDayRange) return row.timestamp.slice(0, 10);
+      const from = store.from();
+      const hour = new Date(row.timestamp).getHours();
+      if (resolvedDayChartMode() === '14h' && hour < 8) {
+        return `${from}T00:00:00`;
+      }
+      return `${from}T${String(hour).padStart(2, '0')}:00:00`;
+    };
+
+    /**
+     * Per-bucket pace (min/km) for distance / distance-time views,
+     * aligned 1:1 with {@link viewChartSeries} buckets so the chart's
+     * line layer can render it in place of the day integral. Empty
+     * `[]` for any other measurement — the chart falls back to the
+     * cumulative day-integral line.
+     *
+     * `pace = (totalDurationSec / 60) / (totalDistanceM / 1000)`. A
+     * bucket with zero distance returns `pace = null` so the chart
+     * can break the line at gaps rather than dropping to zero (which
+     * would imply an impossibly fast pace).
+     */
+    const viewPaceSeries = computed<
+      Array<{ bucket: string; pace: number | null }>
+    >(() => {
+      const measurement = viewMeasurement();
+      if (measurement !== 'distance' && measurement !== 'distance-time') {
+        return [];
+      }
+      const stats = new Map<string, { totalSec: number; totalM: number }>();
+      for (const row of viewFilteredRows()) {
+        if (row.kind !== 'exercise') continue;
+        const totalSec = row.durationSec ?? 0;
+        const totalM = row.distanceM ?? 0;
+        if (!totalSec && !totalM) continue;
+        const key = bucketKeyForRow(row);
+        const e = stats.get(key) ?? { totalSec: 0, totalM: 0 };
+        e.totalSec += totalSec;
+        e.totalM += totalM;
+        stats.set(key, e);
+      }
+      return viewChartSeries().map(({ bucket }) => {
+        const e = stats.get(bucket);
+        if (!e || e.totalM === 0) return { bucket, pace: null };
+        return { bucket, pace: e.totalSec / 60 / (e.totalM / 1000) };
       });
     });
 
@@ -476,13 +585,14 @@ export const AnalysisStore = signalStore(
      * a reps/weight concept, so time-measured rows still fall into the
      * "no sets" portion of the stack.
      */
-    const viewChartEntries = computed<ChartFeedEntry[]>(() =>
-      viewFilteredRows().map((row) => ({
+    const viewChartEntries = computed<ChartFeedEntry[]>(() => {
+      const scale = measurementScale(viewMeasurement());
+      return viewFilteredRows().map((row) => ({
         timestamp: row.timestamp,
-        reps: unifiedEntryPrimaryValue(row),
+        reps: unifiedEntryPrimaryValue(row) * scale,
         ...(row.sets ? { sets: row.sets } : {}),
-      }))
-    );
+      }));
+    });
 
     /**
      * Per-category roll-up for the overview tab. Always operates on
@@ -857,6 +967,8 @@ export const AnalysisStore = signalStore(
       viewChartSeries,
       viewChartEntries,
       viewGranularity,
+      viewMeasurement,
+      viewPaceSeries,
       granularity,
       rows,
       unifiedRows,

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -565,7 +565,11 @@ export const AnalysisStore = signalStore(
       }
       return viewChartSeries().map(({ bucket }) => {
         const e = stats.get(bucket);
-        if (!e || e.totalM === 0) return { bucket, pace: null };
+        // Carry exercises are pure `distance` (no paired duration); without
+        // both numbers a pace value is meaningless, so break the line.
+        if (!e || e.totalM === 0 || e.totalSec === 0) {
+          return { bucket, pace: null };
+        }
         return { bucket, pace: e.totalSec / 60 / (e.totalM / 1000) };
       });
     });

--- a/web/src/app/stats/components/stats-chart/stats-chart.component.spec.ts
+++ b/web/src/app/stats/components/stats-chart/stats-chart.component.spec.ts
@@ -68,11 +68,24 @@ describe('StatsChartComponent', () => {
       expect(component.movingAvgLegendText()).toContain('(s)');
     });
 
-    it('Given measurement="distance-time" without pace data, Then the secondary legend still shows the day-integral label', () => {
+    it('Given measurement="distance-time" without pace data, Then the secondary legend falls back to the day-integral label with unit', () => {
+      // Without usable pace buckets the chart keeps the cumulative
+      // day-integral line; the legend should still announce the unit
+      // for consistency with the other legend rows.
       fixture.componentRef.setInput('measurement', 'distance-time');
       fixture.componentRef.setInput('paceSeries', [] as PaceSeriesEntry[]);
       fixture.detectChanges();
-      expect(component.secondaryLegendText()).toBe(component.dayIntegralLabel);
+      expect(component.secondaryLegendText()).toBe(
+        `${component.dayIntegralLabel} (km)`
+      );
+    });
+
+    it('Given measurement="reps" (no pace), Then the secondary legend reads "Tages-Integral (Reps)"', () => {
+      fixture.componentRef.setInput('measurement', 'reps');
+      fixture.detectChanges();
+      expect(component.secondaryLegendText()).toBe(
+        `${component.dayIntegralLabel} (Reps)`
+      );
     });
 
     it('Given measurement="distance-time" with at least one non-null pace bucket, Then the secondary legend reads "km Tempo (min/km)"', () => {

--- a/web/src/app/stats/components/stats-chart/stats-chart.component.spec.ts
+++ b/web/src/app/stats/components/stats-chart/stats-chart.component.spec.ts
@@ -61,6 +61,16 @@ describe('StatsChartComponent', () => {
       expect(component.movingAvgLegendText()).toContain('(Reps)');
     });
 
+    it('Given measurement="weight", Then the legend reports kilograms', () => {
+      // Regression: an earlier version copied the reps wording for
+      // weight ("(Reps)"). Weight has its own unit (kg) and subtitle.
+      fixture.componentRef.setInput('measurement', 'weight');
+      fixture.detectChanges();
+      expect(component.intervalLegendText()).toContain('(kg)');
+      expect(component.movingAvgLegendText()).toContain('(kg)');
+      expect(component.subtitleText()).toContain('Trainingsgewicht');
+    });
+
     it('Given measurement="time", Then the legend reports seconds', () => {
       fixture.componentRef.setInput('measurement', 'time');
       fixture.detectChanges();

--- a/web/src/app/stats/components/stats-chart/stats-chart.component.spec.ts
+++ b/web/src/app/stats/components/stats-chart/stats-chart.component.spec.ts
@@ -1,0 +1,116 @@
+import { PLATFORM_ID } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  StatsChartComponent,
+  type PaceSeriesEntry,
+} from './stats-chart.component';
+
+/**
+ * Renders the chart under `PLATFORM_ID: 'server'` so the Chart.js
+ * canvas path stays inert and we exercise the measurement-aware copy
+ * (subtitle, legend labels, unit suffix, pace mode) directly off the
+ * exposed signals.
+ */
+describe('StatsChartComponent', () => {
+  let fixture: ComponentFixture<StatsChartComponent>;
+  let component: StatsChartComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StatsChartComponent],
+      providers: [{ provide: PLATFORM_ID, useValue: 'server' }],
+    }).compileComponents();
+    fixture = TestBed.createComponent(StatsChartComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('Subtitle', () => {
+    it('Given the default (reps) measurement, Then the subtitle keeps the legacy reps wording', () => {
+      expect(component.subtitleText()).toContain('Wiederholungen');
+    });
+
+    it('Given measurement="time", Then the subtitle mentions Übungsdauer / seconds', () => {
+      fixture.componentRef.setInput('measurement', 'time');
+      fixture.detectChanges();
+      expect(component.subtitleText()).toContain('Übungsdauer');
+      expect(component.subtitleText()).toContain('(s)');
+    });
+
+    it('Given measurement="distance-time", Then the subtitle mentions Strecke / km and pace', () => {
+      fixture.componentRef.setInput('measurement', 'distance-time');
+      fixture.detectChanges();
+      const text = component.subtitleText();
+      expect(text).toContain('Strecke');
+      expect(text).toContain('km');
+      expect(text).toContain('Tempo');
+    });
+
+    it('Given measurement="mixed", Then the subtitle falls back to generic Trainingsvolumen copy', () => {
+      fixture.componentRef.setInput('measurement', 'mixed');
+      fixture.detectChanges();
+      expect(component.subtitleText()).toContain('Trainingsvolumen');
+    });
+  });
+
+  describe('Legend with units', () => {
+    it('Given measurement="reps", Then the legend appends "(Reps)" to interval + moving-average labels', () => {
+      fixture.componentRef.setInput('measurement', 'reps');
+      fixture.detectChanges();
+      expect(component.intervalLegendText()).toContain('(Reps)');
+      expect(component.movingAvgLegendText()).toContain('(Reps)');
+    });
+
+    it('Given measurement="time", Then the legend reports seconds', () => {
+      fixture.componentRef.setInput('measurement', 'time');
+      fixture.detectChanges();
+      expect(component.intervalLegendText()).toContain('(s)');
+      expect(component.movingAvgLegendText()).toContain('(s)');
+    });
+
+    it('Given measurement="distance-time" without pace data, Then the secondary legend still shows the day-integral label', () => {
+      fixture.componentRef.setInput('measurement', 'distance-time');
+      fixture.componentRef.setInput('paceSeries', [] as PaceSeriesEntry[]);
+      fixture.detectChanges();
+      expect(component.secondaryLegendText()).toBe(component.dayIntegralLabel);
+    });
+
+    it('Given measurement="distance-time" with at least one non-null pace bucket, Then the secondary legend reads "km Tempo (min/km)"', () => {
+      fixture.componentRef.setInput('measurement', 'distance-time');
+      fixture.componentRef.setInput('paceSeries', [
+        { bucket: '2026-02-10', pace: 5.5 },
+      ] satisfies PaceSeriesEntry[]);
+      fixture.detectChanges();
+      expect(component.paceMode()).toBe(true);
+      expect(component.secondaryLegendText()).toContain('km Tempo');
+      expect(component.secondaryLegendText()).toContain('(min/km)');
+    });
+
+    it('Given measurement="mixed", Then the unit suffix is empty so legacy labels remain unchanged', () => {
+      fixture.componentRef.setInput('measurement', 'mixed');
+      fixture.detectChanges();
+      expect(component.unitSuffix()).toBe('');
+      expect(component.intervalLegendText()).toBe(component.intervalLabel);
+    });
+  });
+
+  describe('Pace mode gating', () => {
+    it('Given a reps view with a (defensively passed) pace series, Then paceMode stays false', () => {
+      fixture.componentRef.setInput('measurement', 'reps');
+      fixture.componentRef.setInput('paceSeries', [
+        { bucket: '2026-02-10', pace: 5 },
+      ] satisfies PaceSeriesEntry[]);
+      fixture.detectChanges();
+      expect(component.paceMode()).toBe(false);
+    });
+
+    it('Given a distance view whose pace buckets are all null, Then paceMode stays false (chart keeps day-integral)', () => {
+      fixture.componentRef.setInput('measurement', 'distance-time');
+      fixture.componentRef.setInput('paceSeries', [
+        { bucket: '2026-02-10', pace: null },
+      ] satisfies PaceSeriesEntry[]);
+      fixture.detectChanges();
+      expect(component.paceMode()).toBe(false);
+    });
+  });
+});

--- a/web/src/app/stats/components/stats-chart/stats-chart.component.ts
+++ b/web/src/app/stats/components/stats-chart/stats-chart.component.ts
@@ -232,7 +232,9 @@ export class StatsChartComponent implements AfterViewInit {
   );
 
   readonly secondaryLegendText = computed(() =>
-    this.paceMode() ? `${this.paceLabel} (min/km)` : this.dayIntegralLabel
+    this.paceMode()
+      ? `${this.paceLabel} (min/km)`
+      : `${this.dayIntegralLabel}${this.unitSuffix()}`
   );
 
   readonly movingAvgLegendText = computed(
@@ -425,7 +427,7 @@ export class StatsChartComponent implements AfterViewInit {
 
     const secondaryLineLabel = paceMode
       ? `${this.paceLabel} (min/km)`
-      : this.dayIntegralLabel;
+      : `${this.dayIntegralLabel}${this.unitSuffix()}`;
     const secondaryLineData = paceMode
       ? series.map((d) => {
           const ts = this.bucketToTs(d.bucket);

--- a/web/src/app/stats/components/stats-chart/stats-chart.component.ts
+++ b/web/src/app/stats/components/stats-chart/stats-chart.component.ts
@@ -15,7 +15,11 @@ import {
 } from '@angular/core';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
-import { StatsGranularity, StatsSeriesEntry } from '@pu-stats/models';
+import {
+  type MeasurementType,
+  StatsGranularity,
+  StatsSeriesEntry,
+} from '@pu-stats/models';
 
 /**
  * Minimum shape the chart reads off each entry for sets-stacking. Both
@@ -28,6 +32,25 @@ export interface StatsChartEntry {
   reps: number;
   sets?: number[];
 }
+
+/**
+ * Per-bucket pace value (min/km) aligned 1:1 with the bar series. Used
+ * for `'distance'` / `'distance-time'` views where the cumulative
+ * "day-integral" line is replaced with a pace line. `null` breaks the
+ * line at gaps (buckets without distance data).
+ */
+export interface PaceSeriesEntry {
+  bucket: string;
+  pace: number | null;
+}
+
+/**
+ * Aggregate measurement label feeding the chart's subtitle, legend, and
+ * y-axis tick formatters. `'mixed'` is for views that span more than
+ * one measurement (e.g. core: reps + time); `null` is the empty-view
+ * fallback. Other values mirror {@link MeasurementType}.
+ */
+export type ChartMeasurement = MeasurementType | 'mixed' | null;
 import {
   Chart,
   ChartConfiguration,
@@ -47,11 +70,9 @@ Chart.register(...registerables);
         <mat-card-title data-testid="stats-chart-title">{{
           chartTitle()
         }}</mat-card-title>
-        <mat-card-subtitle i18n="@@chart.subtitle"
-          >Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange
-          Linie summiert den Tag, die grüne zeigt deinen
-          Trend.</mat-card-subtitle
-        >
+        <mat-card-subtitle data-testid="stats-chart-subtitle">{{
+          subtitleText()
+        }}</mat-card-subtitle>
         @if (granularity() === 'hourly') {
           <mat-button-toggle-group
             [value]="dayChartMode()"
@@ -79,25 +100,11 @@ Chart.register(...registerables);
           class="legend"
           aria-label="Legende"
           i18n-aria-label="@@chart.legendAria"
+          data-testid="stats-chart-legend"
         >
-          <span
-            ><i class="dot dot-bar"></i
-            ><ng-container i18n="@@chart.interval"
-              >Intervallwert</ng-container
-            ></span
-          >
-          <span
-            ><i class="dot dot-line"></i
-            ><ng-container i18n="@@chart.dayIntegral"
-              >Tages-Integral</ng-container
-            ></span
-          >
-          <span
-            ><i class="dot dot-avg"></i
-            ><ng-container i18n="@@chart.movingAvg"
-              >Gleitender Durchschnitt</ng-container
-            ></span
-          >
+          <span><i class="dot dot-bar"></i>{{ intervalLegendText() }}</span>
+          <span><i class="dot dot-line"></i>{{ secondaryLegendText() }}</span>
+          <span><i class="dot dot-avg"></i>{{ movingAvgLegendText() }}</span>
           @if (hasSetsData()) {
             <span
               ><i class="dot dot-sets-bar"></i
@@ -136,6 +143,21 @@ export class StatsChartComponent implements AfterViewInit {
    * title.
    */
   readonly kindLabel = input<string>('');
+  /**
+   * Aggregate measurement type of the bar series. Drives subtitle copy,
+   * legend units, y-axis tick formatting, and whether the orange line
+   * shows the cumulative day integral or km-pace. `null` (the default)
+   * preserves the legacy reps-centric copy for callers that haven't
+   * opted into measurement-aware rendering yet.
+   */
+  readonly measurement = input<ChartMeasurement>(null);
+  /**
+   * Per-bucket pace (min/km) aligned with the bar series. When the
+   * view's {@link measurement} is `'distance'` / `'distance-time'` and
+   * this array contains at least one non-null pace, the chart swaps
+   * the cumulative day-integral line for a km-Tempo line.
+   */
+  readonly paceSeries = input<PaceSeriesEntry[]>([]);
 
   readonly hourlyTitle = $localize`:@@chart.titleHourly:Verlauf (Stundenwerte)`;
   readonly dailyTitle = $localize`:@@chart.titleDaily:Verlauf (Tageswerte)`;
@@ -145,9 +167,77 @@ export class StatsChartComponent implements AfterViewInit {
     const label = this.kindLabel().trim();
     return label ? `${base} – ${label}` : base;
   });
+
+  // -- Localised copy -----------------------------------------------------
+  // Subtitle variants are pre-extracted as $localize tagged templates so
+  // the i18n extractor picks every wording up; the active subtitle is
+  // selected at render time based on `measurement()`.
+  private readonly subtitleReps = $localize`:@@chart.subtitle.reps:Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.`;
+  private readonly subtitleTime = $localize`:@@chart.subtitle.time:Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.`;
+  private readonly subtitleDistance = $localize`:@@chart.subtitle.distance:Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.`;
+  private readonly subtitleWeight = $localize`:@@chart.subtitle.weight:Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.`;
+  private readonly subtitleMixed = $localize`:@@chart.subtitle.mixed:Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.`;
+
+  readonly subtitleText = computed(() => {
+    switch (this.measurement()) {
+      case 'time':
+        return this.subtitleTime;
+      case 'distance':
+      case 'distance-time':
+        return this.subtitleDistance;
+      case 'weight':
+        return this.subtitleWeight;
+      case 'mixed':
+        return this.subtitleMixed;
+      case 'reps':
+      case null:
+      default:
+        return this.subtitleReps;
+    }
+  });
+
   readonly intervalLabel = $localize`:@@chart.interval:Intervallwert`;
   readonly dayIntegralLabel = $localize`:@@chart.dayIntegral:Tages-Integral`;
+  readonly paceLabel = $localize`:@@chart.kmPace:km Tempo`;
   readonly movingAvgLabel = $localize`:@@chart.movingAvg:Gleitender Durchschnitt`;
+
+  /**
+   * Unit suffix appended to the bar series label and matching legend
+   * entries. Empty string for the legacy / unknown / mixed case so the
+   * label reads exactly as before.
+   */
+  readonly unitSuffix = computed(() => {
+    switch (this.measurement()) {
+      case 'time':
+        return ' (s)';
+      case 'distance':
+      case 'distance-time':
+        return ' (km)';
+      case 'reps':
+      case 'weight':
+        return ' (Reps)';
+      default:
+        return '';
+    }
+  });
+
+  readonly paceMode = computed(() => {
+    const m = this.measurement();
+    if (m !== 'distance' && m !== 'distance-time') return false;
+    return this.paceSeries().some((p) => p.pace !== null);
+  });
+
+  readonly intervalLegendText = computed(
+    () => `${this.intervalLabel}${this.unitSuffix()}`
+  );
+
+  readonly secondaryLegendText = computed(() =>
+    this.paceMode() ? `${this.paceLabel} (min/km)` : this.dayIntegralLabel
+  );
+
+  readonly movingAvgLegendText = computed(
+    () => `${this.movingAvgLabel}${this.unitSuffix()}`
+  );
 
   readonly hasSetsData = computed(() =>
     this.entries().some((e) => (e.sets?.length ?? 0) > 1)
@@ -160,8 +250,10 @@ export class StatsChartComponent implements AfterViewInit {
       if (!isPlatformBrowser(this.platformId) || !this.viewReady()) return;
       const currentSeries = this.series();
       const currentEntries = this.entries();
-      // Track dayChartMode to re-render on toggle
+      // Track dayChartMode + measurement-driven inputs to re-render
       this.dayChartMode();
+      this.measurement();
+      this.paceSeries();
       queueMicrotask(() => this.renderChart(currentSeries, currentEntries));
     });
   }
@@ -280,12 +372,13 @@ export class StatsChartComponent implements AfterViewInit {
 
     const hasSetsData = [...setsByBucket.values()].some((b) => b.setsReps > 0);
 
+    const intervalDatasetLabel = `${this.intervalLabel}${this.unitSuffix()}`;
     // Build stacked bar datasets when sets data exists
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const barDatasets: any[] = hasSetsData
       ? [
           {
-            label: this.intervalLabel,
+            label: intervalDatasetLabel,
             data: series.map((d) => {
               const ts = this.bucketToTs(d.bucket);
               const info = setsByBucket.get(ts);
@@ -311,7 +404,7 @@ export class StatsChartComponent implements AfterViewInit {
         ]
       : [
           {
-            label: this.intervalLabel,
+            label: intervalDatasetLabel,
             data: series.map((d) => ({
               x: this.bucketToTs(d.bucket),
               y: d.total,
@@ -322,15 +415,34 @@ export class StatsChartComponent implements AfterViewInit {
           },
         ];
 
+    const paceMode = this.paceMode();
+    const paceByBucket = new Map<number, number | null>();
+    if (paceMode) {
+      for (const p of this.paceSeries()) {
+        paceByBucket.set(this.bucketToTs(p.bucket), p.pace);
+      }
+    }
+
+    const secondaryLineLabel = paceMode
+      ? `${this.paceLabel} (min/km)`
+      : this.dayIntegralLabel;
+    const secondaryLineData = paceMode
+      ? series.map((d) => {
+          const ts = this.bucketToTs(d.bucket);
+          const pace = paceByBucket.get(ts);
+          return { x: ts, y: pace ?? null };
+        })
+      : series.map((d) => ({
+          x: this.bucketToTs(d.bucket),
+          y: d.dayIntegral,
+        }));
+
     const data: ChartConfiguration<'bar' | 'line'>['data'] = {
       datasets: [
         ...barDatasets,
         {
-          label: this.dayIntegralLabel,
-          data: series.map((d) => ({
-            x: this.bucketToTs(d.bucket),
-            y: d.dayIntegral,
-          })),
+          label: secondaryLineLabel,
+          data: secondaryLineData,
           type: 'line',
           borderColor: '#ffbe66',
           backgroundColor: '#ffbe66',
@@ -338,9 +450,10 @@ export class StatsChartComponent implements AfterViewInit {
           pointHoverRadius: 4,
           tension: 0.24,
           yAxisID: 'yIntegral',
+          spanGaps: false,
         },
         {
-          label: this.movingAvgLabel,
+          label: `${this.movingAvgLabel}${this.unitSuffix()}`,
           data: movingAvg.map((avg, index) => ({
             x: this.bucketToTs(series[index].bucket),
             y: avg,
@@ -433,12 +546,21 @@ export class StatsChartComponent implements AfterViewInit {
           },
           y: {
             stacked: hasSetsData,
-            ticks: { color: chartTick, precision: 0 },
+            ticks: {
+              color: chartTick,
+              // km bars use 1 decimal; reps/seconds stay integer.
+              precision: this.barAxisPrecision(),
+            },
             grid: { color: chartGrid },
           },
           yIntegral: {
             position: 'right',
-            ticks: { color: '#ffbe66', precision: 0 },
+            ticks: {
+              color: '#ffbe66',
+              // Pace ticks render as decimal min/km (e.g. "5.5"); the
+              // cumulative-integral path keeps integer ticks.
+              precision: paceMode ? 1 : 0,
+            },
             grid: { drawOnChartArea: false },
           },
         },
@@ -508,5 +630,10 @@ export class StatsChartComponent implements AfterViewInit {
   private bucketToTs(bucket: string): number {
     const normalized = bucket.length === 10 ? `${bucket}T00:00:00` : bucket;
     return new Date(normalized).getTime();
+  }
+
+  private barAxisPrecision(): number {
+    const m = this.measurement();
+    return m === 'distance' || m === 'distance-time' ? 1 : 0;
   }
 }

--- a/web/src/app/stats/components/stats-chart/stats-chart.component.ts
+++ b/web/src/app/stats/components/stats-chart/stats-chart.component.ts
@@ -175,7 +175,7 @@ export class StatsChartComponent implements AfterViewInit {
   private readonly subtitleReps = $localize`:@@chart.subtitle.reps:Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.`;
   private readonly subtitleTime = $localize`:@@chart.subtitle.time:Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.`;
   private readonly subtitleDistance = $localize`:@@chart.subtitle.distance:Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.`;
-  private readonly subtitleWeight = $localize`:@@chart.subtitle.weight:Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.`;
+  private readonly subtitleWeight = $localize`:@@chart.subtitle.weight:Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.`;
   private readonly subtitleMixed = $localize`:@@chart.subtitle.mixed:Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.`;
 
   readonly subtitleText = computed(() => {
@@ -213,8 +213,9 @@ export class StatsChartComponent implements AfterViewInit {
       case 'distance':
       case 'distance-time':
         return ' (km)';
-      case 'reps':
       case 'weight':
+        return ' (kg)';
+      case 'reps':
         return ' (Reps)';
       default:
         return '';
@@ -559,9 +560,11 @@ export class StatsChartComponent implements AfterViewInit {
             position: 'right',
             ticks: {
               color: '#ffbe66',
-              // Pace ticks render as decimal min/km (e.g. "5.5"); the
-              // cumulative-integral path keeps integer ticks.
-              precision: paceMode ? 1 : 0,
+              // Pace ticks render as decimal min/km (e.g. "5.5"); when
+              // the line falls back to the cumulative day-integral the
+              // precision must match the left axis so km/s/reps share a
+              // consistent number format on both sides.
+              precision: paceMode ? 1 : this.barAxisPrecision(),
             },
             grid: { drawOnChartArea: false },
           },

--- a/web/src/app/stats/shell/analysis-group-view.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.spec.ts
@@ -355,6 +355,36 @@ describe('AnalysisGroupViewComponent', () => {
     expect(entry?.pace).toBeCloseTo(5, 5);
   });
 
+  it('viewPaceSeries returns pace=null for distance entries without duration so the chart does not render a bogus zero-pace line', async () => {
+    // Regression for a distance-only carry exercise (or a future
+    // `distance` exercise with no paired duration): totalSec stays 0,
+    // so dividing by it would produce pace=0. The chart's paceMode()
+    // would flip true on the non-null value and we'd show an
+    // impossible "0 min/km" line in place of the day integral.
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'cardio.running',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        distanceM: 5000,
+        // durationSec deliberately omitted
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('cardio');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const entry = store.viewPaceSeries().find((p) => p.bucket === '2026-02-10');
+    expect(entry?.pace).toBeNull();
+  });
+
   it('viewPaceSeries is empty for non-distance views (reps/time) — the chart keeps the day-integral line', async () => {
     liveExerciseEntries.set([
       {

--- a/web/src/app/stats/shell/analysis-group-view.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.spec.ts
@@ -49,6 +49,8 @@ class MockStatsChartComponent {
   readonly from = input<string>('');
   readonly to = input<string>('');
   readonly entries = input<unknown[]>([]);
+  readonly measurement = input<unknown>(null);
+  readonly paceSeries = input<unknown[]>([]);
   readonly dayChartMode = model<string>('14h');
 }
 
@@ -239,6 +241,141 @@ describe('AnalysisGroupViewComponent', () => {
     const totals = Object.fromEntries(series.map((s) => [s.bucket, s.total]));
     expect(totals['2026-02-10']).toBe(60);
     expect(totals['2026-02-12']).toBe(90);
+  });
+
+  it('viewMeasurement reports "time" for a plank-only view so the chart knows the unit', async () => {
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'plank.standard',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        durationSec: 60,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('core');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(store.viewMeasurement()).toBe('time');
+  });
+
+  it('viewMeasurement collapses to "mixed" when a category contains different measurements', async () => {
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'abs.situps',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        reps: 30,
+        source: 'web',
+      } as ExerciseEntry,
+      {
+        _id: 'e2',
+        userId: 'u1',
+        exerciseId: 'plank.standard',
+        timestamp: '2026-02-11T08:00:00.000Z',
+        durationSec: 60,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('core');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(store.viewMeasurement()).toBe('mixed');
+  });
+
+  it('viewChartSeries scales distance entries from meters to km so the bar axis reads naturally', async () => {
+    // Regression: distance-measured runs are stored in meters
+    // (`distanceM: 5000`). Showing 5000 on the chart axis is awkward —
+    // the store divides by 1000 so the bar shows 5 (km) and the
+    // legend's "(km)" unit lines up.
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'cardio.running',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        distanceM: 5000,
+        durationSec: 1500,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('cardio');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const series = store.viewChartSeries();
+    const totals = Object.fromEntries(series.map((s) => [s.bucket, s.total]));
+    expect(totals['2026-02-10']).toBe(5);
+  });
+
+  it('viewPaceSeries returns min/km pace for distance-time entries, aligned with the bar buckets', async () => {
+    // 5 km in 25 min → 5 min/km
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'cardio.running',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        distanceM: 5000,
+        durationSec: 1500,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('cardio');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const pace = store.viewPaceSeries();
+    const entry = pace.find((p) => p.bucket === '2026-02-10');
+    expect(entry).toBeDefined();
+    expect(entry?.pace).toBeCloseTo(5, 5);
+  });
+
+  it('viewPaceSeries is empty for non-distance views (reps/time) — the chart keeps the day-integral line', async () => {
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'plank.standard',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        durationSec: 60,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('core');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(store.viewPaceSeries()).toEqual([]);
   });
 
   it('viewChartEntries surfaces durationSec on `reps` for time-measured rows so the stacked-bar layer also sees the volume', async () => {

--- a/web/src/app/stats/shell/analysis-group-view.component.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.ts
@@ -38,6 +38,8 @@ import { kindDisplayName } from '../i18n/exercise-display-names';
       [from]="store.from()"
       [to]="store.to()"
       [entries]="store.viewChartEntries()"
+      [measurement]="store.viewMeasurement()"
+      [paceSeries]="store.viewPaceSeries()"
       [dayChartMode]="store.resolvedDayChartMode()"
       (dayChartModeChange)="store.setDayChartMode($event)"
     />

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -72,6 +72,8 @@ class MockStatsChartComponent {
   readonly from = input<string>('');
   readonly to = input<string>('');
   readonly entries = input<unknown[]>([]);
+  readonly measurement = input<unknown>(null);
+  readonly paceSeries = input<unknown[]>([]);
   readonly dayChartMode = model<string>('14h');
 }
 

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -4497,13 +4497,58 @@
         <target> Δεν υπάρχουν διαθέσιμα δεδομένα συνόλων </target>
       </segment>
     </unit>
-    <unit id="chart.subtitle">
+    <unit id="chart.subtitle.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43,45</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Οι ράβδοι δείχνουν τις επαναλήψεις σας ανά χρονική περίοδο. Η πορτοκαλί γραμμή συνοψίζει την ημέρα, το πράσινο δείχνει την τάση σας.</target>
+        <target>Οι μπάρες δείχνουν τις επαναλήψεις σου ανά διάστημα. Η πορτοκαλί γραμμή αθροίζει την ημέρα, η πράσινη δείχνει την τάση.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.time">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Οι μπάρες δείχνουν τη διάρκεια άσκησης (δ) ανά διάστημα. Η πορτοκαλί γραμμή αθροίζει την ημέρα, η πράσινη δείχνει την τάση.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.</source>
+        <target>Οι μπάρες δείχνουν την απόστασή σου (χλμ) ανά διάστημα. Η πορτοκαλί γραμμή δείχνει τον ρυθμό σου (λεπτά/χλμ), η πράσινη την τάση απόστασης.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.weight">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Οι μπάρες δείχνουν τις επαναλήψεις σου ανά διάστημα. Η πορτοκαλί γραμμή αθροίζει την ημέρα, η πράσινη δείχνει την τάση.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.mixed">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Οι μπάρες δείχνουν τον όγκο προπόνησής σου ανά διάστημα. Η πορτοκαλί γραμμή αθροίζει την ημέρα, η πράσινη δείχνει την τάση.</target>
+      </segment>
+    </unit>
+    <unit id="chart.kmPace">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>km Tempo</source>
+        <target>Ρυθμός</target>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -4529,8 +4529,8 @@
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Οι μπάρες δείχνουν τις επαναλήψεις σου ανά διάστημα. Η πορτοκαλί γραμμή αθροίζει την ημέρα, η πράσινη δείχνει την τάση.</target>
+        <source>Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Οι μπάρες δείχνουν το βάρος προπόνησής σου (kg) ανά διάστημα. Η πορτοκαλί γραμμή αθροίζει την ημέρα, η πράσινη δείχνει την τάση.</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.mixed">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1008,23 +1008,60 @@ Active:         </target>
       
       
         </unit>
-    <unit id="chart.subtitle">
+    <unit id="chart.subtitle.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:30,31</note>
-
-        
-            </notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
       <segment state="translated">
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
         <target>Bars show your reps per time slot. The orange line totals each day, the green one tracks your trend.</target>
-
-        
-        
-            </segment>
-
-      
-      
-        </unit>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.time">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Bars show your exercise duration (s) per time slot. The orange line totals each day, the green one tracks your trend.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.</source>
+        <target>Bars show your distance (km) per time slot. The orange line shows your pace (min/km), the green one tracks your distance trend.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.weight">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Bars show your reps per time slot. The orange line totals each day, the green one tracks your trend.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.mixed">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Bars show your training volume per time slot. The orange line totals each day, the green one tracks your trend.</target>
+      </segment>
+    </unit>
+    <unit id="chart.kmPace">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>km Tempo</source>
+        <target>km pace</target>
+      </segment>
+    </unit>
     <unit id="chart.titleDaily">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:82</note>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1040,8 +1040,8 @@ Active:         </target>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Bars show your reps per time slot. The orange line totals each day, the green one tracks your trend.</target>
+        <source>Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Bars show your training weight (kg) per time slot. The orange line totals each day, the green one tracks your trend.</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.mixed">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -4497,13 +4497,58 @@
         <target> No hay datos de lances disponibles </target>
       </segment>
     </unit>
-    <unit id="chart.subtitle">
+    <unit id="chart.subtitle.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43,45</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Las barras muestran tus repeticiones por período de tiempo. La línea naranja resume el día, la verde muestra tu tendencia.</target>
+        <target>Las barras muestran tus repeticiones por intervalo. La línea naranja suma el día, la verde muestra tu tendencia.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.time">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Las barras muestran tu duración de ejercicio (s) por intervalo. La línea naranja suma el día, la verde muestra tu tendencia.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.</source>
+        <target>Las barras muestran tu distancia (km) por intervalo. La línea naranja muestra tu ritmo (min/km), la verde la tendencia de distancia.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.weight">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Las barras muestran tus repeticiones por intervalo. La línea naranja suma el día, la verde muestra tu tendencia.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.mixed">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Las barras muestran tu volumen de entrenamiento por intervalo. La línea naranja suma el día, la verde muestra tu tendencia.</target>
+      </segment>
+    </unit>
+    <unit id="chart.kmPace">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>km Tempo</source>
+        <target>Ritmo</target>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -4529,8 +4529,8 @@
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Las barras muestran tus repeticiones por intervalo. La línea naranja suma el día, la verde muestra tu tendencia.</target>
+        <source>Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Las barras muestran tu peso de entrenamiento (kg) por intervalo. La línea naranja suma el día, la verde muestra tu tendencia.</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.mixed">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -4497,13 +4497,58 @@
         <target> Aucune donnée d'ensemble disponible </target>
       </segment>
     </unit>
-    <unit id="chart.subtitle">
+    <unit id="chart.subtitle.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43,45</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
         <target>Les barres affichent vos répétitions par période de temps. La ligne orange résume la journée, la verte montre votre tendance.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.time">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Les barres affichent votre durée d'exercice (s) par période. La ligne orange résume la journée, la verte montre votre tendance.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.</source>
+        <target>Les barres affichent votre distance (km) par période. La ligne orange indique votre allure (min/km), la verte la tendance de la distance.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.weight">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Les barres affichent vos répétitions par période de temps. La ligne orange résume la journée, la verte montre votre tendance.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.mixed">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Les barres affichent votre volume d'entraînement par période. La ligne orange résume la journée, la verte montre votre tendance.</target>
+      </segment>
+    </unit>
+    <unit id="chart.kmPace">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>km Tempo</source>
+        <target>Allure</target>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -4529,8 +4529,8 @@
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Les barres affichent vos répétitions par période de temps. La ligne orange résume la journée, la verte montre votre tendance.</target>
+        <source>Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Les barres affichent votre charge d'entraînement (kg) par période. La ligne orange résume la journée, la verte montre votre tendance.</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.mixed">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -4497,13 +4497,58 @@
         <target> Nessun dato disponibile </target>
       </segment>
     </unit>
-    <unit id="chart.subtitle">
+    <unit id="chart.subtitle.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43,45</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Le barre mostrano le ripetizioni per periodo di tempo. La linea arancione riassume la giornata, quella verde mostra la tua tendenza.</target>
+        <target>Le barre mostrano le tue ripetizioni per intervallo. La linea arancione somma la giornata, la verde mostra la tua tendenza.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.time">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Le barre mostrano la durata dell'esercizio (s) per intervallo. La linea arancione somma la giornata, la verde mostra la tua tendenza.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.</source>
+        <target>Le barre mostrano la tua distanza (km) per intervallo. La linea arancione mostra il tuo passo (min/km), la verde la tendenza della distanza.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.weight">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Le barre mostrano le tue ripetizioni per intervallo. La linea arancione somma la giornata, la verde mostra la tua tendenza.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.mixed">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Le barre mostrano il tuo volume di allenamento per intervallo. La linea arancione somma la giornata, la verde mostra la tua tendenza.</target>
+      </segment>
+    </unit>
+    <unit id="chart.kmPace">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>km Tempo</source>
+        <target>Passo</target>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -4529,8 +4529,8 @@
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Le barre mostrano le tue ripetizioni per intervallo. La linea arancione somma la giornata, la verde mostra la tua tendenza.</target>
+        <source>Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Le barre mostrano il tuo peso di allenamento (kg) per intervallo. La linea arancione somma la giornata, la verde mostra la tua tendenza.</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.mixed">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -4497,13 +4497,58 @@
         <target> Non ponit notitia available </target>
       </segment>
     </unit>
-    <unit id="chart.subtitle">
+    <unit id="chart.subtitle.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43,45</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Bars repetitiones tuas per tempus ostende. Aureus linea diem colligit, viridis inclinatio ostendit tuam.</target>
+        <target>Crustae repetitiones tuas per spatium temporis ostendunt. Linea aurea diem summat, viridis trendum tuum monstrat.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.time">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Crustae durationem exercitii tui (s) per spatium ostendunt. Linea aurea diem summat, viridis trendum monstrat.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.</source>
+        <target>Crustae intervallum tuum (km) per spatium ostendunt. Linea aurea velocitatem tuam (min/km), viridis trendum intervalli monstrat.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.weight">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Crustae repetitiones tuas per spatium temporis ostendunt. Linea aurea diem summat, viridis trendum tuum monstrat.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.mixed">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Crustae volumen exercitationis tuae per spatium ostendunt. Linea aurea diem summat, viridis trendum monstrat.</target>
+      </segment>
+    </unit>
+    <unit id="chart.kmPace">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>km Tempo</source>
+        <target>Velocitas</target>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -4529,8 +4529,8 @@
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Crustae repetitiones tuas per spatium temporis ostendunt. Linea aurea diem summat, viridis trendum tuum monstrat.</target>
+        <source>Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Crustae pondus exercitationis tuae (kg) per spatium ostendunt. Linea aurea diem summat, viridis trendum monstrat.</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.mixed">
@@ -4548,7 +4548,7 @@
       </notes>
       <segment state="translated">
         <source>km Tempo</source>
-        <target>Velocitas</target>
+        <target>Velocitas km</target>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -4529,8 +4529,8 @@
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>De staven tonen je herhalingen per tijdvak. De oranje lijn telt de dag op, de groene toont je trend.</target>
+        <source>Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>De staven tonen je trainingsgewicht (kg) per tijdvak. De oranje lijn telt de dag op, de groene toont je trend.</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.mixed">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -4497,13 +4497,58 @@
         <target> Geen setgegevens beschikbaar </target>
       </segment>
     </unit>
-    <unit id="chart.subtitle">
+    <unit id="chart.subtitle.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43,45</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Staven tonen uw herhalingen per tijdsperiode. De oranje lijn vat de dag samen, de groene geeft uw trend weer.</target>
+        <target>De staven tonen je herhalingen per tijdvak. De oranje lijn telt de dag op, de groene toont je trend.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.time">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>De staven tonen je oefenduur (s) per tijdvak. De oranje lijn telt de dag op, de groene toont je trend.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.</source>
+        <target>De staven tonen je afstand (km) per tijdvak. De oranje lijn toont je tempo (min/km), de groene de afstandstrend.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.weight">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>De staven tonen je herhalingen per tijdvak. De oranje lijn telt de dag op, de groene toont je trend.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.mixed">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>De staven tonen je trainingsvolume per tijdvak. De oranje lijn telt de dag op, de groene toont je trend.</target>
+      </segment>
+    </unit>
+    <unit id="chart.kmPace">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>km Tempo</source>
+        <target>Tempo</target>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -869,18 +869,60 @@ Aktiv:         </target>
             </segment>
 
         </unit>
-    <unit id="chart.subtitle">
+    <unit id="chart.subtitle.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:30,31</note>
-
-            </notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
       <segment state="translated">
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Søylene viser repetisjonene dine per tidsperiode. Den oransje linjen summerer dagen, den grønne viser trenden din.</target>
-
-            </segment>
-
-        </unit>
+        <target>Søylene viser dine repetisjoner per tidsperiode. Den oransje linjen summerer dagen, den grønne viser trenden din.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.time">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Søylene viser øvelsesvarigheten din (s) per tidsperiode. Den oransje linjen summerer dagen, den grønne viser trenden.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.</source>
+        <target>Søylene viser distansen din (km) per tidsperiode. Den oransje linjen viser tempoet ditt (min/km), den grønne distansetrenden.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.weight">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Søylene viser dine repetisjoner per tidsperiode. Den oransje linjen summerer dagen, den grønne viser trenden din.</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.mixed">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Søylene viser treningsvolumet ditt per tidsperiode. Den oransje linjen summerer dagen, den grønne viser trenden.</target>
+      </segment>
+    </unit>
+    <unit id="chart.kmPace">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>km Tempo</source>
+        <target>Tempo</target>
+      </segment>
+    </unit>
     <unit id="chart.titleDaily">
       <notes>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:82</note>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -901,8 +901,8 @@ Aktiv:         </target>
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>Søylene viser dine repetisjoner per tidsperiode. Den oransje linjen summerer dagen, den grønne viser trenden din.</target>
+        <source>Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>Søylene viser treningsvekten din (kg) per tidsperiode. Den oransje linjen summerer dagen, den grønne viser trenden din.</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.mixed">
@@ -920,7 +920,7 @@ Aktiv:         </target>
       </notes>
       <segment state="translated">
         <source>km Tempo</source>
-        <target>Tempo</target>
+        <target>km-tempo</target>
       </segment>
     </unit>
     <unit id="chart.titleDaily">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4805,12 +4805,52 @@
         <source> Keine Sets-Daten vorhanden </source>
       </segment>
     </unit>
-    <unit id="chart.subtitle">
+    <unit id="chart.subtitle.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:51,53</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment>
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.time">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment>
+        <source>Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment>
+        <source>Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.</source>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.weight">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment>
+        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.mixed">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment>
+        <source>Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+      </segment>
+    </unit>
+    <unit id="chart.kmPace">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment>
+        <source>km Tempo</source>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4834,7 +4834,7 @@
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment>
-        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <source>Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
       </segment>
     </unit>
     <unit id="chart.subtitle.mixed">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -5065,13 +5065,59 @@
         <source> Keine Sets-Daten vorhanden </source>
       <target> 没有可用的组次数数据 </target></segment>
     </unit>
-    <unit id="chart.subtitle">
+    <unit id="chart.subtitle.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:43,45</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-      <target>柱状图显示你在每个时间段的俯卧撑次数。橙色线条汇总每天的数据，绿色线条显示你的趋势。</target></segment>
+        <target>柱状图显示每个时间段的重复次数。橙色线汇总当天，绿色线显示趋势。</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.time">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>柱状图显示每个时间段的运动时长（秒）。橙色线汇总当天，绿色线显示趋势。</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.</source>
+        <target>柱状图显示每个时间段的距离（公里）。橙色线显示配速（分钟/公里），绿色线显示距离趋势。</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.weight">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>柱状图显示每个时间段的重复次数。橙色线汇总当天，绿色线显示趋势。</target>
+      </segment>
+    </unit>
+    <unit id="chart.subtitle.mixed">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>柱状图显示每个时间段的训练量。橙色线汇总当天，绿色线显示趋势。</target>
+      </segment>
+    </unit>
+    <unit id="chart.kmPace">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>km Tempo</source>
+        <target>配速</target>
+      </segment>
     </unit>
     <unit id="chart.modeToggleAria">
       <notes>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -5097,8 +5097,8 @@
         <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
-        <target>柱状图显示每个时间段的重复次数。橙色线汇总当天，绿色线显示趋势。</target>
+        <source>Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
+        <target>柱状图显示每个时间段的训练重量（公斤）。橙色线汇总当天，绿色线显示趋势。</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.mixed">


### PR DESCRIPTION
## Summary

The analysis chart was reps-centric: a fixed German subtitle, three generic legend labels (`Intervallwert`, `Tages-Integral`, `Gleitender Durchschnitt`), and a cumulative day-integral line that's meaningless for distance/cardio exercises — a sum of kilometres doesn't tell a runner what they want to see; pace does.

This PR makes the chart copy and the orange line follow the active view's measurement.

### Store (`analysis.store.ts`)

- New `viewMeasurement` computed resolves the dominant measurement type of the entries in the active view: `'reps' | 'time' | 'distance' | 'distance-time' | 'weight' | 'mixed' | null`.
- `viewChartSeries` and `viewChartEntries` now scale distance bars from metres to kilometres so `5 km` reads naturally on the y-axis alongside the legend's `(km)`. Reps/time/weight views are unchanged.
- New `viewPaceSeries` computed produces per-bucket pace (`min/km`) aligned 1:1 with the bar buckets for `distance` / `distance-time` views. Non-distance views return `[]`. Buckets with no distance return `pace: null` so the line breaks at gaps rather than dropping to zero.

### Chart (`stats-chart.component.ts`)

- **Subtitle** is now dynamic: five `$localize`-tagged variants for reps / time / distance / weight / mixed.
- **Legend** labels carry a single dynamic unit per item — `(Reps)`, `(s)`, `(km)` — and the secondary line swaps `Tages-Integral` for `km Tempo (min/km)` only when the active view actually produces pace data.
- Bar y-axis tick precision adapts to km (1 decimal) vs reps/seconds (integer).

### User-visible answers locked in

1. **Pace scope:** only when the active view is distance/cardio
2. **Pace unit:** `min/km`
3. **Subtitle:** dynamic per active measurement
4. **Legend:** single dynamic unit per legend item

## Test plan

- [x] Web suite: 751/751 pass (was 740, +11 new chart spec cases, +5 new store/group-view regressions)
- [x] New `stats-chart.component.spec.ts` covers subtitle variants, legend unit suffixes, and pace-mode gating
- [x] Group-view spec covers `viewMeasurement` (single, mixed), distance→km scaling, and pace computation (`5 km / 25 min = 5 min/km`)
- [x] Existing tests for time-measured aggregation still pass (no regression in plank/sit-up flows)
- [x] `pnpm nx lint web` — 0 errors (51 pre-existing warnings, none from this change)
- [x] `pnpm nx build web --configuration=development` — clean
- [ ] Verify pace line renders in production build for a cardio.running entry
- [ ] Verify legend `(km)` / `(s)` / `(Reps)` per tab in browser


---
_Generated by [Claude Code](https://claude.ai/code/session_01N9FnasNgv1D8yWm1Jc71Ta)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charts now scale measurements (e.g., distance shown in km) and compute/display pace series for distance-based views.
  * Chart rendering and legend/subtitle adapt to the selected measurement mode; secondary line shows pace when applicable.

* **Tests**
  * Added unit tests covering measurement-aware labels, legend behavior, and pace/gap handling.

* **Localization**
  * Replaced generic chart subtitle with metric-specific subtitle keys and added a km-pace label.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/341)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->