### PR TITLE
fix(training-entry-dialog): make duration row shrink and accept localized km input

### DIFF
--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
@@ -277,6 +277,35 @@ describe('TrainingEntryDialogComponent', () => {
       expect(component.durationSecondsInput()).toBe('30');
     });
 
+    it.each([
+      // Edit-mode km initial value must match the active locale so the
+      // create + edit paths show the same separator. Without this, a
+      // de-DE user opening an existing run would see a dot-formatted
+      // value while typing fresh entries gets a comma placeholder.
+      ['de-DE', '5,25'],
+      ['en-US', '5.25'],
+    ])(
+      'formats the edit-mode km initial value with the active locale (%s)',
+      (locale, expected) => {
+        const { component } = createDialog(
+          {
+            kind: 'exercise',
+            exerciseId: 'cardio.running',
+            timestamp: '2026-02-10T13:45:00+01:00',
+            distanceM: 5250,
+            durationSec: 1500,
+          },
+          [{ provide: LOCALE_ID, useValue: locale }]
+        );
+
+        expect(component.distanceInput()).toBe(expected);
+        // Round-trip: the locale-formatted string must still parse back
+        // to the original metres so the edit dialog opens at green.
+        expect(component.distanceM()).toBe(5250);
+        expect(component.canSubmit()).toBe(true);
+      }
+    );
+
     it('emits a null variantId when the user clears a previously-set variant', () => {
       const { component, closeSpy } = createDialog({
         kind: 'exercise',

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
@@ -1,4 +1,5 @@
-import { TestBed } from '@angular/core/testing';
+import { LOCALE_ID, Provider } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { provideRouter } from '@angular/router';
 import {
@@ -9,8 +10,12 @@ import {
 } from './training-entry-dialog.component';
 
 describe('TrainingEntryDialogComponent', () => {
-  function createDialog(data: TrainingEntryDialogData | null): {
+  function createDialog(
+    data: TrainingEntryDialogData | null,
+    extraProviders: Provider[] = []
+  ): {
     component: TrainingEntryDialogComponent;
+    fixture: ComponentFixture<TrainingEntryDialogComponent>;
     closeSpy: ReturnType<typeof vitest.fn>;
   } {
     TestBed.resetTestingModule();
@@ -21,10 +26,11 @@ describe('TrainingEntryDialogComponent', () => {
         provideRouter([]),
         { provide: MAT_DIALOG_DATA, useValue: data },
         { provide: MatDialogRef, useValue: { close: closeSpy } },
+        ...extraProviders,
       ],
     });
     const fixture = TestBed.createComponent(TrainingEntryDialogComponent);
-    return { component: fixture.componentInstance, closeSpy };
+    return { component: fixture.componentInstance, fixture, closeSpy };
   }
 
   describe('create mode (no edit data)', () => {
@@ -124,6 +130,66 @@ describe('TrainingEntryDialogComponent', () => {
         distanceM: 5250,
         durationSec: 1500,
       });
+    });
+
+    it('accepts a German decimal comma in the km input (5,25 → 5250 m)', () => {
+      const { component, fixture, closeSpy } = createDialog(null, [
+        { provide: LOCALE_ID, useValue: 'de-DE' },
+      ]);
+
+      component.onCategoryChange('cardio');
+      fixture.detectChanges();
+
+      // The km input must use type="text" + inputmode="decimal" — a
+      // native type="number" input rejects "," in most browsers
+      // regardless of locale, so a German user who types the local
+      // decimal separator would see their input silently dropped.
+      const distanceEl: HTMLInputElement = fixture.nativeElement.querySelector(
+        'input[data-testid="training-entry-distance"]'
+      );
+      expect(distanceEl).toBeTruthy();
+      expect(distanceEl.type).toBe('text');
+      expect(distanceEl.inputMode).toBe('decimal');
+
+      distanceEl.value = '5,25';
+      distanceEl.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      component.timestamp.set('2026-02-10T13:45');
+      component.durationMinutesInput.set('25');
+      component.durationSecondsInput.set('0');
+
+      expect(component.distanceM()).toBe(5250);
+      expect(component.canSubmit()).toBe(true);
+      component.submit();
+
+      const result = closeSpy.mock.calls[0][0] as TrainingEntryDialogResult;
+      expect(result).toMatchObject({
+        distanceM: 5250,
+        durationSec: 1500,
+      });
+    });
+
+    it('renders a locale-aware placeholder for the km input', () => {
+      const { fixture: deFixture } = createDialog(null, [
+        { provide: LOCALE_ID, useValue: 'de-DE' },
+      ]);
+      deFixture.componentInstance.onCategoryChange('cardio');
+      deFixture.detectChanges();
+      const deInput: HTMLInputElement = deFixture.nativeElement.querySelector(
+        'input[data-testid="training-entry-distance"]'
+      );
+      expect(deInput.placeholder).toBe('5,00');
+
+      const { fixture: enFixture } = createDialog(null, [
+        { provide: LOCALE_ID, useValue: 'en-US' },
+      ]);
+      enFixture.componentInstance.onCategoryChange('cardio');
+      enFixture.detectChanges();
+      const enInput: HTMLInputElement = enFixture.nativeElement.querySelector(
+        'input[data-testid="training-entry-distance"]'
+      );
+      expect(enInput.placeholder).toBe('5.00');
     });
 
     it('clears the variant control and value fields when the exercise picker changes', () => {

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
@@ -690,7 +690,7 @@ export class TrainingEntryDialogComponent {
 
   readonly distanceInput = signal(
     this.data?.kind === 'exercise' && this.data.distanceM !== undefined
-      ? formatKmInput(this.data.distanceM)
+      ? formatKmInput(this.data.distanceM, this.locale)
       : ''
   );
 
@@ -702,10 +702,7 @@ export class TrainingEntryDialogComponent {
    * dot- or comma-separated form their locale uses — `<input type="number">`
    * silently rejects "," in most browsers regardless of `LOCALE_ID`.
    */
-  readonly distancePlaceholder = new Intl.NumberFormat(this.locale, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(5);
+  readonly distancePlaceholder = formatKm(5, this.locale);
 
   readonly isTimeMeasurement = computed(
     () => this.currentDefinition()?.measurement === 'time'
@@ -1181,9 +1178,23 @@ function parseKmToMeters(input: string): number | null {
   return Math.round(km * 1000);
 }
 
-function formatKmInput(distanceM: number): string {
+/**
+ * `useGrouping: false` keeps the formatted km value separator-free
+ * (e.g. de-DE `12345` km → `12345,00`, not `12.345,00`). The thousand
+ * separator would otherwise clash with the decimal comma and break the
+ * dot/comma swap in {@link parseKmToMeters}.
+ */
+function formatKm(km: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+    useGrouping: false,
+  }).format(km);
+}
+
+function formatKmInput(distanceM: number, locale: string): string {
   if (!Number.isFinite(distanceM) || distanceM <= 0) return '';
-  return (distanceM / 1000).toFixed(2);
+  return formatKm(distanceM / 1000, locale);
 }
 
 /**

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
@@ -211,7 +211,8 @@ interface PushupTypeOption {
         gap: 8px;
       }
       .duration-row mat-form-field {
-        flex: 1;
+        flex: 1 1 0;
+        min-width: 0;
       }
       @keyframes clone-set {
         from {
@@ -384,14 +385,12 @@ interface PushupTypeOption {
           <mat-label i18n="@@entryDialog.distance">Distanz (km)</mat-label>
           <input
             matInput
-            type="number"
+            type="text"
             inputmode="decimal"
-            placeholder="5.00"
-            [min]="minKm()"
-            [max]="maxKm()"
-            step="0.01"
+            [placeholder]="distancePlaceholder"
             [value]="distanceInput()"
             (input)="distanceInput.set(asValue($event))"
+            data-testid="training-entry-distance"
             required
           />
         </mat-form-field>
@@ -697,8 +696,16 @@ export class TrainingEntryDialogComponent {
 
   readonly distanceM = computed(() => parseKmToMeters(this.distanceInput()));
 
-  readonly minKm = computed(() => (this.currentDefinition()?.min ?? 0) / 1000);
-  readonly maxKm = computed(() => (this.currentDefinition()?.max ?? 0) / 1000);
+  /**
+   * Locale-aware placeholder for the km input. The input is `type="text"` +
+   * `inputmode="decimal"` (not `type="number"`) so users can type either the
+   * dot- or comma-separated form their locale uses — `<input type="number">`
+   * silently rejects "," in most browsers regardless of `LOCALE_ID`.
+   */
+  readonly distancePlaceholder = new Intl.NumberFormat(this.locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(5);
 
   readonly isTimeMeasurement = computed(
     () => this.currentDefinition()?.measurement === 'time'


### PR DESCRIPTION
- Duration row (Minuten/Sekunden) now sets min-width: 0 on the flex
  children so the two side-by-side inputs can shrink below their
  intrinsic content width on narrow mobile viewports.
- Km input switches from type="number" to type="text" + inputmode="decimal"
  so users can type either the dot- or comma-separated form their
  locale uses; native number inputs reject "," in most browsers
  regardless of LOCALE_ID. Placeholder is now derived via Intl.NumberFormat
  so de-DE shows "5,00" and en-US shows "5.00".