### PR TITLE
feat(stats): add intervals breakdown alongside sets for endurance entries

### DIFF
--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -196,6 +196,13 @@ service cloud.firestore {
     //   - `plank.standard` (time): require `durationSec` int 1..7200;
     //     forbid `reps` and `sets`.
     //
+    // Breakdown fields are split by exercise type:
+    //   - `sets`: per-set rep counts, only for reps-measured exercises.
+    //   - `intervals`: per-interval primary values (sprint repeats,
+    //     HIIT), only for time/distance/distance-time exercises.
+    //   They are mutually exclusive — the wrong field on the wrong
+    //   measurement type is rejected here.
+    //
     // Schema is also pinned via `keys().hasOnly([...])` so unknown
     // fields can't sneak past the trigger / aggregation logic.
     //
@@ -210,7 +217,7 @@ service cloud.firestore {
       allow create: if request.auth != null
                     && request.resource.data.keys().hasOnly([
                       'userId', 'exerciseId', 'reps', 'durationSec', 'distanceM',
-                      'sets', 'variantId', 'timestamp', 'source',
+                      'sets', 'intervals', 'variantId', 'timestamp', 'source',
                       'createdAt', 'updatedAt'
                     ])
                     && request.resource.data.userId == request.auth.uid
@@ -225,12 +232,15 @@ service cloud.firestore {
                       // like `cardio.jumprope`; per-exercise caps are
                       // enforced client-side via the catalog
                       // `min`/`max` plus the `applyDelta` trigger.
+                      // `intervals` is blocked here — endurance-only
+                      // breakdown, symmetric to the `sets` ban below.
                       (isRepsExerciseId(request.resource.data.exerciseId)
                         && request.resource.data.reps is int
                         && request.resource.data.reps >= 1
                         && request.resource.data.reps <= 10000
                         && !('durationSec' in request.resource.data.keys())
-                        && !('distanceM' in request.resource.data.keys()))
+                        && !('distanceM' in request.resource.data.keys())
+                        && !('intervals' in request.resource.data.keys()))
                       ||
                       // Time-measured exercises (plank, hollow hold,
                       // wall sit, dead hang, mobility holds, …). `sets`
@@ -269,12 +279,17 @@ service cloud.firestore {
                     // forever.
                     && (!('sets' in request.resource.data.keys())
                         || (request.resource.data.sets is list
-                            && request.resource.data.sets.size() <= 50));
+                            && request.resource.data.sets.size() <= 50))
+                    // Same bound for `intervals` (endurance breakdown).
+                    // Same NaN-poisoning concern via future delta logic.
+                    && (!('intervals' in request.resource.data.keys())
+                        || (request.resource.data.intervals is list
+                            && request.resource.data.intervals.size() <= 50));
       allow update: if request.auth != null
                     && resource.data.userId == request.auth.uid
                     && request.resource.data.keys().hasOnly([
                       'userId', 'exerciseId', 'reps', 'durationSec', 'distanceM',
-                      'sets', 'variantId', 'timestamp', 'source',
+                      'sets', 'intervals', 'variantId', 'timestamp', 'source',
                       'createdAt', 'updatedAt'
                     ])
                     && request.resource.data.userId == request.auth.uid
@@ -286,12 +301,14 @@ service cloud.firestore {
                     // pin to `resource.data.exerciseId`.
                     && (
                       // Reps-measured exercises: reject `durationSec`/
-                      // `distanceM` and validate reps when changed.
-                      // Caps mirror the create branch (single source of
-                      // truth via `isRepsExerciseId()` at the top).
+                      // `distanceM`/`intervals` and validate reps when
+                      // changed. Caps mirror the create branch (single
+                      // source of truth via `isRepsExerciseId()` at the
+                      // top).
                       (isRepsExerciseId(resource.data.exerciseId)
                         && !('durationSec' in request.resource.data.keys())
                         && !('distanceM' in request.resource.data.keys())
+                        && !('intervals' in request.resource.data.keys())
                         && (!('reps' in request.resource.data.diff(resource.data).affectedKeys())
                             || (request.resource.data.reps is int
                                 && request.resource.data.reps >= 1
@@ -328,7 +345,11 @@ service cloud.firestore {
                     && (!('sets' in request.resource.data.diff(resource.data).affectedKeys())
                         || !('sets' in request.resource.data.keys())
                         || (request.resource.data.sets is list
-                            && request.resource.data.sets.size() <= 50));
+                            && request.resource.data.sets.size() <= 50))
+                    && (!('intervals' in request.resource.data.diff(resource.data).affectedKeys())
+                        || !('intervals' in request.resource.data.keys())
+                        || (request.resource.data.intervals is list
+                            && request.resource.data.intervals.size() <= 50));
     }
 
     // Active training plan — owner-only. Single doc per user.

--- a/libs/data-access/src/lib/api/exercise-firestore.service.spec.ts
+++ b/libs/data-access/src/lib/api/exercise-firestore.service.spec.ts
@@ -279,6 +279,34 @@ describe('ExerciseFirestoreService', () => {
       expect(data['sets']).toEqual([10, 10, 10]);
     });
 
+    it('omits empty intervals array from the Firestore payload', async () => {
+      const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
+      await firstValueFrom(
+        service.createEntry('u1', {
+          exerciseId: 'plank.standard',
+          timestamp: '2026-04-15T08:00:00Z',
+          durationSec: 90,
+          intervals: [],
+        })
+      );
+      const data = setDocSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(data['intervals']).toBeUndefined();
+    });
+
+    it('preserves a non-empty intervals array on the Firestore payload', async () => {
+      const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
+      await firstValueFrom(
+        service.createEntry('u1', {
+          exerciseId: 'plank.standard',
+          timestamp: '2026-04-15T08:00:00Z',
+          durationSec: 90,
+          intervals: [30, 30, 30],
+        })
+      );
+      const data = setDocSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(data['intervals']).toEqual([30, 30, 30]);
+    });
+
     it('defaults source to "web" when not provided', async () => {
       const setDocSpy = jest.spyOn(firestoreFns, 'setDoc');
       await firstValueFrom(
@@ -304,9 +332,7 @@ describe('ExerciseFirestoreService', () => {
 
     it('errors when the new reps value is out of range', async () => {
       await expect(
-        firstValueFrom(
-          service.updateEntry('s1', 'abs.situps', { reps: 9999 })
-        )
+        firstValueFrom(service.updateEntry('s1', 'abs.situps', { reps: 9999 }))
       ).rejects.toThrow(/out-of-range/);
     });
 
@@ -345,6 +371,26 @@ describe('ExerciseFirestoreService', () => {
       // jest.mock call above; the real Firestore SDK returns a sentinel
       // object with the same role.
       expect(patch['sets']).toBe('__deleted__');
+    });
+
+    it('clears the intervals field when the patch sends an empty array', async () => {
+      const updateSpy = jest.spyOn(firestoreFns, 'updateDoc');
+      const deleteFieldSpy = jest.spyOn(firestoreFns, 'deleteField');
+      await firstValueFrom(
+        service.updateEntry('s1', 'abs.situps', { intervals: [] })
+      );
+      expect(deleteFieldSpy).toHaveBeenCalled();
+      const patch = updateSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(patch['intervals']).toBe('__deleted__');
+    });
+
+    it('preserves a non-empty intervals array on the update patch', async () => {
+      const updateSpy = jest.spyOn(firestoreFns, 'updateDoc');
+      await firstValueFrom(
+        service.updateEntry('s1', 'abs.situps', { intervals: [30, 30, 30] })
+      );
+      const patch = updateSpy.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(patch['intervals']).toEqual([30, 30, 30]);
     });
 
     it('uses partial validation so a variantId-only update is allowed', async () => {

--- a/libs/data-access/src/lib/api/exercise-firestore.service.spec.ts
+++ b/libs/data-access/src/lib/api/exercise-firestore.service.spec.ts
@@ -377,7 +377,7 @@ describe('ExerciseFirestoreService', () => {
       const updateSpy = jest.spyOn(firestoreFns, 'updateDoc');
       const deleteFieldSpy = jest.spyOn(firestoreFns, 'deleteField');
       await firstValueFrom(
-        service.updateEntry('s1', 'abs.situps', { intervals: [] })
+        service.updateEntry('s1', 'plank.standard', { intervals: [] })
       );
       expect(deleteFieldSpy).toHaveBeenCalled();
       const patch = updateSpy.mock.calls[0]?.[1] as Record<string, unknown>;
@@ -387,10 +387,28 @@ describe('ExerciseFirestoreService', () => {
     it('preserves a non-empty intervals array on the update patch', async () => {
       const updateSpy = jest.spyOn(firestoreFns, 'updateDoc');
       await firstValueFrom(
-        service.updateEntry('s1', 'abs.situps', { intervals: [30, 30, 30] })
+        service.updateEntry('s1', 'plank.standard', {
+          intervals: [30, 30, 30],
+        })
       );
       const patch = updateSpy.mock.calls[0]?.[1] as Record<string, unknown>;
       expect(patch['intervals']).toEqual([30, 30, 30]);
+    });
+
+    it('rejects an intervals patch on a reps-measured exercise', async () => {
+      await expect(
+        firstValueFrom(
+          service.updateEntry('s1', 'abs.situps', { intervals: [30, 30, 30] })
+        )
+      ).rejects.toThrow(/wrong-measurement-field/);
+    });
+
+    it('rejects a sets patch on a time-measured exercise', async () => {
+      await expect(
+        firstValueFrom(
+          service.updateEntry('s1', 'plank.standard', { sets: [10, 10, 10] })
+        )
+      ).rejects.toThrow(/wrong-measurement-field/);
     });
 
     it('uses partial validation so a variantId-only update is allowed', async () => {

--- a/libs/data-access/src/lib/api/exercise-firestore.service.ts
+++ b/libs/data-access/src/lib/api/exercise-firestore.service.ts
@@ -51,7 +51,7 @@ function violationObservable<T>(
   exerciseId: string,
   payload: Pick<
     ExerciseEntry,
-    'reps' | 'durationSec' | 'distanceM' | 'weightKg'
+    'reps' | 'durationSec' | 'distanceM' | 'weightKg' | 'sets' | 'intervals'
   > & { variantId?: string | null },
   options?: { partial?: boolean }
 ): Observable<T> | null {
@@ -97,15 +97,16 @@ export class ExerciseFirestoreService {
       // categories are far below that, but guarding here keeps the
       // failure mode predictable for future larger catalogs (and
       // avoids a cryptic Firestore error to the caller).
-      if (options.exerciseIds.length > 30) {
+      const exerciseIds = options.exerciseIds;
+      if (exerciseIds.length > 30) {
         return throwError(
           () =>
             new Error(
-              `listEntries: exerciseIds supports at most 30 ids, got ${options.exerciseIds!.length}`
+              `listEntries: exerciseIds supports at most 30 ids, got ${exerciseIds.length}`
             )
         );
       }
-      constraints.push(where('exerciseId', 'in', [...options.exerciseIds]));
+      constraints.push(where('exerciseId', 'in', [...exerciseIds]));
     }
     if (options?.filter?.from) {
       constraints.push(
@@ -230,7 +231,15 @@ export class ExerciseFirestoreService {
       );
     }
     const valueChanges = (
-      ['reps', 'durationSec', 'distanceM', 'weightKg', 'variantId'] as const
+      [
+        'reps',
+        'durationSec',
+        'distanceM',
+        'weightKg',
+        'variantId',
+        'sets',
+        'intervals',
+      ] as const
     ).some((k) => payload[k] !== undefined);
     if (valueChanges) {
       const violation = violationObservable<void>(exerciseId, payload, {

--- a/libs/data-access/src/lib/api/exercise-firestore.service.ts
+++ b/libs/data-access/src/lib/api/exercise-firestore.service.ts
@@ -63,9 +63,7 @@ function violationObservable<T>(
   }
   const violation = validateExerciseEntry(payload, def, options);
   if (!violation) return null;
-  return throwError(
-    () => new ExerciseValidationError(exerciseId, violation)
-  );
+  return throwError(() => new ExerciseValidationError(exerciseId, violation));
 }
 
 @Injectable({ providedIn: 'root' })
@@ -179,6 +177,7 @@ export class ExerciseFirestoreService {
       ...(payload.variantId ? { variantId: payload.variantId } : {}),
       ...companionPatch,
       ...(payload.sets?.length ? { sets: payload.sets } : {}),
+      ...(payload.intervals?.length ? { intervals: payload.intervals } : {}),
       source: payload.source ?? 'web',
       createdAt: nowIso,
       updatedAt: nowIso,
@@ -196,6 +195,9 @@ export class ExerciseFirestoreService {
     };
     if (payload.variantId) firestoreData['variantId'] = payload.variantId;
     if (payload.sets?.length) firestoreData['sets'] = payload.sets;
+    if (payload.intervals?.length) {
+      firestoreData['intervals'] = payload.intervals;
+    }
 
     return from(setDoc(newRef, firestoreData)).pipe(map(() => record));
   }
@@ -222,10 +224,7 @@ export class ExerciseFirestoreService {
     exerciseId: string,
     payload: ExerciseEntryUpdate
   ): Observable<void> {
-    if (
-      payload.exerciseId !== undefined &&
-      payload.exerciseId !== exerciseId
-    ) {
+    if (payload.exerciseId !== undefined && payload.exerciseId !== exerciseId) {
       return throwError(
         () => new ExerciseValidationError(exerciseId, 'unknown-exercise')
       );
@@ -252,13 +251,18 @@ export class ExerciseFirestoreService {
     // entirely would silently keep the stale value on the doc; mapping
     // it to `deleteField()` makes the patch actually clear the field.
     //   - `sets: []` clears the per-set breakdown.
+    //   - `intervals: []` clears the per-interval breakdown.
     //   - `variantId: null` clears a previously-set variant (the dialog
     //     forwards `null` when the user picked the "no variant" option
     //     in edit mode).
     const cleanPayload: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(patchable)) {
       if (v === undefined) continue;
-      if (k === 'sets' && Array.isArray(v) && v.length === 0) {
+      if (
+        (k === 'sets' || k === 'intervals') &&
+        Array.isArray(v) &&
+        v.length === 0
+      ) {
         cleanPayload[k] = deleteField();
         continue;
       }

--- a/libs/data-access/src/lib/api/pushup-firestore.service.spec.ts
+++ b/libs/data-access/src/lib/api/pushup-firestore.service.spec.ts
@@ -59,7 +59,7 @@ describe('PushupFirestoreService', () => {
             }),
           },
         ],
-      } as any);
+      } as never);
 
       const result = await firstValueFrom(service.listPushups('u1'));
 
@@ -84,7 +84,7 @@ describe('PushupFirestoreService', () => {
     it('adds userId and orderBy constraints to query', async () => {
       jest.spyOn(firestoreFns, 'getDocs').mockResolvedValueOnce({
         docs: [],
-      } as any);
+      } as never);
 
       await firstValueFrom(service.listPushups('u1'));
 
@@ -95,7 +95,7 @@ describe('PushupFirestoreService', () => {
     it('adds a from constraint when filter.from is provided', async () => {
       jest.spyOn(firestoreFns, 'getDocs').mockResolvedValueOnce({
         docs: [],
-      } as any);
+      } as never);
 
       await firstValueFrom(service.listPushups('u1', { from: '2024-01-05' }));
 
@@ -109,7 +109,7 @@ describe('PushupFirestoreService', () => {
     it('adds a to constraint when filter.to is provided', async () => {
       jest.spyOn(firestoreFns, 'getDocs').mockResolvedValueOnce({
         docs: [],
-      } as any);
+      } as never);
 
       await firstValueFrom(service.listPushups('u1', { to: '2024-01-10' }));
 
@@ -123,7 +123,7 @@ describe('PushupFirestoreService', () => {
     it('does not add from/to constraints when filter is empty', async () => {
       jest.spyOn(firestoreFns, 'getDocs').mockResolvedValueOnce({
         docs: [],
-      } as any);
+      } as never);
 
       await firstValueFrom(service.listPushups('u1', {}));
 
@@ -162,7 +162,7 @@ describe('PushupFirestoreService', () => {
             }),
           },
         ],
-      } as any);
+      } as never);
 
       const result = await firstValueFrom(
         service.listPushups('u1', { from: '2024-01-05' })
@@ -199,7 +199,7 @@ describe('PushupFirestoreService', () => {
             }),
           },
         ],
-      } as any);
+      } as never);
 
       const result = await firstValueFrom(
         service.listPushups('u1', { to: '2024-01-10' })
@@ -236,7 +236,7 @@ describe('PushupFirestoreService', () => {
             }),
           },
         ],
-      } as any);
+      } as never);
 
       const result = await firstValueFrom(
         service.listPushups('u1', { from: '2024-01-05', to: '2024-01-10' })
@@ -249,10 +249,10 @@ describe('PushupFirestoreService', () => {
   describe('createPushup', () => {
     it('calls setDoc and returns a PushupRecord with the new id', async () => {
       const newRef = { id: 'created-id' };
-      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(newRef as any);
+      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(newRef as never);
       const setDocSpy = jest
         .spyOn(firestoreFns, 'setDoc')
-        .mockResolvedValueOnce(undefined as any);
+        .mockResolvedValueOnce(undefined as never);
 
       const result = await firstValueFrom(
         service.createPushup('u1', {
@@ -278,10 +278,10 @@ describe('PushupFirestoreService', () => {
 
     it('persists sets array when provided', async () => {
       const newRef = { id: 'sets-id' };
-      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(newRef as any);
+      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(newRef as never);
       const setDocSpy = jest
         .spyOn(firestoreFns, 'setDoc')
-        .mockResolvedValueOnce(undefined as any);
+        .mockResolvedValueOnce(undefined as never);
 
       const result = await firstValueFrom(
         service.createPushup('u1', {
@@ -304,10 +304,10 @@ describe('PushupFirestoreService', () => {
 
     it('omits sets from Firestore when not provided', async () => {
       const newRef = { id: 'no-sets-id' };
-      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(newRef as any);
+      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(newRef as never);
       const setDocSpy = jest
         .spyOn(firestoreFns, 'setDoc')
-        .mockResolvedValueOnce(undefined as any);
+        .mockResolvedValueOnce(undefined as never);
 
       await firstValueFrom(
         service.createPushup('u1', {
@@ -322,10 +322,10 @@ describe('PushupFirestoreService', () => {
 
     it('omits sets from Firestore when empty array is provided', async () => {
       const newRef = { id: 'empty-sets-id' };
-      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(newRef as any);
+      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(newRef as never);
       const setDocSpy = jest
         .spyOn(firestoreFns, 'setDoc')
-        .mockResolvedValueOnce(undefined as any);
+        .mockResolvedValueOnce(undefined as never);
 
       await firstValueFrom(
         service.createPushup('u1', {
@@ -395,10 +395,10 @@ describe('PushupFirestoreService', () => {
 
     it('defaults source to "web" and type to "Standard" when omitted', async () => {
       const newRef = { id: 'default-id' };
-      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(newRef as any);
+      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(newRef as never);
       jest
         .spyOn(firestoreFns, 'setDoc')
-        .mockResolvedValueOnce(undefined as any);
+        .mockResolvedValueOnce(undefined as never);
 
       const result = await firstValueFrom(
         service.createPushup('u1', {
@@ -415,10 +415,10 @@ describe('PushupFirestoreService', () => {
   describe('updatePushup', () => {
     it('calls updateDoc with the patch and updatedAt timestamp', async () => {
       const rowRef = {};
-      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(rowRef as any);
+      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(rowRef as never);
       const updateDocSpy = jest
         .spyOn(firestoreFns, 'updateDoc')
-        .mockResolvedValueOnce(undefined as any);
+        .mockResolvedValueOnce(undefined as never);
 
       await firstValueFrom(service.updatePushup('id1', { reps: 8 }));
 
@@ -443,10 +443,10 @@ describe('PushupFirestoreService', () => {
 
       it('Then allows updates that omit reps entirely', async () => {
         const rowRef = {};
-        jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(rowRef as any);
+        jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(rowRef as never);
         const updateDocSpy = jest
           .spyOn(firestoreFns, 'updateDoc')
-          .mockResolvedValueOnce(undefined as any);
+          .mockResolvedValueOnce(undefined as never);
 
         await firstValueFrom(service.updatePushup('id1', { source: 'web' }));
 
@@ -456,10 +456,10 @@ describe('PushupFirestoreService', () => {
 
     it('strips undefined values from payload before calling updateDoc', async () => {
       const rowRef = {};
-      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(rowRef as any);
+      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(rowRef as never);
       const updateDocSpy = jest
         .spyOn(firestoreFns, 'updateDoc')
-        .mockResolvedValueOnce(undefined as any);
+        .mockResolvedValueOnce(undefined as never);
 
       await firstValueFrom(
         service.updatePushup('id1', {
@@ -480,10 +480,10 @@ describe('PushupFirestoreService', () => {
   describe('deletePushup', () => {
     it('calls deleteDoc and returns { ok: true }', async () => {
       const rowRef = {};
-      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(rowRef as any);
+      jest.spyOn(firestoreFns, 'doc').mockReturnValueOnce(rowRef as never);
       const deleteDocSpy = jest
         .spyOn(firestoreFns, 'deleteDoc')
-        .mockResolvedValueOnce(undefined as any);
+        .mockResolvedValueOnce(undefined as never);
 
       const result = await firstValueFrom(service.deletePushup('id1'));
 

--- a/libs/data-access/src/lib/provide-firestore.spec.ts
+++ b/libs/data-access/src/lib/provide-firestore.spec.ts
@@ -6,7 +6,10 @@ jest.mock('@angular/fire/firestore', () => ({
 }));
 
 import { withEmulator } from './provide-firestore';
-import { connectFirestoreEmulator } from '@angular/fire/firestore';
+import {
+  connectFirestoreEmulator,
+  type Firestore,
+} from '@angular/fire/firestore';
 
 describe('withEmulator', () => {
   beforeEach(() => {
@@ -14,7 +17,7 @@ describe('withEmulator', () => {
   });
 
   it('uses hostname/port from a full emulator URL', () => {
-    const firestore = {} as any;
+    const firestore = {} as Firestore;
 
     withEmulator('http://127.0.0.1:8080')(firestore);
 
@@ -26,7 +29,7 @@ describe('withEmulator', () => {
   });
 
   it('supports host:port input without protocol', () => {
-    const firestore = {} as any;
+    const firestore = {} as Firestore;
 
     withEmulator('localhost:9090')(firestore);
 
@@ -38,7 +41,7 @@ describe('withEmulator', () => {
   });
 
   it('falls back to default port when no port is provided', () => {
-    const firestore = {} as any;
+    const firestore = {} as Firestore;
 
     withEmulator('http://localhost')(firestore);
 

--- a/libs/stats/src/lib/models/exercise.models.spec.ts
+++ b/libs/stats/src/lib/models/exercise.models.spec.ts
@@ -393,6 +393,74 @@ describe('validateExerciseEntry — partial / patch mode', () => {
   });
 });
 
+describe('validateExerciseEntry — breakdown field mutex', () => {
+  it('accepts sets on a reps exercise', () => {
+    expect(
+      validateExerciseEntry({ reps: 30, sets: [10, 10, 10] }, repsDef)
+    ).toBeNull();
+  });
+
+  it('rejects intervals on a reps exercise', () => {
+    expect(
+      validateExerciseEntry({ reps: 30, intervals: [30, 30, 30] }, repsDef)
+    ).toBe('wrong-measurement-field');
+  });
+
+  it('accepts intervals on a time exercise', () => {
+    expect(
+      validateExerciseEntry(
+        { durationSec: 90, intervals: [30, 30, 30] },
+        timeDef
+      )
+    ).toBeNull();
+  });
+
+  it('rejects sets on a time exercise', () => {
+    expect(
+      validateExerciseEntry({ durationSec: 90, sets: [10, 10, 10] }, timeDef)
+    ).toBe('wrong-measurement-field');
+  });
+
+  it('rejects sets on a distance exercise', () => {
+    expect(
+      validateExerciseEntry(
+        { distanceM: 5000, sets: [10, 10, 10] },
+        distanceDef
+      )
+    ).toBe('wrong-measurement-field');
+  });
+
+  it('accepts intervals on a distance exercise', () => {
+    expect(
+      validateExerciseEntry(
+        { distanceM: 1200, intervals: [400, 400, 400] },
+        distanceDef
+      )
+    ).toBeNull();
+  });
+
+  it('rejects intervals on a weight exercise (strength uses sets)', () => {
+    expect(
+      validateExerciseEntry(
+        { reps: 5, weightKg: 80, intervals: [5, 5, 5] },
+        weightDef
+      )
+    ).toBe('wrong-measurement-field');
+  });
+
+  it('allows an empty wrong-side array as the clear sentinel', () => {
+    // `[]` is the deleteField sentinel used by updateEntry — it must
+    // pass through the validator even on the "wrong" side so a caller
+    // wiping a stale field doesn't have to know the measurement type.
+    expect(
+      validateExerciseEntry({ reps: 30, intervals: [] }, repsDef)
+    ).toBeNull();
+    expect(
+      validateExerciseEntry({ durationSec: 60, sets: [] }, timeDef)
+    ).toBeNull();
+  });
+});
+
 describe('validateExerciseEntry — variants', () => {
   const defWithVariants: Pick<
     ExerciseDefinition,

--- a/libs/stats/src/lib/models/exercise.models.spec.ts
+++ b/libs/stats/src/lib/models/exercise.models.spec.ts
@@ -1,5 +1,6 @@
 import {
   companionFields,
+  entryBreakdownField,
   measurementCompanionValueField,
   measurementValueField,
   requiredCompanionFields,
@@ -79,6 +80,18 @@ describe('measurementCompanionValueField', () => {
   });
 });
 
+describe('entryBreakdownField', () => {
+  it.each<[MeasurementType, 'sets' | 'intervals']>([
+    ['reps', 'sets'],
+    ['weight', 'sets'],
+    ['time', 'intervals'],
+    ['distance', 'intervals'],
+    ['distance-time', 'intervals'],
+  ])('Then %s exposes its breakdown as %s', (m, expected) => {
+    expect(entryBreakdownField(m)).toBe(expected);
+  });
+});
+
 describe('companionFields', () => {
   it.each<[MeasurementType, string[]]>([
     ['reps', []],
@@ -144,9 +157,9 @@ describe('validateExerciseEntry — reps measurement', () => {
     it.each(['durationSec', 'distanceM', 'weightKg'] as const)(
       'Then setting %s alongside reps is rejected as wrong-measurement-field',
       (field) => {
-        expect(
-          validateExerciseEntry({ reps: 10, [field]: 5 }, repsDef)
-        ).toBe('wrong-measurement-field');
+        expect(validateExerciseEntry({ reps: 10, [field]: 5 }, repsDef)).toBe(
+          'wrong-measurement-field'
+        );
       }
     );
   });
@@ -180,10 +193,7 @@ describe('validateExerciseEntry — distance measurement', () => {
 
   it('accepts a valid distance with an optional durationSec companion (pace)', () => {
     expect(
-      validateExerciseEntry(
-        { distanceM: 5000, durationSec: 1650 },
-        distanceDef
-      )
+      validateExerciseEntry({ distanceM: 5000, durationSec: 1650 }, distanceDef)
     ).toBeNull();
   });
 
@@ -195,10 +205,7 @@ describe('validateExerciseEntry — distance measurement', () => {
 
   it('rejects a non-integer durationSec companion', () => {
     expect(
-      validateExerciseEntry(
-        { distanceM: 5000, durationSec: 27.5 },
-        distanceDef
-      )
+      validateExerciseEntry({ distanceM: 5000, durationSec: 27.5 }, distanceDef)
     ).toBe('companion-value-invalid');
   });
 
@@ -272,21 +279,17 @@ describe('validateExerciseEntry — distance-time measurement', () => {
 
   it('skips the duration-required check in partial-update mode', () => {
     expect(
-      validateExerciseEntry(
-        { distanceM: 5000 },
-        distanceTimeDef,
-        { partial: true }
-      )
+      validateExerciseEntry({ distanceM: 5000 }, distanceTimeDef, {
+        partial: true,
+      })
     ).toBeNull();
   });
 
   it('accepts a duration-only patch in partial-update mode (no primary)', () => {
     expect(
-      validateExerciseEntry(
-        { durationSec: 1500 },
-        distanceTimeDef,
-        { partial: true }
-      )
+      validateExerciseEntry({ durationSec: 1500 }, distanceTimeDef, {
+        partial: true,
+      })
     ).toBeNull();
   });
 });
@@ -317,12 +320,12 @@ describe('validateExerciseEntry — weight measurement', () => {
   });
 
   it('rejects an out-of-range weightKg', () => {
-    expect(
-      validateExerciseEntry({ reps: 5, weightKg: 0 }, weightDef)
-    ).toBe('companion-value-out-of-range');
-    expect(
-      validateExerciseEntry({ reps: 5, weightKg: 1000 }, weightDef)
-    ).toBe('companion-value-out-of-range');
+    expect(validateExerciseEntry({ reps: 5, weightKg: 0 }, weightDef)).toBe(
+      'companion-value-out-of-range'
+    );
+    expect(validateExerciseEntry({ reps: 5, weightKg: 1000 }, weightDef)).toBe(
+      'companion-value-out-of-range'
+    );
   });
 
   it('rejects a non-finite weightKg', () => {
@@ -414,10 +417,7 @@ describe('validateExerciseEntry — variants', () => {
 
   it('rejects an entry with an unknown variantId', () => {
     expect(
-      validateExerciseEntry(
-        { reps: 10, variantId: 'diamond' },
-        defWithVariants
-      )
+      validateExerciseEntry({ reps: 10, variantId: 'diamond' }, defWithVariants)
     ).toBe('invalid-variant');
   });
 

--- a/libs/stats/src/lib/models/exercise.models.ts
+++ b/libs/stats/src/lib/models/exercise.models.ts
@@ -115,6 +115,17 @@ export interface ExerciseEntry {
   weightKg?: number;
   /** Optional per-set breakdown, only meaningful for reps/weight. */
   sets?: number[];
+  /**
+   * Optional per-interval breakdown, only meaningful for endurance
+   * measurements (`time`, `distance`, `distance-time`). Each entry is
+   * one repetition of the primary measurement — e.g. for sprint
+   * training a `time` exercise might record `intervals: [30, 30, 30]`
+   * (three 30-second sprints), a `distance` interval workout might
+   * record `intervals: [400, 400, 400]` (3 × 400 m). Mutually
+   * exclusive with `sets` in practice: pick the field that matches
+   * the exercise's measurement type via {@link entryBreakdownField}.
+   */
+  intervals?: number[];
   source: string;
   createdAt?: string;
   updatedAt?: string;
@@ -129,6 +140,7 @@ export interface ExerciseEntryCreate {
   distanceM?: number;
   weightKg?: number;
   sets?: number[];
+  intervals?: number[];
   source?: string;
 }
 
@@ -150,6 +162,7 @@ export interface ExerciseEntryUpdate {
   distanceM?: number;
   weightKg?: number;
   sets?: number[];
+  intervals?: number[];
   source?: string;
 }
 
@@ -209,6 +222,34 @@ export function measurementCompanionValueField(
   measurement: MeasurementType
 ): MeasurementValueField | undefined {
   return measurement === 'distance-time' ? 'durationSec' : undefined;
+}
+
+/**
+ * Returns the per-segment breakdown field that's meaningful for a
+ * measurement type:
+ *
+ *   - `'sets'` for `reps` / `weight` — rep counts per set
+ *     (e.g. 30 squats logged as `sets: [10, 10, 10]`).
+ *   - `'intervals'` for `time` / `distance` / `distance-time` — per-interval
+ *     primary values (e.g. sprint repeats `intervals: [400, 400, 400]` for a
+ *     distance workout, or `intervals: [30, 30, 30]` for 30-second sprints
+ *     on a time-measured exercise).
+ *
+ * Endurance training (sprint repeats, HIIT) doesn't use the strength term
+ * "Sätze/Sets"; UI labels and entry shape pick the field via this helper.
+ */
+export function entryBreakdownField(
+  measurement: MeasurementType
+): 'sets' | 'intervals' {
+  switch (measurement) {
+    case 'reps':
+    case 'weight':
+      return 'sets';
+    case 'time':
+    case 'distance':
+    case 'distance-time':
+      return 'intervals';
+  }
 }
 
 /**

--- a/libs/stats/src/lib/models/exercise.models.ts
+++ b/libs/stats/src/lib/models/exercise.models.ts
@@ -352,7 +352,7 @@ export function requiredCompanionFields(
 export function validateExerciseEntry(
   entry: Pick<
     ExerciseEntry,
-    'reps' | 'durationSec' | 'distanceM' | 'weightKg'
+    'reps' | 'durationSec' | 'distanceM' | 'weightKg' | 'sets' | 'intervals'
   > & {
     // `null` is the patch sentinel for "clear the variant"; the
     // persisted `ExerciseEntry.variantId` is `string | undefined`
@@ -378,6 +378,22 @@ export function validateExerciseEntry(
     if (entry[f] !== undefined) {
       return 'wrong-measurement-field';
     }
+  }
+  // Breakdown fields are mutually exclusive by measurement type:
+  // strength entries use `sets` (rep counts), endurance entries use
+  // `intervals` (per-segment durations/distances). The wrong field
+  // on the wrong measurement type would corrupt aggregations — the
+  // Firestore rules enforce this server-side, but failing fast here
+  // gives callers a structured violation code before the round-trip.
+  // An empty `[]` is the clear-breakdown sentinel and is allowed on
+  // either side so existing entries can be wiped during a measurement
+  // change-of-mind without a special-cased reset path.
+  const wrongBreakdown =
+    entryBreakdownField(def.measurement) === 'sets'
+      ? entry.intervals
+      : entry.sets;
+  if (Array.isArray(wrongBreakdown) && wrongBreakdown.length > 0) {
+    return 'wrong-measurement-field';
   }
   const value = entry[expectedField];
   if (value === undefined || value === null) {

--- a/libs/stats/src/lib/models/unified-entry.models.spec.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.spec.ts
@@ -125,6 +125,35 @@ describe('exerciseEntryToUnified', () => {
       expect('weightKg' in out).toBe(false);
     });
   });
+
+  describe('Given an endurance entry with an intervals breakdown', () => {
+    it('forwards intervals verbatim (sprint repeats)', () => {
+      const e: ExerciseEntry = {
+        _id: 'e5',
+        userId: 'u1',
+        exerciseId: 'cardio.sprints',
+        timestamp: '2026-04-15T10:00:00Z',
+        durationSec: 90,
+        intervals: [30, 30, 30],
+        source: 'web',
+      };
+      const out = exerciseEntryToUnified(e);
+      expect(out.intervals).toEqual([30, 30, 30]);
+    });
+
+    it('omits intervals when the source doc has none', () => {
+      const e: ExerciseEntry = {
+        _id: 'e6',
+        userId: 'u1',
+        exerciseId: 'core.plank',
+        timestamp: '2026-04-15T10:00:00Z',
+        durationSec: 60,
+        source: 'web',
+      };
+      const out = exerciseEntryToUnified(e);
+      expect('intervals' in out).toBe(false);
+    });
+  });
 });
 
 describe('unifiedEntryFilterKey', () => {

--- a/libs/stats/src/lib/models/unified-entry.models.ts
+++ b/libs/stats/src/lib/models/unified-entry.models.ts
@@ -28,6 +28,9 @@ export interface UnifiedEntryBase {
   timestamp: string;
   reps: number;
   sets?: number[];
+  /** Per-interval breakdown for endurance exercises (sprints, HIIT). See
+   *  `ExerciseEntry.intervals`. Never set on legacy pushup entries. */
+  intervals?: number[];
   source: string;
   createdAt?: string;
   updatedAt?: string;
@@ -87,6 +90,7 @@ export function exerciseEntryToUnified(e: ExerciseEntry): UnifiedExerciseEntry {
     // tell consumers what value is actually meaningful.
     reps: e.reps ?? 0,
     ...(e.sets ? { sets: e.sets } : {}),
+    ...(e.intervals ? { intervals: e.intervals } : {}),
     source: e.source,
     exerciseId: e.exerciseId,
     ...(e.variantId ? { variantId: e.variantId } : {}),


### PR DESCRIPTION
Strength entries (reps/weight) keep recording per-set rep counts via
`sets: number[]`. Endurance entries (time/distance/distance-time) now
accept an `intervals: number[]` breakdown for sprint/HIIT logging —
e.g. `intervals: [400, 400, 400]` for 3×400 m or `[30, 30, 30]` for
three 30-second sprints. The new `entryBreakdownField(measurement)`
helper picks the right field name so UI labels can switch between
"Sätze" and "Intervalle" based on the exercise.

ExerciseFirestoreService mirrors the sets persistence behaviour:
empty `intervals: []` patches translate to `deleteField()` so the
doc loses the breakdown entirely. UnifiedEntry forwards intervals
through the same path as sets.