### PR TITLE
feat(auto-count): live Form-Check overlay for the camera dialog

### DIFF
--- a/libs/auto-count/src/index.ts
+++ b/libs/auto-count/src/index.ts
@@ -36,4 +36,7 @@ export {
   type PoseFrameSource,
 } from './lib/pose-frame-source.port';
 export { poseToAngleSample } from './lib/pose-to-sample';
-export { PoseRepCounterService } from './lib/pose-rep-counter.service';
+export {
+  PoseRepCounterService,
+  type FormCheckFrame,
+} from './lib/pose-rep-counter.service';

--- a/libs/auto-count/src/lib/pose-rep-counter.service.spec.ts
+++ b/libs/auto-count/src/lib/pose-rep-counter.service.spec.ts
@@ -199,6 +199,34 @@ describe('PoseRepCounterService', () => {
     expect(frameSource.subscribed).toBe(1);
   });
 
+  it('given active counting, when a frame is processed, then formCheckFrame exposes angle + confidence', async () => {
+    const svc = TestBed.inject(PoseRepCounterService);
+    svc.bindVideoElement(video);
+    detector.script = [STRAIGHT];
+    await svc.start({ exerciseId: 'pushup' });
+
+    frameSource.emit(123);
+
+    const frame = svc.formCheckFrame();
+    expect(frame).not.toBeNull();
+    expect(frame?.angleDeg).toBeCloseTo(180, 5);
+    expect(frame?.confidence).toBeCloseTo(VISIBLE, 5);
+    expect(frame?.timestampMs).toBe(123);
+  });
+
+  it('given stop is called after a frame, then formCheckFrame returns to null', async () => {
+    const svc = TestBed.inject(PoseRepCounterService);
+    svc.bindVideoElement(video);
+    detector.script = [STRAIGHT];
+    await svc.start({ exerciseId: 'pushup' });
+    frameSource.emit(0);
+    expect(svc.formCheckFrame()).not.toBeNull();
+
+    await svc.stop();
+
+    expect(svc.formCheckFrame()).toBeNull();
+  });
+
   it('given start is called again while a previous start is awaiting the detector, then second call is a no-op', async () => {
     TestBed.resetTestingModule();
     let resolveFactory: ((d: PoseDetector) => void) | null = null;

--- a/libs/auto-count/src/lib/pose-rep-counter.service.spec.ts
+++ b/libs/auto-count/src/lib/pose-rep-counter.service.spec.ts
@@ -227,6 +227,21 @@ describe('PoseRepCounterService', () => {
     expect(svc.formCheckFrame()).toBeNull();
   });
 
+  it('given a frame with no detected pose, then formCheckFrame clears so the overlay does not stale', async () => {
+    const svc = TestBed.inject(PoseRepCounterService);
+    svc.bindVideoElement(video);
+    // First a good frame populates the overlay, then an empty frame
+    // (no landmarks) must clear it again.
+    detector.script = [STRAIGHT, []];
+    await svc.start({ exerciseId: 'pushup' });
+
+    frameSource.emit(0);
+    expect(svc.formCheckFrame()).not.toBeNull();
+
+    frameSource.emit(33);
+    expect(svc.formCheckFrame()).toBeNull();
+  });
+
   it('given start is called again while a previous start is awaiting the detector, then second call is a no-op', async () => {
     TestBed.resetTestingModule();
     let resolveFactory: ((d: PoseDetector) => void) | null = null;

--- a/libs/auto-count/src/lib/pose-rep-counter.service.ts
+++ b/libs/auto-count/src/lib/pose-rep-counter.service.ts
@@ -21,6 +21,20 @@ const snapshotEqual = (a: RepCountSnapshot, b: RepCountSnapshot): boolean =>
   a.count === b.count && a.phase === b.phase && a.lastRepAtMs === b.lastRepAtMs;
 
 /**
+ * Per-frame raw values surfaced for the Form-Check overlay. Updates on
+ * every accepted frame (regardless of state-machine phase change), so
+ * downstream consumers see live angle and confidence ticks at camera
+ * rate. Separate from `snapshot` because `snapshot` uses value-equality
+ * to keep stat displays from re-rendering 60×/s — we explicitly DO
+ * want that high frequency here.
+ */
+export interface FormCheckFrame {
+  readonly angleDeg: number;
+  readonly confidence: number;
+  readonly timestampMs: number;
+}
+
+/**
  * Pose-based rep counter. Browser-only — on the server it stays in
  * `isActive=false` and `start()` resolves immediately as a no-op so SSR
  * prerender doesn't pull MediaPipe/camera code into the server bundle.
@@ -39,9 +53,16 @@ export class PoseRepCounterService implements RepCounter {
     equal: snapshotEqual,
   });
   private readonly _isActive = signal(false);
+  private readonly _formCheckFrame = signal<FormCheckFrame | null>(null);
 
   readonly snapshot = this._snapshot.asReadonly();
   readonly isActive = this._isActive.asReadonly();
+  /**
+   * Live per-frame angle + confidence + timestamp. Powers the
+   * Form-Check overlay so users can sanity-check that the detector is
+   * tracking the right joint with sufficient confidence.
+   */
+  readonly formCheckFrame = this._formCheckFrame.asReadonly();
 
   private machine: RepStateMachine | null = null;
   private detector: PoseDetector | null = null;
@@ -107,6 +128,11 @@ export class PoseRepCounterService implements RepCounter {
       const result = this.detector.detectForVideo(video, tick.timestampMs);
       const sample = poseToAngleSample(result, profile, tick.timestampMs);
       if (!sample) return;
+      this._formCheckFrame.set({
+        angleDeg: sample.angleDeg,
+        confidence: sample.confidence,
+        timestampMs: sample.timestampMs,
+      });
       const out = this.machine.process(sample);
       this._snapshot.set(out.snapshot);
     });
@@ -123,10 +149,12 @@ export class PoseRepCounterService implements RepCounter {
     this.detector?.close();
     this.detector = null;
     this._isActive.set(false);
+    this._formCheckFrame.set(null);
   }
 
   reset(): void {
     this.machine?.reset();
     this._snapshot.set(this.machine?.snapshot() ?? INITIAL_SNAPSHOT);
+    this._formCheckFrame.set(null);
   }
 }

--- a/libs/auto-count/src/lib/pose-rep-counter.service.ts
+++ b/libs/auto-count/src/lib/pose-rep-counter.service.ts
@@ -127,7 +127,13 @@ export class PoseRepCounterService implements RepCounter {
       if (!this.detector || !this.machine) return;
       const result = this.detector.detectForVideo(video, tick.timestampMs);
       const sample = poseToAngleSample(result, profile, tick.timestampMs);
-      if (!sample) return;
+      if (!sample) {
+        // Tracking lost (user moved out of frame, landmarks unreadable):
+        // clear the overlay so the user sees an honest "—" instead of
+        // a stale angle/confidence pair frozen from the last good frame.
+        this._formCheckFrame.set(null);
+        return;
+      }
       this._formCheckFrame.set({
         angleDeg: sample.angleDeg,
         confidence: sample.confidence,

--- a/web/src/app/auto-count/auto-count-dialog.component.html
+++ b/web/src/app/auto-count/auto-count-dialog.component.html
@@ -42,6 +42,47 @@
         <span class="count-value">{{ count() }}</span>
         <span class="count-label" i18n="@@autoCount.repsLabel">Reps</span>
       </div>
+      <button
+        type="button"
+        mat-icon-button
+        class="form-check-toggle"
+        (click)="toggleFormCheck()"
+        [attr.aria-pressed]="formCheckOpen()"
+        aria-label="Form-Check anzeigen oder ausblenden"
+        i18n-aria-label="@@autoCount.formCheck.toggleAria"
+      >
+        <mat-icon>{{
+          formCheckOpen() ? 'visibility' : 'visibility_off'
+        }}</mat-icon>
+      </button>
+      @if (formCheckOpen()) {
+        <div class="form-check-panel" aria-live="polite">
+          <div class="form-check-cell">
+            <span i18n="@@autoCount.formCheck.angle">Winkel</span>
+            <strong>
+              @if (frame(); as f) {
+                {{ f.angleDeg | number: '1.0-0' }}°
+              } @else {
+                —
+              }
+            </strong>
+          </div>
+          <div class="form-check-cell">
+            <span i18n="@@autoCount.formCheck.confidence">Sicherheit</span>
+            <strong>
+              @if (frame(); as f) {
+                {{ f.confidence * 100 | number: '1.0-0' }}%
+              } @else {
+                —
+              }
+            </strong>
+          </div>
+          <div class="form-check-cell">
+            <span i18n="@@autoCount.formCheck.phase">Phase</span>
+            <strong>{{ phaseLabel() }}</strong>
+          </div>
+        </div>
+      }
       @if (phase() === 'awaiting-up') {
         <div class="position-hint" i18n="@@autoCount.positionHint">
           In Startposition gehen

--- a/web/src/app/auto-count/auto-count-dialog.component.html
+++ b/web/src/app/auto-count/auto-count-dialog.component.html
@@ -56,7 +56,13 @@
         }}</mat-icon>
       </button>
       @if (formCheckOpen()) {
-        <div class="form-check-panel" aria-live="polite">
+        <!--
+          Intentionally NOT aria-live: values tick at 30-60 Hz, which would
+          flood screen readers. The reps counter overlay further up already
+          carries the discrete `aria-live="polite"` for assistive tech; this
+          panel is visual telemetry for sighted users.
+        -->
+        <div class="form-check-panel">
           <div class="form-check-cell">
             <span i18n="@@autoCount.formCheck.angle">Winkel</span>
             <strong>

--- a/web/src/app/auto-count/auto-count-dialog.component.scss
+++ b/web/src/app/auto-count/auto-count-dialog.component.scss
@@ -104,9 +104,7 @@
       max-width: 280px;
     }
   }
-}
 
-.video-stage {
   .form-check-toggle {
     position: absolute;
     top: 8px;

--- a/web/src/app/auto-count/auto-count-dialog.component.scss
+++ b/web/src/app/auto-count/auto-count-dialog.component.scss
@@ -105,3 +105,47 @@
     }
   }
 }
+
+.video-stage {
+  .form-check-toggle {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    color: #fff;
+    background: rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(4px);
+  }
+
+  .form-check-panel {
+    position: absolute;
+    top: 8px;
+    right: 56px;
+    display: flex;
+    gap: 16px;
+    padding: 8px 14px;
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    border-radius: 10px;
+    font-variant-numeric: tabular-nums;
+    backdrop-filter: blur(4px);
+
+    .form-check-cell {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      line-height: 1.1;
+    }
+
+    span {
+      font-size: 10px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      opacity: 0.72;
+    }
+
+    strong {
+      font-size: 17px;
+      font-weight: 600;
+    }
+  }
+}

--- a/web/src/app/auto-count/auto-count-dialog.component.spec.ts
+++ b/web/src/app/auto-count/auto-count-dialog.component.spec.ts
@@ -1,7 +1,8 @@
-import { PLATFORM_ID, signal } from '@angular/core';
+import { PLATFORM_ID, signal, type WritableSignal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import {
+  type FormCheckFrame,
   PoseRepCounterService,
   type RepCountSnapshot,
 } from '@pu-stats/auto-count';
@@ -20,14 +21,24 @@ const flushAsync = (): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, 0));
 
 const makeCounter = (
-  state = signal<RepCountSnapshot>(INITIAL_SNAPSHOT)
+  state = signal<RepCountSnapshot>(INITIAL_SNAPSHOT),
+  frame: WritableSignal<FormCheckFrame | null> = signal<FormCheckFrame | null>(
+    null
+  )
 ): Pick<
   PoseRepCounterService,
-  'snapshot' | 'isActive' | 'bindVideoElement' | 'start' | 'stop' | 'reset'
+  | 'snapshot'
+  | 'isActive'
+  | 'formCheckFrame'
+  | 'bindVideoElement'
+  | 'start'
+  | 'stop'
+  | 'reset'
 > & {
   startSpy: ReturnType<typeof vi.fn>;
   stopSpy: ReturnType<typeof vi.fn>;
   bindSpy: ReturnType<typeof vi.fn>;
+  frame: WritableSignal<FormCheckFrame | null>;
 } => {
   const isActive = signal(false);
   const start = vi.fn(async () => {
@@ -35,11 +46,13 @@ const makeCounter = (
   });
   const stop = vi.fn(async () => {
     isActive.set(false);
+    frame.set(null);
   });
   const bind = vi.fn();
   return {
     snapshot: state.asReadonly(),
     isActive: isActive.asReadonly(),
+    formCheckFrame: frame.asReadonly(),
     bindVideoElement: bind,
     start,
     stop,
@@ -47,6 +60,7 @@ const makeCounter = (
     startSpy: start,
     stopSpy: stop,
     bindSpy: bind,
+    frame,
   };
 };
 
@@ -117,5 +131,38 @@ describe('AutoCountDialogComponent', () => {
     expect(fixture.nativeElement.textContent.includes('NotAllowedError')).toBe(
       true
     );
+  });
+
+  it('given an emitted form-check frame, when the panel is open, then angle and confidence render', async () => {
+    const fixture = TestBed.createComponent(AutoCountDialogComponent);
+    fixture.detectChanges();
+    await flushAsync();
+    await flushAsync();
+
+    counter.frame.set({ angleDeg: 142.3, confidence: 0.87, timestampMs: 100 });
+    fixture.detectChanges();
+
+    const text: string = fixture.nativeElement.textContent;
+    expect(text).toContain('142°');
+    expect(text).toContain('87%');
+  });
+
+  it('given the Form-Check is toggled off, when the panel is hidden, then no angle row is rendered', async () => {
+    const fixture = TestBed.createComponent(AutoCountDialogComponent);
+    fixture.detectChanges();
+    await flushAsync();
+    await flushAsync();
+
+    counter.frame.set({ angleDeg: 99, confidence: 0.5, timestampMs: 0 });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('99°');
+
+    const toggle = fixture.nativeElement.querySelector(
+      '.form-check-toggle'
+    ) as HTMLButtonElement;
+    toggle.click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('99°');
   });
 });

--- a/web/src/app/auto-count/auto-count-dialog.component.ts
+++ b/web/src/app/auto-count/auto-count-dialog.component.ts
@@ -1,3 +1,4 @@
+import { DecimalPipe } from '@angular/common';
 import {
   afterNextRender,
   ChangeDetectionStrategy,
@@ -35,6 +36,7 @@ interface ExerciseOption {
   selector: 'app-auto-count-dialog',
   standalone: true,
   imports: [
+    DecimalPipe,
     MatDialogModule,
     MatButtonModule,
     MatButtonToggleModule,
@@ -61,9 +63,21 @@ export class AutoCountDialogComponent {
   protected readonly error = signal<string | null>(null);
   protected readonly switching = signal(false);
   protected readonly exerciseId = signal<AutoCountExerciseId>('pushup');
+  protected readonly formCheckOpen = signal(true);
 
   protected readonly count = computed(() => this.counter.snapshot().count);
   protected readonly phase = computed(() => this.counter.snapshot().phase);
+  protected readonly frame = computed(() => this.counter.formCheckFrame());
+  protected readonly phaseLabel = computed(() => {
+    switch (this.phase()) {
+      case 'up':
+        return $localize`:@@autoCount.formCheck.phase.up:Oben`;
+      case 'down':
+        return $localize`:@@autoCount.formCheck.phase.down:Unten`;
+      default:
+        return $localize`:@@autoCount.formCheck.phase.waiting:Bereit`;
+    }
+  });
 
   protected readonly exercises: ReadonlyArray<ExerciseOption> = [
     {
@@ -146,6 +160,10 @@ export class AutoCountDialogComponent {
 
   protected reset(): void {
     this.counter.reset();
+  }
+
+  protected toggleFormCheck(): void {
+    this.formCheckOpen.update((open) => !open);
   }
 
   private async teardown(): Promise<void> {

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -708,7 +708,49 @@
         <target>Εισαγάγετε τη δική σας τιμή</target>
       </segment>
     </unit>
-            <unit id="autoCount.title">
+            <unit id="autoCount.formCheck.toggleAria">
+      <segment state="translated">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Εμφάνιση ή απόκρυψη ελέγχου φόρμας</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.angle">
+      <segment state="translated">
+        <source>Winkel</source>
+        <target>Γωνία</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.confidence">
+      <segment state="translated">
+        <source>Sicherheit</source>
+        <target>Αξιοπιστία</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase">
+      <segment state="translated">
+        <source>Phase</source>
+        <target>Φάση</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.up">
+      <segment state="translated">
+        <source>Oben</source>
+        <target>Πάνω</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.down">
+      <segment state="translated">
+        <source>Unten</source>
+        <target>Κάτω</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.waiting">
+      <segment state="translated">
+        <source>Bereit</source>
+        <target>Έτοιμο</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.title">
       <segment state="translated">
         <source>Übungen automatisch zählen</source>
         <target>Αυτόματη μέτρηση ασκήσεων</target>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -5300,7 +5300,49 @@ Deine Position: # ·  Reps        </source>
         <target>Close quick-add</target>
       </segment>
     </unit>
-            <unit id="autoCount.title">
+            <unit id="autoCount.formCheck.toggleAria">
+      <segment state="translated">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Show or hide Form Check</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.angle">
+      <segment state="translated">
+        <source>Winkel</source>
+        <target>Angle</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.confidence">
+      <segment state="translated">
+        <source>Sicherheit</source>
+        <target>Confidence</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase">
+      <segment state="translated">
+        <source>Phase</source>
+        <target>Phase</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.up">
+      <segment state="translated">
+        <source>Oben</source>
+        <target>Up</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.down">
+      <segment state="translated">
+        <source>Unten</source>
+        <target>Down</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.waiting">
+      <segment state="translated">
+        <source>Bereit</source>
+        <target>Ready</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.title">
       <segment state="translated">
         <source>Übungen automatisch zählen</source>
         <target>Auto-count exercises</target>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -708,7 +708,49 @@
         <target>Introduce tu propio valor</target>
       </segment>
     </unit>
-            <unit id="autoCount.title">
+            <unit id="autoCount.formCheck.toggleAria">
+      <segment state="translated">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Mostrar u ocultar verificación de forma</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.angle">
+      <segment state="translated">
+        <source>Winkel</source>
+        <target>Ángulo</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.confidence">
+      <segment state="translated">
+        <source>Sicherheit</source>
+        <target>Confianza</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase">
+      <segment state="translated">
+        <source>Phase</source>
+        <target>Fase</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.up">
+      <segment state="translated">
+        <source>Oben</source>
+        <target>Arriba</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.down">
+      <segment state="translated">
+        <source>Unten</source>
+        <target>Abajo</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.waiting">
+      <segment state="translated">
+        <source>Bereit</source>
+        <target>Listo</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.title">
       <segment state="translated">
         <source>Übungen automatisch zählen</source>
         <target>Conteo automático de ejercicios</target>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -708,7 +708,49 @@
         <target>Entrez votre propre valeur</target>
       </segment>
     </unit>
-            <unit id="autoCount.title">
+            <unit id="autoCount.formCheck.toggleAria">
+      <segment state="translated">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Afficher ou masquer le contrôle de la forme</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.angle">
+      <segment state="translated">
+        <source>Winkel</source>
+        <target>Angle</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.confidence">
+      <segment state="translated">
+        <source>Sicherheit</source>
+        <target>Confiance</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase">
+      <segment state="translated">
+        <source>Phase</source>
+        <target>Phase</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.up">
+      <segment state="translated">
+        <source>Oben</source>
+        <target>Haut</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.down">
+      <segment state="translated">
+        <source>Unten</source>
+        <target>Bas</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.waiting">
+      <segment state="translated">
+        <source>Bereit</source>
+        <target>Prêt</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.title">
       <segment state="translated">
         <source>Übungen automatisch zählen</source>
         <target>Comptage automatique des exercices</target>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -708,7 +708,49 @@
         <target>Inserisci il tuo valore</target>
       </segment>
     </unit>
-            <unit id="autoCount.title">
+            <unit id="autoCount.formCheck.toggleAria">
+      <segment state="translated">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Mostra o nascondi il controllo della forma</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.angle">
+      <segment state="translated">
+        <source>Winkel</source>
+        <target>Angolo</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.confidence">
+      <segment state="translated">
+        <source>Sicherheit</source>
+        <target>Affidabilità</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase">
+      <segment state="translated">
+        <source>Phase</source>
+        <target>Fase</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.up">
+      <segment state="translated">
+        <source>Oben</source>
+        <target>Su</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.down">
+      <segment state="translated">
+        <source>Unten</source>
+        <target>Giù</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.waiting">
+      <segment state="translated">
+        <source>Bereit</source>
+        <target>Pronto</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.title">
       <segment state="translated">
         <source>Übungen automatisch zählen</source>
         <target>Conteggio automatico degli esercizi</target>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -708,7 +708,49 @@
         <target>Intra valorem suum</target>
       </segment>
     </unit>
-            <unit id="autoCount.title">
+            <unit id="autoCount.formCheck.toggleAria">
+      <segment state="translated">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Form-Check monstrare aut celare</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.angle">
+      <segment state="translated">
+        <source>Winkel</source>
+        <target>Angulus</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.confidence">
+      <segment state="translated">
+        <source>Sicherheit</source>
+        <target>Fiducia</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase">
+      <segment state="translated">
+        <source>Phase</source>
+        <target>Phasis</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.up">
+      <segment state="translated">
+        <source>Oben</source>
+        <target>Sursum</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.down">
+      <segment state="translated">
+        <source>Unten</source>
+        <target>Deorsum</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.waiting">
+      <segment state="translated">
+        <source>Bereit</source>
+        <target>Paratus</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.title">
       <segment state="translated">
         <source>Übungen automatisch zählen</source>
         <target>Exercitia automatice numerare</target>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -708,7 +708,49 @@
         <target>Voer uw eigen waarde in</target>
       </segment>
     </unit>
-            <unit id="autoCount.title">
+            <unit id="autoCount.formCheck.toggleAria">
+      <segment state="translated">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Form Check tonen of verbergen</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.angle">
+      <segment state="translated">
+        <source>Winkel</source>
+        <target>Hoek</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.confidence">
+      <segment state="translated">
+        <source>Sicherheit</source>
+        <target>Zekerheid</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase">
+      <segment state="translated">
+        <source>Phase</source>
+        <target>Fase</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.up">
+      <segment state="translated">
+        <source>Oben</source>
+        <target>Boven</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.down">
+      <segment state="translated">
+        <source>Unten</source>
+        <target>Onder</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.waiting">
+      <segment state="translated">
+        <source>Bereit</source>
+        <target>Klaar</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.title">
       <segment state="translated">
         <source>Übungen automatisch zählen</source>
         <target>Oefeningen automatisch tellen</target>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -4401,7 +4401,49 @@ Deine Position: # ·  Reps        </source>
         <target>Lukk hurtiglogging</target>
       </segment>
     </unit>
-            <unit id="autoCount.title">
+            <unit id="autoCount.formCheck.toggleAria">
+      <segment state="translated">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Vis eller skjul form-sjekk</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.angle">
+      <segment state="translated">
+        <source>Winkel</source>
+        <target>Vinkel</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.confidence">
+      <segment state="translated">
+        <source>Sicherheit</source>
+        <target>Sikkerhet</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase">
+      <segment state="translated">
+        <source>Phase</source>
+        <target>Fase</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.up">
+      <segment state="translated">
+        <source>Oben</source>
+        <target>Opp</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.down">
+      <segment state="translated">
+        <source>Unten</source>
+        <target>Ned</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.waiting">
+      <segment state="translated">
+        <source>Bereit</source>
+        <target>Klar</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.title">
       <segment state="translated">
         <source>Übungen automatisch zählen</source>
         <target>Tell øvelser automatisk</target>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -236,7 +236,7 @@
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:550,551</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:549,550</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
       </notes>
       <segment>
@@ -2622,16 +2622,15 @@
     </unit>
     <unit id="autoCount.title">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:2,5</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:1,3</note>
       </notes>
       <segment>
-        <source> Übungen automatisch zählen
-</source>
+        <source>Übungen automatisch zählen</source>
       </segment>
     </unit>
     <unit id="autoCount.exercisePickerAria">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:10,11</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:8,9</note>
       </notes>
       <segment>
         <source>Übung wählen</source>
@@ -2639,7 +2638,7 @@
     </unit>
     <unit id="autoCount.instructions">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:21,24</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:19,23</note>
       </notes>
       <segment>
         <source> Halte das Gerät so, dass die relevanten Gelenke (Schulter/Ellbogen/Handgelenk bzw. Hüfte/Knie/Fuß) im Bild sind. Reps werden bei sauberem Down‑Up gezählt. </source>
@@ -2647,7 +2646,7 @@
     </unit>
     <unit id="autoCount.cameraStarting">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:29,32</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:28,31</note>
       </notes>
       <segment>
         <source>Kamera startet …</source>
@@ -2655,7 +2654,7 @@
     </unit>
     <unit id="autoCount.unavailable">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:36,38</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:35,37</note>
       </notes>
       <segment>
         <source> Auto‑Zählen nicht verfügbar </source>
@@ -2663,15 +2662,47 @@
     </unit>
     <unit id="autoCount.repsLabel">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:44,46</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:43,45</note>
       </notes>
       <segment>
         <source>Reps</source>
       </segment>
     </unit>
+    <unit id="autoCount.formCheck.toggleAria">
+      <notes>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:51,52</note>
+      </notes>
+      <segment>
+        <source>Form-Check anzeigen oder ausblenden</source>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.angle">
+      <notes>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:61,63</note>
+      </notes>
+      <segment>
+        <source>Winkel</source>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.confidence">
+      <notes>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:71,73</note>
+      </notes>
+      <segment>
+        <source>Sicherheit</source>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase">
+      <notes>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:81,82</note>
+      </notes>
+      <segment>
+        <source>Phase</source>
+      </segment>
+    </unit>
     <unit id="autoCount.positionHint">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:48,51</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:88,91</note>
       </notes>
       <segment>
         <source> In Startposition gehen </source>
@@ -2679,7 +2710,7 @@
     </unit>
     <unit id="autoCount.reset">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:61,63</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:101,103</note>
       </notes>
       <segment>
         <source> Zurücksetzen </source>
@@ -2687,7 +2718,7 @@
     </unit>
     <unit id="autoCount.cancel">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:64,67</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:104,107</note>
       </notes>
       <segment>
         <source> Abbrechen </source>
@@ -2695,15 +2726,39 @@
     </unit>
     <unit id="autoCount.save">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:73,75</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:113,115</note>
       </notes>
       <segment>
         <source> Übernehmen </source>
       </segment>
     </unit>
+    <unit id="autoCount.formCheck.phase.up">
+      <notes>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:74</note>
+      </notes>
+      <segment>
+        <source>Oben</source>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.down">
+      <notes>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:76</note>
+      </notes>
+      <segment>
+        <source>Unten</source>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.waiting">
+      <notes>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:78</note>
+      </notes>
+      <segment>
+        <source>Bereit</source>
+      </segment>
+    </unit>
     <unit id="autoCount.exercise.pushup">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:69</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:86</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -2711,7 +2766,7 @@
     </unit>
     <unit id="autoCount.exercise.squat">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:70</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:91</note>
       </notes>
       <segment>
         <source>Kniebeugen</source>
@@ -2719,7 +2774,7 @@
     </unit>
     <unit id="autoCount.exercise.pullup">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:71</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:96</note>
       </notes>
       <segment>
         <source>Klimmzüge</source>
@@ -2727,7 +2782,7 @@
     </unit>
     <unit id="autoCount.exercise.situp">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:72</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:101</note>
       </notes>
       <segment>
         <source>Sit-ups</source>
@@ -2864,8 +2919,8 @@
     </unit>
     <unit id="quickAdd.success.create">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:74</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:259</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:75</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:264</note>
       </notes>
       <segment>
         <source>Eintrag gespeichert.</source>
@@ -2873,9 +2928,9 @@
     </unit>
     <unit id="quickAdd.error.create">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:86</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:125</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:275</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:87</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:126</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:280</note>
       </notes>
       <segment>
         <source>Eintrag konnte nicht gespeichert werden.</source>
@@ -2883,7 +2938,7 @@
     </unit>
     <unit id="quickAdd.success.goalReached">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:112</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:113</note>
       </notes>
       <segment>
         <source>Tagesziel erreicht 🎉</source>
@@ -4429,7 +4484,7 @@
       <notes>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:147</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:200</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1100</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1104</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:197</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:272</note>
@@ -5197,7 +5252,7 @@
     </unit>
     <unit id="editDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:265,267</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:266,268</note>
       </notes>
       <segment>
         <source>Eintrag bearbeiten</source>
@@ -5205,7 +5260,7 @@
     </unit>
     <unit id="trainingEntryDialog.title">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:267,271</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:268,272</note>
       </notes>
       <segment>
         <source>Trainingseintrag anlegen</source>
@@ -5213,7 +5268,7 @@
     </unit>
     <unit id="trainingEntryDialog.category">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:273,275</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:274,276</note>
       </notes>
       <segment>
         <source>Kategorie</source>
@@ -5221,7 +5276,7 @@
     </unit>
     <unit id="trainingEntryDialog.exercise">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:288,290</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:289,291</note>
       </notes>
       <segment>
         <source>Übung</source>
@@ -5229,7 +5284,7 @@
     </unit>
     <unit id="timestampLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:303,305</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:304,306</note>
       </notes>
       <segment>
         <source>Zeitpunkt</source>
@@ -5237,7 +5292,7 @@
     </unit>
     <unit id="typeLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:316,317</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:317,318</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -5245,7 +5300,7 @@
     </unit>
     <unit id="typePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:322,323</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:323,324</note>
       </notes>
       <segment>
         <source>Auswählen oder eintippen</source>
@@ -5253,7 +5308,7 @@
     </unit>
     <unit id="typeWikiLinkAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:361,363</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:362,364</note>
       </notes>
       <segment>
         <source>Anleitung zum Liegestütztyp öffnen</source>
@@ -5261,7 +5316,7 @@
     </unit>
     <unit id="entryDialog.variant">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:368,369</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:369,370</note>
       </notes>
       <segment>
         <source>Variante</source>
@@ -5269,7 +5324,7 @@
     </unit>
     <unit id="entryDialog.variantNone">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:371,373</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:372,374</note>
       </notes>
       <segment>
         <source>—</source>
@@ -5277,7 +5332,7 @@
     </unit>
     <unit id="entryDialog.distance">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:384,386</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:385,387</note>
       </notes>
       <segment>
         <source>Distanz (km)</source>
@@ -5285,8 +5340,8 @@
     </unit>
     <unit id="entryDialog.durationMinutes">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:400,402</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:430,432</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:399,401</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:429,431</note>
       </notes>
       <segment>
         <source>Minuten</source>
@@ -5294,8 +5349,8 @@
     </unit>
     <unit id="entryDialog.durationSeconds">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:413,415</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:443,445</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:412,414</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:442,444</note>
       </notes>
       <segment>
         <source>Sekunden</source>
@@ -5303,7 +5358,7 @@
     </unit>
     <unit id="setLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:462,463</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:461,462</note>
       </notes>
       <segment>
         <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -5311,7 +5366,7 @@
     </unit>
     <unit id="repsLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:464,465</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:463,464</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5319,7 +5374,7 @@
     </unit>
     <unit id="removeSetAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:483,485</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:482,484</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -5327,7 +5382,7 @@
     </unit>
     <unit id="addSetAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:494,495</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:493,494</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -5335,7 +5390,7 @@
     </unit>
     <unit id="addSetTooltip">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:496,498</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:495,497</note>
       </notes>
       <segment>
         <source>Weiteres Set hinzufügen</source>
@@ -5343,7 +5398,7 @@
     </unit>
     <unit id="totalReps">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:505,507</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:504,506</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -5351,7 +5406,7 @@
     </unit>
     <unit id="entryDialog.overCapDuration">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:514,515</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:513,514</note>
       </notes>
       <segment>
         <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
@@ -5359,7 +5414,7 @@
     </unit>
     <unit id="entryDialog.overCapTime">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:518,519</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:517,518</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
@@ -5367,7 +5422,7 @@
     </unit>
     <unit id="entryDialog.overCap">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:522,523</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:521,522</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ repsMax() }}"/> pro Eintrag</source>
@@ -5375,7 +5430,7 @@
     </unit>
     <unit id="sourceLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:530,531</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:529,530</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -5383,7 +5438,7 @@
     </unit>
     <unit id="sourcePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:536,537</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:535,536</note>
       </notes>
       <segment>
         <source>web / whatsapp / eigene Quelle</source>
@@ -5391,7 +5446,7 @@
     </unit>
     <unit id="saveEntry">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:560,562</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:559,561</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -5399,7 +5454,7 @@
     </unit>
     <unit id="trainingEntryDialog.pushup.exercise">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:615</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:614</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -5407,7 +5462,7 @@
     </unit>
     <unit id="typeWikiLinkTooltip.generic">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:777</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:781</note>
       </notes>
       <segment>
         <source>Anleitung zu Liegestütztypen öffnen</source>
@@ -5415,7 +5470,7 @@
     </unit>
     <unit id="typeWikiLinkTooltip.specific">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:779</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:783</note>
       </notes>
       <segment>
         <source>Anleitung öffnen</source>
@@ -5423,7 +5478,7 @@
     </unit>
     <unit id="exercise.category.push">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1101</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1105</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:222</note>
       </notes>
       <segment>
@@ -5432,7 +5487,7 @@
     </unit>
     <unit id="exercise.category.pull">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1102</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1106</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:223</note>
       </notes>
       <segment>
@@ -5441,7 +5496,7 @@
     </unit>
     <unit id="exercise.category.squat">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1103</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1107</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:224</note>
       </notes>
       <segment>
@@ -5450,7 +5505,7 @@
     </unit>
     <unit id="exercise.category.hinge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1104</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1108</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:225</note>
       </notes>
       <segment>
@@ -5459,7 +5514,7 @@
     </unit>
     <unit id="exercise.category.lunge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1105</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1109</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:226</note>
       </notes>
       <segment>
@@ -5468,7 +5523,7 @@
     </unit>
     <unit id="exercise.category.carry">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1106</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1110</note>
       </notes>
       <segment>
         <source>Tragen</source>
@@ -5476,7 +5531,7 @@
     </unit>
     <unit id="exercise.category.core">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1107</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1111</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:227</note>
       </notes>
       <segment>
@@ -5485,7 +5540,7 @@
     </unit>
     <unit id="exercise.category.cardio">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1108</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1112</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:228</note>
       </notes>
       <segment>
@@ -5494,7 +5549,7 @@
     </unit>
     <unit id="exercise.category.mobility">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1109</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1113</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:229</note>
       </notes>
       <segment>
@@ -5503,7 +5558,7 @@
     </unit>
     <unit id="exercise.category.strength">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1110</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1114</note>
       </notes>
       <segment>
         <source>Krafttraining</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -634,7 +634,49 @@
         <source>Eigenen Wert eingeben</source>
       <target>输入自定义值</target></segment>
     </unit>
-            <unit id="autoCount.title">
+            <unit id="autoCount.formCheck.toggleAria">
+      <segment state="translated">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>显示或隐藏动作检查</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.angle">
+      <segment state="translated">
+        <source>Winkel</source>
+        <target>角度</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.confidence">
+      <segment state="translated">
+        <source>Sicherheit</source>
+        <target>置信度</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase">
+      <segment state="translated">
+        <source>Phase</source>
+        <target>阶段</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.up">
+      <segment state="translated">
+        <source>Oben</source>
+        <target>上</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.down">
+      <segment state="translated">
+        <source>Unten</source>
+        <target>下</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.formCheck.phase.waiting">
+      <segment state="translated">
+        <source>Bereit</source>
+        <target>就绪</target>
+      </segment>
+    </unit>
+    <unit id="autoCount.title">
       <segment state="translated">
         <source>Übungen automatisch zählen</source>
         <target>自动计数练习</target>


### PR DESCRIPTION
## Summary

Adds **Form-Check** to the admin-gated auto-counter: a live overlay inside the camera dialog that shows the active joint angle, detector confidence, and rep phase. Default-on, toggleable via an eye-icon in the top-right of the video stage so users can verify the counter is locking onto the right joint with enough certainty before committing reps.

This is intentionally framed as a *user-facing feature* rather than a debug surface — the same data the developer would want for diagnosis is exactly what an exercising user needs to trust the count.

## Lib changes (`@pu-stats/auto-count`)

- `PoseRepCounterService` exposes `formCheckFrame: Signal<FormCheckFrame | null>` that updates on every accepted frame (`{ angleDeg, confidence, timestampMs }`).
- Kept separate from `snapshot` (value-equality deduped) so high-frequency overlay ticks don't churn downstream stat displays.
- Cleared on `stop()` / `reset()` so a closed dialog doesn't leave stale numbers.

## UI

- `AutoCountDialogComponent` grows a toggle button + overlay panel with three cells (Winkel, Sicherheit, Phase). Phase label is computed and localized (Oben / Unten / Bereit).
- Eye / eye-off icon flips with the toggle state.

## i18n

7 new `@@autoCount.formCheck.*` keys, propagated to all 9 non-source locales (en/es/fr/it/nl/el/la/no/zh).

## QA

- `nx test auto-count`: **51/51** (+2 for the frame-publish & clear-on-stop paths)
- `nx test web`: **790/790** (+2 for the form-check render & toggle paths)
- `nx test stats-quick-add`: **24/24**
- `nx test auth`: **104/104**
- `nx lint`: **0 errors**
- `nx run web:build -c production`: **success**, initial bundle **2.25 MB** (unchanged, well under the 2.5 MB error budget).

## Test plan

- [ ] As an admin, open Auto-Zählen and confirm the form-check panel renders top-right with three labelled values.
- [ ] Move out of frame: confidence should drop toward 0 (or — if no pose detected — the row should show `—`).
- [ ] Switch exercises: the panel should keep updating with the new joint's angle.
- [ ] Tap the eye-icon: panel collapses; tap again: panel returns.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8v5btmabrrYcwwer7xJ6u)_