### PR TITLE
fix(analysis): keep active tab pinned across filter shifts and surface empty-range copy

### DIFF
--- a/web/src/app/stats/components/filter-bar/filter-bar.component.scss
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.scss
@@ -44,6 +44,13 @@
   align-items: center;
 }
 
+.range-summary {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.9rem;
+  opacity: 0.85;
+  white-space: nowrap;
+}
+
 .picker-toggle {
   display: none;
 }
@@ -67,6 +74,12 @@
 
   .step-actions {
     gap: 2px;
+  }
+
+  .range-summary {
+    font-size: 0.8rem;
+    width: 100%;
+    text-align: center;
   }
 
   .step-btn {

--- a/web/src/app/stats/components/filter-bar/filter-bar.component.spec.ts
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.spec.ts
@@ -1,3 +1,4 @@
+import { LOCALE_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FilterBarComponent } from './filter-bar.component';
 
@@ -8,6 +9,10 @@ describe('FilterBarComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [FilterBarComponent],
+      // Pin LOCALE_ID so the range-summary `Intl.DateTimeFormat` lookup is
+      // deterministic — Vitest's default would resolve to the host's locale
+      // (typically `en-US` in CI) and break the German-formatted assertions.
+      providers: [{ provide: LOCALE_ID, useValue: 'de' }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(FilterBarComponent);
@@ -254,6 +259,48 @@ describe('FilterBarComponent', () => {
 
     expect(component.range.controls.start.value).toEqual(start);
     expect(component.range.controls.end.value).toEqual(end);
+  });
+
+  it('renders a compact from-to date label derived from the inputs', async () => {
+    fixture.componentRef.setInput('from', '2026-01-26');
+    fixture.componentRef.setInput('to', '2026-02-01');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    const label = host.querySelector(
+      '[data-testid="filter-bar-range-summary"]'
+    );
+    expect(label).toBeTruthy();
+    // German source locale → dd.mm.yyyy. Trim because the template wraps
+    // the text in newlines for readability.
+    expect(label?.textContent?.trim()).toBe('26.01.2026 – 01.02.2026');
+  });
+
+  it('collapses the range label to a single date when from === to', async () => {
+    fixture.componentRef.setInput('from', '2026-02-14');
+    fixture.componentRef.setInput('to', '2026-02-14');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    const label = host.querySelector(
+      '[data-testid="filter-bar-range-summary"]'
+    );
+    expect(label?.textContent?.trim()).toBe('14.02.2026');
+  });
+
+  it('hides the range label entirely while either bound is unset', async () => {
+    fixture.componentRef.setInput('from', '');
+    fixture.componentRef.setInput('to', '');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    const label = host.querySelector(
+      '[data-testid="filter-bar-range-summary"]'
+    );
+    expect(label).toBeNull();
   });
 
   it('switches to week mode using first day when today is outside current range', () => {

--- a/web/src/app/stats/components/filter-bar/filter-bar.component.ts
+++ b/web/src/app/stats/components/filter-bar/filter-bar.component.ts
@@ -1,7 +1,10 @@
 import {
   Component,
+  computed,
+  inject,
   input,
   linkedSignal,
+  LOCALE_ID,
   OnChanges,
   output,
   signal,
@@ -114,6 +117,16 @@ import {
             <mat-icon>date_range</mat-icon>
           </button>
         </div>
+
+        @if (rangeSummary()) {
+          <span
+            class="range-summary"
+            data-testid="filter-bar-range-summary"
+            aria-live="polite"
+          >
+            {{ rangeSummary() }}
+          </span>
+        }
       </section>
 
       <mat-form-field
@@ -170,6 +183,24 @@ export class FilterBarComponent implements OnChanges {
   readonly range = new FormGroup({
     start: new FormControl<Date | null>(null),
     end: new FormControl<Date | null>(null),
+  });
+
+  private readonly locale = inject(LOCALE_ID);
+
+  /**
+   * Compact "DD.MM.YYYY – DD.MM.YYYY" label for the currently-selected
+   * range. A single-day range collapses to one date; an unbounded
+   * range (either side missing) hides the label entirely so the bar
+   * doesn't display a half-formed string while the parent is still
+   * resolving its initial filter.
+   */
+  readonly rangeSummary = computed<string>(() => {
+    const start = parseIsoDate(this.from());
+    const end = parseIsoDate(this.to());
+    if (!start || !end) return '';
+    const startLabel = this.formatRangeDate(start);
+    if (start.getTime() === end.getTime()) return startLabel;
+    return `${startLabel} – ${this.formatRangeDate(end)}`;
   });
 
   constructor() {
@@ -352,5 +383,18 @@ export class FilterBarComponent implements OnChanges {
   private toIsoDate(value: Date | null): string {
     if (!value) return '';
     return toLocalIsoDate(value);
+  }
+
+  private formatRangeDate(value: Date): string {
+    // `Intl.DateTimeFormat` is locale-aware so the German source format
+    // (DD.MM.YYYY) and the English translation (MM/DD/YYYY) both fall
+    // out of the same call. `numeric` keeps the label compact enough
+    // to fit alongside the Zurück/Heute/Vor buttons without wrapping
+    // on narrow viewports.
+    return new Intl.DateTimeFormat(this.locale, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(value);
   }
 }

--- a/web/src/app/stats/shell/analysis-group-view.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.spec.ts
@@ -433,6 +433,42 @@ describe('AnalysisGroupViewComponent', () => {
     expect(entries[0].reps).toBe(75);
   });
 
+  it('renders the "Keine Einträge im gewählten Zeitraum" notice when the active category has no entries in the range', async () => {
+    // Regression: when the user shifts the filter past the last entry
+    // in their active category, the tab body needs an explicit empty
+    // copy instead of zero-state KPI cards. The pinned tab keeps the
+    // user's selection (see analysis-page.component.spec.ts) and this
+    // copy explains *why* nothing is rendered.
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    // Mobility has no entries in the seeded mock, so switching to it
+    // collapses viewFilteredRows() to [].
+    store.setActiveView('mobility');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    const empty = host.querySelector(
+      '[data-testid="analysis-group-view-empty"]'
+    );
+    expect(empty).toBeTruthy();
+    expect(empty?.textContent).toContain(
+      'Keine Einträge im gewählten Zeitraum'
+    );
+    // The trend section stays visible — it spans a fixed window
+    // independent of the page filter.
+    expect(
+      host.querySelector('[data-testid="analysis-trends-section"]')
+    ).toBeTruthy();
+    // The chart and KPI grid are gone so the page doesn't read as
+    // "0 reps everywhere".
+    expect(host.querySelector('app-stats-chart')).toBeNull();
+    expect(host.querySelector('.grid')).toBeNull();
+  });
+
   it('typeBreakdownDisplay localises bare exerciseIds in kind mode', async () => {
     // Regression: in kind mode (a non-pushup active view, or a kinds
     // filter that excludes pushups) the store emits raw catalog ids

--- a/web/src/app/stats/shell/analysis-group-view.component.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.ts
@@ -31,142 +31,154 @@ import { kindDisplayName } from '../i18n/exercise-display-names';
     TypePieComponent,
   ],
   template: `
-    <app-stats-chart
-      [series]="store.viewChartSeries()"
-      [granularity]="store.viewGranularity()"
-      [rangeMode]="store.rangeMode()"
-      [from]="store.from()"
-      [to]="store.to()"
-      [entries]="store.viewChartEntries()"
-      [measurement]="store.viewMeasurement()"
-      [paceSeries]="store.viewPaceSeries()"
-      [dayChartMode]="store.resolvedDayChartMode()"
-      (dayChartModeChange)="store.setDayChartMode($event)"
-    />
+    @if (isEmptyRange()) {
+      <p
+        class="empty"
+        data-testid="analysis-group-view-empty"
+        i18n="@@noEntriesInSelectedRange"
+      >
+        Keine Einträge im gewählten Zeitraum.
+      </p>
+    } @else {
+      <app-stats-chart
+        [series]="store.viewChartSeries()"
+        [granularity]="store.viewGranularity()"
+        [rangeMode]="store.rangeMode()"
+        [from]="store.from()"
+        [to]="store.to()"
+        [entries]="store.viewChartEntries()"
+        [measurement]="store.viewMeasurement()"
+        [paceSeries]="store.viewPaceSeries()"
+        [dayChartMode]="store.resolvedDayChartMode()"
+        (dayChartModeChange)="store.setDayChartMode($event)"
+      />
+    }
 
-    <section class="grid">
-      <mat-card>
-        <mat-card-header>
-          <mat-card-title i18n="@@analysis.bestStreaksTitle"
-            >Bestwerte & Streaks</mat-card-title
-          >
-        </mat-card-header>
-        <mat-card-content class="best-grid">
-          <div>
-            <strong i18n="@@analysis.bestSingleEntry"
-              >Bestwert Einzel-Eintrag:</strong
-            >
-            <div>{{ store.bestSingleEntry()?.reps ?? 0 }} Reps</div>
-          </div>
-          <div>
-            <strong i18n="@@analysis.bestDay">Bester Tag:</strong>
-            <div>
-              {{ store.bestDay()?.date ?? '—' }} ·
-              {{ store.bestDay()?.total ?? 0 }} Reps
-            </div>
-          </div>
-          @if (store.bestSingleSet()) {
-            <div>
-              <strong i18n="@@analysis.bestSingleSet"
-                >Bestes Einzel-Set:</strong
-              >
-              <div>
-                {{ store.bestSingleSet() }}
-                <span i18n="@@analysis.repsUnit">Wdh.</span>
-              </div>
-            </div>
-          }
-          <div>
-            <strong i18n="@@analysis.currentStreak">Aktuelle Streak:</strong>
-            <div>
-              <ng-container i18n="@@analysis.streakDays"
-                >{{ store.currentStreak() }} Tage</ng-container
-              >
-            </div>
-          </div>
-          <div>
-            <strong i18n="@@analysis.longestStreak">Längste Streak:</strong>
-            <div>
-              <ng-container i18n="@@analysis.streakDays"
-                >{{ store.longestStreak() }} Tage</ng-container
-              >
-            </div>
-          </div>
-        </mat-card-content>
-      </mat-card>
-
-      <mat-card>
-        <mat-card-header>
-          <mat-card-title i18n="@@analysis.typesTitle"
-            >Typen (Anteile)</mat-card-title
-          >
-        </mat-card-header>
-        <mat-card-content>
-          @defer (hydrate on viewport) {
-            <app-type-pie [data]="typeBreakdownDisplay()" />
-          }
-        </mat-card-content>
-      </mat-card>
-
-      @if (store.avgSetSize()) {
+    @if (!isEmptyRange()) {
+      <section class="grid">
         <mat-card>
           <mat-card-header>
-            <mat-card-title i18n="@@analysis.avgSetSizeTitle"
-              >&#x2300; Set-Gr&#x00F6;&#x00DF;e</mat-card-title
+            <mat-card-title i18n="@@analysis.bestStreaksTitle"
+              >Bestwerte & Streaks</mat-card-title
             >
           </mat-card-header>
-          <mat-card-content class="kpi-big">
-            <b>{{ store.avgSetSize() }}</b>
-            <span i18n="@@analysis.repsPerSet">Reps / Set</span>
+          <mat-card-content class="best-grid">
+            <div>
+              <strong i18n="@@analysis.bestSingleEntry"
+                >Bestwert Einzel-Eintrag:</strong
+              >
+              <div>{{ store.bestSingleEntry()?.reps ?? 0 }} Reps</div>
+            </div>
+            <div>
+              <strong i18n="@@analysis.bestDay">Bester Tag:</strong>
+              <div>
+                {{ store.bestDay()?.date ?? '—' }} ·
+                {{ store.bestDay()?.total ?? 0 }} Reps
+              </div>
+            </div>
+            @if (store.bestSingleSet()) {
+              <div>
+                <strong i18n="@@analysis.bestSingleSet"
+                  >Bestes Einzel-Set:</strong
+                >
+                <div>
+                  {{ store.bestSingleSet() }}
+                  <span i18n="@@analysis.repsUnit">Wdh.</span>
+                </div>
+              </div>
+            }
+            <div>
+              <strong i18n="@@analysis.currentStreak">Aktuelle Streak:</strong>
+              <div>
+                <ng-container i18n="@@analysis.streakDays"
+                  >{{ store.currentStreak() }} Tage</ng-container
+                >
+              </div>
+            </div>
+            <div>
+              <strong i18n="@@analysis.longestStreak">Längste Streak:</strong>
+              <div>
+                <ng-container i18n="@@analysis.streakDays"
+                  >{{ store.longestStreak() }} Tage</ng-container
+                >
+              </div>
+            </div>
           </mat-card-content>
         </mat-card>
-      }
 
-      @if (store.setsDistribution().length) {
         <mat-card>
           <mat-card-header>
-            <mat-card-title i18n="@@analysis.setsDistTitle"
-              >Sets-Verteilung</mat-card-title
+            <mat-card-title i18n="@@analysis.typesTitle"
+              >Typen (Anteile)</mat-card-title
             >
           </mat-card-header>
           <mat-card-content>
             @defer (hydrate on viewport) {
-              <app-sets-distribution [data]="store.setsDistribution()" />
+              <app-type-pie [data]="typeBreakdownDisplay()" />
             }
           </mat-card-content>
         </mat-card>
-      }
-    </section>
 
-    <mat-card class="heatmap-full">
-      <mat-card-header>
-        <mat-card-title i18n="@@analysis.heatmapTitle"
-          >Heatmap (Wochentag/Uhrzeit)</mat-card-title
-        >
-        <mat-button-toggle-group
-          [value]="heatmapMode()"
-          (change)="heatmapMode.set($event.value)"
-          class="heatmap-toggle"
-          aria-label="Heatmap-Modus auswählen"
-          i18n-aria-label="@@analysis.heatmapToggleAriaLabel"
-        >
-          <mat-button-toggle value="reps" i18n="@@analysis.heatmapReps"
-            >Reps</mat-button-toggle
-          >
-          <mat-button-toggle value="sets" i18n="@@analysis.heatmapSets"
-            >Sets</mat-button-toggle
-          >
-        </mat-button-toggle-group>
-      </mat-card-header>
-      <mat-card-content class="heatmap-wrap">
-        @defer (hydrate on viewport) {
-          <app-heatmap
-            [entries]="store.viewFilteredRows()"
-            [mode]="heatmapMode()"
-          />
+        @if (store.avgSetSize()) {
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title i18n="@@analysis.avgSetSizeTitle"
+                >&#x2300; Set-Gr&#x00F6;&#x00DF;e</mat-card-title
+              >
+            </mat-card-header>
+            <mat-card-content class="kpi-big">
+              <b>{{ store.avgSetSize() }}</b>
+              <span i18n="@@analysis.repsPerSet">Reps / Set</span>
+            </mat-card-content>
+          </mat-card>
         }
-      </mat-card-content>
-    </mat-card>
+
+        @if (store.setsDistribution().length) {
+          <mat-card>
+            <mat-card-header>
+              <mat-card-title i18n="@@analysis.setsDistTitle"
+                >Sets-Verteilung</mat-card-title
+              >
+            </mat-card-header>
+            <mat-card-content>
+              @defer (hydrate on viewport) {
+                <app-sets-distribution [data]="store.setsDistribution()" />
+              }
+            </mat-card-content>
+          </mat-card>
+        }
+      </section>
+
+      <mat-card class="heatmap-full">
+        <mat-card-header>
+          <mat-card-title i18n="@@analysis.heatmapTitle"
+            >Heatmap (Wochentag/Uhrzeit)</mat-card-title
+          >
+          <mat-button-toggle-group
+            [value]="heatmapMode()"
+            (change)="heatmapMode.set($event.value)"
+            class="heatmap-toggle"
+            aria-label="Heatmap-Modus auswählen"
+            i18n-aria-label="@@analysis.heatmapToggleAriaLabel"
+          >
+            <mat-button-toggle value="reps" i18n="@@analysis.heatmapReps"
+              >Reps</mat-button-toggle
+            >
+            <mat-button-toggle value="sets" i18n="@@analysis.heatmapSets"
+              >Sets</mat-button-toggle
+            >
+          </mat-button-toggle-group>
+        </mat-card-header>
+        <mat-card-content class="heatmap-wrap">
+          @defer (hydrate on viewport) {
+            <app-heatmap
+              [entries]="store.viewFilteredRows()"
+              [mode]="heatmapMode()"
+            />
+          }
+        </mat-card-content>
+      </mat-card>
+    }
 
     <section class="trends-section" data-testid="analysis-trends-section">
       <mat-card>
@@ -318,6 +330,10 @@ import { kindDisplayName } from '../i18n/exercise-display-names';
     .heatmap-toggle {
       margin-left: auto;
     }
+    .empty {
+      opacity: 0.7;
+      margin: 0;
+    }
     @media (max-width: 900px) {
       :host {
         gap: 12px;
@@ -349,6 +365,22 @@ export class AnalysisGroupViewComponent {
   readonly store = inject(AnalysisStore);
   readonly trendColumnsWithSets = ['label', 'total', 'avgSetsPerEntry'];
   readonly heatmapMode = signal<'reps' | 'sets'>('reps');
+
+  /**
+   * True for per-category tabs whose currently-selected range contains
+   * no entries — flips the template into the "Keine Einträge im
+   * gewählten Zeitraum" branch so the user keeps their tab selection
+   * while the filter walks past empty windows. Overview never enters
+   * this branch: the page shell hides this component behind the
+   * `showEmptyCta` gate when the whole dataset is empty, and the
+   * overview tab renders `<app-analysis-overview>` instead of this
+   * component, which has its own empty-state copy.
+   */
+  readonly isEmptyRange = computed(
+    () =>
+      this.store.activeView() !== 'overview' &&
+      this.store.viewFilteredRows().length === 0
+  );
 
   /**
    * Resolves the bare-id labels emitted by `store.typeBreakdown()` (in

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -861,18 +861,48 @@ describe('AnalysisPageComponent', () => {
       expect(component.selectedTabIndex()).toBe(0);
     });
 
-    it('falls back to Overview when activeView points at a tab that is not visible', () => {
-      // The seeded dataset only has pushup entries, so the core/squat tabs
-      // never render. Pointing activeView at an empty category — e.g. via
-      // a stale `?view=mobility` deep link — must surface index 0 rather
-      // than leaving the binding referencing an out-of-range slot.
+    it('preserves the active category tab when the filter shifts to a range with no entries for that category', () => {
+      // Regression: walking the filter forward/back used to drop the
+      // tab back to Overview the moment the new range fell outside the
+      // active category's entries — `categorySummaries()` shrunk,
+      // `selectedTabIndex()` defaulted to 0, mat-tab-group fired
+      // `selectedIndexChange(0)`, and `onTabIndexChange(0)` clobbered
+      // `activeView`. The fix pins the active category in `visibleTabs`
+      // so the index keeps pointing at it.
+      const component = fixture.componentInstance;
+      component.store.setActiveView('pushup');
+      expect(component.store.activeView()).toBe('pushup');
+
+      // Shift the range somewhere with zero pushup entries. The seeded
+      // mock only has data in Feb 9–15 2026, so January is empty.
+      component.store.setRange('2026-01-05', '2026-01-11');
+      fixture.detectChanges();
+
+      expect(component.store.activeView()).toBe('pushup');
+      expect(component.visibleTabs().map((t) => t.id)).toContain('pushup');
+      const pushupIdx = component
+        .visibleTabs()
+        .findIndex((t) => t.id === 'pushup');
+      expect(component.selectedTabIndex()).toBe(pushupIdx + 1);
+    });
+
+    it('keeps the active category tab visible even when it has no entries in the current range', () => {
+      // Regression: when the user shifts the filter past the last entry
+      // in their active category, the tab used to fall back to Overview
+      // and the user lost their selection. The tab must stay pinned and
+      // the body surfaces a "Keine Einträge im gewählten Zeitraum"
+      // notice instead, so navigating back and forth in the filter is
+      // non-destructive.
       const component = fixture.componentInstance;
       component.store.setActiveView('mobility');
       fixture.detectChanges();
       expect(component.visibleTabs().some((t) => t.id === 'mobility')).toBe(
-        false
+        true
       );
-      expect(component.selectedTabIndex()).toBe(0);
+      const mobilityIdx = component
+        .visibleTabs()
+        .findIndex((t) => t.id === 'mobility');
+      expect(component.selectedTabIndex()).toBe(mobilityIdx + 1);
     });
 
     it('selecting an overview card emits the category and switches the active view', () => {

--- a/web/src/app/stats/shell/analysis-page.component.ts
+++ b/web/src/app/stats/shell/analysis-page.component.ts
@@ -250,25 +250,41 @@ export class AnalysisPageComponent {
   } | null;
 
   /**
-   * Categories that have at least one entry in the active date range.
-   * Mirrors `categorySummaries` because both consume the same per-range
-   * roll-up, so a card in the overview always matches a tab here.
+   * Categories with entries in the active range, plus the active view's
+   * category when the user is parked on it — keeping the selected tab
+   * pinned across forward/back filter shifts even if the new range is
+   * empty for that category. The tab body falls back to the
+   * "Keine Einträge im gewählten Zeitraum" notice in that case.
    */
-  readonly visibleTabs = computed<VisibleTab[]>(() =>
-    this.store.categorySummaries().map((s) => ({
+  readonly visibleTabs = computed<VisibleTab[]>(() => {
+    const summaries = this.store.categorySummaries();
+    const tabs: VisibleTab[] = summaries.map((s) => ({
       id: s.categoryId,
       label: categoryDisplayName(s.categoryId),
       icon: s.icon,
-    }))
-  );
+    }));
+    const view = this.store.activeView();
+    if (view !== 'overview' && !tabs.some((t) => t.id === view)) {
+      const meta = EXERCISE_CATEGORIES.find((c) => c.id === view);
+      if (meta) {
+        tabs.push({
+          id: meta.id,
+          label: categoryDisplayName(meta.id),
+          icon: meta.icon,
+        });
+        const orderOf = (id: ExerciseCategoryId): number =>
+          EXERCISE_CATEGORIES.find((c) => c.id === id)?.order ?? 0;
+        tabs.sort((a, b) => orderOf(a.id) - orderOf(b.id));
+      }
+    }
+    return tabs;
+  });
 
   /**
    * Overview is index 0; category tabs follow in `visibleTabs` order.
-   * When the active view points at a category that isn't visible (e.g.
-   * the user narrowed the range past its last entry, or arrived via a
-   * stale deep link), we surface the Overview tab rather than leave the
-   * group falsely selected — the category will reappear once the range
-   * widens again, which also brings its data back.
+   * The active view is always present in `visibleTabs` (as long as it
+   * refers to a valid category), so the only way to land on Overview is
+   * for the user to pick it explicitly.
    */
   readonly selectedTabIndex = computed<number>(() => {
     const view = this.store.activeView();


### PR DESCRIPTION
The analysis page's per-category tabs used to disappear from `visibleTabs`
as soon as the new filter range contained no entries for that category;
mat-tab-group then fired `selectedIndexChange(0)` programmatically and
`onTabIndexChange` clobbered `activeView` back to Overview, dropping the
user's selection every time they stepped the filter forward or back.

`visibleTabs` now always includes the active category (sorted into its
canonical order) so the binding keeps pointing at it, and the
group-view's body falls back to the "Keine Einträge im gewählten
Zeitraum" notice when the active category is empty in the current range.
The notice reuses the existing `@@noEntriesInSelectedRange` id so no
XLIFF churn is needed. The trends section stays visible because its
8-week/6-month windows are independent of the page filter.

The filter bar also gains a compact `DD.MM.YYYY – DD.MM.YYYY` summary
next to the Zurück/Heute/Vor buttons (collapsed to a single date for a
single-day range, hidden while either bound is unset) so the user can
read the selected range without expanding the date-range picker.

https://claude.ai/code/session_016FuedDz6tRkP2hcpdQRUcs