### PR TITLE
fix(auto-count): retune sit-up profile so reps actually count

### DIFF
--- a/libs/auto-count/src/lib/exercise-angle-profile.ts
+++ b/libs/auto-count/src/lib/exercise-angle-profile.ts
@@ -111,24 +111,30 @@ export const PULLUP_PROFILE: ExerciseAngleProfile = {
 };
 
 /**
- * Sit-up rep. The "up" zone is the **lying-flat** start position
- * (hip angle ≈ 180°, shoulder/hip/knee on a line). The "down" zone is
- * the curled-up peak (hip flexed, ≈ 80°). Naming is intentional and
- * matches every other profile: "up" always means the high-angle /
- * extended joint, "down" always means the flexed one — that lets the
- * shared `RepStateMachine` count `down → up` cycles uniformly. The
- * `'awaiting-up'` UI hint therefore reads correctly: "go to starting
- * position" = lie flat on your back.
+ * Sit-up rep. The "up" zone is the **lying-flat** start position and
+ * the "down" zone is the curled-up peak. Naming matches every other
+ * profile: "up" = high-angle (hip extended), "down" = low-angle (hip
+ * flexed). The shared `RepStateMachine` then counts `down → up`
+ * cycles uniformly.
+ *
+ * Threshold tuning is more permissive than the other profiles because
+ * the standard sit-up form keeps the knees bent at ~90° throughout
+ * (feet flat on the floor), so the shoulder-hip-knee angle in the
+ * lying-flat position is closer to ~110-140° than 180° — the previous
+ * 160° / 90° pair caused the "up" zone to be unreachable, which made
+ * the counter silently drop reps. The lower `minConfidence` reflects
+ * the harder camera framing of a lying user (selfie cam looking down
+ * the body, partial body crop) compared to a standing pushup/squat.
  */
 export const SITUP_PROFILE: ExerciseAngleProfile = {
   id: 'situp',
   tripletLeft: HIP_TRIPLETS.left,
   tripletRight: HIP_TRIPLETS.right,
-  upAngleDeg: 160,
-  downAngleDeg: 90,
-  minDwellMs: 250,
-  minConfidence: 0.5,
-  maxFrameGapMs: 600,
+  upAngleDeg: 130,
+  downAngleDeg: 60,
+  minDwellMs: 200,
+  minConfidence: 0.4,
+  maxFrameGapMs: 700,
 };
 
 const PROFILES: ReadonlyMap<string, ExerciseAngleProfile> = new Map([


### PR DESCRIPTION
## Summary

Field-feedback fix: sit-ups weren't being counted in the auto-counter. The previous profile assumed a fully-extended hip line (shoulder-hip-knee ≈ 180°) for the lying-flat start position, but the standard sit-up keeps the knees bent at ~90° (feet flat on floor) so the angle there is closer to ~110-140°. With `upAngleDeg: 160` the "up" zone was effectively unreachable, the state machine never confirmed the start phase, and the counter silently dropped every rep.

## Retuned

| Field | Before | After | Why |
|---|---|---|---|
| `upAngleDeg` | 160 | **130** | Matches actual lying-flat-with-bent-knees hip angle. |
| `downAngleDeg` | 90 | **60** | Chest curled toward knees on a full sit-up. |
| `minConfidence` | 0.5 | **0.4** | Lying-down framing from a selfie cam has partial-body crop and lower per-landmark visibility than the standing pushup/squat poses. |
| `minDwellMs` | 250 | **200** | Sit-up cadence is typically faster than the bottom-of-squat hold. |
| `maxFrameGapMs` | 600 | **700** | Bit more tolerance for dropped frames during the explosive sit-up phase. |

## QA

Pure tuning data — no schema, code, test, or i18n change.

- `nx test auto-count`: **52/52**
- `nx test web`: **804/804**
- `nx lint`: clean

## Test plan

- [ ] As an admin, open Auto-Zählen → select Sit-ups.
- [ ] Lie flat with knees bent at ~90°; confirm the form-check panel shows hip angle ~110-130° and the phase moves from "Bereit" to "Oben" within ~0.2 s.
- [ ] Curl up to a full sit-up; confirm phase moves to "Unten".
- [ ] Return to lying; confirm the rep count increments.
- [ ] Repeat 5 reps; confirm count = 5.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8v5btmabrrYcwwer7xJ6u)_