### PR TITLE
feat(analysis): measurement-aware category overview cards

### DIFF
--- a/web/src/app/stats/analysis.store.facet.spec.ts
+++ b/web/src/app/stats/analysis.store.facet.spec.ts
@@ -1,0 +1,21 @@
+import { facetKindFor } from './analysis.store';
+
+describe('facetKindFor', () => {
+  it('routes reps and weight to the same facet kind', () => {
+    // Regression (Codex P2): the card template iterates facets with
+    // `@for … track facet.kind`. If `weight` and `reps` produced two
+    // separate bucket entries with the same emitted kind, Angular
+    // would surface NG0955 and reuse the wrong DOM row. Collapsing at
+    // the kind level (here) is the single source of truth that
+    // prevents the duplicate bucket — the catalog has no `weight`
+    // entries today, but custom user exercises can declare one.
+    expect(facetKindFor('reps')).toBe('reps');
+    expect(facetKindFor('weight')).toBe('reps');
+  });
+
+  it('preserves time, distance and distance-time as their own kinds', () => {
+    expect(facetKindFor('time')).toBe('time');
+    expect(facetKindFor('distance')).toBe('distance');
+    expect(facetKindFor('distance-time')).toBe('distance-time');
+  });
+});

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -70,11 +70,69 @@ export interface TypeBreakdownDatum {
 }
 
 /**
+ * Reps-measurement facet of a {@link CategorySummary.volume}. Carries
+ * the set count (only meaningful when entries log per-set breakdowns).
+ */
+export interface CategoryRepsFacet {
+  kind: 'reps';
+  totalReps: number;
+  todayReps: number;
+  totalSets: number;
+  bestDay: { date: string; total: number } | null;
+}
+
+/** Time-measurement facet (planks, hollow holds, mobility holds). */
+export interface CategoryTimeFacet {
+  kind: 'time';
+  totalSec: number;
+  todaySec: number;
+  bestDay: { date: string; totalSec: number } | null;
+}
+
+/** Distance-only facet (loaded carries, future cycling). */
+export interface CategoryDistanceFacet {
+  kind: 'distance';
+  totalM: number;
+  todayM: number;
+  bestDay: { date: string; totalM: number } | null;
+}
+
+/** Distance-time composite facet (cardio runs). */
+export interface CategoryDistanceTimeFacet {
+  kind: 'distance-time';
+  totalM: number;
+  totalSec: number;
+  todayM: number;
+  todaySec: number;
+  bestDay: { date: string; totalM: number; totalSec: number } | null;
+}
+
+export type CategorySingleFacet =
+  | CategoryRepsFacet
+  | CategoryTimeFacet
+  | CategoryDistanceFacet
+  | CategoryDistanceTimeFacet;
+
+/**
+ * Mixed-measurement bucket: emitted when a category contains entries
+ * of more than one measurement type (e.g. `core` mixes sit-ups (reps)
+ * and plank (time)). The card renders one section per facet so neither
+ * dimension swallows the other.
+ */
+export interface CategoryMixedVolume {
+  kind: 'mixed';
+  facets: ReadonlyArray<CategorySingleFacet>;
+}
+
+export type CategoryVolume = CategorySingleFacet | CategoryMixedVolume;
+
+/**
  * Per-category roll-up consumed by the analysis overview tab. The
- * cards render `nameKey`/`icon`, and the comparison chart pulls
- * `totalReps`/`totalSets` from the same shape so the two views stay
- * in lockstep. Categories with no entries in the current date range
- * are filtered out upstream — every entry here represents a present,
+ * cards render `nameKey`/`icon` plus a measurement-aware `volume`,
+ * and the comparison chart compares categories by `entries` (count of
+ * logged trainings) so reps, seconds and meters can no longer share a
+ * bar. Categories with no entries in the current date range are
+ * filtered out upstream — every entry here represents a present,
  * non-empty group.
  */
 export interface CategorySummary {
@@ -82,18 +140,20 @@ export interface CategorySummary {
   nameKey: string;
   icon: string;
   order: number;
-  totalReps: number;
-  totalSets: number;
-  todayReps: number;
+  entries: number;
   currentStreak: number;
-  bestDay: { date: string; total: number } | null;
+  volume: CategoryVolume;
 }
 
-/** Series shape consumed by the overview comparison chart. */
+/**
+ * Series shape consumed by the overview comparison chart. `entries`
+ * counts logged trainings per category — the only metric that lets
+ * reps-, time- and distance-categories share one axis without
+ * mis-comparing seconds vs. repetitions.
+ */
 export interface CategoryComparison {
   labels: ReadonlyArray<string>;
-  reps: ReadonlyArray<number>;
-  sets: ReadonlyArray<number>;
+  entries: ReadonlyArray<number>;
 }
 
 type AnalysisState = {
@@ -193,6 +253,188 @@ function measurementScale(
   return measurement === 'distance' || measurement === 'distance-time'
     ? 1 / 1000
     : 1;
+}
+
+/**
+ * Folds rows that share a single measurement into the matching
+ * {@link CategorySingleFacet}. Pulled out of `categorySummaries` so the
+ * mixed-bucket path can call it once per measurement subset.
+ *
+ * Pushup entries (`kind: 'pushup'`) and `'weight'`-measurement
+ * exercises (currently none in the catalog, but reserved) route through
+ * the reps facet — both expose their volume on `entry.reps`.
+ *
+ * Best-day always picks the day with the largest primary volume in the
+ * facet's dimension; the comparator on a `distance-time` facet uses
+ * distance because that's what users intuitively rank a "best run" by.
+ */
+function durationOf(entry: UnifiedEntry): number {
+  return entry.kind === 'exercise' ? (entry.durationSec ?? 0) : 0;
+}
+
+function distanceOf(entry: UnifiedEntry): number {
+  return entry.kind === 'exercise' ? (entry.distanceM ?? 0) : 0;
+}
+
+function buildFacet(
+  measurement: MeasurementType,
+  rows: ReadonlyArray<UnifiedEntry>,
+  todayKey: string
+): CategorySingleFacet {
+  switch (measurement) {
+    case 'time': {
+      const totalSec = rows.reduce((s, r) => s + durationOf(r), 0);
+      const todaySec = rows.reduce(
+        (s, r) =>
+          r.timestamp.slice(0, 10) === todayKey ? s + durationOf(r) : s,
+        0
+      );
+      const byDay = new Map<string, number>();
+      for (const r of rows) {
+        const k = r.timestamp.slice(0, 10);
+        byDay.set(k, (byDay.get(k) ?? 0) + durationOf(r));
+      }
+      const bestPair = pickBestDay(byDay);
+      return {
+        kind: 'time',
+        totalSec,
+        todaySec,
+        bestDay: bestPair ? { date: bestPair[0], totalSec: bestPair[1] } : null,
+      };
+    }
+    case 'distance': {
+      const totalM = rows.reduce((s, r) => s + distanceOf(r), 0);
+      const todayM = rows.reduce(
+        (s, r) =>
+          r.timestamp.slice(0, 10) === todayKey ? s + distanceOf(r) : s,
+        0
+      );
+      const byDay = new Map<string, number>();
+      for (const r of rows) {
+        const k = r.timestamp.slice(0, 10);
+        byDay.set(k, (byDay.get(k) ?? 0) + distanceOf(r));
+      }
+      const bestPair = pickBestDay(byDay);
+      return {
+        kind: 'distance',
+        totalM,
+        todayM,
+        bestDay: bestPair ? { date: bestPair[0], totalM: bestPair[1] } : null,
+      };
+    }
+    case 'distance-time': {
+      const totalM = rows.reduce((s, r) => s + distanceOf(r), 0);
+      const totalSec = rows.reduce((s, r) => s + durationOf(r), 0);
+      const todayM = rows.reduce(
+        (s, r) =>
+          r.timestamp.slice(0, 10) === todayKey ? s + distanceOf(r) : s,
+        0
+      );
+      const todaySec = rows.reduce(
+        (s, r) =>
+          r.timestamp.slice(0, 10) === todayKey ? s + durationOf(r) : s,
+        0
+      );
+      const byDay = new Map<string, { m: number; sec: number }>();
+      for (const r of rows) {
+        const k = r.timestamp.slice(0, 10);
+        const cur = byDay.get(k) ?? { m: 0, sec: 0 };
+        cur.m += distanceOf(r);
+        cur.sec += durationOf(r);
+        byDay.set(k, cur);
+      }
+      let bestEntry: [string, { m: number; sec: number }] | null = null;
+      for (const e of byDay.entries()) {
+        if (!bestEntry || e[1].m > bestEntry[1].m) bestEntry = e;
+      }
+      return {
+        kind: 'distance-time',
+        totalM,
+        totalSec,
+        todayM,
+        todaySec,
+        bestDay: bestEntry
+          ? {
+              date: bestEntry[0],
+              totalM: bestEntry[1].m,
+              totalSec: bestEntry[1].sec,
+            }
+          : null,
+      };
+    }
+    case 'reps':
+    case 'weight':
+    default: {
+      const totalReps = rows.reduce((s, r) => s + r.reps, 0);
+      const totalSets = rows.reduce((s, r) => s + (r.sets?.length ?? 0), 0);
+      const todayReps = rows.reduce(
+        (s, r) => (r.timestamp.slice(0, 10) === todayKey ? s + r.reps : s),
+        0
+      );
+      const byDay = new Map<string, number>();
+      for (const r of rows) {
+        const k = r.timestamp.slice(0, 10);
+        byDay.set(k, (byDay.get(k) ?? 0) + r.reps);
+      }
+      const bestPair = pickBestDay(byDay);
+      return {
+        kind: 'reps',
+        totalReps,
+        totalSets,
+        todayReps,
+        bestDay: bestPair ? { date: bestPair[0], total: bestPair[1] } : null,
+      };
+    }
+  }
+}
+
+function pickBestDay(byDay: Map<string, number>): [string, number] | null {
+  let best: [string, number] | null = null;
+  for (const e of byDay.entries()) {
+    if (!best || e[1] > best[1]) best = e;
+  }
+  return best;
+}
+
+/**
+ * Resolves a category's rows into a single measurement facet or a
+ * mixed bucket. Unknown exerciseIds (custom catalog entries deleted
+ * from the device's local catalog) fold into the reps facet so they
+ * still surface a number — the rationale matches
+ * {@link unifiedEntryPrimaryValue}'s fallback.
+ */
+function computeCategoryVolume(
+  rows: ReadonlyArray<UnifiedEntry>,
+  todayKey: string
+): CategoryVolume {
+  const byMeasurement = new Map<MeasurementType, UnifiedEntry[]>();
+  for (const row of rows) {
+    const m = unifiedEntryMeasurement(row) ?? 'reps';
+    const bucket = byMeasurement.get(m);
+    if (bucket) bucket.push(row);
+    else byMeasurement.set(m, [row]);
+  }
+  if (byMeasurement.size === 1) {
+    const [[measurement, group]] = [...byMeasurement.entries()];
+    return buildFacet(measurement, group, todayKey);
+  }
+  // Stable facet order: reps → time → distance → distance-time → weight
+  // — matches the dominant-to-rare frequency in the catalog so the
+  // primary-movement facet leads the card.
+  const order: MeasurementType[] = [
+    'reps',
+    'time',
+    'distance',
+    'distance-time',
+    'weight',
+  ];
+  const facets: CategorySingleFacet[] = [];
+  for (const m of order) {
+    const group = byMeasurement.get(m);
+    if (!group?.length) continue;
+    facets.push(buildFacet(m, group, todayKey));
+  }
+  return { kind: 'mixed', facets };
 }
 
 /**
@@ -653,24 +895,6 @@ export const AnalysisStore = signalStore(
       for (const meta of EXERCISE_CATEGORIES) {
         const catRows = byCategory.get(meta.id);
         if (!catRows || !catRows.length) continue;
-        const totalReps = catRows.reduce((s, r) => s + r.reps, 0);
-        const totalSets = catRows.reduce(
-          (s, r) => s + (r.sets?.length ?? 0),
-          0
-        );
-        const todayReps = catRows.reduce(
-          (s, r) => (r.timestamp.slice(0, 10) === todayKey ? s + r.reps : s),
-          0
-        );
-        const byDay = new Map<string, number>();
-        for (const r of catRows) {
-          const k = r.timestamp.slice(0, 10);
-          byDay.set(k, (byDay.get(k) ?? 0) + r.reps);
-        }
-        let bestDayPair: [string, number] | null = null;
-        for (const e of byDay.entries()) {
-          if (!bestDayPair || e[1] > bestDayPair[1]) bestDayPair = e;
-        }
         const dates = sortedUniqueDates(catRows);
         let streak = 0;
         if (dates.length) {
@@ -685,28 +909,25 @@ export const AnalysisStore = signalStore(
           nameKey: meta.nameKey,
           icon: meta.icon,
           order: meta.order,
-          totalReps,
-          totalSets,
-          todayReps,
+          entries: catRows.length,
           currentStreak: streak,
-          bestDay: bestDayPair
-            ? { date: bestDayPair[0], total: bestDayPair[1] }
-            : null,
+          volume: computeCategoryVolume(catRows, todayKey),
         });
       }
       return result.sort((a, b) => a.order - b.order);
     });
 
-    // Labels are resolved here rather than left to the chart component
-    // because Chart.js has no `$localize` hook — feeding it the raw
-    // XLIFF id would render the legend like a developer string in
-    // production builds.
+    // Labels are resolved here (not in the chart component) because the
+    // chart now compares categories by training count — a measurement-
+    // agnostic axis. Reps, seconds and meters can no longer share a
+    // bar, so summed-volume metrics are intentionally omitted: any
+    // future side-by-side reps-vs-time comparison belongs in a
+    // measurement-specific drill-down view, not the overview chart.
     const categoryComparison = computed<CategoryComparison>(() => {
       const summaries = categorySummaries();
       return {
         labels: summaries.map((s) => categoryDisplayName(s.categoryId)),
-        reps: summaries.map((s) => s.totalReps),
-        sets: summaries.map((s) => s.totalSets),
+        entries: summaries.map((s) => s.entries),
       };
     });
 

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -397,42 +397,77 @@ function pickBestDay(byDay: Map<string, number>): [string, number] | null {
 }
 
 /**
+ * Maps a measurement type to the facet kind {@link buildFacet} emits
+ * for it. `weight` shares the reps-shaped facet (both expose volume on
+ * `entry.reps`), so the catalog's reserved `weight` measurement must
+ * not produce a second `kind: 'reps'` facet alongside a real reps
+ * bucket — that would push two entries with identical
+ * `facet.kind` into the card's `@for … track facet.kind` loop and
+ * trigger Angular NG0955 (duplicate keys, incorrect row reuse).
+ */
+export function facetKindFor(
+  measurement: MeasurementType
+): CategorySingleFacet['kind'] {
+  switch (measurement) {
+    case 'time':
+      return 'time';
+    case 'distance':
+      return 'distance';
+    case 'distance-time':
+      return 'distance-time';
+    case 'reps':
+    case 'weight':
+    default:
+      return 'reps';
+  }
+}
+
+/**
  * Resolves a category's rows into a single measurement facet or a
  * mixed bucket. Unknown exerciseIds (custom catalog entries deleted
  * from the device's local catalog) fold into the reps facet so they
  * still surface a number — the rationale matches
  * {@link unifiedEntryPrimaryValue}'s fallback.
+ *
+ * Bucketing is keyed by *facet kind* rather than the raw
+ * {@link MeasurementType}: `reps` and `weight` collapse into one
+ * `'reps'` bucket so a category mixing custom weight entries with
+ * bodyweight reps doesn't emit two `kind: 'reps'` facets (which would
+ * collide under `@for … track facet.kind`).
  */
 function computeCategoryVolume(
   rows: ReadonlyArray<UnifiedEntry>,
   todayKey: string
 ): CategoryVolume {
-  const byMeasurement = new Map<MeasurementType, UnifiedEntry[]>();
+  const byKind = new Map<
+    CategorySingleFacet['kind'],
+    { measurement: MeasurementType; rows: UnifiedEntry[] }
+  >();
   for (const row of rows) {
-    const m = unifiedEntryMeasurement(row) ?? 'reps';
-    const bucket = byMeasurement.get(m);
-    if (bucket) bucket.push(row);
-    else byMeasurement.set(m, [row]);
+    const measurement = unifiedEntryMeasurement(row) ?? 'reps';
+    const kind = facetKindFor(measurement);
+    const bucket = byKind.get(kind);
+    if (bucket) bucket.rows.push(row);
+    else byKind.set(kind, { measurement, rows: [row] });
   }
-  if (byMeasurement.size === 1) {
-    const [[measurement, group]] = [...byMeasurement.entries()];
+  if (byKind.size === 1) {
+    const [{ measurement, rows: group }] = [...byKind.values()];
     return buildFacet(measurement, group, todayKey);
   }
-  // Stable facet order: reps → time → distance → distance-time → weight
-  // — matches the dominant-to-rare frequency in the catalog so the
+  // Stable facet order: reps → time → distance → distance-time.
+  // Matches the dominant-to-rare frequency in the catalog so the
   // primary-movement facet leads the card.
-  const order: MeasurementType[] = [
+  const order: ReadonlyArray<CategorySingleFacet['kind']> = [
     'reps',
     'time',
     'distance',
     'distance-time',
-    'weight',
   ];
   const facets: CategorySingleFacet[] = [];
-  for (const m of order) {
-    const group = byMeasurement.get(m);
-    if (!group?.length) continue;
-    facets.push(buildFacet(m, group, todayKey));
+  for (const kind of order) {
+    const bucket = byKind.get(kind);
+    if (!bucket?.rows.length) continue;
+    facets.push(buildFacet(bucket.measurement, bucket.rows, todayKey));
   }
   return { kind: 'mixed', facets };
 }

--- a/web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.spec.ts
+++ b/web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.spec.ts
@@ -1,6 +1,4 @@
-import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatButtonToggleHarness } from '@angular/material/button-toggle/testing';
 import { Component, signal } from '@angular/core';
 
 import type { CategoryComparison } from '../../analysis.store';
@@ -15,8 +13,7 @@ import { CategoryComparisonChartComponent } from './category-comparison-chart.co
 class HostComponent {
   readonly data = signal<CategoryComparison>({
     labels: [],
-    reps: [],
-    sets: [],
+    entries: [],
   });
 }
 
@@ -31,7 +28,7 @@ describe('CategoryComparisonChartComponent', () => {
   });
 
   it('renders the empty state when there are no categories', () => {
-    fixture.componentInstance.data.set({ labels: [], reps: [], sets: [] });
+    fixture.componentInstance.data.set({ labels: [], entries: [] });
     fixture.detectChanges();
     const host: HTMLElement = fixture.nativeElement;
     expect(
@@ -42,11 +39,14 @@ describe('CategoryComparisonChartComponent', () => {
     ).toBeNull();
   });
 
-  it('renders one bar per category with reps as the default metric', () => {
+  it('renders one bar per category sized by training count', () => {
+    // Bar metric is intentionally a count of trainings — reps,
+    // seconds and meters live on different scales, so the redesign
+    // dropped the reps/sets toggle in favour of a single measurement-
+    // agnostic axis.
     fixture.componentInstance.data.set({
-      labels: ['Pushups', 'Abs', 'Legs'],
-      reps: [100, 50, 25],
-      sets: [10, 5, 2],
+      labels: ['Pushups', 'Abs', 'Cardio'],
+      entries: [12, 4, 2],
     });
     fixture.detectChanges();
     const host: HTMLElement = fixture.nativeElement;
@@ -56,53 +56,40 @@ describe('CategoryComparisonChartComponent', () => {
     const labels = Array.from(host.querySelectorAll('.bar-label')).map((el) =>
       el.textContent?.trim()
     );
-    expect(labels).toEqual(['Pushups', 'Abs', 'Legs']);
+    expect(labels).toEqual(['Pushups', 'Abs', 'Cardio']);
 
-    // First row carries the max — fill is 100%.
-    const firstFill = host.querySelector('.bar-row .bar-fill') as HTMLElement;
-    expect(firstFill.style.width).toBe('100%');
-  });
+    const fills = Array.from(
+      host.querySelectorAll('.bar-fill')
+    ) as HTMLElement[];
+    expect(fills[0].style.width).toBe('100%');
+    expect(fills[1].style.width).toBe(`${(4 / 12) * 100}%`);
+    expect(fills[2].style.width).toBe(`${(2 / 12) * 100}%`);
 
-  it('switching to sets scales the bars by sets and updates the displayed value', async () => {
-    fixture.componentInstance.data.set({
-      labels: ['Pushups', 'Abs'],
-      reps: [100, 50],
-      sets: [10, 40],
-    });
-    fixture.detectChanges();
-
-    const loader = TestbedHarnessEnvironment.loader(fixture);
-    const toggles = await loader.getAllHarnesses(MatButtonToggleHarness);
-    // `Array.prototype.find` with an async predicate is a footgun — the
-    // predicate always returns a truthy Promise, so the first toggle
-    // wins regardless of its label. Resolve labels first and match by
-    // value.
-    const labels = await Promise.all(toggles.map((t) => t.getText()));
-    const setsIdx = labels.findIndex((l) => l.trim() === 'Sätze');
-    expect(setsIdx).toBeGreaterThanOrEqual(0);
-    await toggles[setsIdx].toggle();
-    fixture.detectChanges();
-
-    const host: HTMLElement = fixture.nativeElement;
     const values = Array.from(host.querySelectorAll('.bar-value')).map((el) =>
       el.textContent?.trim()
     );
-    expect(values).toEqual(['10', '40']);
-    // Max is now Abs (40), so its bar fills the full track.
-    const fills = host.querySelectorAll('.bar-fill');
-    expect((fills[0] as HTMLElement).style.width).toBe('25%');
-    expect((fills[1] as HTMLElement).style.width).toBe('100%');
+    expect(values).toEqual(['12', '4', '2']);
   });
 
   it('renders zero-width fills without dividing by zero when every value is zero', () => {
     fixture.componentInstance.data.set({
       labels: ['Pushups'],
-      reps: [0],
-      sets: [0],
+      entries: [0],
     });
     fixture.detectChanges();
     const host: HTMLElement = fixture.nativeElement;
     const fill = host.querySelector('.bar-fill') as HTMLElement;
     expect(fill.style.width).toBe('0%');
+  });
+
+  it('shows the metric label so users can read the axis without a legend', () => {
+    fixture.componentInstance.data.set({
+      labels: ['Pushups'],
+      entries: [3],
+    });
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    // German source locale.
+    expect(host.textContent).toContain('Trainingseinheiten');
   });
 });

--- a/web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts
+++ b/web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts
@@ -1,16 +1,20 @@
 import { DecimalPipe } from '@angular/common';
-import { Component, computed, input, signal } from '@angular/core';
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { Component, computed, input } from '@angular/core';
 
 import type { CategoryComparison } from '../../analysis.store';
-
-type Metric = 'reps' | 'sets';
 
 /**
  * Horizontal bar comparison across exercise categories. Sits in the
  * Overview tab next to the per-category cards and shares the same
  * `CategorySummary`-derived data, so a category visible here always
  * has a matching card and a matching tab.
+ *
+ * The bar metric is intentionally a measurement-agnostic count of
+ * logged trainings ("Trainingseinheiten"). Reps, seconds and meters
+ * each live on their own scale — summing 60 s of plank onto 60 reps
+ * of pushups in one bar was the original bug behind this redesign.
+ * Drilling into a single measurement type belongs in the per-category
+ * detail tab, not the overview comparison.
  *
  * CSS bars rather than Chart.js: with at most ~7 categories the SVG
  * chart pulls in framework, registration and PLATFORM_ID/canvas
@@ -19,32 +23,15 @@ type Metric = 'reps' | 'sets';
 @Component({
   selector: 'app-category-comparison-chart',
   standalone: true,
-  imports: [DecimalPipe, MatButtonToggleModule],
+  imports: [DecimalPipe],
   template: `
     <header class="head">
       <h3 class="title" i18n="@@analysis.overview.comparison.title">
         Vergleich nach Übungsgruppe
       </h3>
-      <mat-button-toggle-group
-        [value]="metric()"
-        (change)="metric.set($event.value)"
-        aria-label="Kennzahl"
-        i18n-aria-label="@@analysis.overview.comparison.metricAria"
-        data-testid="category-comparison-metric"
-      >
-        <mat-button-toggle
-          value="reps"
-          i18n="@@analysis.overview.comparison.metric.reps"
-        >
-          Wdh.
-        </mat-button-toggle>
-        <mat-button-toggle
-          value="sets"
-          i18n="@@analysis.overview.comparison.metric.sets"
-        >
-          Sätze
-        </mat-button-toggle>
-      </mat-button-toggle-group>
+      <p class="metric" i18n="@@analysis.overview.comparison.metricLabel">
+        Trainingseinheiten
+      </p>
     </header>
 
     @if (rows().length === 0) {
@@ -75,7 +62,7 @@ type Metric = 'reps' | 'sets';
     }
     .head {
       display: flex;
-      align-items: center;
+      align-items: baseline;
       justify-content: space-between;
       gap: 12px;
       margin-bottom: 12px;
@@ -85,6 +72,13 @@ type Metric = 'reps' | 'sets';
       margin: 0;
       font-size: 1rem;
       font-weight: 600;
+    }
+    .metric {
+      margin: 0;
+      font-size: 0.75rem;
+      opacity: 0.7;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
     }
     .bars {
       list-style: none;
@@ -140,11 +134,10 @@ type Metric = 'reps' | 'sets';
 })
 export class CategoryComparisonChartComponent {
   readonly data = input.required<CategoryComparison>();
-  readonly metric = signal<Metric>('reps');
 
   readonly rows = computed(() => {
     const data = this.data();
-    const values = this.metric() === 'reps' ? data.reps : data.sets;
+    const values = data.entries;
     const max = values.reduce((m, v) => (v > m ? v : m), 0);
     return data.labels.map((label, idx) => {
       const value = values[idx] ?? 0;

--- a/web/src/app/stats/components/category-summary-card/category-summary-card.component.html
+++ b/web/src/app/stats/components/category-summary-card/category-summary-card.component.html
@@ -209,7 +209,7 @@
         }
       }
     </div>
-    <div class="meta-row">
+    <dl class="meta-row">
       <div>
         <dt i18n="@@analysis.overview.cards.streak">Streak</dt>
         <dd>
@@ -228,7 +228,7 @@
           {{ summary().entries | number }}
         </dd>
       </div>
-    </div>
+    </dl>
   </mat-card-content>
   <mat-card-actions align="end">
     <button

--- a/web/src/app/stats/components/category-summary-card/category-summary-card.component.html
+++ b/web/src/app/stats/components/category-summary-card/category-summary-card.component.html
@@ -1,0 +1,245 @@
+<mat-card
+  class="card"
+  [attr.data-testid]="'category-summary-card-' + summary().categoryId"
+>
+  <mat-card-header>
+    <mat-icon mat-card-avatar aria-hidden="true">{{ summary().icon }}</mat-icon>
+    <mat-card-title>{{ displayName() }}</mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <div
+      class="facets"
+      [attr.data-testid]="
+        'category-summary-card-facets-' + summary().categoryId
+      "
+    >
+      @for (facet of facets(); track facet.kind) {
+        @if (isReps(facet)) {
+          <section
+            class="facet"
+            [attr.data-testid]="
+              'category-summary-card-facet-' +
+              facet.kind +
+              '-' +
+              summary().categoryId
+            "
+          >
+            @if (summary().volume.kind === 'mixed') {
+              <h4
+                class="facet-title"
+                i18n="@@analysis.overview.cards.facet.repsTitle"
+              >
+                Wiederholungen
+              </h4>
+            }
+            <dl class="stats">
+              <div>
+                <dt i18n="@@analysis.overview.cards.totalReps">Reps gesamt</dt>
+                <dd
+                  [attr.data-testid]="
+                    'category-summary-card-totalReps-' + summary().categoryId
+                  "
+                >
+                  {{ facet.totalReps | number }}
+                </dd>
+              </div>
+              <div>
+                <dt i18n="@@analysis.overview.cards.todayReps">Heute</dt>
+                <dd>{{ facet.todayReps | number }}</dd>
+              </div>
+              <div>
+                <dt i18n="@@analysis.overview.cards.bestDay">Bester Tag</dt>
+                @if (facet.bestDay; as best) {
+                  <dd>{{ best.date }} · {{ best.total | number }}</dd>
+                } @else {
+                  <dd>—</dd>
+                }
+              </div>
+              <div>
+                <dt i18n="@@analysis.overview.cards.totalSets">Sätze gesamt</dt>
+                <dd>{{ facet.totalSets | number }}</dd>
+              </div>
+            </dl>
+          </section>
+        } @else if (isTime(facet)) {
+          <section
+            class="facet"
+            [attr.data-testid]="
+              'category-summary-card-facet-' +
+              facet.kind +
+              '-' +
+              summary().categoryId
+            "
+          >
+            @if (summary().volume.kind === 'mixed') {
+              <h4
+                class="facet-title"
+                i18n="@@analysis.overview.cards.facet.timeTitle"
+              >
+                Zeit
+              </h4>
+            }
+            <dl class="stats">
+              <div>
+                <dt i18n="@@analysis.overview.cards.totalTime">Zeit gesamt</dt>
+                <dd
+                  [attr.data-testid]="
+                    'category-summary-card-totalTime-' + summary().categoryId
+                  "
+                >
+                  {{ formatSeconds(facet.totalSec) }}
+                </dd>
+              </div>
+              <div>
+                <dt i18n="@@analysis.overview.cards.todayTime">Heute</dt>
+                <dd>{{ formatSeconds(facet.todaySec) }}</dd>
+              </div>
+              <div>
+                <dt i18n="@@analysis.overview.cards.bestDay">Bester Tag</dt>
+                @if (facet.bestDay; as best) {
+                  <dd>{{ best.date }} · {{ formatSeconds(best.totalSec) }}</dd>
+                } @else {
+                  <dd>—</dd>
+                }
+              </div>
+            </dl>
+          </section>
+        } @else if (isDistance(facet)) {
+          <section
+            class="facet"
+            [attr.data-testid]="
+              'category-summary-card-facet-' +
+              facet.kind +
+              '-' +
+              summary().categoryId
+            "
+          >
+            @if (summary().volume.kind === 'mixed') {
+              <h4
+                class="facet-title"
+                i18n="@@analysis.overview.cards.facet.distanceTitle"
+              >
+                Strecke
+              </h4>
+            }
+            <dl class="stats">
+              <div>
+                <dt i18n="@@analysis.overview.cards.totalDistance">
+                  Strecke gesamt
+                </dt>
+                <dd
+                  [attr.data-testid]="
+                    'category-summary-card-totalDistance-' +
+                    summary().categoryId
+                  "
+                >
+                  {{ formatMeters(facet.totalM) }}
+                </dd>
+              </div>
+              <div>
+                <dt i18n="@@analysis.overview.cards.todayDistance">Heute</dt>
+                <dd>{{ formatMeters(facet.todayM) }}</dd>
+              </div>
+              <div>
+                <dt i18n="@@analysis.overview.cards.bestDay">Bester Tag</dt>
+                @if (facet.bestDay; as best) {
+                  <dd>{{ best.date }} · {{ formatMeters(best.totalM) }}</dd>
+                } @else {
+                  <dd>—</dd>
+                }
+              </div>
+            </dl>
+          </section>
+        } @else if (isDistanceTime(facet)) {
+          <section
+            class="facet"
+            [attr.data-testid]="
+              'category-summary-card-facet-' +
+              facet.kind +
+              '-' +
+              summary().categoryId
+            "
+          >
+            @if (summary().volume.kind === 'mixed') {
+              <h4
+                class="facet-title"
+                i18n="@@analysis.overview.cards.facet.distanceTimeTitle"
+              >
+                Strecke &amp; Zeit
+              </h4>
+            }
+            <dl class="stats">
+              <div>
+                <dt i18n="@@analysis.overview.cards.totalDistance">
+                  Strecke gesamt
+                </dt>
+                <dd
+                  [attr.data-testid]="
+                    'category-summary-card-totalDistance-' +
+                    summary().categoryId
+                  "
+                >
+                  {{ formatMeters(facet.totalM) }}
+                </dd>
+              </div>
+              <div>
+                <dt i18n="@@analysis.overview.cards.totalTime">Zeit gesamt</dt>
+                <dd>{{ formatSeconds(facet.totalSec) }}</dd>
+              </div>
+              <div>
+                <dt i18n="@@analysis.overview.cards.todayDistance">Heute</dt>
+                <dd>
+                  {{ formatMeters(facet.todayM) }} ·
+                  {{ formatSeconds(facet.todaySec) }}
+                </dd>
+              </div>
+              <div>
+                <dt i18n="@@analysis.overview.cards.bestDay">Bester Tag</dt>
+                @if (facet.bestDay; as best) {
+                  <dd>
+                    {{ best.date }} · {{ formatMeters(best.totalM) }} ·
+                    {{ formatPace(best.totalM, best.totalSec) }}
+                  </dd>
+                } @else {
+                  <dd>—</dd>
+                }
+              </div>
+            </dl>
+          </section>
+        }
+      }
+    </div>
+    <div class="meta-row">
+      <div>
+        <dt i18n="@@analysis.overview.cards.streak">Streak</dt>
+        <dd>
+          <ng-container i18n="@@analysis.streakDays"
+            >{{ summary().currentStreak }} Tage</ng-container
+          >
+        </dd>
+      </div>
+      <div>
+        <dt i18n="@@analysis.overview.cards.entries">Trainingseinheiten</dt>
+        <dd
+          [attr.data-testid]="
+            'category-summary-card-entries-' + summary().categoryId
+          "
+        >
+          {{ summary().entries | number }}
+        </dd>
+      </div>
+    </div>
+  </mat-card-content>
+  <mat-card-actions align="end">
+    <button
+      mat-flat-button
+      color="primary"
+      (click)="viewSelect.emit(summary().categoryId)"
+      [attr.data-testid]="
+        'category-summary-card-drilldown-' + summary().categoryId
+      "
+    >
+      <span i18n="@@analysis.overview.cards.viewDetails">Details ansehen</span>
+    </button>
+  </mat-card-actions>
+</mat-card>

--- a/web/src/app/stats/components/category-summary-card/category-summary-card.component.spec.ts
+++ b/web/src/app/stats/components/category-summary-card/category-summary-card.component.spec.ts
@@ -22,11 +22,15 @@ class HostComponent {
     nameKey: '@@exercise.category.pushup',
     icon: 'fitness_center',
     order: 10,
-    totalReps: 123,
-    totalSets: 12,
-    todayReps: 7,
+    entries: 5,
     currentStreak: 3,
-    bestDay: { date: '2026-02-13', total: 25 },
+    volume: {
+      kind: 'reps',
+      totalReps: 123,
+      totalSets: 12,
+      todayReps: 7,
+      bestDay: { date: '2026-02-13', total: 25 },
+    },
   });
   readonly lastEmitted = signal<string | null>(null);
 }
@@ -42,7 +46,7 @@ describe('CategorySummaryCardComponent', () => {
     fixture.detectChanges();
   });
 
-  it('renders the localised category name and quick stats', () => {
+  it('renders the localised category name and quick stats for a reps facet', () => {
     const host: HTMLElement = fixture.nativeElement;
     // TestBed default locale is `de` — categoryDisplayName returns the
     // German source string.
@@ -56,7 +60,13 @@ describe('CategorySummaryCardComponent', () => {
   it('renders the bestDay placeholder when no best day is available', () => {
     fixture.componentInstance.summary.set({
       ...fixture.componentInstance.summary(),
-      bestDay: null,
+      volume: {
+        kind: 'reps',
+        totalReps: 0,
+        totalSets: 0,
+        todayReps: 0,
+        bestDay: null,
+      },
     });
     fixture.detectChanges();
     const host: HTMLElement = fixture.nativeElement;
@@ -92,5 +102,119 @@ describe('CategorySummaryCardComponent', () => {
   it('reflects the icon prop on the mat-icon avatar', () => {
     const icon = fixture.debugElement.query(By.css('mat-icon'));
     expect(icon.nativeElement.textContent.trim()).toBe('fitness_center');
+  });
+
+  it('renders the entry count in the meta row', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    const entries = host.querySelector(
+      '[data-testid="category-summary-card-entries-pushup"]'
+    );
+    expect(entries?.textContent?.trim()).toBe('5');
+  });
+
+  it('renders a time facet as mm:ss instead of reps for time-only categories', () => {
+    // Mobility / plank-style category: durations live on durationSec
+    // and rendering them as reps would show "0 Reps gesamt" — the
+    // bug this redesign exists to fix.
+    fixture.componentInstance.summary.set({
+      categoryId: 'mobility',
+      nameKey: '@@exercise.category.mobility',
+      icon: 'accessibility_new',
+      order: 90,
+      entries: 3,
+      currentStreak: 2,
+      volume: {
+        kind: 'time',
+        totalSec: 210,
+        todaySec: 120,
+        bestDay: { date: '2026-02-15', totalSec: 120 },
+      },
+    });
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    const total = host.querySelector(
+      '[data-testid="category-summary-card-totalTime-mobility"]'
+    );
+    expect(total?.textContent?.trim()).toBe('3:30');
+    // No reps slot for a pure-time facet — the reps test-id only
+    // exists for the reps facet branch.
+    expect(
+      host.querySelector(
+        '[data-testid="category-summary-card-totalReps-mobility"]'
+      )
+    ).toBeNull();
+    expect(host.textContent).toContain('2:00');
+  });
+
+  it('renders a distance-time facet with km, mm:ss and pace for cardio runs', () => {
+    fixture.componentInstance.summary.set({
+      categoryId: 'cardio',
+      nameKey: '@@exercise.category.cardio',
+      icon: 'directions_run',
+      order: 80,
+      entries: 1,
+      currentStreak: 1,
+      volume: {
+        kind: 'distance-time',
+        totalM: 5000,
+        totalSec: 1500,
+        todayM: 0,
+        todaySec: 0,
+        bestDay: { date: '2026-02-13', totalM: 5000, totalSec: 1500 },
+      },
+    });
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    const total = host.querySelector(
+      '[data-testid="category-summary-card-totalDistance-cardio"]'
+    );
+    expect(total?.textContent?.trim()).toBe('5.00 km');
+    expect(host.textContent).toContain('25:00');
+    // 1500 s / 5000 m → 5:00 /km pace.
+    expect(host.textContent).toContain('5:00 /km');
+  });
+
+  it('renders one facet section per measurement for mixed categories (core: reps + time)', () => {
+    fixture.componentInstance.summary.set({
+      categoryId: 'core',
+      nameKey: '@@exercise.category.core',
+      icon: 'self_improvement',
+      order: 70,
+      entries: 3,
+      currentStreak: 1,
+      volume: {
+        kind: 'mixed',
+        facets: [
+          {
+            kind: 'reps',
+            totalReps: 30,
+            totalSets: 0,
+            todayReps: 0,
+            bestDay: { date: '2026-02-12', total: 30 },
+          },
+          {
+            kind: 'time',
+            totalSec: 210,
+            todaySec: 120,
+            bestDay: { date: '2026-02-15', totalSec: 120 },
+          },
+        ],
+      },
+    });
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(
+      host.querySelector(
+        '[data-testid="category-summary-card-facet-reps-core"]'
+      )
+    ).toBeTruthy();
+    expect(
+      host.querySelector(
+        '[data-testid="category-summary-card-facet-time-core"]'
+      )
+    ).toBeTruthy();
+    // Reps facet renders its number; time facet renders mm:ss alongside.
+    expect(host.textContent).toContain('30');
+    expect(host.textContent).toContain('3:30');
   });
 });

--- a/web/src/app/stats/components/category-summary-card/category-summary-card.component.ts
+++ b/web/src/app/stats/components/category-summary-card/category-summary-card.component.ts
@@ -81,9 +81,14 @@ import { categoryDisplayName } from '../../i18n/exercise-display-names';
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 12px;
-      margin-top: 12px;
+      margin: 12px 0 0;
       padding-top: 12px;
       border-top: 1px solid rgba(0, 0, 0, 0.08);
+    }
+    .meta-row > div {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
     }
     :host-context(html:not(.light-theme)) .meta-row {
       border-top-color: rgba(255, 255, 255, 0.08);

--- a/web/src/app/stats/components/category-summary-card/category-summary-card.component.ts
+++ b/web/src/app/stats/components/category-summary-card/category-summary-card.component.ts
@@ -3,81 +3,36 @@ import { Component, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import type { ExerciseCategoryId } from '@pu-stats/models';
+import {
+  type ExerciseCategoryId,
+  formatExerciseValue,
+  formatPaceMinPerKm,
+} from '@pu-stats/models';
 
-import type { CategorySummary } from '../../analysis.store';
+import type {
+  CategoryDistanceFacet,
+  CategoryDistanceTimeFacet,
+  CategoryRepsFacet,
+  CategorySingleFacet,
+  CategorySummary,
+  CategoryTimeFacet,
+} from '../../analysis.store';
 import { categoryDisplayName } from '../../i18n/exercise-display-names';
 
 /**
- * Per-category quick-stats card shown in the Overview tab. Emits
- * `select` with the category id so the parent shell can switch the
- * mat-tab to the matching detail view without prop-drilling the store.
+ * Per-category quick-stats card shown in the Overview tab. Renders a
+ * measurement-aware volume block (reps / time / distance / pace) so a
+ * time-only category like `mobility` no longer shows "0 Reps gesamt"
+ * and a mixed category like `core` (sit-ups + planks) lists each
+ * dimension on its own row. Emits `select` with the category id so
+ * the parent shell can switch the mat-tab to the matching detail view
+ * without prop-drilling the store.
  */
 @Component({
   selector: 'app-category-summary-card',
   standalone: true,
   imports: [DecimalPipe, MatButtonModule, MatCardModule, MatIconModule],
-  template: `
-    <mat-card
-      class="card"
-      [attr.data-testid]="'category-summary-card-' + summary().categoryId"
-    >
-      <mat-card-header>
-        <mat-icon mat-card-avatar aria-hidden="true">{{
-          summary().icon
-        }}</mat-icon>
-        <mat-card-title>{{ displayName() }}</mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <dl class="stats">
-          <div>
-            <dt i18n="@@analysis.overview.cards.totalReps">Reps gesamt</dt>
-            <dd
-              [attr.data-testid]="
-                'category-summary-card-totalReps-' + summary().categoryId
-              "
-            >
-              {{ summary().totalReps | number }}
-            </dd>
-          </div>
-          <div>
-            <dt i18n="@@analysis.overview.cards.todayReps">Heute</dt>
-            <dd>{{ summary().todayReps | number }}</dd>
-          </div>
-          <div>
-            <dt i18n="@@analysis.overview.cards.streak">Streak</dt>
-            <dd>
-              <ng-container i18n="@@analysis.streakDays"
-                >{{ summary().currentStreak }} Tage</ng-container
-              >
-            </dd>
-          </div>
-          <div>
-            <dt i18n="@@analysis.overview.cards.bestDay">Bester Tag</dt>
-            @if (summary().bestDay; as best) {
-              <dd>{{ best.date }} · {{ best.total | number }}</dd>
-            } @else {
-              <dd>—</dd>
-            }
-          </div>
-        </dl>
-      </mat-card-content>
-      <mat-card-actions align="end">
-        <button
-          mat-flat-button
-          color="primary"
-          (click)="viewSelect.emit(summary().categoryId)"
-          [attr.data-testid]="
-            'category-summary-card-drilldown-' + summary().categoryId
-          "
-        >
-          <span i18n="@@analysis.overview.cards.viewDetails"
-            >Details ansehen</span
-          >
-        </button>
-      </mat-card-actions>
-    </mat-card>
-  `,
+  templateUrl: './category-summary-card.component.html',
   styles: `
     :host {
       display: block;
@@ -90,11 +45,22 @@ import { categoryDisplayName } from '../../i18n/exercise-display-names';
     mat-card-content {
       flex: 1;
     }
+    .facets {
+      display: grid;
+      gap: 12px;
+      margin: 8px 0 0;
+    }
+    .facet-title {
+      font-size: 0.75rem;
+      font-weight: 600;
+      opacity: 0.85;
+      margin: 0 0 4px;
+    }
     .stats {
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 12px;
-      margin: 8px 0 0;
+      margin: 0;
     }
     .stats > div {
       display: flex;
@@ -111,6 +77,17 @@ import { categoryDisplayName } from '../../i18n/exercise-display-names';
       font-weight: 600;
       font-variant-numeric: tabular-nums;
     }
+    .meta-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid rgba(0, 0, 0, 0.08);
+    }
+    :host-context(html:not(.light-theme)) .meta-row {
+      border-top-color: rgba(255, 255, 255, 0.08);
+    }
   `,
 })
 export class CategorySummaryCardComponent {
@@ -119,5 +96,42 @@ export class CategorySummaryCardComponent {
 
   displayName(): string {
     return categoryDisplayName(this.summary().categoryId);
+  }
+
+  /**
+   * Flatten the discriminated `volume` into a stable list of single
+   * facets so the template can `@for` over them. A non-mixed volume
+   * always yields one facet; a mixed volume yields its `facets`
+   * array (already in `reps → time → distance → distance-time`
+   * order from the store).
+   */
+  facets(): ReadonlyArray<CategorySingleFacet> {
+    const v = this.summary().volume;
+    return v.kind === 'mixed' ? v.facets : [v];
+  }
+
+  isReps(facet: CategorySingleFacet): facet is CategoryRepsFacet {
+    return facet.kind === 'reps';
+  }
+  isTime(facet: CategorySingleFacet): facet is CategoryTimeFacet {
+    return facet.kind === 'time';
+  }
+  isDistance(facet: CategorySingleFacet): facet is CategoryDistanceFacet {
+    return facet.kind === 'distance';
+  }
+  isDistanceTime(
+    facet: CategorySingleFacet
+  ): facet is CategoryDistanceTimeFacet {
+    return facet.kind === 'distance-time';
+  }
+
+  formatSeconds(value: number): string {
+    return formatExerciseValue(value, 's');
+  }
+  formatMeters(value: number): string {
+    return formatExerciseValue(value, 'm');
+  }
+  formatPace(distanceM: number, durationSec: number): string {
+    return formatPaceMinPerKm(distanceM, durationSec);
   }
 }

--- a/web/src/app/stats/shell/analysis-overview.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-overview.component.spec.ts
@@ -21,7 +21,7 @@ import { CategorySummaryCardComponent } from '../components/category-summary-car
 class StubComparisonChartComponent {
   // Mirror the real component's signal input surface so the overview's
   // `[data]="..."` binding type-checks against the stub.
-  readonly data = input<CategoryComparison>({ labels: [], reps: [], sets: [] });
+  readonly data = input<CategoryComparison>({ labels: [], entries: [] });
 }
 
 @Component({
@@ -58,8 +58,7 @@ function makeFakeStore(): FakeStore {
     categorySummaries: signal<CategorySummary[]>([]),
     categoryComparison: signal<CategoryComparison>({
       labels: [],
-      reps: [],
-      sets: [],
+      entries: [],
     }),
     unifiedRows: signal<unknown[]>([]),
     activeView,
@@ -150,22 +149,30 @@ describe('AnalysisOverviewComponent', () => {
         nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
-        totalReps: 100,
-        totalSets: 12,
-        todayReps: 7,
+        entries: 5,
         currentStreak: 3,
-        bestDay: { date: '2026-02-13', total: 25 },
+        volume: {
+          kind: 'reps',
+          totalReps: 100,
+          totalSets: 12,
+          todayReps: 7,
+          bestDay: { date: '2026-02-13', total: 25 },
+        },
       },
       {
         categoryId: 'core',
         nameKey: '@@exercise.category.core',
         icon: 'self_improvement',
         order: 20,
-        totalReps: 30,
-        totalSets: 0,
-        todayReps: 0,
+        entries: 2,
         currentStreak: 1,
-        bestDay: { date: '2026-02-12', total: 30 },
+        volume: {
+          kind: 'reps',
+          totalReps: 30,
+          totalSets: 0,
+          todayReps: 0,
+          bestDay: { date: '2026-02-12', total: 30 },
+        },
       },
     ]);
     fixture.detectChanges();
@@ -193,11 +200,15 @@ describe('AnalysisOverviewComponent', () => {
         nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
-        totalReps: 100,
-        totalSets: 12,
-        todayReps: 7,
+        entries: 5,
         currentStreak: 3,
-        bestDay: { date: '2026-02-13', total: 25 },
+        volume: {
+          kind: 'reps',
+          totalReps: 100,
+          totalSets: 12,
+          todayReps: 7,
+          bestDay: { date: '2026-02-13', total: 25 },
+        },
       },
     ]);
     store.unifiedRows.set([{ id: 'orphan' }]);
@@ -226,11 +237,15 @@ describe('AnalysisOverviewComponent', () => {
         nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
-        totalReps: 100,
-        totalSets: 12,
-        todayReps: 7,
+        entries: 5,
         currentStreak: 3,
-        bestDay: null,
+        volume: {
+          kind: 'reps',
+          totalReps: 100,
+          totalSets: 12,
+          todayReps: 7,
+          bestDay: null,
+        },
       },
     ]);
     fixture.detectChanges();
@@ -272,11 +287,15 @@ describe('AnalysisOverviewComponent', () => {
         nameKey: '@@exercise.category.pushup',
         icon: 'fitness_center',
         order: 10,
-        totalReps: 100,
-        totalSets: 12,
-        todayReps: 7,
+        entries: 5,
         currentStreak: 3,
-        bestDay: null,
+        volume: {
+          kind: 'reps',
+          totalReps: 100,
+          totalSets: 12,
+          todayReps: 7,
+          bestDay: null,
+        },
       },
     ]);
     fixture.detectChanges();

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -582,7 +582,9 @@ describe('AnalysisPageComponent', () => {
       const { store } = fixture.componentInstance;
       const summaries = store.categorySummaries();
       const pushup = summaries.find((s) => s.categoryId === 'pushup');
-      expect(pushup).toMatchObject({
+      expect(pushup?.entries).toBe(6);
+      expect(pushup?.volume).toEqual({
+        kind: 'reps',
         totalReps: 93,
         // 5+5 + 6+6 + 10+5+5 + 10+8+7 + 9+9 = 12 sets across 5 entries.
         totalSets: 12,
@@ -591,30 +593,32 @@ describe('AnalysisPageComponent', () => {
         bestDay: { date: '2026-02-13', total: 25 },
       });
       const abs = summaries.find((s) => s.categoryId === 'core');
-      expect(abs).toMatchObject({
+      expect(abs?.currentStreak).toBe(1);
+      expect(abs?.volume).toEqual({
+        kind: 'reps',
         totalReps: 30,
         totalSets: 0,
         todayReps: 0,
-        currentStreak: 1,
         bestDay: { date: '2026-02-12', total: 30 },
       });
       const legs = summaries.find((s) => s.categoryId === 'squat');
-      expect(legs).toMatchObject({
+      expect(legs?.volume).toMatchObject({
+        kind: 'reps',
         totalReps: 40,
         bestDay: { date: '2026-02-13', total: 40 },
       });
     });
 
     it('categoryComparison projects summaries into chart-friendly arrays with translated labels', () => {
-      // Chart.js cannot resolve $localize ids at runtime, so labels
-      // are pre-translated by the store. TestBed defaults to the
-      // source locale (de) — assertions use the German source strings
-      // for the movement-pattern category names.
+      // Chart bar metric is `entries` — a measurement-agnostic count
+      // of logged trainings — so the chart can compare reps-, time-
+      // and distance-categories without mixing dimensions on one axis.
+      // TestBed defaults to the source locale (de).
       const { store } = fixture.componentInstance;
       const cmp = store.categoryComparison();
       expect(cmp.labels).toEqual(['Liegestütze', 'Kniebeuge', 'Rumpf']);
-      expect(cmp.reps).toEqual([93, 40, 30]);
-      expect(cmp.sets).toEqual([12, 0, 0]);
+      // 6 pushups + 1 legs ex + 1 abs ex
+      expect(cmp.entries).toEqual([6, 1, 1]);
     });
 
     it('categorySummaries stays insensitive to the active view (it powers the overview)', () => {
@@ -624,6 +628,122 @@ describe('AnalysisPageComponent', () => {
       expect(store.categorySummaries().map((s) => s.categoryId)).toEqual(
         baseline
       );
+    });
+
+    it('categorySummaries emits a mixed volume when a category combines reps and time entries', () => {
+      // `core` collects both sit-ups (reps) and plank (time). Pre-redesign
+      // the roll-up summed `r.reps` across both — pushing plank's true
+      // `durationSec` volume into a `0` reps row and showing "0 Reps
+      // gesamt" on a card that actually had 3.5 min of plank.
+      liveExerciseEntries.set([
+        {
+          _id: 'ex-abs',
+          userId: 'u1',
+          exerciseId: 'abs.situps',
+          timestamp: '2026-02-12T08:00:00.000Z',
+          reps: 30,
+          source: 'web',
+        } as ExerciseEntry,
+        {
+          _id: 'ex-plank-1',
+          userId: 'u1',
+          exerciseId: 'plank.standard',
+          timestamp: '2026-02-13T08:00:00.000Z',
+          reps: 0,
+          durationSec: 90,
+          source: 'web',
+        } as ExerciseEntry,
+        {
+          _id: 'ex-plank-2',
+          userId: 'u1',
+          exerciseId: 'plank.standard',
+          timestamp: '2026-02-15T08:00:00.000Z',
+          reps: 0,
+          durationSec: 120,
+          source: 'web',
+        } as ExerciseEntry,
+      ]);
+      const { store } = fixture.componentInstance;
+      const summaries = store.categorySummaries();
+      const core = summaries.find((s) => s.categoryId === 'core');
+      expect(core?.entries).toBe(3);
+      expect(core?.volume.kind).toBe('mixed');
+      if (core?.volume.kind !== 'mixed') return;
+      // Stable facet order: reps before time.
+      expect(core.volume.facets.map((f) => f.kind)).toEqual(['reps', 'time']);
+      expect(core.volume.facets[0]).toEqual({
+        kind: 'reps',
+        totalReps: 30,
+        totalSets: 0,
+        todayReps: 0,
+        bestDay: { date: '2026-02-12', total: 30 },
+      });
+      expect(core.volume.facets[1]).toEqual({
+        kind: 'time',
+        totalSec: 210,
+        // Locked clock is Sun Feb 15 2026 → only the 120 s entry is "today".
+        todaySec: 120,
+        bestDay: { date: '2026-02-15', totalSec: 120 },
+      });
+    });
+
+    it('categorySummaries emits a distance-time facet for cardio runs', () => {
+      liveExerciseEntries.set([
+        {
+          _id: 'ex-run-1',
+          userId: 'u1',
+          exerciseId: 'cardio.running',
+          timestamp: '2026-02-13T08:00:00.000Z',
+          reps: 0,
+          durationSec: 1500,
+          distanceM: 5000,
+          source: 'web',
+        } as ExerciseEntry,
+      ]);
+      const { store } = fixture.componentInstance;
+      const summaries = store.categorySummaries();
+      const cardio = summaries.find((s) => s.categoryId === 'cardio');
+      expect(cardio?.entries).toBe(1);
+      expect(cardio?.volume).toEqual({
+        kind: 'distance-time',
+        totalM: 5000,
+        totalSec: 1500,
+        todayM: 0,
+        todaySec: 0,
+        bestDay: { date: '2026-02-13', totalM: 5000, totalSec: 1500 },
+      });
+    });
+
+    it('categorySummaries collapses to a single facet when every entry shares one measurement (mobility/time)', () => {
+      liveExerciseEntries.set([
+        {
+          _id: 'ex-mob-1',
+          userId: 'u1',
+          exerciseId: 'mobility.stretching',
+          timestamp: '2026-02-13T08:00:00.000Z',
+          reps: 0,
+          durationSec: 45,
+          source: 'web',
+        } as ExerciseEntry,
+        {
+          _id: 'ex-mob-2',
+          userId: 'u1',
+          exerciseId: 'mobility.stretching',
+          timestamp: '2026-02-14T08:00:00.000Z',
+          reps: 0,
+          durationSec: 60,
+          source: 'web',
+        } as ExerciseEntry,
+      ]);
+      const { store } = fixture.componentInstance;
+      const summaries = store.categorySummaries();
+      const mobility = summaries.find((s) => s.categoryId === 'mobility');
+      expect(mobility?.volume).toEqual({
+        kind: 'time',
+        totalSec: 105,
+        todaySec: 0,
+        bestDay: { date: '2026-02-14', totalSec: 60 },
+      });
     });
 
     it('typeBreakdown collapses to the active category in kind mode (abs)', () => {

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -671,6 +671,12 @@ describe('AnalysisPageComponent', () => {
       if (core?.volume.kind !== 'mixed') return;
       // Stable facet order: reps before time.
       expect(core.volume.facets.map((f) => f.kind)).toEqual(['reps', 'time']);
+      // Facet kinds must stay unique — the card template tracks
+      // `@for … track facet.kind`, so duplicates would trigger
+      // Angular NG0955 (e.g. if a future `weight`-measurement entry
+      // were ever placed alongside reps without collapsing first).
+      const kinds = core.volume.facets.map((f) => f.kind);
+      expect(new Set(kinds).size).toBe(kinds.length);
       expect(core.volume.facets[0]).toEqual({
         kind: 'reps',
         totalReps: 30,

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -7681,7 +7681,7 @@
     <unit id="analysis.overview.cards.facet.distanceTimeTitle">
       <segment state="translated">
         <source/>
-        <target>Απόσταση & χρόνος</target>
+        <target>Απόσταση &amp; χρόνος</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.entries">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -7594,24 +7594,6 @@
         <target>Σύγκριση ανά ομάδα ασκήσεων</target>
       </segment>
     </unit>
-    <unit id="analysis.overview.comparison.metricAria">
-      <segment state="translated">
-        <source/>
-        <target>Μέγεθος</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.reps">
-      <segment state="translated">
-        <source/>
-        <target>Επαναλήψεις</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.sets">
-      <segment state="translated">
-        <source/>
-        <target>Σετ</target>
-      </segment>
-    </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
@@ -7640,6 +7622,72 @@
       <segment state="translated">
         <source/>
         <target>Καλύτερη ημέρα</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricLabel">
+      <segment state="translated">
+        <source/>
+        <target>Προπονήσεις</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.repsTitle">
+      <segment state="translated">
+        <source/>
+        <target>Επαναλήψεις</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalSets">
+      <segment state="translated">
+        <source/>
+        <target>Σύνολο σετ</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.timeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Χρόνος</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalTime">
+      <segment state="translated">
+        <source/>
+        <target>Συνολικός χρόνος</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayTime">
+      <segment state="translated">
+        <source/>
+        <target>Σήμερα</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTitle">
+      <segment state="translated">
+        <source/>
+        <target>Απόσταση</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalDistance">
+      <segment state="translated">
+        <source/>
+        <target>Συνολική απόσταση</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayDistance">
+      <segment state="translated">
+        <source/>
+        <target>Σήμερα</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTimeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Απόσταση & χρόνος</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.entries">
+      <segment state="translated">
+        <source/>
+        <target>Προπονήσεις</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -7877,7 +7877,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="analysis.overview.comparison.metricLabel">
       <segment state="translated">
         <source/>
-        <target>Trainings</target>
+        <target>Training sessions</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.repsTitle">
@@ -7931,13 +7931,13 @@ Deine Position: # ·  Reps        </source>
     <unit id="analysis.overview.cards.facet.distanceTimeTitle">
       <segment state="translated">
         <source/>
-        <target>Distance & Time</target>
+        <target>Distance &amp; Time</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.entries">
       <segment state="translated">
         <source/>
-        <target>Trainings</target>
+        <target>Training sessions</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -7844,24 +7844,6 @@ Deine Position: # ·  Reps        </source>
         <target>Comparison by exercise group</target>
       </segment>
     </unit>
-    <unit id="analysis.overview.comparison.metricAria">
-      <segment state="translated">
-        <source/>
-        <target>Metric</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.reps">
-      <segment state="translated">
-        <source/>
-        <target>Reps</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.sets">
-      <segment state="translated">
-        <source/>
-        <target>Sets</target>
-      </segment>
-    </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
@@ -7880,16 +7862,82 @@ Deine Position: # ·  Reps        </source>
         <target>Today</target>
       </segment>
     </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <segment state="translated">
+        <source/>
+        <target>Best day</target>
+      </segment>
+    </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
         <source/>
         <target>Streak</target>
       </segment>
     </unit>
-    <unit id="analysis.overview.cards.bestDay">
+    <unit id="analysis.overview.comparison.metricLabel">
       <segment state="translated">
         <source/>
-        <target>Best day</target>
+        <target>Trainings</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.repsTitle">
+      <segment state="translated">
+        <source/>
+        <target>Reps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalSets">
+      <segment state="translated">
+        <source/>
+        <target>Total sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.timeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Time</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalTime">
+      <segment state="translated">
+        <source/>
+        <target>Total time</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayTime">
+      <segment state="translated">
+        <source/>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTitle">
+      <segment state="translated">
+        <source/>
+        <target>Distance</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalDistance">
+      <segment state="translated">
+        <source/>
+        <target>Total distance</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayDistance">
+      <segment state="translated">
+        <source/>
+        <target>Today</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTimeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Distance & Time</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.entries">
+      <segment state="translated">
+        <source/>
+        <target>Trainings</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -7594,24 +7594,6 @@
         <target>Comparación por grupo de ejercicios</target>
       </segment>
     </unit>
-    <unit id="analysis.overview.comparison.metricAria">
-      <segment state="translated">
-        <source/>
-        <target>Métrica</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.reps">
-      <segment state="translated">
-        <source/>
-        <target>Repeticiones</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.sets">
-      <segment state="translated">
-        <source/>
-        <target>Series</target>
-      </segment>
-    </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
@@ -7640,6 +7622,72 @@
       <segment state="translated">
         <source/>
         <target>Mejor día</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricLabel">
+      <segment state="translated">
+        <source/>
+        <target>Sesiones</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.repsTitle">
+      <segment state="translated">
+        <source/>
+        <target>Repeticiones</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalSets">
+      <segment state="translated">
+        <source/>
+        <target>Total de series</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.timeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Tiempo</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalTime">
+      <segment state="translated">
+        <source/>
+        <target>Tiempo total</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayTime">
+      <segment state="translated">
+        <source/>
+        <target>Hoy</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTitle">
+      <segment state="translated">
+        <source/>
+        <target>Distancia</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalDistance">
+      <segment state="translated">
+        <source/>
+        <target>Distancia total</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayDistance">
+      <segment state="translated">
+        <source/>
+        <target>Hoy</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTimeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Distancia y tiempo</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.entries">
+      <segment state="translated">
+        <source/>
+        <target>Sesiones</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -7594,24 +7594,6 @@
         <target>Comparaison par groupe d'exercices</target>
       </segment>
     </unit>
-    <unit id="analysis.overview.comparison.metricAria">
-      <segment state="translated">
-        <source/>
-        <target>Métrique</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.reps">
-      <segment state="translated">
-        <source/>
-        <target>Répétitions</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.sets">
-      <segment state="translated">
-        <source/>
-        <target>Séries</target>
-      </segment>
-    </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
@@ -7640,6 +7622,72 @@
       <segment state="translated">
         <source/>
         <target>Meilleur jour</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricLabel">
+      <segment state="translated">
+        <source/>
+        <target>Séances</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.repsTitle">
+      <segment state="translated">
+        <source/>
+        <target>Répétitions</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalSets">
+      <segment state="translated">
+        <source/>
+        <target>Total des séries</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.timeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Temps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalTime">
+      <segment state="translated">
+        <source/>
+        <target>Temps total</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayTime">
+      <segment state="translated">
+        <source/>
+        <target>Aujourd'hui</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTitle">
+      <segment state="translated">
+        <source/>
+        <target>Distance</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalDistance">
+      <segment state="translated">
+        <source/>
+        <target>Distance totale</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayDistance">
+      <segment state="translated">
+        <source/>
+        <target>Aujourd'hui</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTimeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Distance et temps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.entries">
+      <segment state="translated">
+        <source/>
+        <target>Séances</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -7594,24 +7594,6 @@
         <target>Confronto per gruppo di esercizi</target>
       </segment>
     </unit>
-    <unit id="analysis.overview.comparison.metricAria">
-      <segment state="translated">
-        <source/>
-        <target>Metrica</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.reps">
-      <segment state="translated">
-        <source/>
-        <target>Ripetizioni</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.sets">
-      <segment state="translated">
-        <source/>
-        <target>Serie</target>
-      </segment>
-    </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
@@ -7640,6 +7622,72 @@
       <segment state="translated">
         <source/>
         <target>Miglior giorno</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricLabel">
+      <segment state="translated">
+        <source/>
+        <target>Allenamenti</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.repsTitle">
+      <segment state="translated">
+        <source/>
+        <target>Ripetizioni</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalSets">
+      <segment state="translated">
+        <source/>
+        <target>Totale serie</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.timeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Tempo</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalTime">
+      <segment state="translated">
+        <source/>
+        <target>Tempo totale</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayTime">
+      <segment state="translated">
+        <source/>
+        <target>Oggi</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTitle">
+      <segment state="translated">
+        <source/>
+        <target>Distanza</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalDistance">
+      <segment state="translated">
+        <source/>
+        <target>Distanza totale</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayDistance">
+      <segment state="translated">
+        <source/>
+        <target>Oggi</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTimeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Distanza e tempo</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.entries">
+      <segment state="translated">
+        <source/>
+        <target>Allenamenti</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -7594,24 +7594,6 @@
         <target>Comparison by exercise group</target>
       </segment>
     </unit>
-    <unit id="analysis.overview.comparison.metricAria">
-      <segment state="translated">
-        <source/>
-        <target>Metric</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.reps">
-      <segment state="translated">
-        <source/>
-        <target>Reps</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.sets">
-      <segment state="translated">
-        <source/>
-        <target>Sets</target>
-      </segment>
-    </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
@@ -7640,6 +7622,72 @@
       <segment state="translated">
         <source/>
         <target>Best day</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricLabel">
+      <segment state="translated">
+        <source/>
+        <target>Exercitationes</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.repsTitle">
+      <segment state="translated">
+        <source/>
+        <target>Repetitiones</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalSets">
+      <segment state="translated">
+        <source/>
+        <target>Summa seriorum</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.timeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Tempus</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalTime">
+      <segment state="translated">
+        <source/>
+        <target>Tempus totum</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayTime">
+      <segment state="translated">
+        <source/>
+        <target>Hodie</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTitle">
+      <segment state="translated">
+        <source/>
+        <target>Spatium</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalDistance">
+      <segment state="translated">
+        <source/>
+        <target>Spatium totum</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayDistance">
+      <segment state="translated">
+        <source/>
+        <target>Hodie</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTimeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Spatium et tempus</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.entries">
+      <segment state="translated">
+        <source/>
+        <target>Exercitationes</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -7681,7 +7681,7 @@
     <unit id="analysis.overview.cards.facet.distanceTimeTitle">
       <segment state="translated">
         <source/>
-        <target>Afstand & tijd</target>
+        <target>Afstand &amp; tijd</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.entries">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -7594,24 +7594,6 @@
         <target>Vergelijking per oefeningsgroep</target>
       </segment>
     </unit>
-    <unit id="analysis.overview.comparison.metricAria">
-      <segment state="translated">
-        <source/>
-        <target>Eenheid</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.reps">
-      <segment state="translated">
-        <source/>
-        <target>Herhalingen</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.sets">
-      <segment state="translated">
-        <source/>
-        <target>Sets</target>
-      </segment>
-    </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
@@ -7640,6 +7622,72 @@
       <segment state="translated">
         <source/>
         <target>Beste dag</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricLabel">
+      <segment state="translated">
+        <source/>
+        <target>Trainingen</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.repsTitle">
+      <segment state="translated">
+        <source/>
+        <target>Herhalingen</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalSets">
+      <segment state="translated">
+        <source/>
+        <target>Totaal sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.timeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Tijd</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalTime">
+      <segment state="translated">
+        <source/>
+        <target>Totale tijd</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayTime">
+      <segment state="translated">
+        <source/>
+        <target>Vandaag</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTitle">
+      <segment state="translated">
+        <source/>
+        <target>Afstand</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalDistance">
+      <segment state="translated">
+        <source/>
+        <target>Totale afstand</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayDistance">
+      <segment state="translated">
+        <source/>
+        <target>Vandaag</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTimeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Afstand & tijd</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.entries">
+      <segment state="translated">
+        <source/>
+        <target>Trainingen</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -6854,24 +6854,6 @@ Deine Position: # ·  Reps        </source>
         <target>Sammenligning etter øvelsesgruppe</target>
       </segment>
     </unit>
-    <unit id="analysis.overview.comparison.metricAria">
-      <segment state="translated">
-        <source/>
-        <target>Måleverdi</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.reps">
-      <segment state="translated">
-        <source/>
-        <target>Repetisjoner</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.sets">
-      <segment state="translated">
-        <source/>
-        <target>Sett</target>
-      </segment>
-    </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
@@ -6900,6 +6882,72 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source/>
         <target>Beste dag</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricLabel">
+      <segment state="translated">
+        <source/>
+        <target>Økter</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.repsTitle">
+      <segment state="translated">
+        <source/>
+        <target>Repetisjoner</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalSets">
+      <segment state="translated">
+        <source/>
+        <target>Totalt antall sett</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.timeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Tid</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalTime">
+      <segment state="translated">
+        <source/>
+        <target>Total tid</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayTime">
+      <segment state="translated">
+        <source/>
+        <target>I dag</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTitle">
+      <segment state="translated">
+        <source/>
+        <target>Distanse</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalDistance">
+      <segment state="translated">
+        <source/>
+        <target>Total distanse</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayDistance">
+      <segment state="translated">
+        <source/>
+        <target>I dag</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTimeTitle">
+      <segment state="translated">
+        <source/>
+        <target>Distanse og tid</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.entries">
+      <segment state="translated">
+        <source/>
+        <target>Økter</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -236,7 +236,7 @@
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:75,76</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:550,551</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:549,550</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
       </notes>
       <segment>
@@ -2622,16 +2622,15 @@
     </unit>
     <unit id="autoCount.title">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:2,5</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:1,3</note>
       </notes>
       <segment>
-        <source> Übungen automatisch zählen
-</source>
+        <source>Übungen automatisch zählen</source>
       </segment>
     </unit>
     <unit id="autoCount.exercisePickerAria">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:10,11</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:8,9</note>
       </notes>
       <segment>
         <source>Übung wählen</source>
@@ -2639,7 +2638,7 @@
     </unit>
     <unit id="autoCount.instructions">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:21,24</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:19,23</note>
       </notes>
       <segment>
         <source> Halte das Gerät so, dass die relevanten Gelenke (Schulter/Ellbogen/Handgelenk bzw. Hüfte/Knie/Fuß) im Bild sind. Reps werden bei sauberem Down‑Up gezählt. </source>
@@ -2647,7 +2646,7 @@
     </unit>
     <unit id="autoCount.cameraStarting">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:29,32</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:28,31</note>
       </notes>
       <segment>
         <source>Kamera startet …</source>
@@ -2655,7 +2654,7 @@
     </unit>
     <unit id="autoCount.unavailable">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:36,38</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:35,37</note>
       </notes>
       <segment>
         <source> Auto‑Zählen nicht verfügbar </source>
@@ -2663,7 +2662,7 @@
     </unit>
     <unit id="autoCount.repsLabel">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:44,46</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:43,45</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -2671,7 +2670,7 @@
     </unit>
     <unit id="autoCount.positionHint">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:48,51</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:47,50</note>
       </notes>
       <segment>
         <source> In Startposition gehen </source>
@@ -2679,7 +2678,7 @@
     </unit>
     <unit id="autoCount.reset">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:61,63</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:60,62</note>
       </notes>
       <segment>
         <source> Zurücksetzen </source>
@@ -2687,7 +2686,7 @@
     </unit>
     <unit id="autoCount.cancel">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:64,67</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:63,66</note>
       </notes>
       <segment>
         <source> Abbrechen </source>
@@ -2695,7 +2694,7 @@
     </unit>
     <unit id="autoCount.save">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:73,75</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.html:72,74</note>
       </notes>
       <segment>
         <source> Übernehmen </source>
@@ -2703,7 +2702,7 @@
     </unit>
     <unit id="autoCount.exercise.pushup">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:69</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:72</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -2711,7 +2710,7 @@
     </unit>
     <unit id="autoCount.exercise.squat">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:70</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:77</note>
       </notes>
       <segment>
         <source>Kniebeugen</source>
@@ -2719,7 +2718,7 @@
     </unit>
     <unit id="autoCount.exercise.pullup">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:71</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:82</note>
       </notes>
       <segment>
         <source>Klimmzüge</source>
@@ -2727,7 +2726,7 @@
     </unit>
     <unit id="autoCount.exercise.situp">
       <notes>
-        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:72</note>
+        <note category="location">web/src/app/auto-count/auto-count-dialog.component.ts:87</note>
       </notes>
       <segment>
         <source>Sit-ups</source>
@@ -2864,8 +2863,8 @@
     </unit>
     <unit id="quickAdd.success.create">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:74</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:259</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:75</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:264</note>
       </notes>
       <segment>
         <source>Eintrag gespeichert.</source>
@@ -2873,9 +2872,9 @@
     </unit>
     <unit id="quickAdd.error.create">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:86</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:125</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:275</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:87</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:126</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:280</note>
       </notes>
       <segment>
         <source>Eintrag konnte nicht gespeichert werden.</source>
@@ -2883,7 +2882,7 @@
     </unit>
     <unit id="quickAdd.success.goalReached">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:112</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:113</note>
       </notes>
       <segment>
         <source>Tagesziel erreicht 🎉</source>
@@ -4429,7 +4428,7 @@
       <notes>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:147</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:200</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1100</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1104</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:197</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:272</note>
@@ -4440,47 +4439,39 @@
     </unit>
     <unit id="analysis.overview.comparison.title">
       <notes>
-        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:26,28</note>
+        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:30,32</note>
       </notes>
       <segment>
         <source> Vergleich nach Übungsgruppe </source>
       </segment>
     </unit>
-    <unit id="analysis.overview.comparison.metricAria">
+    <unit id="analysis.overview.comparison.metricLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:31,32</note>
+        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:33,37</note>
       </notes>
       <segment>
-        <source>Kennzahl</source>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.reps">
-      <notes>
-        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:39,41</note>
-      </notes>
-      <segment>
-        <source> Wdh. </source>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.sets">
-      <notes>
-        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:45,47</note>
-      </notes>
-      <segment>
-        <source> Sätze </source>
+        <source> Trainingseinheiten </source>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.empty">
       <notes>
-        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:56,59</note>
+        <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:43,46</note>
       </notes>
       <segment>
         <source> Keine Daten im aktuellen Zeitraum. </source>
       </segment>
     </unit>
+    <unit id="analysis.overview.cards.facet.repsTitle">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:15,18</note>
+      </notes>
+      <segment>
+        <source>Wiederholungen</source>
+      </segment>
+    </unit>
     <unit id="analysis.overview.cards.totalReps">
       <notes>
-        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:34,36</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:19,21</note>
       </notes>
       <segment>
         <source>Reps gesamt</source>
@@ -4488,15 +4479,93 @@
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <notes>
-        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:44,45</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:25,26</note>
       </notes>
       <segment>
         <source>Heute</source>
       </segment>
     </unit>
+    <unit id="analysis.overview.cards.bestDay">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:29,30</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:59,60</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:85,86</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:115,116</note>
+      </notes>
+      <segment>
+        <source>Bester Tag</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalSets">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:37,38</note>
+      </notes>
+      <segment>
+        <source>Sätze gesamt</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.timeTitle">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:45,48</note>
+      </notes>
+      <segment>
+        <source>Zeit</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalTime">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:49,51</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:107,108</note>
+      </notes>
+      <segment>
+        <source>Zeit gesamt</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayTime">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:55,56</note>
+      </notes>
+      <segment>
+        <source>Heute</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTitle">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:71,74</note>
+      </notes>
+      <segment>
+        <source>Strecke</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalDistance">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:75,77</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:101,103</note>
+      </notes>
+      <segment>
+        <source>Strecke gesamt</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayDistance">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:81,82</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:111,112</note>
+      </notes>
+      <segment>
+        <source>Heute</source>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTimeTitle">
+      <notes>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:97,100</note>
+      </notes>
+      <segment>
+        <source>Strecke &amp; Zeit</source>
+      </segment>
+    </unit>
     <unit id="analysis.overview.cards.streak">
       <notes>
-        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:48,50</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:133,135</note>
       </notes>
       <segment>
         <source>Streak</source>
@@ -4504,7 +4573,7 @@
     </unit>
     <unit id="analysis.streakDays">
       <notes>
-        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:51,52</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:136,137</note>
         <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:83,84</note>
         <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:91,92</note>
       </notes>
@@ -4512,17 +4581,17 @@
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ summary().currentStreak }}"/> Tage</source>
       </segment>
     </unit>
-    <unit id="analysis.overview.cards.bestDay">
+    <unit id="analysis.overview.cards.entries">
       <notes>
-        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:56,57</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:141,143</note>
       </notes>
       <segment>
-        <source>Bester Tag</source>
+        <source>Trainingseinheiten</source>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <notes>
-        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.ts:75,78</note>
+        <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:155,158</note>
       </notes>
       <segment>
         <source>Details ansehen</source>
@@ -5197,7 +5266,7 @@
     </unit>
     <unit id="editDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:265,267</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:266,268</note>
       </notes>
       <segment>
         <source>Eintrag bearbeiten</source>
@@ -5205,7 +5274,7 @@
     </unit>
     <unit id="trainingEntryDialog.title">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:267,271</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:268,272</note>
       </notes>
       <segment>
         <source>Trainingseintrag anlegen</source>
@@ -5213,7 +5282,7 @@
     </unit>
     <unit id="trainingEntryDialog.category">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:273,275</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:274,276</note>
       </notes>
       <segment>
         <source>Kategorie</source>
@@ -5221,7 +5290,7 @@
     </unit>
     <unit id="trainingEntryDialog.exercise">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:288,290</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:289,291</note>
       </notes>
       <segment>
         <source>Übung</source>
@@ -5229,7 +5298,7 @@
     </unit>
     <unit id="timestampLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:303,305</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:304,306</note>
       </notes>
       <segment>
         <source>Zeitpunkt</source>
@@ -5237,7 +5306,7 @@
     </unit>
     <unit id="typeLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:316,317</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:317,318</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -5245,7 +5314,7 @@
     </unit>
     <unit id="typePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:322,323</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:323,324</note>
       </notes>
       <segment>
         <source>Auswählen oder eintippen</source>
@@ -5253,7 +5322,7 @@
     </unit>
     <unit id="typeWikiLinkAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:361,363</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:362,364</note>
       </notes>
       <segment>
         <source>Anleitung zum Liegestütztyp öffnen</source>
@@ -5261,7 +5330,7 @@
     </unit>
     <unit id="entryDialog.variant">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:368,369</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:369,370</note>
       </notes>
       <segment>
         <source>Variante</source>
@@ -5269,7 +5338,7 @@
     </unit>
     <unit id="entryDialog.variantNone">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:371,373</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:372,374</note>
       </notes>
       <segment>
         <source>—</source>
@@ -5277,7 +5346,7 @@
     </unit>
     <unit id="entryDialog.distance">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:384,386</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:385,387</note>
       </notes>
       <segment>
         <source>Distanz (km)</source>
@@ -5285,8 +5354,8 @@
     </unit>
     <unit id="entryDialog.durationMinutes">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:400,402</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:430,432</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:399,401</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:429,431</note>
       </notes>
       <segment>
         <source>Minuten</source>
@@ -5294,8 +5363,8 @@
     </unit>
     <unit id="entryDialog.durationSeconds">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:413,415</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:443,445</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:412,414</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:442,444</note>
       </notes>
       <segment>
         <source>Sekunden</source>
@@ -5303,7 +5372,7 @@
     </unit>
     <unit id="setLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:462,463</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:461,462</note>
       </notes>
       <segment>
         <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -5311,7 +5380,7 @@
     </unit>
     <unit id="repsLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:464,465</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:463,464</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -5319,7 +5388,7 @@
     </unit>
     <unit id="removeSetAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:483,485</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:482,484</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -5327,7 +5396,7 @@
     </unit>
     <unit id="addSetAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:494,495</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:493,494</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -5335,7 +5404,7 @@
     </unit>
     <unit id="addSetTooltip">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:496,498</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:495,497</note>
       </notes>
       <segment>
         <source>Weiteres Set hinzufügen</source>
@@ -5343,7 +5412,7 @@
     </unit>
     <unit id="totalReps">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:505,507</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:504,506</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -5351,7 +5420,7 @@
     </unit>
     <unit id="entryDialog.overCapDuration">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:514,515</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:513,514</note>
       </notes>
       <segment>
         <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
@@ -5359,7 +5428,7 @@
     </unit>
     <unit id="entryDialog.overCapTime">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:518,519</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:517,518</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
@@ -5367,7 +5436,7 @@
     </unit>
     <unit id="entryDialog.overCap">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:522,523</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:521,522</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ repsMax() }}"/> pro Eintrag</source>
@@ -5375,7 +5444,7 @@
     </unit>
     <unit id="sourceLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:530,531</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:529,530</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -5383,7 +5452,7 @@
     </unit>
     <unit id="sourcePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:536,537</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:535,536</note>
       </notes>
       <segment>
         <source>web / whatsapp / eigene Quelle</source>
@@ -5391,7 +5460,7 @@
     </unit>
     <unit id="saveEntry">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:560,562</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:559,561</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -5399,7 +5468,7 @@
     </unit>
     <unit id="trainingEntryDialog.pushup.exercise">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:615</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:614</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -5407,7 +5476,7 @@
     </unit>
     <unit id="typeWikiLinkTooltip.generic">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:777</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:781</note>
       </notes>
       <segment>
         <source>Anleitung zu Liegestütztypen öffnen</source>
@@ -5415,7 +5484,7 @@
     </unit>
     <unit id="typeWikiLinkTooltip.specific">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:779</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:783</note>
       </notes>
       <segment>
         <source>Anleitung öffnen</source>
@@ -5423,7 +5492,7 @@
     </unit>
     <unit id="exercise.category.push">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1101</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1105</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:222</note>
       </notes>
       <segment>
@@ -5432,7 +5501,7 @@
     </unit>
     <unit id="exercise.category.pull">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1102</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1106</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:223</note>
       </notes>
       <segment>
@@ -5441,7 +5510,7 @@
     </unit>
     <unit id="exercise.category.squat">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1103</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1107</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:224</note>
       </notes>
       <segment>
@@ -5450,7 +5519,7 @@
     </unit>
     <unit id="exercise.category.hinge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1104</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1108</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:225</note>
       </notes>
       <segment>
@@ -5459,7 +5528,7 @@
     </unit>
     <unit id="exercise.category.lunge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1105</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1109</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:226</note>
       </notes>
       <segment>
@@ -5468,7 +5537,7 @@
     </unit>
     <unit id="exercise.category.carry">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1106</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1110</note>
       </notes>
       <segment>
         <source>Tragen</source>
@@ -5476,7 +5545,7 @@
     </unit>
     <unit id="exercise.category.core">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1107</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1111</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:227</note>
       </notes>
       <segment>
@@ -5485,7 +5554,7 @@
     </unit>
     <unit id="exercise.category.cardio">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1108</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1112</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:228</note>
       </notes>
       <segment>
@@ -5494,7 +5563,7 @@
     </unit>
     <unit id="exercise.category.mobility">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1109</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1113</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:229</note>
       </notes>
       <segment>
@@ -5503,7 +5572,7 @@
     </unit>
     <unit id="exercise.category.strength">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1110</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1114</note>
       </notes>
       <segment>
         <source>Krafttraining</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -7212,24 +7212,6 @@
         <target>按训练组对比</target>
       </segment>
     </unit>
-    <unit id="analysis.overview.comparison.metricAria">
-      <segment state="translated">
-        <source/>
-        <target>指标</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.reps">
-      <segment state="translated">
-        <source/>
-        <target>次数</target>
-      </segment>
-    </unit>
-    <unit id="analysis.overview.comparison.metric.sets">
-      <segment state="translated">
-        <source/>
-        <target>组数</target>
-      </segment>
-    </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
         <source/>
@@ -7258,6 +7240,72 @@
       <segment state="translated">
         <source/>
         <target>最佳日</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.comparison.metricLabel">
+      <segment state="translated">
+        <source/>
+        <target>训练次数</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.repsTitle">
+      <segment state="translated">
+        <source/>
+        <target>次数</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalSets">
+      <segment state="translated">
+        <source/>
+        <target>总组数</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.timeTitle">
+      <segment state="translated">
+        <source/>
+        <target>时间</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalTime">
+      <segment state="translated">
+        <source/>
+        <target>总时间</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayTime">
+      <segment state="translated">
+        <source/>
+        <target>今天</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTitle">
+      <segment state="translated">
+        <source/>
+        <target>距离</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.totalDistance">
+      <segment state="translated">
+        <source/>
+        <target>总距离</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.todayDistance">
+      <segment state="translated">
+        <source/>
+        <target>今天</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.facet.distanceTimeTitle">
+      <segment state="translated">
+        <source/>
+        <target>距离与时间</target>
+      </segment>
+    </unit>
+    <unit id="analysis.overview.cards.entries">
+      <segment state="translated">
+        <source/>
+        <target>训练次数</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">


### PR DESCRIPTION
Replace the one-size-fits-all "Reps gesamt" card with a discriminated
volume facet (reps / time / distance / distance-time) plus a mixed
bucket for categories like core that combine sit-ups and plank. Time-
only categories (mobility, plank-style core entries) now read out as
mm:ss instead of "0 Reps" and cardio shows km · pace.

The comparison chart drops the reps/sets toggle and switches to a
single measurement-agnostic "Trainingseinheiten" (training count)
axis — reps, seconds and meters can no longer share a bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stats now organized by measurement type (reps, time, distance, and combinations) with type-specific formatting.
  * Added training sessions metric to the analysis overview.

* **Improvements**
  * Category summary cards now display current streaks and total entries.
  * Simplified comparison chart to show entries-based comparison.
  * Enhanced locale support with updated translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/352)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->