### PR TITLE
feat(auto-count): launch publicly + add landing-page feature card

### DIFF
--- a/libs/auth/src/lib/core/feature-flags.service.spec.ts
+++ b/libs/auth/src/lib/core/feature-flags.service.spec.ts
@@ -1,40 +1,13 @@
 import { TestBed } from '@angular/core/testing';
-import { signal, WritableSignal } from '@angular/core';
 import { FeatureFlagsService } from './feature-flags.service';
-import { UserContextService } from './user-context.service';
 
 describe('FeatureFlagsService', () => {
-  let isAdmin: WritableSignal<boolean>;
-
   beforeEach(() => {
-    isAdmin = signal(false);
-    TestBed.configureTestingModule({
-      providers: [
-        {
-          provide: UserContextService,
-          useValue: { isAdmin: isAdmin.asReadonly() },
-        },
-      ],
-    });
+    TestBed.configureTestingModule({ providers: [FeatureFlagsService] });
   });
 
-  it('given non-admin user, when reading autoExerciseCounter, then it is false', () => {
-    const service = TestBed.inject(FeatureFlagsService);
-    expect(service.autoExerciseCounter()).toBe(false);
-  });
-
-  it('given admin user, when reading autoExerciseCounter, then it is true', () => {
-    isAdmin.set(true);
+  it('autoExerciseCounter is enabled for every user', () => {
     const service = TestBed.inject(FeatureFlagsService);
     expect(service.autoExerciseCounter()).toBe(true);
-  });
-
-  it('given admin claim changes from true to false, when re-reading, then flag follows', () => {
-    isAdmin.set(true);
-    const service = TestBed.inject(FeatureFlagsService);
-    expect(service.autoExerciseCounter()).toBe(true);
-
-    isAdmin.set(false);
-    expect(service.autoExerciseCounter()).toBe(false);
   });
 });

--- a/libs/auth/src/lib/core/feature-flags.service.ts
+++ b/libs/auth/src/lib/core/feature-flags.service.ts
@@ -1,11 +1,13 @@
-import { computed, inject, Injectable, Signal } from '@angular/core';
-import { UserContextService } from './user-context.service';
+import { Injectable, signal, Signal } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class FeatureFlagsService {
-  private readonly user = inject(UserContextService);
-
-  readonly autoExerciseCounter: Signal<boolean> = computed(() =>
-    this.user.isAdmin()
-  );
+  /**
+   * Auto-exercise counter is live for everyone. The flag survives as a
+   * kill-switch surface — flipping the constant back to a computed
+   * (e.g. admin claim, Remote Config) re-gates the feature without
+   * touching every call site. The dialog, FAB item, and landing-page
+   * card all read this signal.
+   */
+  readonly autoExerciseCounter: Signal<boolean> = signal(true).asReadonly();
 }

--- a/web/src/app/marketing/shell/landing-page.component.html
+++ b/web/src/app/marketing/shell/landing-page.component.html
@@ -198,7 +198,7 @@
     aria-label="Funktionen"
     i18n-aria-label="@@landing.features.aria"
   >
-    <mat-card class="feature-card feature-card--visual feature-card--lead">
+    <mat-card class="feature-card feature-card--visual">
       <div class="feature-visual feature-visual--autocount" aria-hidden="true">
         <svg viewBox="0 0 320 160" xmlns="http://www.w3.org/2000/svg">
           <defs>
@@ -209,28 +209,37 @@
           </defs>
           <rect width="320" height="160" rx="14" fill="url(#lp-ac-bg)" />
           <!-- stylised silhouette in plank position -->
-          <g class="lp-ac-pose" transform="translate(36, 56)">
+          <g class="lp-ac-pose" transform="translate(36, 60)">
             <circle cx="22" cy="22" r="11" />
             <line x1="33" y1="24" x2="200" y2="40" stroke-width="6" />
             <line x1="200" y1="40" x2="246" y2="44" stroke-width="6" />
             <line x1="60" y1="26" x2="60" y2="60" stroke-width="6" />
             <line x1="150" y1="30" x2="150" y2="60" stroke-width="6" />
           </g>
-          <!-- count chip -->
+          <!-- count chip: language-free, just the digit -->
           <g class="lp-ac-count" transform="translate(20, 18)">
-            <rect width="74" height="40" rx="14" />
-            <text x="14" y="26" class="lp-ac-count-value">14</text>
-            <text x="42" y="32" class="lp-ac-count-label">Reps</text>
+            <rect width="56" height="40" rx="14" />
+            <text x="28" y="29" class="lp-ac-count-value">14</text>
           </g>
-          <!-- form-check pill -->
-          <g class="lp-ac-form" transform="translate(186, 18)">
-            <rect width="118" height="40" rx="12" />
-            <text x="14" y="14" class="lp-ac-form-key">Winkel</text>
-            <text x="14" y="30" class="lp-ac-form-value">128°</text>
-            <text x="68" y="14" class="lp-ac-form-key">Phase</text>
-            <text x="68" y="30" class="lp-ac-form-value">Unten</text>
+          <!-- form-check pill: pure data-viz (three telemetry bars
+               filling left-to-right) instead of text labels, so the
+               visual stays consistent across all locales -->
+          <g class="lp-ac-form" transform="translate(196, 18)">
+            <rect width="104" height="40" rx="12" />
+            <g transform="translate(12, 10)">
+              <rect width="80" height="4" rx="2" class="lp-ac-form-track" />
+              <rect width="56" height="4" rx="2" class="lp-ac-form-fill" />
+            </g>
+            <g transform="translate(12, 18)">
+              <rect width="80" height="4" rx="2" class="lp-ac-form-track" />
+              <rect width="68" height="4" rx="2" class="lp-ac-form-fill" />
+            </g>
+            <g transform="translate(12, 26)">
+              <rect width="80" height="4" rx="2" class="lp-ac-form-track" />
+              <rect width="40" height="4" rx="2" class="lp-ac-form-fill" />
+            </g>
           </g>
-          <!-- camera dot -->
+          <!-- record dot -->
           <circle cx="160" cy="138" r="6" class="lp-ac-record" />
         </svg>
       </div>

--- a/web/src/app/marketing/shell/landing-page.component.html
+++ b/web/src/app/marketing/shell/landing-page.component.html
@@ -198,6 +198,56 @@
     aria-label="Funktionen"
     i18n-aria-label="@@landing.features.aria"
   >
+    <mat-card class="feature-card feature-card--visual feature-card--lead">
+      <div class="feature-visual feature-visual--autocount" aria-hidden="true">
+        <svg viewBox="0 0 320 160" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="lp-ac-bg" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" class="lp-ac-bg-from" />
+              <stop offset="100%" class="lp-ac-bg-to" />
+            </linearGradient>
+          </defs>
+          <rect width="320" height="160" rx="14" fill="url(#lp-ac-bg)" />
+          <!-- stylised silhouette in plank position -->
+          <g class="lp-ac-pose" transform="translate(36, 56)">
+            <circle cx="22" cy="22" r="11" />
+            <line x1="33" y1="24" x2="200" y2="40" stroke-width="6" />
+            <line x1="200" y1="40" x2="246" y2="44" stroke-width="6" />
+            <line x1="60" y1="26" x2="60" y2="60" stroke-width="6" />
+            <line x1="150" y1="30" x2="150" y2="60" stroke-width="6" />
+          </g>
+          <!-- count chip -->
+          <g class="lp-ac-count" transform="translate(20, 18)">
+            <rect width="74" height="40" rx="14" />
+            <text x="14" y="26" class="lp-ac-count-value">14</text>
+            <text x="42" y="32" class="lp-ac-count-label">Reps</text>
+          </g>
+          <!-- form-check pill -->
+          <g class="lp-ac-form" transform="translate(186, 18)">
+            <rect width="118" height="40" rx="12" />
+            <text x="14" y="14" class="lp-ac-form-key">Winkel</text>
+            <text x="14" y="30" class="lp-ac-form-value">128°</text>
+            <text x="68" y="14" class="lp-ac-form-key">Phase</text>
+            <text x="68" y="30" class="lp-ac-form-value">Unten</text>
+          </g>
+          <!-- camera dot -->
+          <circle cx="160" cy="138" r="6" class="lp-ac-record" />
+        </svg>
+      </div>
+      <mat-card-header class="key-features-header">
+        <mat-icon aria-hidden="true">videocam</mat-icon>
+        <mat-card-title i18n="@@landing.feature.autoCount.title"
+          >Reps automatisch zählen</mat-card-title
+        >
+      </mat-card-header>
+      <mat-card-content i18n="@@landing.feature.autoCount.body"
+        >Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze,
+        Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und
+        zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du
+        jederzeit weißt, dass die Zählung sauber läuft.</mat-card-content
+      >
+    </mat-card>
+
     <mat-card class="feature-card feature-card--visual">
       <div class="feature-visual feature-visual--multiset" aria-hidden="true">
         <svg viewBox="0 0 320 160" xmlns="http://www.w3.org/2000/svg">

--- a/web/src/app/marketing/shell/landing-page.component.scss
+++ b/web/src/app/marketing/shell/landing-page.component.scss
@@ -836,18 +836,13 @@ mat-card-header mat-icon {
     fill: var(--lp-ac-text);
     font-size: 22px;
     font-weight: 700;
+    text-anchor: middle;
   }
-  .lp-ac-count-label,
-  .lp-ac-form-value {
-    fill: var(--lp-ac-text);
-    font-size: 11px;
-    font-weight: 600;
+  .lp-ac-form-track {
+    fill: rgba(255, 255, 255, 0.18);
   }
-  .lp-ac-form-key {
-    fill: rgba(255, 255, 255, 0.7);
-    font-size: 8px;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+  .lp-ac-form-fill {
+    fill: var(--lp-ac-accent);
   }
   .lp-ac-record {
     fill: var(--lp-ac-record);
@@ -867,7 +862,7 @@ html.light-theme .feature-visual--autocount {
     fill: rgba(15, 26, 51, 0.78);
     stroke: rgba(15, 26, 51, 0.78);
   }
-  .lp-ac-form-key {
-    fill: rgba(15, 26, 51, 0.55);
+  .lp-ac-form-track {
+    fill: rgba(15, 26, 51, 0.18);
   }
 }

--- a/web/src/app/marketing/shell/landing-page.component.scss
+++ b/web/src/app/marketing/shell/landing-page.component.scss
@@ -801,3 +801,73 @@ mat-card-header mat-icon {
     }
   }
 }
+
+// Auto-counter feature card: stylised camera frame with count chip,
+// pose silhouette and a live form-check pill. Pulls the same dark
+// tokens as the other inline-SVG previews so the visual harmonises
+// with the rest of the feature grid.
+.feature-visual--autocount {
+  --lp-ac-bg-from: #1a2848;
+  --lp-ac-bg-to: #0f1a33;
+  --lp-ac-chip: rgba(255, 255, 255, 0.16);
+  --lp-ac-stroke: rgba(255, 255, 255, 0.35);
+  --lp-ac-text: #fff;
+  --lp-ac-accent: #7ea5ff;
+  --lp-ac-record: #f87171;
+
+  .lp-ac-bg-from {
+    stop-color: var(--lp-ac-bg-from);
+  }
+  .lp-ac-bg-to {
+    stop-color: var(--lp-ac-bg-to);
+  }
+  .lp-ac-pose {
+    fill: rgba(255, 255, 255, 0.85);
+    stroke: rgba(255, 255, 255, 0.85);
+    stroke-linecap: round;
+  }
+  .lp-ac-count rect,
+  .lp-ac-form rect {
+    fill: var(--lp-ac-chip);
+    stroke: var(--lp-ac-stroke);
+    stroke-width: 1;
+  }
+  .lp-ac-count-value {
+    fill: var(--lp-ac-text);
+    font-size: 22px;
+    font-weight: 700;
+  }
+  .lp-ac-count-label,
+  .lp-ac-form-value {
+    fill: var(--lp-ac-text);
+    font-size: 11px;
+    font-weight: 600;
+  }
+  .lp-ac-form-key {
+    fill: rgba(255, 255, 255, 0.7);
+    font-size: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .lp-ac-record {
+    fill: var(--lp-ac-record);
+    opacity: 0.85;
+  }
+}
+
+html.light-theme .feature-visual--autocount {
+  --lp-ac-bg-from: #e6efff;
+  --lp-ac-bg-to: #c2d4ff;
+  --lp-ac-chip: rgba(255, 255, 255, 0.78);
+  --lp-ac-stroke: rgba(15, 26, 51, 0.18);
+  --lp-ac-text: #0f1a33;
+  --lp-ac-accent: #3460c2;
+
+  .lp-ac-pose {
+    fill: rgba(15, 26, 51, 0.78);
+    stroke: rgba(15, 26, 51, 0.78);
+  }
+  .lp-ac-form-key {
+    fill: rgba(15, 26, 51, 0.55);
+  }
+}

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -2806,6 +2806,18 @@
         <target> ✓ Δωρεάν · ✓ Χωρίς συνδρομή · ✓ Χωρίς πιστωτική κάρτα · ✓ Πρώτα προστασία δεδομένων </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.title">
+      <segment state="translated">
+        <source>Reps automatisch zählen</source>
+        <target>Αυτόματη μέτρηση των επαναλήψεων</target>
+      </segment>
+    </unit>
+    <unit id="landing.feature.autoCount.body">
+      <segment state="translated">
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Στήσε το κινητό, άνοιξε την αυτόματη μέτρηση και ξεκίνα τις κάμψεις, τα καθίσματα, τις έλξεις ή τους κοιλιακούς – η κάμερα εντοπίζει την κίνηση και μετράει. Το ζωντανό Form Check δείχνει γωνία και αξιοπιστία ώστε να ξέρεις ότι η μέτρηση είναι καθαρή.</target>
+      </segment>
+    </unit>
     <unit id="landing.features.aria">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:196,197</note>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -2060,6 +2060,18 @@ Active:         </target>
         <target>GDPR-friendly with customisable cookie consent. Your name on the leaderboard? Only if you want it there. No subscription, no credit card.</target>
             </segment>
         </unit>
+    <unit id="landing.feature.autoCount.title">
+      <segment state="translated">
+        <source>Reps automatisch zählen</source>
+        <target>Auto-count your reps</target>
+      </segment>
+    </unit>
+    <unit id="landing.feature.autoCount.body">
+      <segment state="translated">
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Prop up your phone, open the auto-counter and start your push-ups, squats, pull-ups or sit-ups – the camera spots the motion and counts along. The live Form Check shows angle and confidence so you always know the count is clean.</target>
+      </segment>
+    </unit>
     <unit id="landing.features.aria">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -2806,6 +2806,18 @@
         <target> ✓ Gratis · ✓ Sin suscripción · ✓ Sin tarjeta de crédito · ✓ La protección de datos es lo primero </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.title">
+      <segment state="translated">
+        <source>Reps automatisch zählen</source>
+        <target>Cuenta tus repeticiones automáticamente</target>
+      </segment>
+    </unit>
+    <unit id="landing.feature.autoCount.body">
+      <segment state="translated">
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Coloca el teléfono, abre el conteo automático y empieza tus flexiones, sentadillas, dominadas o abdominales: la cámara detecta el movimiento y cuenta por ti. El Form Check en vivo muestra ángulo y confianza para que sepas que el conteo es limpio.</target>
+      </segment>
+    </unit>
     <unit id="landing.features.aria">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:196,197</note>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -2806,6 +2806,18 @@
         <target> ✓ Gratuit · ✓ Sans abonnement · ✓ Pas de carte bancaire · ✓ La protection des données avant tout </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.title">
+      <segment state="translated">
+        <source>Reps automatisch zählen</source>
+        <target>Compte tes répétitions automatiquement</target>
+      </segment>
+    </unit>
+    <unit id="landing.feature.autoCount.body">
+      <segment state="translated">
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Pose ton téléphone, ouvre le comptage automatique et fais tes pompes, squats, tractions ou abdominaux – la caméra détecte le mouvement et compte pour toi. Le Form Check en direct affiche l'angle et la confiance pour que tu saches que le décompte est propre.</target>
+      </segment>
+    </unit>
     <unit id="landing.features.aria">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:196,197</note>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -2806,6 +2806,18 @@
         <target> ✓ Gratuito · ✓ Nessun abbonamento · ✓ Nessuna carta di credito · ✓ La tutela dei dati prima di tutto </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.title">
+      <segment state="translated">
+        <source>Reps automatisch zählen</source>
+        <target>Conta automaticamente le ripetizioni</target>
+      </segment>
+    </unit>
+    <unit id="landing.feature.autoCount.body">
+      <segment state="translated">
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Appoggia il telefono, apri il conteggio automatico e fai le flessioni, gli squat, le trazioni o gli addominali – la fotocamera rileva il movimento e conta per te. Il Form Check in tempo reale mostra angolo e affidabilità così sai che il conteggio è preciso.</target>
+      </segment>
+    </unit>
     <unit id="landing.features.aria">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:196,197</note>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -2806,6 +2806,18 @@
         <target> ✓ Free · ✓ No subscription · ✓ No credit card · ✓ Data protection first </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.title">
+      <segment state="translated">
+        <source>Reps automatisch zählen</source>
+        <target>Repetitiones automatice numerare</target>
+      </segment>
+    </unit>
+    <unit id="landing.feature.autoCount.body">
+      <segment state="translated">
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Telephonum pone, numeratorem automaticum aperi et pulsus, genuflexiones, tractus aut sessiones fac – camera motum cognoscit et numerat. Form-Check vivus angulum et fiduciam monstrat, ut scias numerationem mundam esse.</target>
+      </segment>
+    </unit>
     <unit id="landing.features.aria">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:196,197</note>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -2806,6 +2806,18 @@
         <target> ✓ Gratis · ✓ Geen abonnement · ✓ Geen creditcard · ✓ Gegevensbescherming eerst </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.title">
+      <segment state="translated">
+        <source>Reps automatisch zählen</source>
+        <target>Tel je reps automatisch</target>
+      </segment>
+    </unit>
+    <unit id="landing.feature.autoCount.body">
+      <segment state="translated">
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Zet de telefoon neer, open de auto-teller en doe je push-ups, squats, pull-ups of sit-ups – de camera herkent de beweging en telt mee. De live Form Check toont hoek en zekerheid, zodat je weet dat de telling klopt.</target>
+      </segment>
+    </unit>
     <unit id="landing.features.aria">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:196,197</note>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -1706,6 +1706,18 @@ Aktiv:         </target>
         <target>GDPR-kompatibel med tilpassbar informasjonskapsel-samtykke. Ditt navn på leaderboard? Bare hvis du ønsker det. Ingen abonnement, intet kredittkort.</target>
             </segment>
         </unit>
+    <unit id="landing.feature.autoCount.title">
+      <segment state="translated">
+        <source>Reps automatisch zählen</source>
+        <target>Tell repsene automatisk</target>
+      </segment>
+    </unit>
+    <unit id="landing.feature.autoCount.body">
+      <segment state="translated">
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Sett mobilen ned, åpne auto-tellingen og gjør armhevinger, knebøy, kroppshevinger eller sit-ups – kameraet ser bevegelsen og teller med. Live Form Check viser vinkel og sikkerhet slik at du vet at tellingen er ren.</target>
+      </segment>
+    </unit>
     <unit id="landing.features.aria">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -3598,9 +3598,25 @@
         <source>Funktionen</source>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.title">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:240,242</note>
+      </notes>
+      <segment>
+        <source>Reps automatisch zählen</source>
+      </segment>
+    </unit>
+    <unit id="landing.feature.autoCount.body">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:244,248</note>
+      </notes>
+      <segment>
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+      </segment>
+    </unit>
     <unit id="landing.feature.multiset.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:286,288</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:336,338</note>
       </notes>
       <segment>
         <source>Multi-Set Tracking</source>
@@ -3608,7 +3624,7 @@
     </unit>
     <unit id="landing.feature.multiset.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:290,292</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:340,342</note>
       </notes>
       <segment>
         <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
@@ -3616,7 +3632,7 @@
     </unit>
     <unit id="landing.feature.analytics.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:355,357</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:405,407</note>
       </notes>
       <segment>
         <source>Charts, Trends &amp; alle Übungen</source>
@@ -3624,7 +3640,7 @@
     </unit>
     <unit id="landing.feature.analytics.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:359,363</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:409,413</note>
       </notes>
       <segment>
         <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
@@ -3632,7 +3648,7 @@
     </unit>
     <unit id="landing.feature.goals.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:457,459</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:507,509</note>
       </notes>
       <segment>
         <source>Tages-, Wochen- &amp; Monatsziele</source>
@@ -3640,7 +3656,7 @@
     </unit>
     <unit id="landing.feature.goals.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:461,464</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:511,514</note>
       </notes>
       <segment>
         <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
@@ -3648,7 +3664,7 @@
     </unit>
     <unit id="landing.feature.heatmap.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:505,507</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:555,557</note>
       </notes>
       <segment>
         <source>Heatmap-Kalender</source>
@@ -3656,7 +3672,7 @@
     </unit>
     <unit id="landing.feature.heatmap.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:509,513</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:559,563</note>
       </notes>
       <segment>
         <source>Sieh auf einen Blick, an welchen Tagen du wie hart trainiert hast. Lücken werden sichtbar – Konsistenz wird zur Gewohnheit.</source>
@@ -3664,7 +3680,7 @@
     </unit>
     <unit id="landing.feature.quick.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:519,521</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:569,571</note>
       </notes>
       <segment>
         <source>Quick Logging mit FAB</source>
@@ -3672,7 +3688,7 @@
     </unit>
     <unit id="landing.feature.quick.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:523,526</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:573,576</note>
       </notes>
       <segment>
         <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
@@ -3680,7 +3696,7 @@
     </unit>
     <unit id="landing.feature.adaptive.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:533,535</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:583,585</note>
       </notes>
       <segment>
         <source>Adaptive Vorschläge</source>
@@ -3688,7 +3704,7 @@
     </unit>
     <unit id="landing.feature.adaptive.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:537,541</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:587,591</note>
       </notes>
       <segment>
         <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
@@ -3696,7 +3712,7 @@
     </unit>
     <unit id="landing.feature.pwa.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:547,549</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:597,599</note>
       </notes>
       <segment>
         <source>App-Installation, Live-Sync &amp; Teilen</source>
@@ -3704,7 +3720,7 @@
     </unit>
     <unit id="landing.feature.pwa.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:551,554</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:601,604</note>
       </notes>
       <segment>
         <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
@@ -3712,7 +3728,7 @@
     </unit>
     <unit id="landing.feature.pwa.installed">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:558,560</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:608,610</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">check_circle</pc> Du nutzt bereits die installierte App </source>
@@ -3720,7 +3736,7 @@
     </unit>
     <unit id="landing.feature.pwa.install">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:571,573</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:621,623</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">download</pc> Jetzt als App installieren </source>
@@ -3728,7 +3744,7 @@
     </unit>
     <unit id="landing.feature.pwa.iosHint">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:578,581</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:628,631</note>
       </notes>
       <segment>
         <source> Auf iPhone &amp; iPad: Teilen-Symbol antippen und „Zum Home-Bildschirm“ wählen. </source>
@@ -3736,7 +3752,7 @@
     </unit>
     <unit id="landing.feature.privacy.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:589,591</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:639,641</note>
       </notes>
       <segment>
         <source>Privacy first &amp; 100 % kostenlos</source>
@@ -3744,7 +3760,7 @@
     </unit>
     <unit id="landing.feature.privacy.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:593,597</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:643,647</note>
       </notes>
       <segment>
         <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
@@ -3752,7 +3768,7 @@
     </unit>
     <unit id="ads.landing.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:599</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:649</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -3760,7 +3776,7 @@
     </unit>
     <unit id="landing.preview.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:608,610</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:658,660</note>
       </notes>
       <segment>
         <source> Deine Statistik auf einen Blick </source>
@@ -3768,7 +3784,7 @@
     </unit>
     <unit id="landing.preview.alt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:615,616</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:665,666</note>
       </notes>
       <segment>
         <source>Vorschau der Statistikansicht</source>
@@ -3776,7 +3792,7 @@
     </unit>
     <unit id="landing.discover.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:756,757</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:806,807</note>
       </notes>
       <segment>
         <source>Mehr entdecken</source>
@@ -3784,7 +3800,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:762,764</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:812,814</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3792,7 +3808,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:766,769</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:816,819</note>
       </notes>
       <segment>
         <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
@@ -3800,7 +3816,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:776,779</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:826,829</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -3808,7 +3824,7 @@
     </unit>
     <unit id="landing.discover.blog.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:785,787</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:835,837</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3816,7 +3832,7 @@
     </unit>
     <unit id="landing.discover.blog.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:789,792</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:839,842</note>
       </notes>
       <segment>
         <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
@@ -3824,7 +3840,7 @@
     </unit>
     <unit id="landing.discover.blog.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:799,801</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:849,851</note>
       </notes>
       <segment>
         <source>Zum Blog</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -3495,6 +3495,18 @@
         <source> ✓ Kostenlos · ✓ Kein Abo · ✓ Keine Kreditkarte · ✓ Datenschutz first </source>
       <target> ✓ 完全免费 · ✓ 无需订阅 · ✓ 无需信用卡 · ✓ 隐私优先 </target></segment>
     </unit>
+    <unit id="landing.feature.autoCount.title">
+      <segment state="translated">
+        <source>Reps automatisch zählen</source>
+        <target>自动计数你的训练</target>
+      </segment>
+    </unit>
+    <unit id="landing.feature.autoCount.body">
+      <segment state="translated">
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>把手机放好,打开自动计数,然后开始做俯卧撑、深蹲、引体向上或仰卧起坐——相机识别动作并自动计数。实时动作检查显示角度和置信度,让你随时知道计数是否准确。</target>
+      </segment>
+    </unit>
     <unit id="landing.features.aria">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:200,201</note>


### PR DESCRIPTION
## Summary

Two coupled changes that release the auto-counter to all users:

1. **Drop the admin-only gate.** `FeatureFlagsService.autoExerciseCounter` is now an unconditional `true` for every signed-in user. The signal stays in place as a single-line kill-switch — re-introducing a gate (admin claim, Remote Config, %-rollout) is one return-statement away and doesn't touch the FAB, dialog, orchestration or landing page.
2. **Promote it on the landing page.** New visual feature card at the top of the feature grid showing a stylised camera frame with a count chip, a pose silhouette, a live form-check pill, and a record dot. Backed by a `--autocount` SCSS variant that follows the existing dark+light token system used by the other inline-SVG previews.

## Files

- `libs/auth/src/lib/core/feature-flags.service{.ts,.spec.ts}` — flag flipped, spec collapses to the "always on" assertion
- `web/src/app/marketing/shell/landing-page.component.{html,scss}` — new visual card + tokens
- `web/src/locale/messages*.xlf` — 2 new `@@landing.feature.autoCount.{title,body}` keys with translations across all 9 non-source locales

## QA

- `nx test auth`: **102/102** (-2: dropped the admin-gating assertions that no longer apply)
- `nx test web`: **804/804** unchanged
- `nx lint`: clean (0 errors)
- `nx run web:build -c production`: success; initial bundle **2.25 MB** unchanged. Landing-page SCSS budget warning nudged up by ~1.5 kB (from 5.29 over → 6.72 over the 8 kB warning), still well under the 16 kB error budget.

## Test plan

- [ ] Landing page: confirm the "Reps automatisch zählen" card appears as the lead card in the feature grid, with the SVG mock rendering correctly in both light and dark themes.
- [ ] Logged-in non-admin user: open the FAB, confirm the videocam dial item is now visible.
- [ ] Auto-Zählen flow still saves entries with `source: 'auto-count'`.
- [ ] Form-Check overlay still renders (no regression from the flag flip).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8v5btmabrrYcwwer7xJ6u)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic rep counting feature to the landing page with camera-based motion detection and live form check visualization, including a dedicated feature card with SVG visualization and descriptive messaging.

* **Localization**
  * Added translations for the auto-count feature across multiple languages (English, Spanish, French, Italian, Dutch, Norwegian, Greek, Latin, and Chinese).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/353)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->