### PR TITLE
fix(intervals-distribution): normalise bar widths by count, not by rounded percent

### DIFF
--- a/web/src/app/stats/components/intervals-distribution/intervals-distribution.component.spec.ts
+++ b/web/src/app/stats/components/intervals-distribution/intervals-distribution.component.spec.ts
@@ -173,7 +173,7 @@ describe('IntervalsDistributionComponent', () => {
       fixture.componentRef.setInput('measurement', 'time');
       fixture.componentRef.setInput('entries', []);
       fixture.detectChanges();
-      expect(component.barWidth(50)).toBe(0);
+      expect(component.barWidth(1)).toBe(0);
     });
 
     it('renders the biggest bin at 100% and scales others proportionally', () => {
@@ -187,10 +187,28 @@ describe('IntervalsDistributionComponent', () => {
       ]);
       fixture.detectChanges();
       const [a, b] = component.data();
-      expect(component.barWidth(a.percent)).toBe(100);
-      // Allow 1px rounding noise: 25/75*100 ≈ 33.33.
-      expect(component.barWidth(b.percent)).toBeGreaterThan(33);
-      expect(component.barWidth(b.percent)).toBeLessThan(34);
+      expect(component.barWidth(a.count)).toBe(100);
+      // Allow 1px rounding noise: 1/3*100 ≈ 33.33.
+      expect(component.barWidth(b.count)).toBeGreaterThan(33);
+      expect(component.barWidth(b.count)).toBeLessThan(34);
+    });
+
+    it('still renders bars when every bin rounds to 0% (many unique values)', () => {
+      // 250 unique interval distances → each count=1, percent=round(0.4)=0
+      // for every bin. Percent-based normalisation would collapse every
+      // bar to width 0; count-based normalisation keeps them at 100%.
+      const intervals = Array.from({ length: 250 }, (_, i) => 100 + i);
+      fixture.componentRef.setInput('measurement', 'distance-time');
+      fixture.componentRef.setInput('entries', [
+        exerciseEntry({ exerciseId: 'cardio.running', intervals }),
+      ]);
+      fixture.detectChanges();
+      const datums = component.data();
+      expect(datums.length).toBe(250);
+      expect(datums.every((d) => d.percent === 0)).toBe(true);
+      expect(datums.every((d) => component.barWidth(d.count) === 100)).toBe(
+        true
+      );
     });
   });
 

--- a/web/src/app/stats/components/intervals-distribution/intervals-distribution.component.ts
+++ b/web/src/app/stats/components/intervals-distribution/intervals-distribution.component.ts
@@ -37,7 +37,7 @@ export interface IntervalsDistributionDatum {
               formatValue(d.value)
             }}</span>
             <div class="bar-track" aria-hidden="true">
-              <div class="bar-fill" [style.width.%]="barWidth(d.percent)"></div>
+              <div class="bar-fill" [style.width.%]="barWidth(d.count)"></div>
             </div>
             <span class="value" aria-hidden="true">{{ d.percent }}%</span>
           </div>
@@ -121,18 +121,18 @@ export class IntervalsDistributionComponent {
       }));
   });
 
-  // Interval workouts (especially distance / distance-time) often have
-  // every value distinct, so raw `percent` would leave the widest bar
-  // very short. Normalising to the largest bin keeps the chart legible
-  // when the distribution is flat.
-  private readonly maxPercent = computed(() =>
-    this.data().reduce((max, d) => Math.max(max, d.percent), 0)
+  // Normalise bar widths against the largest bin's raw count, not its
+  // rounded display percent. With >100 unique interval values (sprint
+  // sessions with many distinct distances), every bin's percent rounds
+  // to 0 and a percent-based normaliser collapses every bar to width 0.
+  private readonly maxCount = computed(() =>
+    this.data().reduce((max, d) => Math.max(max, d.count), 0)
   );
 
-  barWidth(percent: number): number {
-    const max = this.maxPercent();
+  barWidth(count: number): number {
+    const max = this.maxCount();
     if (max <= 0) return 0;
-    return (percent / max) * 100;
+    return (count / max) * 100;
   }
 
   formatValue(value: number): string {


### PR DESCRIPTION
Post-merge follow-up to #354 (Copilot review comment).

## Problem

`IntervalsDistributionComponent.barWidth(percent)` normalises bar widths against `maxPercent`. `percent` is computed as `Math.round((count / total) * 100)` — so when a dataset has many unique interval values (e.g. a sprinter logging dozens of distinct distances), every bin's ratio is below `0.5%` and rounds to `0`. With `maxPercent === 0`, every bar collapses to width `0` and the chart renders empty while the underlying data is fine.

## Fix

Normalise by the raw count instead of the rounded percent:

```ts
private readonly maxCount = computed(() =>
  this.data().reduce((max, d) => Math.max(max, d.count), 0),
);

barWidth(count: number): number {
  const max = this.maxCount();
  if (max <= 0) return 0;
  return (count / max) * 100;
}
```

Template binding updated: `barWidth(d.percent)` → `barWidth(d.count)`. `percent` is still emitted on `IntervalsDistributionDatum` and rendered in the row label / aria-label, just no longer load-bearing for layout.

## Test plan

- [x] `nx test web` — 835 passed, including new regression spec `still renders bars when every bin rounds to 0% (many unique values)` that drives 250 distinct distances through the component and asserts every bar still renders at 100%.
- [x] `nx lint web` — clean.

Refs #354

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6k1hB6w9AFux3CvBkmoAr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intervals distribution chart bar rendering to prevent collapse when displaying many unique values. Bars now properly scale and display proportional widths across all data scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/355)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->