### PR TITLE
feat(landing): replace auto-count SVG with stock photo

### DIFF
--- a/web/src/app/marketing/shell/landing-page.component.html
+++ b/web/src/app/marketing/shell/landing-page.component.html
@@ -202,7 +202,7 @@
       <div class="feature-visual feature-visual--autocount">
         <img
           src="https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1200&h=600&q=80"
-          alt="Person bei Liegestützen, Smartphone daneben"
+          alt="Sportlerin bei einer sauberen Liegestütze auf Holzboden"
           i18n-alt="@@landing.feature.autoCount.imageAlt"
           loading="lazy"
           decoding="async"
@@ -218,9 +218,10 @@
       </mat-card-header>
       <mat-card-content i18n="@@landing.feature.autoCount.body"
         >Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze,
-        Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und
-        zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du
-        jederzeit weißt, dass die Zählung sauber läuft.</mat-card-content
+        Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in
+        Echtzeit direkt im Browser und zählt automatisch mit. Der
+        Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt,
+        dass die Zählung sauber läuft.</mat-card-content
       >
     </mat-card>
 

--- a/web/src/app/marketing/shell/landing-page.component.html
+++ b/web/src/app/marketing/shell/landing-page.component.html
@@ -199,49 +199,16 @@
     i18n-aria-label="@@landing.features.aria"
   >
     <mat-card class="feature-card feature-card--visual">
-      <div class="feature-visual feature-visual--autocount" aria-hidden="true">
-        <svg viewBox="0 0 320 160" xmlns="http://www.w3.org/2000/svg">
-          <defs>
-            <linearGradient id="lp-ac-bg" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" class="lp-ac-bg-from" />
-              <stop offset="100%" class="lp-ac-bg-to" />
-            </linearGradient>
-          </defs>
-          <rect width="320" height="160" rx="14" fill="url(#lp-ac-bg)" />
-          <!-- stylised silhouette in plank position -->
-          <g class="lp-ac-pose" transform="translate(36, 60)">
-            <circle cx="22" cy="22" r="11" />
-            <line x1="33" y1="24" x2="200" y2="40" stroke-width="6" />
-            <line x1="200" y1="40" x2="246" y2="44" stroke-width="6" />
-            <line x1="60" y1="26" x2="60" y2="60" stroke-width="6" />
-            <line x1="150" y1="30" x2="150" y2="60" stroke-width="6" />
-          </g>
-          <!-- count chip: language-free, just the digit -->
-          <g class="lp-ac-count" transform="translate(20, 18)">
-            <rect width="56" height="40" rx="14" />
-            <text x="28" y="29" class="lp-ac-count-value">14</text>
-          </g>
-          <!-- form-check pill: pure data-viz (three telemetry bars
-               filling left-to-right) instead of text labels, so the
-               visual stays consistent across all locales -->
-          <g class="lp-ac-form" transform="translate(196, 18)">
-            <rect width="104" height="40" rx="12" />
-            <g transform="translate(12, 10)">
-              <rect width="80" height="4" rx="2" class="lp-ac-form-track" />
-              <rect width="56" height="4" rx="2" class="lp-ac-form-fill" />
-            </g>
-            <g transform="translate(12, 18)">
-              <rect width="80" height="4" rx="2" class="lp-ac-form-track" />
-              <rect width="68" height="4" rx="2" class="lp-ac-form-fill" />
-            </g>
-            <g transform="translate(12, 26)">
-              <rect width="80" height="4" rx="2" class="lp-ac-form-track" />
-              <rect width="40" height="4" rx="2" class="lp-ac-form-fill" />
-            </g>
-          </g>
-          <!-- record dot -->
-          <circle cx="160" cy="138" r="6" class="lp-ac-record" />
-        </svg>
+      <div class="feature-visual feature-visual--autocount">
+        <img
+          src="https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1200&h=600&q=80"
+          alt="Person bei Liegestützen, Smartphone daneben"
+          i18n-alt="@@landing.feature.autoCount.imageAlt"
+          loading="lazy"
+          decoding="async"
+          width="1200"
+          height="600"
+        />
       </div>
       <mat-card-header class="key-features-header">
         <mat-icon aria-hidden="true">videocam</mat-icon>

--- a/web/src/app/marketing/shell/landing-page.component.scss
+++ b/web/src/app/marketing/shell/landing-page.component.scss
@@ -802,10 +802,6 @@ mat-card-header mat-icon {
   }
 }
 
-// Auto-counter feature card: real stock photo instead of an inline SVG.
-// The image fills the same 2:1 visual slot as the other feature previews;
-// a subtle gradient overlay keeps it cohesive with the surrounding dark
-// theme without washing out the photo's colour.
 .feature-visual--autocount {
   position: relative;
   overflow: hidden;
@@ -832,7 +828,7 @@ mat-card-header mat-icon {
   }
 }
 
-html.light-theme .feature-visual--autocount {
+:host-context(html.light-theme) .feature-visual--autocount {
   background: #e6efff;
 
   &::after {

--- a/web/src/app/marketing/shell/landing-page.component.scss
+++ b/web/src/app/marketing/shell/landing-page.component.scss
@@ -802,67 +802,44 @@ mat-card-header mat-icon {
   }
 }
 
-// Auto-counter feature card: stylised camera frame with count chip,
-// pose silhouette and a live form-check pill. Pulls the same dark
-// tokens as the other inline-SVG previews so the visual harmonises
-// with the rest of the feature grid.
+// Auto-counter feature card: real stock photo instead of an inline SVG.
+// The image fills the same 2:1 visual slot as the other feature previews;
+// a subtle gradient overlay keeps it cohesive with the surrounding dark
+// theme without washing out the photo's colour.
 .feature-visual--autocount {
-  --lp-ac-bg-from: #1a2848;
-  --lp-ac-bg-to: #0f1a33;
-  --lp-ac-chip: rgba(255, 255, 255, 0.16);
-  --lp-ac-stroke: rgba(255, 255, 255, 0.35);
-  --lp-ac-text: #fff;
-  --lp-ac-accent: #7ea5ff;
-  --lp-ac-record: #f87171;
+  position: relative;
+  overflow: hidden;
+  background: #0f1a33;
 
-  .lp-ac-bg-from {
-    stop-color: var(--lp-ac-bg-from);
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center 35%;
   }
-  .lp-ac-bg-to {
-    stop-color: var(--lp-ac-bg-to);
-  }
-  .lp-ac-pose {
-    fill: rgba(255, 255, 255, 0.85);
-    stroke: rgba(255, 255, 255, 0.85);
-    stroke-linecap: round;
-  }
-  .lp-ac-count rect,
-  .lp-ac-form rect {
-    fill: var(--lp-ac-chip);
-    stroke: var(--lp-ac-stroke);
-    stroke-width: 1;
-  }
-  .lp-ac-count-value {
-    fill: var(--lp-ac-text);
-    font-size: 22px;
-    font-weight: 700;
-    text-anchor: middle;
-  }
-  .lp-ac-form-track {
-    fill: rgba(255, 255, 255, 0.18);
-  }
-  .lp-ac-form-fill {
-    fill: var(--lp-ac-accent);
-  }
-  .lp-ac-record {
-    fill: var(--lp-ac-record);
-    opacity: 0.85;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(
+      155deg,
+      rgba(15, 26, 51, 0.05) 0%,
+      rgba(15, 26, 51, 0.55) 100%
+    );
   }
 }
 
 html.light-theme .feature-visual--autocount {
-  --lp-ac-bg-from: #e6efff;
-  --lp-ac-bg-to: #c2d4ff;
-  --lp-ac-chip: rgba(255, 255, 255, 0.78);
-  --lp-ac-stroke: rgba(15, 26, 51, 0.18);
-  --lp-ac-text: #0f1a33;
-  --lp-ac-accent: #3460c2;
+  background: #e6efff;
 
-  .lp-ac-pose {
-    fill: rgba(15, 26, 51, 0.78);
-    stroke: rgba(15, 26, 51, 0.78);
-  }
-  .lp-ac-form-track {
-    fill: rgba(15, 26, 51, 0.18);
+  &::after {
+    background: linear-gradient(
+      155deg,
+      rgba(255, 255, 255, 0) 0%,
+      rgba(15, 26, 51, 0.18) 100%
+    );
   }
 }

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -2808,8 +2808,8 @@
     </unit>
     <unit id="landing.feature.autoCount.imageAlt">
       <segment state="translated">
-        <source>Person bei Liegestützen, Smartphone daneben</source>
-        <target>Άτομο που κάνει push-ups με ένα smartphone δίπλα του</target>
+        <source>Sportlerin bei einer sauberen Liegestütze auf Holzboden</source>
+        <target>Αθλήτρια που κάνει ένα καθαρό push-up σε ξύλινο δάπεδο</target>
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.title">
@@ -2820,8 +2820,8 @@
     </unit>
     <unit id="landing.feature.autoCount.body">
       <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
-        <target>Στήσε το κινητό, άνοιξε την αυτόματη μέτρηση και ξεκίνα τις κάμψεις, τα καθίσματα, τις έλξεις ή τους κοιλιακούς – η κάμερα εντοπίζει την κίνηση και μετράει. Το ζωντανό Form Check δείχνει γωνία και αξιοπιστία ώστε να ξέρεις ότι η μέτρηση είναι καθαρή.</target>
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Στήσε το κινητό, άνοιξε την αυτόματη μέτρηση και ξεκίνα τις κάμψεις, τα καθίσματα, τις έλξεις ή τους κοιλιακούς – η τεχνητή νοημοσύνη μας αναγνωρίζει την κίνησή σου σε πραγματικό χρόνο, απευθείας στον περιηγητή, και μετράει αυτόματα. Το ζωντανό Form Check δείχνει γωνία και αξιοπιστία ώστε να ξέρεις ότι η μέτρηση είναι καθαρή.</target>
       </segment>
     </unit>
     <unit id="landing.features.aria">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -2806,6 +2806,12 @@
         <target> ✓ Δωρεάν · ✓ Χωρίς συνδρομή · ✓ Χωρίς πιστωτική κάρτα · ✓ Πρώτα προστασία δεδομένων </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.imageAlt">
+      <segment state="translated">
+        <source>Person bei Liegestützen, Smartphone daneben</source>
+        <target>Άτομο που κάνει push-ups με ένα smartphone δίπλα του</target>
+      </segment>
+    </unit>
     <unit id="landing.feature.autoCount.title">
       <segment state="translated">
         <source>Reps automatisch zählen</source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -2104,8 +2104,8 @@ Active:         </target>
         </unit>
     <unit id="landing.feature.autoCount.imageAlt">
       <segment state="translated">
-        <source>Person bei Liegestützen, Smartphone daneben</source>
-        <target>Person doing push-ups with a smartphone next to them</target>
+        <source>Sportlerin bei einer sauberen Liegestütze auf Holzboden</source>
+        <target>Athlete doing a clean push-up on a wooden floor</target>
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.title">
@@ -2116,8 +2116,8 @@ Active:         </target>
     </unit>
     <unit id="landing.feature.autoCount.body">
       <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
-        <target>Prop up your phone, open the auto-counter and start your push-ups, squats, pull-ups or sit-ups – the camera spots the motion and counts along. The live Form Check shows angle and confidence so you always know the count is clean.</target>
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Prop up your phone, open the auto-counter and start your push-ups, squats, pull-ups or sit-ups – our AI recognises your motion in real time, right in your browser, and counts along automatically. The live Form Check shows angle and confidence so you always know the count is clean.</target>
       </segment>
     </unit>
     <unit id="landing.features.aria">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -2102,6 +2102,12 @@ Active:         </target>
         <target>GDPR-friendly with customisable cookie consent. Your name on the leaderboard? Only if you want it there. No subscription, no credit card.</target>
             </segment>
         </unit>
+    <unit id="landing.feature.autoCount.imageAlt">
+      <segment state="translated">
+        <source>Person bei Liegestützen, Smartphone daneben</source>
+        <target>Person doing push-ups with a smartphone next to them</target>
+      </segment>
+    </unit>
     <unit id="landing.feature.autoCount.title">
       <segment state="translated">
         <source>Reps automatisch zählen</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -2806,6 +2806,12 @@
         <target> ✓ Gratis · ✓ Sin suscripción · ✓ Sin tarjeta de crédito · ✓ La protección de datos es lo primero </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.imageAlt">
+      <segment state="translated">
+        <source>Person bei Liegestützen, Smartphone daneben</source>
+        <target>Persona haciendo flexiones con un smartphone al lado</target>
+      </segment>
+    </unit>
     <unit id="landing.feature.autoCount.title">
       <segment state="translated">
         <source>Reps automatisch zählen</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -2808,8 +2808,8 @@
     </unit>
     <unit id="landing.feature.autoCount.imageAlt">
       <segment state="translated">
-        <source>Person bei Liegestützen, Smartphone daneben</source>
-        <target>Persona haciendo flexiones con un smartphone al lado</target>
+        <source>Sportlerin bei einer sauberen Liegestütze auf Holzboden</source>
+        <target>Atleta haciendo una flexión limpia sobre suelo de madera</target>
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.title">
@@ -2820,8 +2820,8 @@
     </unit>
     <unit id="landing.feature.autoCount.body">
       <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
-        <target>Coloca el teléfono, abre el conteo automático y empieza tus flexiones, sentadillas, dominadas o abdominales: la cámara detecta el movimiento y cuenta por ti. El Form Check en vivo muestra ángulo y confianza para que sepas que el conteo es limpio.</target>
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Coloca el teléfono, abre el conteo automático y empieza tus flexiones, sentadillas, dominadas o abdominales: nuestra IA reconoce tu movimiento en tiempo real, directamente en el navegador, y cuenta automáticamente por ti. El Form Check en vivo muestra ángulo y confianza para que sepas que el conteo es limpio.</target>
       </segment>
     </unit>
     <unit id="landing.features.aria">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -2806,6 +2806,12 @@
         <target> ✓ Gratuit · ✓ Sans abonnement · ✓ Pas de carte bancaire · ✓ La protection des données avant tout </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.imageAlt">
+      <segment state="translated">
+        <source>Person bei Liegestützen, Smartphone daneben</source>
+        <target>Personne faisant des pompes avec un smartphone à côté</target>
+      </segment>
+    </unit>
     <unit id="landing.feature.autoCount.title">
       <segment state="translated">
         <source>Reps automatisch zählen</source>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -2808,8 +2808,8 @@
     </unit>
     <unit id="landing.feature.autoCount.imageAlt">
       <segment state="translated">
-        <source>Person bei Liegestützen, Smartphone daneben</source>
-        <target>Personne faisant des pompes avec un smartphone à côté</target>
+        <source>Sportlerin bei einer sauberen Liegestütze auf Holzboden</source>
+        <target>Athlète faisant une pompe propre sur un sol en bois</target>
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.title">
@@ -2820,8 +2820,8 @@
     </unit>
     <unit id="landing.feature.autoCount.body">
       <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
-        <target>Pose ton téléphone, ouvre le comptage automatique et fais tes pompes, squats, tractions ou abdominaux – la caméra détecte le mouvement et compte pour toi. Le Form Check en direct affiche l'angle et la confiance pour que tu saches que le décompte est propre.</target>
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Pose ton téléphone, ouvre le comptage automatique et fais tes pompes, squats, tractions ou abdominaux – notre IA détecte ton mouvement en temps réel, directement dans le navigateur, et compte automatiquement pour toi. Le Form Check en direct affiche l'angle et la confiance pour que tu saches que le décompte est propre.</target>
       </segment>
     </unit>
     <unit id="landing.features.aria">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -2806,6 +2806,12 @@
         <target> ✓ Gratuito · ✓ Nessun abbonamento · ✓ Nessuna carta di credito · ✓ La tutela dei dati prima di tutto </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.imageAlt">
+      <segment state="translated">
+        <source>Person bei Liegestützen, Smartphone daneben</source>
+        <target>Persona che fa flessioni con uno smartphone accanto</target>
+      </segment>
+    </unit>
     <unit id="landing.feature.autoCount.title">
       <segment state="translated">
         <source>Reps automatisch zählen</source>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -2808,8 +2808,8 @@
     </unit>
     <unit id="landing.feature.autoCount.imageAlt">
       <segment state="translated">
-        <source>Person bei Liegestützen, Smartphone daneben</source>
-        <target>Persona che fa flessioni con uno smartphone accanto</target>
+        <source>Sportlerin bei einer sauberen Liegestütze auf Holzboden</source>
+        <target>Atleta che fa una flessione pulita su un pavimento di legno</target>
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.title">
@@ -2820,8 +2820,8 @@
     </unit>
     <unit id="landing.feature.autoCount.body">
       <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
-        <target>Appoggia il telefono, apri il conteggio automatico e fai le flessioni, gli squat, le trazioni o gli addominali – la fotocamera rileva il movimento e conta per te. Il Form Check in tempo reale mostra angolo e affidabilità così sai che il conteggio è preciso.</target>
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Appoggia il telefono, apri il conteggio automatico e fai le flessioni, gli squat, le trazioni o gli addominali – la nostra IA riconosce il tuo movimento in tempo reale, direttamente nel browser, e conta automaticamente per te. Il Form Check in tempo reale mostra angolo e affidabilità così sai che il conteggio è preciso.</target>
       </segment>
     </unit>
     <unit id="landing.features.aria">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -2806,6 +2806,12 @@
         <target> ✓ Free · ✓ No subscription · ✓ No credit card · ✓ Data protection first </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.imageAlt">
+      <segment state="translated">
+        <source>Person bei Liegestützen, Smartphone daneben</source>
+        <target>Persona flexiones faciens, telephonum apud eum positum</target>
+      </segment>
+    </unit>
     <unit id="landing.feature.autoCount.title">
       <segment state="translated">
         <source>Reps automatisch zählen</source>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -2808,8 +2808,8 @@
     </unit>
     <unit id="landing.feature.autoCount.imageAlt">
       <segment state="translated">
-        <source>Person bei Liegestützen, Smartphone daneben</source>
-        <target>Persona flexiones faciens, telephonum apud eum positum</target>
+        <source>Sportlerin bei einer sauberen Liegestütze auf Holzboden</source>
+        <target>Athleta flexionem mundam in pavimento ligneo faciens</target>
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.title">
@@ -2820,8 +2820,8 @@
     </unit>
     <unit id="landing.feature.autoCount.body">
       <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
-        <target>Telephonum pone, numeratorem automaticum aperi et pulsus, genuflexiones, tractus aut sessiones fac – camera motum cognoscit et numerat. Form-Check vivus angulum et fiduciam monstrat, ut scias numerationem mundam esse.</target>
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Telephonum pone, numeratorem automaticum aperi et pulsus, genuflexiones, tractus aut sessiones fac – intellegentia artificialis nostra motum tuum tempore vero in navigatro ipso cognoscit et automatice numerat. Form-Check vivus angulum et fiduciam monstrat, ut scias numerationem mundam esse.</target>
       </segment>
     </unit>
     <unit id="landing.features.aria">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -2806,6 +2806,12 @@
         <target> ✓ Gratis · ✓ Geen abonnement · ✓ Geen creditcard · ✓ Gegevensbescherming eerst </target>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.imageAlt">
+      <segment state="translated">
+        <source>Person bei Liegestützen, Smartphone daneben</source>
+        <target>Persoon doet opdrukken met een smartphone ernaast</target>
+      </segment>
+    </unit>
     <unit id="landing.feature.autoCount.title">
       <segment state="translated">
         <source>Reps automatisch zählen</source>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -2808,8 +2808,8 @@
     </unit>
     <unit id="landing.feature.autoCount.imageAlt">
       <segment state="translated">
-        <source>Person bei Liegestützen, Smartphone daneben</source>
-        <target>Persoon doet opdrukken met een smartphone ernaast</target>
+        <source>Sportlerin bei einer sauberen Liegestütze auf Holzboden</source>
+        <target>Atlete die een schone push-up doet op een houten vloer</target>
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.title">
@@ -2820,8 +2820,8 @@
     </unit>
     <unit id="landing.feature.autoCount.body">
       <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
-        <target>Zet de telefoon neer, open de auto-teller en doe je push-ups, squats, pull-ups of sit-ups – de camera herkent de beweging en telt mee. De live Form Check toont hoek en zekerheid, zodat je weet dat de telling klopt.</target>
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Zet de telefoon neer, open de auto-teller en doe je push-ups, squats, pull-ups of sit-ups – onze AI herkent je beweging in realtime, direct in de browser, en telt automatisch mee. De live Form Check toont hoek en zekerheid, zodat je weet dat de telling klopt.</target>
       </segment>
     </unit>
     <unit id="landing.features.aria">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -1750,8 +1750,8 @@ Aktiv:         </target>
         </unit>
     <unit id="landing.feature.autoCount.imageAlt">
       <segment state="translated">
-        <source>Person bei Liegestützen, Smartphone daneben</source>
-        <target>Person som tar armhevninger med en smarttelefon ved siden av</target>
+        <source>Sportlerin bei einer sauberen Liegestütze auf Holzboden</source>
+        <target>Idrettsutøver som tar en ren armheving på tregulv</target>
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.title">
@@ -1762,8 +1762,8 @@ Aktiv:         </target>
     </unit>
     <unit id="landing.feature.autoCount.body">
       <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
-        <target>Sett mobilen ned, åpne auto-tellingen og gjør armhevinger, knebøy, kroppshevinger eller sit-ups – kameraet ser bevegelsen og teller med. Live Form Check viser vinkel og sikkerhet slik at du vet at tellingen er ren.</target>
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>Sett mobilen ned, åpne auto-tellingen og gjør armhevinger, knebøy, kroppshevinger eller sit-ups – KI-en vår gjenkjenner bevegelsen din i sanntid, rett i nettleseren, og teller automatisk for deg. Live Form Check viser vinkel og sikkerhet slik at du vet at tellingen er ren.</target>
       </segment>
     </unit>
     <unit id="landing.features.aria">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -1748,6 +1748,12 @@ Aktiv:         </target>
         <target>GDPR-kompatibel med tilpassbar informasjonskapsel-samtykke. Ditt navn på leaderboard? Bare hvis du ønsker det. Ingen abonnement, intet kredittkort.</target>
             </segment>
         </unit>
+    <unit id="landing.feature.autoCount.imageAlt">
+      <segment state="translated">
+        <source>Person bei Liegestützen, Smartphone daneben</source>
+        <target>Person som tar armhevninger med en smarttelefon ved siden av</target>
+      </segment>
+    </unit>
     <unit id="landing.feature.autoCount.title">
       <segment state="translated">
         <source>Reps automatisch zählen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -3603,7 +3603,7 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:205,206</note>
       </notes>
       <segment>
-        <source>Person bei Liegestützen, Smartphone daneben</source>
+        <source>Sportlerin bei einer sauberen Liegestütze auf Holzboden</source>
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.title">
@@ -3619,12 +3619,12 @@
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:220,224</note>
       </notes>
       <segment>
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
       </segment>
     </unit>
     <unit id="landing.feature.multiset.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:312,314</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:313,315</note>
       </notes>
       <segment>
         <source>Multi-Set Tracking</source>
@@ -3632,7 +3632,7 @@
     </unit>
     <unit id="landing.feature.multiset.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:316,318</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:317,319</note>
       </notes>
       <segment>
         <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
@@ -3640,7 +3640,7 @@
     </unit>
     <unit id="landing.feature.analytics.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:381,383</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:382,384</note>
       </notes>
       <segment>
         <source>Charts, Trends &amp; alle Übungen</source>
@@ -3648,7 +3648,7 @@
     </unit>
     <unit id="landing.feature.analytics.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:385,389</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:386,390</note>
       </notes>
       <segment>
         <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
@@ -3656,7 +3656,7 @@
     </unit>
     <unit id="landing.feature.goals.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:483,485</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:484,486</note>
       </notes>
       <segment>
         <source>Tages-, Wochen- &amp; Monatsziele</source>
@@ -3664,7 +3664,7 @@
     </unit>
     <unit id="landing.feature.goals.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:487,490</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:488,491</note>
       </notes>
       <segment>
         <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
@@ -3672,7 +3672,7 @@
     </unit>
     <unit id="landing.feature.heatmap.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:531,533</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:532,534</note>
       </notes>
       <segment>
         <source>Heatmap-Kalender</source>
@@ -3680,7 +3680,7 @@
     </unit>
     <unit id="landing.feature.heatmap.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:535,539</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:536,540</note>
       </notes>
       <segment>
         <source>Sieh auf einen Blick, an welchen Tagen du wie hart trainiert hast. Lücken werden sichtbar – Konsistenz wird zur Gewohnheit.</source>
@@ -3688,7 +3688,7 @@
     </unit>
     <unit id="landing.feature.quick.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:545,547</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:546,548</note>
       </notes>
       <segment>
         <source>Quick Logging mit FAB</source>
@@ -3696,7 +3696,7 @@
     </unit>
     <unit id="landing.feature.quick.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:549,552</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:550,553</note>
       </notes>
       <segment>
         <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
@@ -3704,7 +3704,7 @@
     </unit>
     <unit id="landing.feature.adaptive.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:559,561</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:560,562</note>
       </notes>
       <segment>
         <source>Adaptive Vorschläge</source>
@@ -3712,7 +3712,7 @@
     </unit>
     <unit id="landing.feature.adaptive.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:563,567</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:564,568</note>
       </notes>
       <segment>
         <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
@@ -3720,7 +3720,7 @@
     </unit>
     <unit id="landing.feature.pwa.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:573,575</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:574,576</note>
       </notes>
       <segment>
         <source>App-Installation, Live-Sync &amp; Teilen</source>
@@ -3728,7 +3728,7 @@
     </unit>
     <unit id="landing.feature.pwa.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:577,580</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:578,581</note>
       </notes>
       <segment>
         <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
@@ -3736,7 +3736,7 @@
     </unit>
     <unit id="landing.feature.pwa.installed">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:584,586</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:585,587</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">check_circle</pc> Du nutzt bereits die installierte App </source>
@@ -3744,7 +3744,7 @@
     </unit>
     <unit id="landing.feature.pwa.install">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:597,599</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:598,600</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">download</pc> Jetzt als App installieren </source>
@@ -3752,7 +3752,7 @@
     </unit>
     <unit id="landing.feature.pwa.iosHint">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:604,607</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:605,608</note>
       </notes>
       <segment>
         <source> Auf iPhone &amp; iPad: Teilen-Symbol antippen und „Zum Home-Bildschirm“ wählen. </source>
@@ -3760,7 +3760,7 @@
     </unit>
     <unit id="landing.feature.privacy.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:615,617</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:616,618</note>
       </notes>
       <segment>
         <source>Privacy first &amp; 100 % kostenlos</source>
@@ -3768,7 +3768,7 @@
     </unit>
     <unit id="landing.feature.privacy.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:619,623</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:620,624</note>
       </notes>
       <segment>
         <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
@@ -3776,7 +3776,7 @@
     </unit>
     <unit id="ads.landing.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:625</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:626</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -3784,7 +3784,7 @@
     </unit>
     <unit id="landing.preview.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:634,636</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:635,637</note>
       </notes>
       <segment>
         <source> Deine Statistik auf einen Blick </source>
@@ -3792,7 +3792,7 @@
     </unit>
     <unit id="landing.preview.alt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:641,642</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:642,643</note>
       </notes>
       <segment>
         <source>Vorschau der Statistikansicht</source>
@@ -3800,7 +3800,7 @@
     </unit>
     <unit id="landing.discover.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:782,783</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:783,784</note>
       </notes>
       <segment>
         <source>Mehr entdecken</source>
@@ -3808,7 +3808,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:788,790</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:789,791</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3816,7 +3816,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:792,795</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:793,796</note>
       </notes>
       <segment>
         <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
@@ -3824,7 +3824,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:802,805</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:803,806</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -3832,7 +3832,7 @@
     </unit>
     <unit id="landing.discover.blog.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:811,813</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:812,814</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3840,7 +3840,7 @@
     </unit>
     <unit id="landing.discover.blog.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:815,818</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:816,819</note>
       </notes>
       <segment>
         <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
@@ -3848,7 +3848,7 @@
     </unit>
     <unit id="landing.discover.blog.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:825,827</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:826,828</note>
       </notes>
       <segment>
         <source>Zum Blog</source>
@@ -5083,6 +5083,22 @@
       </notes>
       <segment>
         <source> Keine Sets-Daten vorhanden </source>
+      </segment>
+    </unit>
+    <unit id="intervalsDistribution.noData">
+      <notes>
+        <note category="location">web/src/app/stats/components/intervals-distribution/intervals-distribution.component.ts</note>
+      </notes>
+      <segment>
+        <source> Keine Intervall-Daten vorhanden </source>
+      </segment>
+    </unit>
+    <unit id="intervalsDistribution.listLabel">
+      <notes>
+        <note category="location">web/src/app/stats/components/intervals-distribution/intervals-distribution.component.ts</note>
+      </notes>
+      <segment>
+        <source>Intervall-Verteilung</source>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -3598,9 +3598,17 @@
         <source>Funktionen</source>
       </segment>
     </unit>
+    <unit id="landing.feature.autoCount.imageAlt">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:205,206</note>
+      </notes>
+      <segment>
+        <source>Person bei Liegestützen, Smartphone daneben</source>
+      </segment>
+    </unit>
     <unit id="landing.feature.autoCount.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:240,242</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:216,218</note>
       </notes>
       <segment>
         <source>Reps automatisch zählen</source>
@@ -3608,7 +3616,7 @@
     </unit>
     <unit id="landing.feature.autoCount.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:244,248</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:220,224</note>
       </notes>
       <segment>
         <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
@@ -3616,7 +3624,7 @@
     </unit>
     <unit id="landing.feature.multiset.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:336,338</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:312,314</note>
       </notes>
       <segment>
         <source>Multi-Set Tracking</source>
@@ -3624,7 +3632,7 @@
     </unit>
     <unit id="landing.feature.multiset.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:340,342</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:316,318</note>
       </notes>
       <segment>
         <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
@@ -3632,7 +3640,7 @@
     </unit>
     <unit id="landing.feature.analytics.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:405,407</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:381,383</note>
       </notes>
       <segment>
         <source>Charts, Trends &amp; alle Übungen</source>
@@ -3640,7 +3648,7 @@
     </unit>
     <unit id="landing.feature.analytics.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:409,413</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:385,389</note>
       </notes>
       <segment>
         <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
@@ -3648,7 +3656,7 @@
     </unit>
     <unit id="landing.feature.goals.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:507,509</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:483,485</note>
       </notes>
       <segment>
         <source>Tages-, Wochen- &amp; Monatsziele</source>
@@ -3656,7 +3664,7 @@
     </unit>
     <unit id="landing.feature.goals.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:511,514</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:487,490</note>
       </notes>
       <segment>
         <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
@@ -3664,7 +3672,7 @@
     </unit>
     <unit id="landing.feature.heatmap.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:555,557</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:531,533</note>
       </notes>
       <segment>
         <source>Heatmap-Kalender</source>
@@ -3672,7 +3680,7 @@
     </unit>
     <unit id="landing.feature.heatmap.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:559,563</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:535,539</note>
       </notes>
       <segment>
         <source>Sieh auf einen Blick, an welchen Tagen du wie hart trainiert hast. Lücken werden sichtbar – Konsistenz wird zur Gewohnheit.</source>
@@ -3680,7 +3688,7 @@
     </unit>
     <unit id="landing.feature.quick.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:569,571</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:545,547</note>
       </notes>
       <segment>
         <source>Quick Logging mit FAB</source>
@@ -3688,7 +3696,7 @@
     </unit>
     <unit id="landing.feature.quick.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:573,576</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:549,552</note>
       </notes>
       <segment>
         <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
@@ -3696,7 +3704,7 @@
     </unit>
     <unit id="landing.feature.adaptive.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:583,585</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:559,561</note>
       </notes>
       <segment>
         <source>Adaptive Vorschläge</source>
@@ -3704,7 +3712,7 @@
     </unit>
     <unit id="landing.feature.adaptive.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:587,591</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:563,567</note>
       </notes>
       <segment>
         <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
@@ -3712,7 +3720,7 @@
     </unit>
     <unit id="landing.feature.pwa.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:597,599</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:573,575</note>
       </notes>
       <segment>
         <source>App-Installation, Live-Sync &amp; Teilen</source>
@@ -3720,7 +3728,7 @@
     </unit>
     <unit id="landing.feature.pwa.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:601,604</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:577,580</note>
       </notes>
       <segment>
         <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
@@ -3728,7 +3736,7 @@
     </unit>
     <unit id="landing.feature.pwa.installed">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:608,610</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:584,586</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">check_circle</pc> Du nutzt bereits die installierte App </source>
@@ -3736,7 +3744,7 @@
     </unit>
     <unit id="landing.feature.pwa.install">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:621,623</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:597,599</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">download</pc> Jetzt als App installieren </source>
@@ -3744,7 +3752,7 @@
     </unit>
     <unit id="landing.feature.pwa.iosHint">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:628,631</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:604,607</note>
       </notes>
       <segment>
         <source> Auf iPhone &amp; iPad: Teilen-Symbol antippen und „Zum Home-Bildschirm“ wählen. </source>
@@ -3752,7 +3760,7 @@
     </unit>
     <unit id="landing.feature.privacy.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:639,641</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:615,617</note>
       </notes>
       <segment>
         <source>Privacy first &amp; 100 % kostenlos</source>
@@ -3760,7 +3768,7 @@
     </unit>
     <unit id="landing.feature.privacy.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:643,647</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:619,623</note>
       </notes>
       <segment>
         <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
@@ -3768,7 +3776,7 @@
     </unit>
     <unit id="ads.landing.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:649</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:625</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -3776,7 +3784,7 @@
     </unit>
     <unit id="landing.preview.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:658,660</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:634,636</note>
       </notes>
       <segment>
         <source> Deine Statistik auf einen Blick </source>
@@ -3784,7 +3792,7 @@
     </unit>
     <unit id="landing.preview.alt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:665,666</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:641,642</note>
       </notes>
       <segment>
         <source>Vorschau der Statistikansicht</source>
@@ -3792,7 +3800,7 @@
     </unit>
     <unit id="landing.discover.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:806,807</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:782,783</note>
       </notes>
       <segment>
         <source>Mehr entdecken</source>
@@ -3800,7 +3808,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:812,814</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:788,790</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3808,7 +3816,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:816,819</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:792,795</note>
       </notes>
       <segment>
         <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
@@ -3816,7 +3824,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:826,829</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:802,805</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -3824,7 +3832,7 @@
     </unit>
     <unit id="landing.discover.blog.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:835,837</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:811,813</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3832,7 +3840,7 @@
     </unit>
     <unit id="landing.discover.blog.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:839,842</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:815,818</note>
       </notes>
       <segment>
         <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
@@ -3840,7 +3848,7 @@
     </unit>
     <unit id="landing.discover.blog.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:849,851</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:825,827</note>
       </notes>
       <segment>
         <source>Zum Blog</source>
@@ -5075,22 +5083,6 @@
       </notes>
       <segment>
         <source> Keine Sets-Daten vorhanden </source>
-      </segment>
-    </unit>
-    <unit id="intervalsDistribution.noData">
-      <notes>
-        <note category="location">web/src/app/stats/components/intervals-distribution/intervals-distribution.component.ts</note>
-      </notes>
-      <segment>
-        <source> Keine Intervall-Daten vorhanden </source>
-      </segment>
-    </unit>
-    <unit id="intervalsDistribution.listLabel">
-      <notes>
-        <note category="location">web/src/app/stats/components/intervals-distribution/intervals-distribution.component.ts</note>
-      </notes>
-      <segment>
-        <source>Intervall-Verteilung</source>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -3495,6 +3495,12 @@
         <source> ✓ Kostenlos · ✓ Kein Abo · ✓ Keine Kreditkarte · ✓ Datenschutz first </source>
       <target> ✓ 完全免费 · ✓ 无需订阅 · ✓ 无需信用卡 · ✓ 隐私优先 </target></segment>
     </unit>
+    <unit id="landing.feature.autoCount.imageAlt">
+      <segment state="translated">
+        <source>Person bei Liegestützen, Smartphone daneben</source>
+        <target>做俯卧撑的人，旁边放着一部智能手机</target>
+      </segment>
+    </unit>
     <unit id="landing.feature.autoCount.title">
       <segment state="translated">
         <source>Reps automatisch zählen</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -3497,8 +3497,8 @@
     </unit>
     <unit id="landing.feature.autoCount.imageAlt">
       <segment state="translated">
-        <source>Person bei Liegestützen, Smartphone daneben</source>
-        <target>做俯卧撑的人，旁边放着一部智能手机</target>
+        <source>Sportlerin bei einer sauberen Liegestütze auf Holzboden</source>
+        <target>女运动员在木地板上做标准俯卧撑</target>
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.title">
@@ -3509,8 +3509,8 @@
     </unit>
     <unit id="landing.feature.autoCount.body">
       <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – die Kamera erkennt die Bewegung und zählt mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
-        <target>把手机放好,打开自动计数,然后开始做俯卧撑、深蹲、引体向上或仰卧起坐——相机识别动作并自动计数。实时动作检查显示角度和置信度,让你随时知道计数是否准确。</target>
+        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+        <target>把手机放好,打开自动计数,然后开始做俯卧撑、深蹲、引体向上或仰卧起坐——我们的 AI 直接在浏览器中实时识别你的动作并自动计数。实时动作检查显示角度和置信度,让你随时知道计数是否准确。</target>
       </segment>
     </unit>
     <unit id="landing.features.aria">


### PR DESCRIPTION
The stylised auto-count SVG (pose silhouette + count chip + form
bars) didn't read well at card size and looked off-brand. Swap in a
real Unsplash photo of someone doing pushups so the card matches the
photographic blog hero style. Adds a localised alt text across all
nine translation files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Refreshed the "auto count" feature card on the landing page with a new photograph and a diagonal overlay for consistent appearance.
  * Improved image loading and rendering with explicit sizing, lazy-loading, async decoding, and tuned focal-point positioning for reliable visual presentation.
  * Clarified feature copy to state real-time AI recognition and live form check in the browser.

* **Localization**
  * Added and updated image alt-text and feature descriptions across multiple languages for better accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/356)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->