### PR TITLE
feat(auto-count): timer counter for isometric holds (plank, hollow hold)

### DIFF
--- a/libs/auto-count/src/index.ts
+++ b/libs/auto-count/src/index.ts
@@ -40,3 +40,20 @@ export {
   PoseRepCounterService,
   type FormCheckFrame,
 } from './lib/pose-rep-counter.service';
+export type { ExerciseHoldProfile } from './lib/exercise-hold-profile';
+export {
+  PLANK_HOLD_PROFILE,
+  HOLLOWHOLD_PROFILE,
+  holdProfileFor,
+  listHoldProfiles,
+} from './lib/exercise-hold-profile';
+export {
+  HoldStateMachine,
+  type HoldPhase,
+  type HoldSnapshot,
+} from './lib/hold-state-machine';
+export {
+  PoseHoldTimerService,
+  type HoldFormCheckFrame,
+  type HoldTimerStartOptions,
+} from './lib/pose-hold-timer.service';

--- a/libs/auto-count/src/lib/exercise-hold-profile.spec.ts
+++ b/libs/auto-count/src/lib/exercise-hold-profile.spec.ts
@@ -1,0 +1,31 @@
+import {
+  HOLLOWHOLD_PROFILE,
+  PLANK_HOLD_PROFILE,
+  holdProfileFor,
+  listHoldProfiles,
+} from './exercise-hold-profile';
+
+describe('exercise-hold-profile', () => {
+  it('given the plank id, when looked up, then returns the plank profile', () => {
+    expect(holdProfileFor('plank')).toBe(PLANK_HOLD_PROFILE);
+  });
+
+  it('given the hollow-hold id, when looked up, then returns the hollow-hold profile', () => {
+    expect(holdProfileFor('hollowhold')).toBe(HOLLOWHOLD_PROFILE);
+  });
+
+  it('given an unknown id, when looked up, then returns null', () => {
+    expect(holdProfileFor('totally-unknown')).toBeNull();
+  });
+
+  it('given listHoldProfiles, when called, then returns at least plank and hollow hold', () => {
+    const ids = listHoldProfiles().map((p) => p.id);
+    expect(ids).toEqual(expect.arrayContaining(['plank', 'hollowhold']));
+  });
+
+  it('given any profile, when inspected, then outPoseAngleDeg is strictly less than inPoseAngleDeg (hysteresis)', () => {
+    for (const profile of listHoldProfiles()) {
+      expect(profile.outPoseAngleDeg).toBeLessThan(profile.inPoseAngleDeg);
+    }
+  });
+});

--- a/libs/auto-count/src/lib/exercise-hold-profile.ts
+++ b/libs/auto-count/src/lib/exercise-hold-profile.ts
@@ -1,0 +1,90 @@
+import type { JointTriplet } from './exercise-angle-profile';
+import { POSE_LANDMARK } from './pose-detector.port';
+
+/**
+ * Tuning parameters for an isometric-hold detector (plank, hollow hold,
+ * wall sit, …). Parallel to {@link ExerciseAngleProfile} but with two
+ * debounce thresholds — entering vs leaving the hold — so brief
+ * mid-set wobbles don't stop the timer while a real "stand up" does.
+ *
+ * The angle is read at the same triplet as the rep detector; for a
+ * plank that's hip flexion (`shoulder-hip-knee`): ≥ ~160° means the
+ * body is straight (in pose) and ≤ ~140° means the hip sagged or the
+ * user stood up (out of pose).
+ */
+export interface ExerciseHoldProfile {
+  readonly id: string;
+  readonly tripletLeft: JointTriplet;
+  readonly tripletRight: JointTriplet;
+  /** Angle in degrees at/above which the joint counts as "in pose". */
+  readonly inPoseAngleDeg: number;
+  /** Angle in degrees at/below which the joint counts as "out of pose". Below `inPoseAngleDeg` for hysteresis. */
+  readonly outPoseAngleDeg: number;
+  /** Min ms an "in pose" candidate must persist before the timer starts. */
+  readonly minHoldMs: number;
+  /** Min ms an "out of pose" candidate must persist before the timer pauses. */
+  readonly minBreakMs: number;
+  /** Per-sample confidence floor; lower samples are dropped. */
+  readonly minConfidence: number;
+  /**
+   * Max ms attributed to a single inter-sample gap. Caps the credit
+   * applied when the detector loses tracking for a while, so a dropped
+   * camera frame doesn't silently add seconds to the hold time.
+   */
+  readonly maxFrameGapMs: number;
+}
+
+const HIP_TRIPLETS = {
+  left: [
+    POSE_LANDMARK.LEFT_SHOULDER,
+    POSE_LANDMARK.LEFT_HIP,
+    POSE_LANDMARK.LEFT_KNEE,
+  ] as const,
+  right: [
+    POSE_LANDMARK.RIGHT_SHOULDER,
+    POSE_LANDMARK.RIGHT_HIP,
+    POSE_LANDMARK.RIGHT_KNEE,
+  ] as const,
+} satisfies { left: JointTriplet; right: JointTriplet };
+
+export const PLANK_HOLD_PROFILE: ExerciseHoldProfile = {
+  id: 'plank',
+  tripletLeft: HIP_TRIPLETS.left,
+  tripletRight: HIP_TRIPLETS.right,
+  inPoseAngleDeg: 160,
+  outPoseAngleDeg: 140,
+  minHoldMs: 600,
+  minBreakMs: 800,
+  minConfidence: 0.4,
+  maxFrameGapMs: 700,
+};
+
+/**
+ * Hollow hold uses the same hip-flexion triplet as plank, but lying
+ * supine with arms/legs raised. The shoulder-hip-knee angle stays open
+ * (body in a banana shape) — collapsing to flat means the hold is lost.
+ */
+export const HOLLOWHOLD_PROFILE: ExerciseHoldProfile = {
+  id: 'hollowhold',
+  tripletLeft: HIP_TRIPLETS.left,
+  tripletRight: HIP_TRIPLETS.right,
+  inPoseAngleDeg: 150,
+  outPoseAngleDeg: 130,
+  minHoldMs: 600,
+  minBreakMs: 800,
+  minConfidence: 0.4,
+  maxFrameGapMs: 700,
+};
+
+const HOLD_PROFILES: ReadonlyMap<string, ExerciseHoldProfile> = new Map([
+  [PLANK_HOLD_PROFILE.id, PLANK_HOLD_PROFILE],
+  [HOLLOWHOLD_PROFILE.id, HOLLOWHOLD_PROFILE],
+]);
+
+export function holdProfileFor(exerciseId: string): ExerciseHoldProfile | null {
+  return HOLD_PROFILES.get(exerciseId) ?? null;
+}
+
+export function listHoldProfiles(): ReadonlyArray<ExerciseHoldProfile> {
+  return [...HOLD_PROFILES.values()];
+}

--- a/libs/auto-count/src/lib/hold-state-machine.spec.ts
+++ b/libs/auto-count/src/lib/hold-state-machine.spec.ts
@@ -152,4 +152,23 @@ describe('HoldStateMachine (plank profile)', () => {
     expect(machine.snapshot().phase).toBe('holding');
     expect(machine.snapshot().totalMs).toBeGreaterThan(totalAtStart);
   });
+
+  it('given a leave-candidate followed by dead-zone samples, when processed, then accumulation continues (no display freeze)', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    feed(machine, [
+      sample(0, inPose),
+      sample(300, inPose),
+      sample(600, inPose),
+    ]);
+    const totalAtHolding = machine.snapshot().totalMs;
+    // Out-zone arms a leave candidate; the immediate next sample
+    // drifts back into the hysteresis dead-zone (between in- and
+    // out-thresholds). Pre-fix, accumulation froze here because the
+    // dead-zone branch guarded against an active candidate. Post-fix
+    // the timer keeps ticking forward until a decisive sample resolves
+    // the candidate.
+    feed(machine, [sample(700, outPose), sample(900, 150), sample(1100, 150)]);
+    expect(machine.snapshot().phase).toBe('holding');
+    expect(machine.snapshot().totalMs).toBeGreaterThan(totalAtHolding);
+  });
 });

--- a/libs/auto-count/src/lib/hold-state-machine.spec.ts
+++ b/libs/auto-count/src/lib/hold-state-machine.spec.ts
@@ -1,0 +1,155 @@
+import { PLANK_HOLD_PROFILE } from './exercise-hold-profile';
+import { HoldStateMachine } from './hold-state-machine';
+import type { PoseSample } from './pose-sample';
+
+const sample = (
+  timestampMs: number,
+  angleDeg: number,
+  confidence = 0.9
+): PoseSample => ({ timestampMs, angleDeg, confidence });
+
+const feed = (machine: HoldStateMachine, samples: PoseSample[]): void => {
+  for (const s of samples) machine.process(s);
+};
+
+const inPose = 170;
+const outPose = 110;
+
+describe('HoldStateMachine (plank profile)', () => {
+  it('given a fresh machine, when snapshot is read, then totalMs is 0 and phase idle', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    expect(machine.snapshot()).toEqual({
+      totalMs: 0,
+      phase: 'idle',
+      segmentStartMs: null,
+    });
+  });
+
+  it('given in-pose samples below minHoldMs, when processed, then phase is still idle', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    feed(machine, [
+      sample(0, inPose),
+      sample(200, inPose),
+      sample(500, inPose),
+    ]);
+    expect(machine.snapshot().phase).toBe('idle');
+    expect(machine.snapshot().totalMs).toBe(0);
+  });
+
+  it('given in-pose samples crossing minHoldMs, when processed, then phase becomes holding and segmentStartMs is the first in-pose sample', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    feed(machine, [
+      sample(0, inPose),
+      sample(300, inPose),
+      sample(600, inPose),
+    ]);
+    expect(machine.snapshot().phase).toBe('holding');
+    expect(machine.snapshot().segmentStartMs).toBe(0);
+  });
+
+  it('given a steady 5-second hold, when processed, then totalMs ≈ 5000', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    const samples: PoseSample[] = [];
+    for (let t = 0; t <= 5000; t += 100) samples.push(sample(t, inPose));
+    feed(machine, samples);
+    expect(machine.snapshot().phase).toBe('holding');
+    expect(machine.snapshot().totalMs).toBe(5000);
+  });
+
+  it('given a hold then a confirmed break, when processed, then phase becomes paused and totalMs is preserved at the break boundary', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    const samples: PoseSample[] = [];
+    for (let t = 0; t <= 3000; t += 100) samples.push(sample(t, inPose));
+    for (let t = 3100; t <= 5000; t += 100) samples.push(sample(t, outPose));
+    feed(machine, samples);
+    expect(machine.snapshot().phase).toBe('paused');
+    expect(machine.snapshot().totalMs).toBeGreaterThanOrEqual(2900);
+    expect(machine.snapshot().totalMs).toBeLessThanOrEqual(3100);
+  });
+
+  it('given a brief out-of-pose blip shorter than minBreakMs, when processed, then the timer keeps running', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    const samples: PoseSample[] = [];
+    for (let t = 0; t <= 3000; t += 100) samples.push(sample(t, inPose));
+    samples.push(sample(3100, outPose));
+    samples.push(sample(3300, outPose));
+    for (let t = 3400; t <= 5000; t += 100) samples.push(sample(t, inPose));
+    feed(machine, samples);
+    expect(machine.snapshot().phase).toBe('holding');
+    expect(machine.snapshot().totalMs).toBeGreaterThanOrEqual(4500);
+  });
+
+  it('given a paused machine, when in-pose resumes, then totalMs continues from the previous total', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    const samples: PoseSample[] = [];
+    for (let t = 0; t <= 3000; t += 100) samples.push(sample(t, inPose));
+    for (let t = 3100; t <= 5000; t += 100) samples.push(sample(t, outPose));
+    feed(machine, samples);
+    const totalAfterPause = machine.snapshot().totalMs;
+
+    const resume: PoseSample[] = [];
+    for (let t = 6000; t <= 9000; t += 100) resume.push(sample(t, inPose));
+    feed(machine, resume);
+
+    expect(machine.snapshot().phase).toBe('holding');
+    expect(machine.snapshot().totalMs).toBeGreaterThan(totalAfterPause);
+    expect(machine.snapshot().totalMs).toBeLessThanOrEqual(
+      totalAfterPause + 3000
+    );
+  });
+
+  it('given samples below minConfidence only, when processed, then they are dropped and the machine stays idle', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    feed(machine, [
+      sample(0, inPose, 0.1),
+      sample(300, inPose, 0.1),
+      sample(600, inPose, 0.1),
+    ]);
+    expect(machine.snapshot().phase).toBe('idle');
+    expect(machine.snapshot().totalMs).toBe(0);
+  });
+
+  it('given a long inter-sample gap during holding, when processed, then the gap credit is capped at maxFrameGapMs', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    feed(machine, [
+      sample(0, inPose),
+      sample(300, inPose),
+      sample(600, inPose),
+    ]);
+    expect(machine.snapshot().phase).toBe('holding');
+    const totalAtStart = machine.snapshot().totalMs;
+    feed(machine, [sample(10_000, inPose)]);
+    const delta = machine.snapshot().totalMs - totalAtStart;
+    expect(delta).toBe(PLANK_HOLD_PROFILE.maxFrameGapMs);
+  });
+
+  it('given reset, when called, then state returns to idle/0', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    feed(machine, [
+      sample(0, inPose),
+      sample(500, inPose),
+      sample(1000, inPose),
+      sample(1500, inPose),
+    ]);
+    expect(machine.snapshot().phase).toBe('holding');
+    machine.reset();
+    expect(machine.snapshot()).toEqual({
+      totalMs: 0,
+      phase: 'idle',
+      segmentStartMs: null,
+    });
+  });
+
+  it('given an angle in the hysteresis dead-zone while holding, when processed, then the timer keeps accumulating', () => {
+    const machine = new HoldStateMachine(PLANK_HOLD_PROFILE);
+    feed(machine, [
+      sample(0, inPose),
+      sample(300, inPose),
+      sample(600, inPose),
+    ]);
+    const totalAtStart = machine.snapshot().totalMs;
+    feed(machine, [sample(800, 150)]);
+    expect(machine.snapshot().phase).toBe('holding');
+    expect(machine.snapshot().totalMs).toBeGreaterThan(totalAtStart);
+  });
+});

--- a/libs/auto-count/src/lib/hold-state-machine.ts
+++ b/libs/auto-count/src/lib/hold-state-machine.ts
@@ -59,9 +59,16 @@ export class HoldStateMachine {
 
     if (zone === 'dead') {
       // Dead-zone samples preserve phase intent: keep accumulating
-      // while holding, leave debounce candidate untouched. They do
-      // not on their own commit or cancel a candidate transition.
-      if (this.phase === 'holding' && this.candidate === null) {
+      // while holding (regardless of any pending leave candidate),
+      // and leave any debounce candidate untouched. They do not on
+      // their own commit or cancel a candidate transition, so an
+      // active leave candidate neither advances toward `paused` nor
+      // resets — the next decisive in/out sample resolves it. Without
+      // accumulating here, the displayed time would freeze for the
+      // duration of the leave debounce when the user briefly drifts
+      // through the hysteresis dead-zone, then jump on the next in-
+      // zone sample.
+      if (this.phase === 'holding') {
         this.accumulate(sample.timestampMs);
       }
       return this.snapshot();

--- a/libs/auto-count/src/lib/hold-state-machine.ts
+++ b/libs/auto-count/src/lib/hold-state-machine.ts
@@ -1,0 +1,181 @@
+import type { ExerciseHoldProfile } from './exercise-hold-profile';
+import type { PoseSample } from './pose-sample';
+
+export type HoldPhase = 'idle' | 'holding' | 'paused';
+
+export interface HoldSnapshot {
+  /** Total accumulated time the user has been in pose, in milliseconds. */
+  readonly totalMs: number;
+  readonly phase: HoldPhase;
+  /**
+   * Timestamp (ms) of the first sample that entered the currently
+   * active holding segment. `null` while idle or paused. Useful for
+   * UIs that want to show a per-segment timer alongside the running
+   * total.
+   */
+  readonly segmentStartMs: number | null;
+}
+
+type Zone = 'in' | 'out' | 'dead';
+
+type Candidate =
+  | { readonly kind: 'enter'; sinceMs: number; lastSeenMs: number }
+  | { readonly kind: 'leave'; sinceMs: number; lastSeenMs: number }
+  | null;
+
+/**
+ * Pure, frame-by-frame isometric-hold detector. Counts accumulated
+ * time-in-pose for exercises like plank or hollow hold. Hysteresis
+ * splits each frame into one of three zones (in / out / dead) using
+ * separate `inPoseAngleDeg` and `outPoseAngleDeg` thresholds, and
+ * symmetric debounce windows guard against pose flicker from camera
+ * noise:
+ *   - entering the hold requires `minHoldMs` of in-zone samples;
+ *   - leaving the hold requires `minBreakMs` of out-zone samples.
+ *
+ * Dead-zone samples (between the two thresholds) preserve the current
+ * phase intent — they neither commit a transition nor stop accumulation
+ * during an active hold — so a slow movement through the middle of the
+ * range doesn't repeatedly reset the debounce candidates.
+ *
+ * Inter-sample gaps are credited up to `profile.maxFrameGapMs`, so a
+ * dropped camera frame can't silently add seconds to the total.
+ */
+export class HoldStateMachine {
+  private totalMs = 0;
+  private phase: HoldPhase = 'idle';
+  private segmentStartMs: number | null = null;
+  private lastTickMs: number | null = null;
+  private candidate: Candidate = null;
+
+  constructor(private readonly profile: ExerciseHoldProfile) {}
+
+  process(sample: PoseSample): HoldSnapshot {
+    if (sample.confidence < this.profile.minConfidence) {
+      return this.snapshot();
+    }
+
+    const zone = this.zoneFor(sample.angleDeg);
+
+    if (zone === 'dead') {
+      // Dead-zone samples preserve phase intent: keep accumulating
+      // while holding, leave debounce candidate untouched. They do
+      // not on their own commit or cancel a candidate transition.
+      if (this.phase === 'holding' && this.candidate === null) {
+        this.accumulate(sample.timestampMs);
+      }
+      return this.snapshot();
+    }
+
+    switch (this.phase) {
+      case 'idle':
+      case 'paused':
+        if (zone === 'in') {
+          this.advanceEnterCandidate(sample.timestampMs);
+        } else {
+          this.candidate = null;
+        }
+        break;
+      case 'holding':
+        if (zone === 'in') {
+          this.candidate = null;
+          this.accumulate(sample.timestampMs);
+        } else {
+          // Out-zone while holding: start/extend a leave candidate.
+          // Do not accumulate during the candidate — the segment is
+          // tentatively paused until either it confirms (→ paused)
+          // or it is cancelled by a return to in-zone.
+          this.advanceLeaveCandidate(sample.timestampMs);
+        }
+        break;
+    }
+
+    return this.snapshot();
+  }
+
+  reset(): void {
+    this.totalMs = 0;
+    this.phase = 'idle';
+    this.segmentStartMs = null;
+    this.lastTickMs = null;
+    this.candidate = null;
+  }
+
+  snapshot(): HoldSnapshot {
+    return {
+      totalMs: this.totalMs,
+      phase: this.phase,
+      segmentStartMs: this.segmentStartMs,
+    };
+  }
+
+  private zoneFor(angleDeg: number): Zone {
+    if (angleDeg >= this.profile.inPoseAngleDeg) return 'in';
+    if (angleDeg <= this.profile.outPoseAngleDeg) return 'out';
+    return 'dead';
+  }
+
+  private accumulate(timestampMs: number): void {
+    if (this.lastTickMs !== null) {
+      const delta = Math.min(
+        timestampMs - this.lastTickMs,
+        this.profile.maxFrameGapMs
+      );
+      if (delta > 0) this.totalMs += delta;
+    }
+    this.lastTickMs = timestampMs;
+  }
+
+  private advanceEnterCandidate(timestampMs: number): void {
+    if (
+      this.candidate === null ||
+      this.candidate.kind !== 'enter' ||
+      timestampMs - this.candidate.lastSeenMs > this.profile.maxFrameGapMs
+    ) {
+      this.candidate = {
+        kind: 'enter',
+        sinceMs: timestampMs,
+        lastSeenMs: timestampMs,
+      };
+    } else {
+      this.candidate.lastSeenMs = timestampMs;
+    }
+
+    const dwell = this.candidate.lastSeenMs - this.candidate.sinceMs;
+    if (dwell >= this.profile.minHoldMs) {
+      // Back-credit the dwell window. The user has been in pose this
+      // whole time; the dwell exists only because the detector needed
+      // confirmation before flipping to "holding". Without this credit
+      // a 1-second hold would show ~0.4s on screen, which feels wrong.
+      this.phase = 'holding';
+      this.segmentStartMs = this.candidate.sinceMs;
+      this.totalMs += dwell;
+      this.lastTickMs = timestampMs;
+      this.candidate = null;
+    }
+  }
+
+  private advanceLeaveCandidate(timestampMs: number): void {
+    if (
+      this.candidate === null ||
+      this.candidate.kind !== 'leave' ||
+      timestampMs - this.candidate.lastSeenMs > this.profile.maxFrameGapMs
+    ) {
+      this.candidate = {
+        kind: 'leave',
+        sinceMs: timestampMs,
+        lastSeenMs: timestampMs,
+      };
+    } else {
+      this.candidate.lastSeenMs = timestampMs;
+    }
+
+    const dwell = this.candidate.lastSeenMs - this.candidate.sinceMs;
+    if (dwell >= this.profile.minBreakMs) {
+      this.phase = 'paused';
+      this.segmentStartMs = null;
+      this.lastTickMs = null;
+      this.candidate = null;
+    }
+  }
+}

--- a/libs/auto-count/src/lib/pose-hold-timer.service.spec.ts
+++ b/libs/auto-count/src/lib/pose-hold-timer.service.spec.ts
@@ -1,0 +1,231 @@
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  POSE_DETECTOR_FACTORY,
+  POSE_LANDMARK,
+  type PoseDetectionResult,
+  type PoseDetector,
+  type PoseLandmark,
+} from './pose-detector.port';
+import {
+  POSE_FRAME_SOURCE,
+  type FrameTick,
+  type PoseFrameSource,
+} from './pose-frame-source.port';
+import { PoseHoldTimerService } from './pose-hold-timer.service';
+
+class FakeDetector implements PoseDetector {
+  script: ReadonlyArray<ReadonlyArray<PoseLandmark>> = [];
+  cursor = 0;
+  closed = false;
+  detectForVideo(): PoseDetectionResult {
+    const lm = this.script[this.cursor++] ?? [];
+    return { landmarks: lm.length ? [lm] : [] };
+  }
+  close(): void {
+    this.closed = true;
+  }
+}
+
+class FakeFrameSource implements PoseFrameSource {
+  private cb: ((t: FrameTick) => void) | null = null;
+  videoBound: HTMLVideoElement | null = null;
+  subscribed = 0;
+  unsubscribed = 0;
+  subscribe(video: HTMLVideoElement, cb: (t: FrameTick) => void): () => void {
+    this.videoBound = video;
+    this.cb = cb;
+    this.subscribed += 1;
+    return () => {
+      this.cb = null;
+      this.unsubscribed += 1;
+    };
+  }
+  emit(timestampMs: number): void {
+    this.cb?.({ timestampMs });
+  }
+}
+
+const VISIBLE = 0.9;
+const makeLandmarks = (
+  overrides: Partial<Record<number, PoseLandmark>>
+): ReadonlyArray<PoseLandmark> => {
+  const arr: PoseLandmark[] = [];
+  for (let i = 0; i < 33; i++) arr[i] = { x: 0, y: 0, visibility: 0 };
+  for (const [idx, lm] of Object.entries(overrides)) {
+    if (lm) arr[Number(idx)] = lm;
+  }
+  return arr;
+};
+
+/**
+ * Hip-flexion triplet near 180° (body straight). Shoulder ←→ hip ←→ knee
+ * are co-linear in x, with the hip in the middle, so the joint angle
+ * is 180° — well inside the plank `inPoseAngleDeg = 160`.
+ */
+const STRAIGHT_PLANK = makeLandmarks({
+  [POSE_LANDMARK.LEFT_SHOULDER]: { x: 0, y: 0, visibility: VISIBLE },
+  [POSE_LANDMARK.LEFT_HIP]: { x: 1, y: 0, visibility: VISIBLE },
+  [POSE_LANDMARK.LEFT_KNEE]: { x: 2, y: 0, visibility: VISIBLE },
+});
+
+/**
+ * Hip sagged — knee dropped sharply, producing a ~90° angle at the hip,
+ * well below the plank `outPoseAngleDeg = 140`.
+ */
+const SAGGED_HIP = makeLandmarks({
+  [POSE_LANDMARK.LEFT_SHOULDER]: { x: 0, y: 0, visibility: VISIBLE },
+  [POSE_LANDMARK.LEFT_HIP]: { x: 1, y: 0, visibility: VISIBLE },
+  [POSE_LANDMARK.LEFT_KNEE]: { x: 1, y: 1, visibility: VISIBLE },
+});
+
+const configure = (params: {
+  detector: FakeDetector;
+  frameSource: FakeFrameSource;
+  platformId?: object | string;
+  detectorFactory?: () => Promise<PoseDetector>;
+}): void => {
+  const factory =
+    params.detectorFactory ?? (() => Promise.resolve(params.detector));
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: PLATFORM_ID, useValue: params.platformId ?? 'browser' },
+      { provide: POSE_DETECTOR_FACTORY, useValue: factory },
+      { provide: POSE_FRAME_SOURCE, useValue: params.frameSource },
+      PoseHoldTimerService,
+    ],
+  });
+};
+
+describe('PoseHoldTimerService', () => {
+  let detector: FakeDetector;
+  let frameSource: FakeFrameSource;
+  let video: HTMLVideoElement;
+
+  beforeEach(() => {
+    detector = new FakeDetector();
+    frameSource = new FakeFrameSource();
+    video = document.createElement('video');
+    configure({ detector, frameSource });
+  });
+
+  it('given a fresh service, when nothing happens, then isActive is false and snapshot is idle/0', () => {
+    const svc = TestBed.inject(PoseHoldTimerService);
+    expect(svc.isActive()).toBe(false);
+    expect(svc.snapshot()).toEqual({
+      totalMs: 0,
+      phase: 'idle',
+      segmentStartMs: null,
+    });
+  });
+
+  it('given start without bindVideoElement, when called, then it rejects with a helpful error', async () => {
+    const svc = TestBed.inject(PoseHoldTimerService);
+    await expect(svc.start({ exerciseId: 'plank' })).rejects.toThrow(
+      /bindVideoElement/
+    );
+  });
+
+  it('given an unknown exercise id, when start is called, then it rejects with a profile-missing error', async () => {
+    const svc = TestBed.inject(PoseHoldTimerService);
+    svc.bindVideoElement(video);
+    await expect(svc.start({ exerciseId: 'not-a-real-id' })).rejects.toThrow(
+      /no hold profile/
+    );
+  });
+
+  it('given a steady plank pose over 1.2s of frames, when emitted, then snapshot transitions to holding with accumulated time', async () => {
+    detector.script = [
+      STRAIGHT_PLANK,
+      STRAIGHT_PLANK,
+      STRAIGHT_PLANK,
+      STRAIGHT_PLANK,
+      STRAIGHT_PLANK,
+    ];
+    const svc = TestBed.inject(PoseHoldTimerService);
+    svc.bindVideoElement(video);
+    await svc.start({ exerciseId: 'plank' });
+    expect(svc.isActive()).toBe(true);
+
+    frameSource.emit(0);
+    frameSource.emit(300);
+    frameSource.emit(600);
+    frameSource.emit(900);
+    frameSource.emit(1200);
+
+    expect(svc.snapshot().phase).toBe('holding');
+    expect(svc.snapshot().totalMs).toBeGreaterThanOrEqual(1200);
+  });
+
+  it('given a steady plank followed by sustained sag, when emitted, then snapshot transitions to paused with preserved total', async () => {
+    detector.script = [
+      STRAIGHT_PLANK,
+      STRAIGHT_PLANK,
+      STRAIGHT_PLANK,
+      STRAIGHT_PLANK,
+      SAGGED_HIP,
+      SAGGED_HIP,
+      SAGGED_HIP,
+      SAGGED_HIP,
+    ];
+    const svc = TestBed.inject(PoseHoldTimerService);
+    svc.bindVideoElement(video);
+    await svc.start({ exerciseId: 'plank' });
+
+    frameSource.emit(0);
+    frameSource.emit(300);
+    frameSource.emit(600);
+    frameSource.emit(900);
+    frameSource.emit(1000);
+    frameSource.emit(1300);
+    frameSource.emit(1600);
+    frameSource.emit(1900);
+
+    expect(svc.snapshot().phase).toBe('paused');
+    expect(svc.snapshot().totalMs).toBeGreaterThanOrEqual(800);
+    expect(svc.snapshot().totalMs).toBeLessThanOrEqual(1100);
+  });
+
+  it('given an active session, when reset is called, then snapshot returns to idle/0', async () => {
+    detector.script = [STRAIGHT_PLANK, STRAIGHT_PLANK, STRAIGHT_PLANK];
+    const svc = TestBed.inject(PoseHoldTimerService);
+    svc.bindVideoElement(video);
+    await svc.start({ exerciseId: 'plank' });
+
+    frameSource.emit(0);
+    frameSource.emit(300);
+    frameSource.emit(600);
+    expect(svc.snapshot().phase).toBe('holding');
+
+    svc.reset();
+    expect(svc.snapshot()).toEqual({
+      totalMs: 0,
+      phase: 'idle',
+      segmentStartMs: null,
+    });
+  });
+
+  it('given stop after start, when called, then frames unsubscribe and detector is closed', async () => {
+    detector.script = [STRAIGHT_PLANK];
+    const svc = TestBed.inject(PoseHoldTimerService);
+    svc.bindVideoElement(video);
+    await svc.start({ exerciseId: 'plank' });
+    expect(svc.isActive()).toBe(true);
+
+    await svc.stop();
+    expect(svc.isActive()).toBe(false);
+    expect(frameSource.unsubscribed).toBe(1);
+    expect(detector.closed).toBe(true);
+  });
+
+  it('given the platform is server, when start is called, then it no-ops without subscribing to frames', async () => {
+    TestBed.resetTestingModule();
+    configure({ detector, frameSource, platformId: 'server' });
+    const svc = TestBed.inject(PoseHoldTimerService);
+    svc.bindVideoElement(video);
+    await svc.start({ exerciseId: 'plank' });
+    expect(svc.isActive()).toBe(false);
+    expect(frameSource.subscribed).toBe(0);
+  });
+});

--- a/libs/auto-count/src/lib/pose-hold-timer.service.ts
+++ b/libs/auto-count/src/lib/pose-hold-timer.service.ts
@@ -1,0 +1,159 @@
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
+
+import {
+  type ExerciseHoldProfile,
+  holdProfileFor,
+} from './exercise-hold-profile';
+import { HoldStateMachine, type HoldSnapshot } from './hold-state-machine';
+import { POSE_DETECTOR_FACTORY, type PoseDetector } from './pose-detector.port';
+import {
+  POSE_FRAME_SOURCE,
+  type PoseFrameSource,
+} from './pose-frame-source.port';
+import { poseToAngleSample } from './pose-to-sample';
+
+const INITIAL_SNAPSHOT: HoldSnapshot = {
+  totalMs: 0,
+  phase: 'idle',
+  segmentStartMs: null,
+};
+
+const snapshotEqual = (a: HoldSnapshot, b: HoldSnapshot): boolean =>
+  a.totalMs === b.totalMs &&
+  a.phase === b.phase &&
+  a.segmentStartMs === b.segmentStartMs;
+
+export interface HoldTimerStartOptions {
+  /** Hold catalog id, e.g. `'plank'`, `'hollowhold'`. */
+  readonly exerciseId: string;
+}
+
+/**
+ * Per-frame raw values surfaced for the Form-Check overlay during a
+ * hold session. Updates on every accepted frame regardless of phase
+ * change so the overlay can show live angle + confidence, the same
+ * pattern as {@link PoseRepCounterService}.
+ */
+export interface HoldFormCheckFrame {
+  readonly angleDeg: number;
+  readonly confidence: number;
+  readonly timestampMs: number;
+}
+
+/**
+ * Pose-based isometric hold timer. Mirrors {@link PoseRepCounterService}
+ * but accumulates time-in-pose instead of counting reps, driven by a
+ * {@link HoldStateMachine}. Browser-only; on the server it stays idle
+ * so SSR doesn't try to load MediaPipe/camera code.
+ */
+@Injectable()
+export class PoseHoldTimerService {
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly detectorFactory = inject(POSE_DETECTOR_FACTORY);
+  private readonly frameSource = inject<PoseFrameSource>(POSE_FRAME_SOURCE);
+
+  private readonly _snapshot = signal<HoldSnapshot>(INITIAL_SNAPSHOT, {
+    equal: snapshotEqual,
+  });
+  private readonly _isActive = signal(false);
+  private readonly _formCheckFrame = signal<HoldFormCheckFrame | null>(null);
+
+  readonly snapshot = this._snapshot.asReadonly();
+  readonly isActive = this._isActive.asReadonly();
+  readonly formCheckFrame = this._formCheckFrame.asReadonly();
+
+  private machine: HoldStateMachine | null = null;
+  private detector: PoseDetector | null = null;
+  private unsubscribeFrames: (() => void) | null = null;
+  private videoEl: HTMLVideoElement | null = null;
+  private startPending = false;
+  private startToken = 0;
+  private activeProfile: ExerciseHoldProfile | null = null;
+
+  bindVideoElement(el: HTMLVideoElement | null): void {
+    this.videoEl = el;
+  }
+
+  async start(options: HoldTimerStartOptions): Promise<void> {
+    if (!isPlatformBrowser(this.platformId)) return;
+    if (this._isActive() || this.startPending) return;
+
+    const profile = holdProfileFor(options.exerciseId);
+    if (!profile) {
+      throw new Error(
+        `PoseHoldTimerService: no hold profile for exercise "${options.exerciseId}"`
+      );
+    }
+
+    const video = this.videoEl;
+    if (!video) {
+      throw new Error(
+        'PoseHoldTimerService: bindVideoElement must be called before start'
+      );
+    }
+
+    this.startPending = true;
+    const token = ++this.startToken;
+
+    this.machine = new HoldStateMachine(profile);
+    this.activeProfile = profile;
+    this._snapshot.set(this.machine.snapshot());
+
+    let detector: PoseDetector;
+    try {
+      detector = await this.detectorFactory();
+    } catch (err) {
+      if (token === this.startToken) this.startPending = false;
+      throw err;
+    }
+
+    if (token !== this.startToken) {
+      detector.close();
+      return;
+    }
+
+    this.detector = detector;
+    this.unsubscribeFrames = this.frameSource.subscribe(video, (tick) => {
+      if (!this.detector || !this.machine || !this.activeProfile) return;
+      const result = this.detector.detectForVideo(video, tick.timestampMs);
+      const sample = poseToAngleSample(
+        result,
+        this.activeProfile,
+        tick.timestampMs
+      );
+      if (!sample) {
+        this._formCheckFrame.set(null);
+        return;
+      }
+      this._formCheckFrame.set({
+        angleDeg: sample.angleDeg,
+        confidence: sample.confidence,
+        timestampMs: sample.timestampMs,
+      });
+      const next = this.machine.process(sample);
+      this._snapshot.set(next);
+    });
+
+    this._isActive.set(true);
+    this.startPending = false;
+  }
+
+  async stop(): Promise<void> {
+    this.startToken += 1;
+    this.startPending = false;
+    this.unsubscribeFrames?.();
+    this.unsubscribeFrames = null;
+    this.detector?.close();
+    this.detector = null;
+    this.activeProfile = null;
+    this._isActive.set(false);
+    this._formCheckFrame.set(null);
+  }
+
+  reset(): void {
+    this.machine?.reset();
+    this._snapshot.set(this.machine?.snapshot() ?? INITIAL_SNAPSHOT);
+    this._formCheckFrame.set(null);
+  }
+}

--- a/libs/auto-count/src/lib/pose-to-sample.ts
+++ b/libs/auto-count/src/lib/pose-to-sample.ts
@@ -1,10 +1,18 @@
 import { angleAtJointDeg } from './joint-angle';
-import type {
-  ExerciseAngleProfile,
-  JointTriplet,
-} from './exercise-angle-profile';
+import type { JointTriplet } from './exercise-angle-profile';
 import type { PoseDetectionResult, PoseLandmark } from './pose-detector.port';
 import type { PoseSample } from './pose-sample';
+
+/**
+ * Minimal shape needed to read a per-frame angle: just the two
+ * joint-triplet sides. Both {@link ExerciseAngleProfile} (rep counter)
+ * and {@link ExerciseHoldProfile} (hold timer) satisfy this, so the
+ * mapper is shared between both pipelines.
+ */
+export interface JointTripletPair {
+  readonly tripletLeft: JointTriplet;
+  readonly tripletRight: JointTriplet;
+}
 
 interface SideSample {
   readonly angleDeg: number;
@@ -42,7 +50,7 @@ const tripletSample = (
  */
 export function poseToAngleSample(
   result: PoseDetectionResult,
-  profile: ExerciseAngleProfile,
+  profile: JointTripletPair,
   timestampMs: number
 ): PoseSample | null {
   const landmarks = result.landmarks[0];

--- a/libs/quick-add/src/lib/quick-add-fab.component.html
+++ b/libs/quick-add/src/lib/quick-add-fab.component.html
@@ -26,6 +26,18 @@
             <mat-icon>{{ item.icon }}</mat-icon>
             <span i18n="@@quickAdd.fab.autoCount">Auto‑Zählen</span>
           </button>
+        } @else if (item.type === 'exercise-timer') {
+          <button
+            mat-fab
+            extended
+            class="exercise-timer-fab"
+            aria-label="Halteübungs-Timer öffnen"
+            i18n-aria-label="@@quickAdd.fab.exerciseTimerAria"
+            (click)="onOpenExerciseTimer()"
+          >
+            <mat-icon>{{ item.icon }}</mat-icon>
+            <span i18n="@@quickAdd.fab.exerciseTimer">Plank‑Timer</span>
+          </button>
         } @else if (item.type === 'custom') {
           <button
             mat-fab

--- a/libs/quick-add/src/lib/quick-add-fab.component.spec.ts
+++ b/libs/quick-add/src/lib/quick-add-fab.component.spec.ts
@@ -16,6 +16,7 @@ describe('QuickAddFabComponent — goal dial item', () => {
     const openFeedback = jest.fn();
     const fillToGoal = jest.fn();
     const openAutoCount = jest.fn();
+    const openExerciseTimer = jest.fn();
     const opened = jest.fn();
 
     // Material disabled buttons set pointer-events:none; skip that check so
@@ -38,6 +39,7 @@ describe('QuickAddFabComponent — goal dial item', () => {
         openFeedback,
         fillToGoal,
         openAutoCount,
+        openExerciseTimer,
         opened,
       },
     });
@@ -55,6 +57,7 @@ describe('QuickAddFabComponent — goal dial item', () => {
       openFeedback,
       fillToGoal,
       openAutoCount,
+      openExerciseTimer,
       opened,
     };
   }
@@ -166,6 +169,22 @@ describe('QuickAddFabComponent — goal dial item', () => {
     expect(
       screen.queryByRole('button', {
         name: /Liegestütze automatisch zählen/i,
+      })
+    ).toBeNull();
+  });
+
+  it('When the exercise-timer item is clicked, Then openExerciseTimer is emitted and the dial closes', async () => {
+    const { user, openExerciseTimer } = await renderFab({});
+
+    const button = screen.getByRole('button', {
+      name: /Halteübungs-Timer öffnen/i,
+    });
+    await user.click(button);
+
+    expect(openExerciseTimer).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole('button', {
+        name: /Halteübungs-Timer öffnen/i,
       })
     ).toBeNull();
   });

--- a/libs/quick-add/src/lib/quick-add-fab.component.ts
+++ b/libs/quick-add/src/lib/quick-add-fab.component.ts
@@ -5,7 +5,13 @@ import { patchState, signalState } from '@ngrx/signals';
 
 interface DialItem {
   readonly value: number;
-  readonly type: 'quick' | 'custom' | 'feedback' | 'goal' | 'auto-count';
+  readonly type:
+    | 'quick'
+    | 'custom'
+    | 'feedback'
+    | 'goal'
+    | 'auto-count'
+    | 'exercise-timer';
   readonly icon: string;
 }
 
@@ -30,6 +36,7 @@ export class QuickAddFabComponent {
   readonly openFeedback = output<void>();
   readonly fillToGoal = output<void>();
   readonly openAutoCount = output<void>();
+  readonly openExerciseTimer = output<void>();
   readonly opened = output<void>();
 
   protected readonly fabState = signalState({ open: false });
@@ -61,6 +68,7 @@ export class QuickAddFabComponent {
     if (this.autoCountEnabled()) {
       items.push({ value: 0, type: 'auto-count', icon: 'videocam' });
     }
+    items.push({ value: 0, type: 'exercise-timer', icon: 'timer' });
     items.push({ value: 0, type: 'custom', icon: 'edit_note' });
     items.push({ value: 0, type: 'feedback', icon: 'feedback' });
 
@@ -103,6 +111,11 @@ export class QuickAddFabComponent {
   protected onOpenAutoCount(): void {
     patchState(this.fabState, { open: false });
     this.openAutoCount.emit();
+  }
+
+  protected onOpenExerciseTimer(): void {
+    patchState(this.fabState, { open: false });
+    this.openExerciseTimer.emit();
   }
 
   protected onOpenFeedback(): void {

--- a/web/src/app/app.html
+++ b/web/src/app/app.html
@@ -276,6 +276,7 @@
   (quickAdd)="handleQuickAdd($event)"
   (openDialog)="handleOpenDialog()"
   (openAutoCount)="handleOpenAutoCount()"
+  (openExerciseTimer)="handleOpenExerciseTimer()"
   (openFeedback)="openFeedbackDialog()"
   (fillToGoal)="handleFillToGoal()"
   (opened)="handleFabOpened()"

--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -1185,5 +1185,49 @@ describe('App (testing-library)', () => {
       fixture.componentInstance.handleOpenAutoCount();
       expect(openAutoCount).toHaveBeenCalledTimes(1);
     });
+
+    it('when handleOpenExerciseTimer is invoked, then it delegates to QuickAddOrchestrationService.openExerciseTimer', async () => {
+      const openExerciseTimer = vitest.fn();
+      const { fixture } = await render(App, {
+        providers: [
+          provideRouter([]),
+          { provide: PLATFORM_ID, useValue: 'browser' },
+          {
+            provide: UserContextService,
+            useValue: {
+              userNameSafe: userNameSignal.asReadonly(),
+              userIdSafe: () => 'u1',
+              isAdmin: () => true,
+              isGuest: () => false,
+            },
+          },
+          {
+            provide: FeatureFlagsService,
+            useValue: { autoExerciseCounter: signal(true).asReadonly() },
+          },
+          { provide: AuthStore, useValue: authMock },
+          { provide: AuthService, useValue: authServiceMock },
+          { provide: Auth, useValue: firebaseAuthMock },
+          { provide: UserConfigApiService, useValue: userConfigApiMock },
+          { provide: StatsApiService, useValue: statsApiMock },
+          { provide: AdsStore, useValue: adsStoreMock },
+          { provide: VAPID_PUBLIC_KEY, useValue: 'test-vapid-key' },
+          {
+            provide: QuickAddOrchestrationService,
+            useValue: {
+              add: vitest.fn(),
+              fillToGoal: vitest.fn(),
+              openDialog: vitest.fn(),
+              openAutoCount: vitest.fn(),
+              openExerciseTimer,
+              fillToGoalInFlight: signal(false).asReadonly(),
+            },
+          },
+        ],
+      });
+
+      fixture.componentInstance.handleOpenExerciseTimer();
+      expect(openExerciseTimer).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -353,6 +353,10 @@ export class App {
     this.quickAdd.openAutoCount();
   }
 
+  handleOpenExerciseTimer(): void {
+    this.quickAdd.openExerciseTimer();
+  }
+
   handleFillToGoal(): void {
     this.quickAdd.fillToGoal();
   }

--- a/web/src/app/auto-count/exercise-timer-dialog.component.html
+++ b/web/src/app/auto-count/exercise-timer-dialog.component.html
@@ -1,0 +1,146 @@
+<h2 mat-dialog-title i18n="@@exerciseTimer.title">Halteübung-Timer</h2>
+<mat-dialog-content>
+  <mat-button-toggle-group
+    class="exercise-picker"
+    [value]="exerciseId()"
+    (change)="onExerciseChange($event.value)"
+    [disabled]="switching()"
+    aria-label="Übung wählen"
+    i18n-aria-label="@@exerciseTimer.exercisePickerAria"
+  >
+    @for (option of exercises; track option.id) {
+      <mat-button-toggle [value]="option.id">
+        <mat-icon>{{ option.icon }}</mat-icon>
+        <span>{{ option.label }}</span>
+      </mat-button-toggle>
+    }
+  </mat-button-toggle-group>
+
+  <div class="mode-row">
+    <mat-slide-toggle
+      [checked]="cameraMode()"
+      (change)="onModeToggle($event.checked)"
+      i18n="@@exerciseTimer.cameraMode"
+    >
+      Kamera: Start/Ende automatisch erkennen
+    </mat-slide-toggle>
+  </div>
+
+  <div class="timer-stage" [class.camera]="cameraMode()">
+    <video
+      #video
+      class="preview"
+      [class.hidden]="!cameraMode()"
+      autoplay
+      playsinline
+      muted
+    ></video>
+
+    @if (cameraMode() && (isStarting() || switching())) {
+      <div class="overlay-message">
+        <mat-spinner diameter="32" />
+        <span i18n="@@exerciseTimer.cameraStarting">Kamera startet …</span>
+      </div>
+    }
+    @if (cameraMode() && error(); as err) {
+      <div class="overlay-message error">
+        <mat-icon>videocam_off</mat-icon>
+        <strong i18n="@@exerciseTimer.cameraUnavailable">
+          Kamera nicht verfügbar
+        </strong>
+        <small>{{ err }}</small>
+      </div>
+    }
+
+    <div class="timer-display" aria-live="polite">
+      <span class="timer-value">{{ totalMmSs() }}</span>
+      <span class="timer-phase">{{ phaseLabel() }}</span>
+    </div>
+
+    @if (cameraMode() && !isStarting() && !switching() && !error()) {
+      <button
+        type="button"
+        mat-icon-button
+        class="form-check-toggle"
+        (click)="toggleFormCheck()"
+        [attr.aria-pressed]="formCheckOpen()"
+        aria-label="Form-Check anzeigen oder ausblenden"
+        i18n-aria-label="@@exerciseTimer.formCheck.toggleAria"
+      >
+        <mat-icon>{{
+          formCheckOpen() ? 'visibility' : 'visibility_off'
+        }}</mat-icon>
+      </button>
+      @if (formCheckOpen()) {
+        <div class="form-check-panel">
+          <div class="form-check-cell">
+            <span i18n="@@exerciseTimer.formCheck.angle">Winkel</span>
+            <strong>
+              @if (frame(); as f) {
+                {{ f.angleDeg | number: '1.0-0' }}°
+              } @else {
+                —
+              }
+            </strong>
+          </div>
+          <div class="form-check-cell">
+            <span i18n="@@exerciseTimer.formCheck.confidence">Sicherheit</span>
+            <strong>
+              @if (frame(); as f) {
+                {{ f.confidence * 100 | number: '1.0-0' }}%
+              } @else {
+                —
+              }
+            </strong>
+          </div>
+        </div>
+      }
+    }
+  </div>
+
+  @if (!cameraMode()) {
+    <div class="manual-controls">
+      <button
+        mat-flat-button
+        color="primary"
+        (click)="toggleManual()"
+        [attr.aria-pressed]="running()"
+      >
+        <mat-icon>{{ running() ? 'pause' : 'play_arrow' }}</mat-icon>
+        @if (running()) {
+          <span i18n="@@exerciseTimer.pause">Pause</span>
+        } @else {
+          <span i18n="@@exerciseTimer.start">Start</span>
+        }
+      </button>
+    </div>
+  } @else {
+    <p class="hint" i18n="@@exerciseTimer.cameraHint">
+      Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der
+      Timer startet automatisch, sobald du in Position bist, und pausiert, wenn
+      du die Position verlässt.
+    </p>
+  }
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button
+    mat-button
+    (click)="reset()"
+    [disabled]="totalSec() === 0"
+    i18n="@@exerciseTimer.reset"
+  >
+    Zurücksetzen
+  </button>
+  <button mat-button (click)="cancel()" i18n="@@exerciseTimer.cancel">
+    Abbrechen
+  </button>
+  <button
+    mat-flat-button
+    color="primary"
+    (click)="save()"
+    [disabled]="totalSec() === 0 || !!error()"
+    i18n="@@exerciseTimer.save"
+  >
+    Übernehmen
+  </button>
+</mat-dialog-actions>

--- a/web/src/app/auto-count/exercise-timer-dialog.component.scss
+++ b/web/src/app/auto-count/exercise-timer-dialog.component.scss
@@ -75,7 +75,14 @@
 
   .timer-display {
     position: absolute;
-    inset: auto;
+    // Centered overlay: anchor at 50%/50% and pull back by half its
+    // own size with translate(-50%, -50%). Using `inset: auto` with no
+    // offsets left placement up to "static position" rules, which only
+    // worked here by accident of the flex container — fragile and
+    // breaks the moment the parent stops being a centering flex box.
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/web/src/app/auto-count/exercise-timer-dialog.component.scss
+++ b/web/src/app/auto-count/exercise-timer-dialog.component.scss
@@ -1,0 +1,168 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.exercise-picker {
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+
+  mat-button-toggle {
+    flex: 1 1 auto;
+    min-width: 96px;
+  }
+
+  mat-icon {
+    margin-right: 4px;
+    vertical-align: middle;
+  }
+}
+
+.mode-row {
+  margin: 4px 0 12px;
+  display: flex;
+  align-items: center;
+}
+
+.hint {
+  margin: 12px 0 0;
+  font-size: 13px;
+  opacity: 0.8;
+}
+
+.manual-controls {
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
+
+  button {
+    min-width: 160px;
+  }
+
+  mat-icon {
+    margin-right: 6px;
+  }
+}
+
+.timer-stage {
+  position: relative;
+  width: 100%;
+  flex: 1;
+  min-height: 220px;
+  background: #111;
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &.camera {
+    background: #000;
+  }
+
+  .preview {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transform: scaleX(-1);
+
+    &.hidden {
+      display: none;
+    }
+  }
+
+  .timer-display {
+    position: absolute;
+    inset: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: #fff;
+    padding: 10px 20px;
+    background: rgba(0, 0, 0, 0.55);
+    border-radius: 16px;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.05;
+
+    .timer-value {
+      font-size: 56px;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+
+    .timer-phase {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      opacity: 0.75;
+    }
+  }
+
+  .overlay-message {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    text-align: center;
+    padding: 16px;
+
+    mat-icon {
+      font-size: 48px;
+      width: 48px;
+      height: 48px;
+    }
+    small {
+      opacity: 0.7;
+      max-width: 280px;
+    }
+  }
+
+  .form-check-toggle {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    color: #fff;
+    background: rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(4px);
+  }
+
+  .form-check-panel {
+    position: absolute;
+    top: 8px;
+    right: 56px;
+    display: flex;
+    gap: 16px;
+    padding: 8px 14px;
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    border-radius: 10px;
+    font-variant-numeric: tabular-nums;
+    backdrop-filter: blur(4px);
+
+    .form-check-cell {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      line-height: 1.1;
+    }
+
+    span {
+      font-size: 10px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      opacity: 0.72;
+    }
+
+    strong {
+      font-size: 17px;
+      font-weight: 600;
+    }
+  }
+}

--- a/web/src/app/auto-count/exercise-timer-dialog.component.spec.ts
+++ b/web/src/app/auto-count/exercise-timer-dialog.component.spec.ts
@@ -1,0 +1,183 @@
+import { PLATFORM_ID, signal, type WritableSignal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import {
+  type HoldFormCheckFrame,
+  type HoldSnapshot,
+  PoseHoldTimerService,
+} from '@pu-stats/auto-count';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CameraService } from './camera.service';
+import { ExerciseTimerDialogComponent } from './exercise-timer-dialog.component';
+
+const INITIAL_SNAPSHOT: HoldSnapshot = {
+  totalMs: 0,
+  phase: 'idle',
+  segmentStartMs: null,
+};
+
+const flushAsync = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+const makeTimer = (
+  state: WritableSignal<HoldSnapshot> = signal<HoldSnapshot>(INITIAL_SNAPSHOT),
+  frame: WritableSignal<HoldFormCheckFrame | null> = signal<HoldFormCheckFrame | null>(
+    null
+  )
+): Pick<
+  PoseHoldTimerService,
+  | 'snapshot'
+  | 'isActive'
+  | 'formCheckFrame'
+  | 'bindVideoElement'
+  | 'start'
+  | 'stop'
+  | 'reset'
+> & {
+  startSpy: ReturnType<typeof vi.fn>;
+  stopSpy: ReturnType<typeof vi.fn>;
+  resetSpy: ReturnType<typeof vi.fn>;
+  bindSpy: ReturnType<typeof vi.fn>;
+  state: WritableSignal<HoldSnapshot>;
+} => {
+  const isActive = signal(false);
+  const start = vi.fn(async () => {
+    isActive.set(true);
+  });
+  const stop = vi.fn(async () => {
+    isActive.set(false);
+    frame.set(null);
+  });
+  const bind = vi.fn();
+  const reset = vi.fn(() => {
+    state.set(INITIAL_SNAPSHOT);
+    frame.set(null);
+  });
+  return {
+    snapshot: state.asReadonly(),
+    isActive: isActive.asReadonly(),
+    formCheckFrame: frame.asReadonly(),
+    bindVideoElement: bind,
+    start,
+    stop,
+    reset,
+    startSpy: start,
+    stopSpy: stop,
+    resetSpy: reset,
+    bindSpy: bind,
+    state,
+  };
+};
+
+describe('ExerciseTimerDialogComponent', () => {
+  let timer: ReturnType<typeof makeTimer>;
+  let cameraOpen: ReturnType<typeof vi.fn>;
+  let cameraClose: ReturnType<typeof vi.fn>;
+  let dialogClose: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    timer = makeTimer();
+    cameraOpen = vi.fn().mockResolvedValue(undefined);
+    cameraClose = vi.fn().mockResolvedValue(undefined);
+    dialogClose = vi.fn();
+
+    TestBed.configureTestingModule({
+      imports: [ExerciseTimerDialogComponent],
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        {
+          provide: CameraService,
+          useValue: { open: cameraOpen, close: cameraClose },
+        },
+        { provide: MatDialogRef, useValue: { close: dialogClose } },
+      ],
+    }).overrideComponent(ExerciseTimerDialogComponent, {
+      set: {
+        providers: [{ provide: PoseHoldTimerService, useValue: timer }],
+      },
+    });
+  });
+
+  it('given the dialog opens in default (manual) mode, when nothing else happens, then the camera is not started', async () => {
+    const fixture = TestBed.createComponent(ExerciseTimerDialogComponent);
+    fixture.detectChanges();
+    await flushAsync();
+
+    expect(cameraOpen).not.toHaveBeenCalled();
+    expect(timer.startSpy).not.toHaveBeenCalled();
+  });
+
+  it('given camera mode is toggled on, when settled, then the camera opens and the timer starts with the active exercise', async () => {
+    const fixture = TestBed.createComponent(ExerciseTimerDialogComponent);
+    fixture.detectChanges();
+    await flushAsync();
+
+    await fixture.componentInstance['onModeToggle'](true);
+    await flushAsync();
+
+    expect(cameraOpen).toHaveBeenCalledTimes(1);
+    expect(timer.bindSpy).toHaveBeenCalledTimes(1);
+    expect(timer.startSpy).toHaveBeenCalledWith({ exerciseId: 'plank' });
+  });
+
+  it('given camera mode and a hold of 7 seconds, when save is invoked, then the dialog closes with durationSec=7', async () => {
+    const fixture = TestBed.createComponent(ExerciseTimerDialogComponent);
+    fixture.detectChanges();
+    await flushAsync();
+    await fixture.componentInstance['onModeToggle'](true);
+    await flushAsync();
+
+    timer.state.set({
+      totalMs: 7100,
+      phase: 'paused',
+      segmentStartMs: null,
+    });
+    fixture.detectChanges();
+
+    fixture.componentInstance['save']();
+    expect(dialogClose).toHaveBeenCalledWith({
+      exerciseId: 'plank',
+      durationSec: 7,
+    });
+  });
+
+  it('given totalSec is 0, when save is invoked, then the dialog closes with null (no entry created)', () => {
+    const fixture = TestBed.createComponent(ExerciseTimerDialogComponent);
+    fixture.detectChanges();
+
+    fixture.componentInstance['save']();
+    expect(dialogClose).toHaveBeenCalledWith(null);
+  });
+
+  it('given the exercise is switched in camera mode, when settled, then the timer is stopped/reset and restarted with the new id', async () => {
+    const fixture = TestBed.createComponent(ExerciseTimerDialogComponent);
+    fixture.detectChanges();
+    await flushAsync();
+    await fixture.componentInstance['onModeToggle'](true);
+    await flushAsync();
+
+    timer.startSpy.mockClear();
+    timer.stopSpy.mockClear();
+    timer.resetSpy.mockClear();
+
+    await fixture.componentInstance['onExerciseChange']('hollowhold');
+    await flushAsync();
+
+    expect(timer.stopSpy).toHaveBeenCalledTimes(1);
+    expect(timer.resetSpy).toHaveBeenCalledTimes(1);
+    expect(timer.startSpy).toHaveBeenCalledWith({ exerciseId: 'hollowhold' });
+  });
+
+  it('given the dialog is destroyed, when teardown runs, then timer.stop and camera.close are each called once', async () => {
+    const fixture = TestBed.createComponent(ExerciseTimerDialogComponent);
+    fixture.detectChanges();
+    await flushAsync();
+
+    fixture.destroy();
+    await flushAsync();
+
+    expect(timer.stopSpy).toHaveBeenCalledTimes(1);
+    expect(cameraClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/app/auto-count/exercise-timer-dialog.component.spec.ts
+++ b/web/src/app/auto-count/exercise-timer-dialog.component.spec.ts
@@ -180,4 +180,55 @@ describe('ExerciseTimerDialogComponent', () => {
     expect(timer.stopSpy).toHaveBeenCalledTimes(1);
     expect(cameraClose).toHaveBeenCalledTimes(1);
   });
+
+  it('given camera mode is toggled off again, when settled, then the camera stream is closed (not left running)', async () => {
+    const fixture = TestBed.createComponent(ExerciseTimerDialogComponent);
+    fixture.detectChanges();
+    await flushAsync();
+    await fixture.componentInstance['onModeToggle'](true);
+    await flushAsync();
+
+    cameraClose.mockClear();
+    timer.stopSpy.mockClear();
+
+    await fixture.componentInstance['onModeToggle'](false);
+    await flushAsync();
+
+    expect(timer.stopSpy).toHaveBeenCalledTimes(1);
+    expect(cameraClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('given camera.open succeeds but timer.start throws, when settled, then both timer.stop and camera.close are invoked to release resources', async () => {
+    timer.startSpy.mockRejectedValueOnce(new Error('detector init failed'));
+    const fixture = TestBed.createComponent(ExerciseTimerDialogComponent);
+    fixture.detectChanges();
+    await flushAsync();
+
+    await fixture.componentInstance['onModeToggle'](true);
+    await flushAsync();
+
+    expect(cameraOpen).toHaveBeenCalledTimes(1);
+    expect(timer.stopSpy).toHaveBeenCalledTimes(1);
+    expect(cameraClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('given the manual stopwatch is toggled twice across a tick, when stopped, then manualMs is not double-counted', async () => {
+    vi.useFakeTimers({ now: 1_000 });
+    try {
+      const fixture = TestBed.createComponent(ExerciseTimerDialogComponent);
+      fixture.detectChanges();
+      const component = fixture.componentInstance as unknown as {
+        toggleManual: () => void;
+        totalSec: () => number;
+      };
+
+      component.toggleManual(); // start at performance.now() = 1000
+      vi.advanceTimersByTime(5_000); // tick → manualMs = 5000
+      component.toggleManual(); // stop at performance.now() = 6000
+
+      expect(component.totalSec()).toBe(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/web/src/app/auto-count/exercise-timer-dialog.component.ts
+++ b/web/src/app/auto-count/exercise-timer-dialog.component.ts
@@ -1,0 +1,268 @@
+import { DecimalPipe, isPlatformBrowser } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  ElementRef,
+  inject,
+  PLATFORM_ID,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { PoseHoldTimerService } from '@pu-stats/auto-count';
+
+import { CameraService } from './camera.service';
+
+export type ExerciseTimerExerciseId = 'plank' | 'hollowhold';
+
+export interface ExerciseTimerResult {
+  readonly exerciseId: ExerciseTimerExerciseId;
+  /** Final hold time in whole seconds. */
+  readonly durationSec: number;
+}
+
+interface ExerciseOption {
+  readonly id: ExerciseTimerExerciseId;
+  readonly icon: string;
+  readonly label: string;
+}
+
+/** How often the manual stopwatch ticks the elapsed display. */
+const STOPWATCH_TICK_MS = 100;
+
+@Component({
+  selector: 'app-exercise-timer-dialog',
+  standalone: true,
+  imports: [
+    DecimalPipe,
+    MatDialogModule,
+    MatButtonModule,
+    MatButtonToggleModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatSlideToggleModule,
+  ],
+  providers: [PoseHoldTimerService],
+  templateUrl: './exercise-timer-dialog.component.html',
+  styleUrl: './exercise-timer-dialog.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ExerciseTimerDialogComponent {
+  private readonly camera = inject(CameraService);
+  protected readonly timer = inject(PoseHoldTimerService);
+  private readonly dialogRef = inject(
+    MatDialogRef<ExerciseTimerDialogComponent, ExerciseTimerResult | null>
+  );
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  protected readonly videoRef =
+    viewChild<ElementRef<HTMLVideoElement>>('video');
+
+  protected readonly exerciseId = signal<ExerciseTimerExerciseId>('plank');
+  protected readonly cameraMode = signal(false);
+  protected readonly isStarting = signal(false);
+  protected readonly switching = signal(false);
+  protected readonly error = signal<string | null>(null);
+  protected readonly formCheckOpen = signal(true);
+
+  /** Wall-clock millisecond total for manual mode. */
+  private readonly manualMs = signal(0);
+  private readonly manualRunning = signal(false);
+  private manualSegmentStartedAt: number | null = null;
+  private stopwatchHandle: ReturnType<typeof setInterval> | null = null;
+
+  protected readonly totalSec = computed(() =>
+    this.cameraMode()
+      ? Math.floor(this.timer.snapshot().totalMs / 1000)
+      : Math.floor(this.manualMs() / 1000)
+  );
+  protected readonly totalMmSs = computed(() => {
+    const sec = this.totalSec();
+    const mm = Math.floor(sec / 60);
+    const ss = sec % 60;
+    return `${mm.toString().padStart(2, '0')}:${ss.toString().padStart(2, '0')}`;
+  });
+  protected readonly running = computed(() =>
+    this.cameraMode()
+      ? this.timer.snapshot().phase === 'holding'
+      : this.manualRunning()
+  );
+  protected readonly phaseLabel = computed(() => {
+    if (this.cameraMode()) {
+      switch (this.timer.snapshot().phase) {
+        case 'holding':
+          return $localize`:@@exerciseTimer.phase.holding:Halten`;
+        case 'paused':
+          return $localize`:@@exerciseTimer.phase.paused:Pause`;
+        default:
+          return $localize`:@@exerciseTimer.phase.ready:Bereit`;
+      }
+    }
+    return this.manualRunning()
+      ? $localize`:@@exerciseTimer.phase.holding:Halten`
+      : $localize`:@@exerciseTimer.phase.ready:Bereit`;
+  });
+  protected readonly frame = computed(() => this.timer.formCheckFrame());
+
+  protected readonly exercises: ReadonlyArray<ExerciseOption> = [
+    {
+      id: 'plank',
+      icon: 'horizontal_rule',
+      label: $localize`:@@exerciseTimer.exercise.plank:Plank`,
+    },
+    {
+      id: 'hollowhold',
+      icon: 'self_improvement',
+      label: $localize`:@@exerciseTimer.exercise.hollowhold:Hollow Hold`,
+    },
+  ];
+
+  private tornDown = false;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      void this.teardown();
+    });
+  }
+
+  protected async onModeToggle(useCamera: boolean): Promise<void> {
+    if (useCamera === this.cameraMode()) return;
+    // Pause whichever path was active so the user always returns to a
+    // clean "press to start" state after switching modes — keeps the
+    // mental model symmetric between the two.
+    this.stopManualStopwatch();
+    if (this.cameraMode()) {
+      await this.timer.stop();
+    }
+    this.cameraMode.set(useCamera);
+    this.error.set(null);
+    if (useCamera) {
+      await this.startCameraSession();
+    }
+  }
+
+  protected async onExerciseChange(
+    next: ExerciseTimerExerciseId
+  ): Promise<void> {
+    if (next === this.exerciseId() || this.switching()) return;
+    this.exerciseId.set(next);
+    if (!this.cameraMode()) return;
+    this.switching.set(true);
+    this.error.set(null);
+    try {
+      await this.timer.stop();
+      this.timer.reset();
+      await this.timer.start({ exerciseId: next });
+    } catch (err) {
+      this.error.set(err instanceof Error ? err.message : String(err));
+    } finally {
+      this.switching.set(false);
+    }
+  }
+
+  protected toggleManual(): void {
+    if (this.cameraMode()) return;
+    if (this.manualRunning()) {
+      this.stopManualStopwatch();
+    } else {
+      this.startManualStopwatch();
+    }
+  }
+
+  protected reset(): void {
+    if (this.cameraMode()) {
+      this.timer.reset();
+    } else {
+      this.stopManualStopwatch();
+      this.manualMs.set(0);
+    }
+  }
+
+  protected save(): void {
+    const seconds = this.totalSec();
+    if (seconds <= 0) {
+      this.dialogRef.close(null);
+      return;
+    }
+    this.dialogRef.close({
+      exerciseId: this.exerciseId(),
+      durationSec: seconds,
+    });
+  }
+
+  protected cancel(): void {
+    this.dialogRef.close(null);
+  }
+
+  protected toggleFormCheck(): void {
+    this.formCheckOpen.update((open) => !open);
+  }
+
+  private startManualStopwatch(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    if (this.manualRunning() || this.stopwatchHandle !== null) return;
+    this.manualSegmentStartedAt = performance.now();
+    this.manualRunning.set(true);
+    const baseMs = this.manualMs();
+    this.stopwatchHandle = setInterval(() => {
+      if (this.manualSegmentStartedAt === null) return;
+      const delta = performance.now() - this.manualSegmentStartedAt;
+      this.manualMs.set(baseMs + delta);
+    }, STOPWATCH_TICK_MS);
+  }
+
+  private stopManualStopwatch(): void {
+    if (this.stopwatchHandle !== null) {
+      clearInterval(this.stopwatchHandle);
+      this.stopwatchHandle = null;
+    }
+    if (this.manualSegmentStartedAt !== null && this.manualRunning()) {
+      const delta = performance.now() - this.manualSegmentStartedAt;
+      this.manualMs.update((m) => m + delta);
+    }
+    this.manualSegmentStartedAt = null;
+    this.manualRunning.set(false);
+  }
+
+  /**
+   * Wires the camera + pose detector. The `<video>` element is always
+   * rendered (just hidden when cameraMode is off), so `viewChild` is
+   * populated as soon as the dialog mounts and we can read it
+   * synchronously here.
+   */
+  private async startCameraSession(): Promise<void> {
+    if (!isPlatformBrowser(this.platformId)) return;
+    const ref = this.videoRef();
+    if (!ref) {
+      this.error.set('Video element not available');
+      return;
+    }
+    this.isStarting.set(true);
+    try {
+      const video = ref.nativeElement;
+      await this.camera.open(video);
+      this.timer.bindVideoElement(video);
+      await this.timer.start({ exerciseId: this.exerciseId() });
+    } catch (err) {
+      this.error.set(err instanceof Error ? err.message : String(err));
+    } finally {
+      this.isStarting.set(false);
+    }
+  }
+
+  private async teardown(): Promise<void> {
+    if (this.tornDown) return;
+    this.tornDown = true;
+    this.stopManualStopwatch();
+    await this.timer.stop();
+    await this.camera.close();
+  }
+}

--- a/web/src/app/auto-count/exercise-timer-dialog.component.ts
+++ b/web/src/app/auto-count/exercise-timer-dialog.component.ts
@@ -77,6 +77,13 @@ export class ExerciseTimerDialogComponent {
   private readonly manualMs = signal(0);
   private readonly manualRunning = signal(false);
   private manualSegmentStartedAt: number | null = null;
+  /**
+   * Snapshot of `manualMs` at the moment the current segment started. The
+   * interval below sets `manualMs = manualSegmentBaseMs + delta` on every
+   * tick, so when we stop we re-compute the same expression instead of
+   * adding `delta` on top of an already-updated `manualMs`.
+   */
+  private manualSegmentBaseMs = 0;
   private stopwatchHandle: ReturnType<typeof setInterval> | null = null;
 
   protected readonly totalSec = computed(() =>
@@ -140,7 +147,14 @@ export class ExerciseTimerDialogComponent {
     // mental model symmetric between the two.
     this.stopManualStopwatch();
     if (this.cameraMode()) {
+      // Stop the timer first (it owns the frame subscription), then
+      // close the underlying MediaStream. Without the `camera.close()`
+      // call the webcam track keeps running in the background after the
+      // user flipped the toggle off — privacy indicator stays on, extra
+      // battery drain, and potentially blocks other tabs from accessing
+      // the camera until the dialog is destroyed.
       await this.timer.stop();
+      await this.camera.close();
     }
     this.cameraMode.set(useCamera);
     this.error.set(null);
@@ -210,12 +224,12 @@ export class ExerciseTimerDialogComponent {
     if (!isPlatformBrowser(this.platformId)) return;
     if (this.manualRunning() || this.stopwatchHandle !== null) return;
     this.manualSegmentStartedAt = performance.now();
+    this.manualSegmentBaseMs = this.manualMs();
     this.manualRunning.set(true);
-    const baseMs = this.manualMs();
     this.stopwatchHandle = setInterval(() => {
       if (this.manualSegmentStartedAt === null) return;
       const delta = performance.now() - this.manualSegmentStartedAt;
-      this.manualMs.set(baseMs + delta);
+      this.manualMs.set(this.manualSegmentBaseMs + delta);
     }, STOPWATCH_TICK_MS);
   }
 
@@ -226,7 +240,7 @@ export class ExerciseTimerDialogComponent {
     }
     if (this.manualSegmentStartedAt !== null && this.manualRunning()) {
       const delta = performance.now() - this.manualSegmentStartedAt;
-      this.manualMs.update((m) => m + delta);
+      this.manualMs.set(this.manualSegmentBaseMs + delta);
     }
     this.manualSegmentStartedAt = null;
     this.manualRunning.set(false);
@@ -253,6 +267,14 @@ export class ExerciseTimerDialogComponent {
       await this.timer.start({ exerciseId: this.exerciseId() });
     } catch (err) {
       this.error.set(err instanceof Error ? err.message : String(err));
+      // Release any partial resources the partial start grabbed: the
+      // camera may have already been opened (granting webcam access)
+      // before the detector failed to initialise. Without this both the
+      // MediaStream and a half-initialised detector would survive until
+      // dialog teardown, blocking other camera consumers and leaking
+      // detector resources.
+      await this.timer.stop().catch(() => undefined);
+      await this.camera.close().catch(() => undefined);
     } finally {
       this.isStarting.set(false);
     }

--- a/web/src/app/core/quick-add-orchestration.service.spec.ts
+++ b/web/src/app/core/quick-add-orchestration.service.spec.ts
@@ -419,3 +419,126 @@ describe('QuickAddOrchestrationService.openAutoCount', () => {
     expect(exerciseApiMock.createEntry).not.toHaveBeenCalled();
   });
 });
+
+describe('QuickAddOrchestrationService.openExerciseTimer', () => {
+  const reloadAfterMutation = vitest.fn();
+  const statsApiMock = { createPushup: vitest.fn() };
+  const exerciseApiMock = { createEntry: vitest.fn() };
+  const snackBarMock = { open: vitest.fn() };
+  const routerMock = { url: '/app', navigate: vitest.fn() };
+  const bridgeMock = { requestOpenDialog: vitest.fn() };
+  const appDataMock: Partial<AppDataFacade> = {
+    remainingToGoal: signal(0).asReadonly(),
+    reloadAfterMutation,
+  };
+
+  function setup(
+    timerResult: {
+      exerciseId: 'plank' | 'hollowhold';
+      durationSec: number;
+    } | null,
+    trainingResult: unknown
+  ) {
+    vitest.clearAllMocks();
+    statsApiMock.createPushup.mockReturnValue(of({ _id: '1' }));
+    exerciseApiMock.createEntry.mockReturnValue(of({ _id: 'e1' }));
+
+    const dialogMock = {
+      open: vitest
+        .fn()
+        .mockReturnValueOnce({ afterClosed: () => of(timerResult) })
+        .mockReturnValueOnce({ afterClosed: () => of(trainingResult) }),
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: baseProviders({
+        statsApiMock,
+        exerciseApiMock,
+        snackBarMock,
+        routerMock,
+        bridgeMock,
+        appDataMock,
+        dialogMock,
+      }),
+    });
+    return {
+      service: TestBed.inject(QuickAddOrchestrationService),
+      dialogMock,
+    };
+  }
+
+  it('Given the timer dialog returns null, Then the entry dialog is not opened', async () => {
+    const { service, dialogMock } = setup(null, undefined);
+
+    await service.openExerciseTimer();
+    await Promise.resolve();
+
+    expect(dialogMock.open).toHaveBeenCalledTimes(1);
+    expect(exerciseApiMock.createEntry).not.toHaveBeenCalled();
+  });
+
+  it('Given the timer dialog returns plank durationSec, Then the entry dialog opens prefilled with kind=exercise and exerciseId=plank.standard', async () => {
+    const { service, dialogMock } = setup(
+      { exerciseId: 'plank', durationSec: 45 },
+      null
+    );
+
+    await service.openExerciseTimer();
+    await vitest.waitFor(() => {
+      expect(dialogMock.open).toHaveBeenCalledTimes(2);
+    });
+
+    const config = dialogMock.open.mock.calls[1][1] as {
+      data: { kind: string; exerciseId: string; durationSec: number };
+    };
+    expect(config.data.kind).toBe('exercise');
+    expect(config.data.exerciseId).toBe('plank.standard');
+    expect(config.data.durationSec).toBe(45);
+  });
+
+  it('Given the timer dialog returns hollow hold durationSec, Then the entry dialog uses core.hollowhold catalog id', async () => {
+    const { service, dialogMock } = setup(
+      { exerciseId: 'hollowhold', durationSec: 30 },
+      null
+    );
+
+    await service.openExerciseTimer();
+    await vitest.waitFor(() => {
+      expect(dialogMock.open).toHaveBeenCalledTimes(2);
+    });
+
+    const config = dialogMock.open.mock.calls[1][1] as {
+      data: { exerciseId: string };
+    };
+    expect(config.data.exerciseId).toBe('core.hollowhold');
+  });
+
+  it('Given the entry dialog returns a confirmed time entry, Then exerciseApi.createEntry is called with the durationSec payload', async () => {
+    const { service } = setup(
+      { exerciseId: 'plank', durationSec: 60 },
+      {
+        kind: 'exercise',
+        timestamp: '2025-01-01T08:00:00+01:00',
+        exerciseId: 'plank.standard',
+        measurement: 'time',
+        durationSec: 60,
+        reps: 0,
+        sets: [],
+        intervals: [],
+      }
+    );
+
+    await service.openExerciseTimer();
+    await vitest.waitFor(() => {
+      expect(exerciseApiMock.createEntry).toHaveBeenCalledTimes(1);
+    });
+    const [userId, payload] = exerciseApiMock.createEntry.mock.calls[0];
+    expect(userId).toBe('u1');
+    expect(payload).toMatchObject({
+      exerciseId: 'plank.standard',
+      durationSec: 60,
+      source: 'exercise-timer',
+    });
+  });
+});

--- a/web/src/app/core/quick-add-orchestration.service.ts
+++ b/web/src/app/core/quick-add-orchestration.service.ts
@@ -19,6 +19,11 @@ import type {
   AutoCountResult,
 } from '../auto-count/auto-count-dialog.component';
 import type {
+  ExerciseTimerDialogComponent,
+  ExerciseTimerExerciseId,
+  ExerciseTimerResult,
+} from '../auto-count/exercise-timer-dialog.component';
+import type {
   ExerciseEntryDialogData,
   ExerciseEntryDialogResult,
   PushupEntryDialogData,
@@ -40,6 +45,17 @@ const EXERCISE_CATALOG_ID: Record<
   squat: 'legs.squats',
   pullup: 'pull.pullups',
   situp: 'abs.situps',
+};
+
+/**
+ * Maps the hold-timer profile id (lives in `libs/auto-count`) to the
+ * catalog `exerciseId` used by `ExerciseFirestoreService`. Plank uses
+ * the legacy id that was migrated into the `core` category; hollow
+ * hold lives there too.
+ */
+const HOLD_TIMER_CATALOG_ID: Record<ExerciseTimerExerciseId, string> = {
+  plank: 'plank.standard',
+  hollowhold: 'core.hollowhold',
 };
 
 @Injectable({ providedIn: 'root' })
@@ -182,6 +198,60 @@ export class QuickAddOrchestrationService {
       .subscribe((result) => {
         if (!result || result.reps <= 0) return;
         void this.confirmAutoCount(result);
+      });
+  }
+
+  /**
+   * Timer dialog for isometric-hold exercises (plank, hollow hold). The
+   * dialog is manual by default, with an optional pose-detection toggle
+   * that mirrors the rep-counter flow: on a non-zero result, chain into
+   * the standard training-entry dialog so the user can review and adjust
+   * the captured duration before persisting.
+   */
+  async openExerciseTimer(): Promise<void> {
+    const { ExerciseTimerDialogComponent } =
+      await import('../auto-count/exercise-timer-dialog.component');
+    this.dialog
+      .open<ExerciseTimerDialogComponent, void, ExerciseTimerResult | null>(
+        ExerciseTimerDialogComponent,
+        {
+          width: 'min(96vw, 480px)',
+          maxWidth: '96vw',
+          panelClass: 'exercise-timer-dialog-panel',
+        }
+      )
+      .afterClosed()
+      .subscribe((result) => {
+        if (!result || result.durationSec <= 0) return;
+        void this.confirmExerciseTimer(result);
+      });
+  }
+
+  private async confirmExerciseTimer(
+    result: ExerciseTimerResult
+  ): Promise<void> {
+    const { TrainingEntryDialogComponent } =
+      await import('../stats/components/training-entry-dialog/training-entry-dialog.component');
+    const data: ExerciseEntryDialogData = {
+      kind: 'exercise',
+      timestamp: nowLocalIso(),
+      exerciseId: HOLD_TIMER_CATALOG_ID[result.exerciseId],
+      durationSec: result.durationSec,
+    };
+    this.dialog
+      .open<
+        TrainingEntryDialogComponent,
+        TrainingEntryDialogData,
+        TrainingEntryDialogResult
+      >(TrainingEntryDialogComponent, {
+        data,
+        width: 'min(92vw, 420px)',
+        maxWidth: '92vw',
+      })
+      .afterClosed()
+      .subscribe((dialogResult) => {
+        if (!dialogResult) return;
+        void this.persistConfirmed(dialogResult, 'exercise-timer');
       });
   }
 

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -8494,5 +8494,131 @@
         <target>Ringe</target>
       </segment>
     </unit>
-  </file>
+      <unit id="exerciseTimer.title">
+      <segment state="initial">
+        <source>Halteübung-Timer</source>
+        <target>Halteübung-Timer</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <segment state="initial">
+        <source>Übung wählen</source>
+        <target>Übung wählen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraMode">
+      <segment state="initial">
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+        <target> Kamera: Start/Ende automatisch erkennen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraStarting">
+      <segment state="initial">
+        <source>Kamera startet …</source>
+        <target>Kamera startet …</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraUnavailable">
+      <segment state="initial">
+        <source> Kamera nicht verfügbar </source>
+        <target> Kamera nicht verfügbar </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <segment state="initial">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Form-Check anzeigen oder ausblenden</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.angle">
+      <segment state="initial">
+        <source>Winkel</source>
+        <target>Winkel</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <segment state="initial">
+        <source>Sicherheit</source>
+        <target>Sicherheit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.pause">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.start">
+      <segment state="initial">
+        <source>Start</source>
+        <target>Start</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraHint">
+      <segment state="initial">
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.reset">
+      <segment state="initial">
+        <source> Zurücksetzen </source>
+        <target> Zurücksetzen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.save">
+      <segment state="initial">
+        <source> Übernehmen </source>
+        <target> Übernehmen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.holding">
+      <segment state="initial">
+        <source>Halten</source>
+        <target>Halten</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.paused">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.ready">
+      <segment state="initial">
+        <source>Bereit</source>
+        <target>Bereit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.plank">
+      <segment state="initial">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimerAria">
+      <segment state="initial">
+        <source>Halteübungs-Timer öffnen</source>
+        <target>Halteübungs-Timer öffnen</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <segment state="initial">
+        <source>Plank‑Timer</source>
+        <target>Plank‑Timer</target>
+      </segment>
+    </unit>
+</file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -8654,5 +8654,131 @@ Deine Position: # ·  Reps        </source>
         <target>Ringe</target>
       </segment>
     </unit>
-  </file>
+      <unit id="exerciseTimer.title">
+      <segment state="translated">
+        <source>Halteübung-Timer</source>
+        <target>Hold-exercise timer</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <segment state="translated">
+        <source>Übung wählen</source>
+        <target>Pick exercise</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraMode">
+      <segment state="translated">
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+        <target>Camera: detect start/end automatically</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraStarting">
+      <segment state="translated">
+        <source>Kamera startet …</source>
+        <target>Camera starting …</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraUnavailable">
+      <segment state="translated">
+        <source> Kamera nicht verfügbar </source>
+        <target>Camera unavailable</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <segment state="translated">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Show or hide form-check</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.angle">
+      <segment state="translated">
+        <source>Winkel</source>
+        <target>Angle</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <segment state="translated">
+        <source>Sicherheit</source>
+        <target>Confidence</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.pause">
+      <segment state="translated">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.start">
+      <segment state="translated">
+        <source>Start</source>
+        <target>Start</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraHint">
+      <segment state="translated">
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+        <target>Position the camera so your shoulder, hip and knee are visible. The timer starts automatically once you are in position and pauses when you leave it.</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.reset">
+      <segment state="translated">
+        <source> Zurücksetzen </source>
+        <target>Reset</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cancel">
+      <segment state="translated">
+        <source> Abbrechen </source>
+        <target>Cancel</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.save">
+      <segment state="translated">
+        <source> Übernehmen </source>
+        <target>Save</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.holding">
+      <segment state="translated">
+        <source>Halten</source>
+        <target>Holding</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.paused">
+      <segment state="translated">
+        <source>Pause</source>
+        <target>Paused</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.ready">
+      <segment state="translated">
+        <source>Bereit</source>
+        <target>Ready</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.plank">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <segment state="translated">
+        <source>Hollow Hold</source>
+        <target>Hollow hold</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimerAria">
+      <segment state="translated">
+        <source>Halteübungs-Timer öffnen</source>
+        <target>Open hold-exercise timer</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <segment state="translated">
+        <source>Plank‑Timer</source>
+        <target>Plank‑timer</target>
+      </segment>
+    </unit>
+</file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -8494,5 +8494,131 @@
         <target>Ringe</target>
       </segment>
     </unit>
-  </file>
+      <unit id="exerciseTimer.title">
+      <segment state="initial">
+        <source>Halteübung-Timer</source>
+        <target>Halteübung-Timer</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <segment state="initial">
+        <source>Übung wählen</source>
+        <target>Übung wählen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraMode">
+      <segment state="initial">
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+        <target> Kamera: Start/Ende automatisch erkennen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraStarting">
+      <segment state="initial">
+        <source>Kamera startet …</source>
+        <target>Kamera startet …</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraUnavailable">
+      <segment state="initial">
+        <source> Kamera nicht verfügbar </source>
+        <target> Kamera nicht verfügbar </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <segment state="initial">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Form-Check anzeigen oder ausblenden</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.angle">
+      <segment state="initial">
+        <source>Winkel</source>
+        <target>Winkel</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <segment state="initial">
+        <source>Sicherheit</source>
+        <target>Sicherheit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.pause">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.start">
+      <segment state="initial">
+        <source>Start</source>
+        <target>Start</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraHint">
+      <segment state="initial">
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.reset">
+      <segment state="initial">
+        <source> Zurücksetzen </source>
+        <target> Zurücksetzen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.save">
+      <segment state="initial">
+        <source> Übernehmen </source>
+        <target> Übernehmen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.holding">
+      <segment state="initial">
+        <source>Halten</source>
+        <target>Halten</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.paused">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.ready">
+      <segment state="initial">
+        <source>Bereit</source>
+        <target>Bereit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.plank">
+      <segment state="initial">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimerAria">
+      <segment state="initial">
+        <source>Halteübungs-Timer öffnen</source>
+        <target>Halteübungs-Timer öffnen</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <segment state="initial">
+        <source>Plank‑Timer</source>
+        <target>Plank‑Timer</target>
+      </segment>
+    </unit>
+</file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -8494,5 +8494,131 @@
         <target>Ringe</target>
       </segment>
     </unit>
-  </file>
+      <unit id="exerciseTimer.title">
+      <segment state="initial">
+        <source>Halteübung-Timer</source>
+        <target>Halteübung-Timer</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <segment state="initial">
+        <source>Übung wählen</source>
+        <target>Übung wählen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraMode">
+      <segment state="initial">
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+        <target> Kamera: Start/Ende automatisch erkennen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraStarting">
+      <segment state="initial">
+        <source>Kamera startet …</source>
+        <target>Kamera startet …</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraUnavailable">
+      <segment state="initial">
+        <source> Kamera nicht verfügbar </source>
+        <target> Kamera nicht verfügbar </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <segment state="initial">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Form-Check anzeigen oder ausblenden</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.angle">
+      <segment state="initial">
+        <source>Winkel</source>
+        <target>Winkel</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <segment state="initial">
+        <source>Sicherheit</source>
+        <target>Sicherheit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.pause">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.start">
+      <segment state="initial">
+        <source>Start</source>
+        <target>Start</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraHint">
+      <segment state="initial">
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.reset">
+      <segment state="initial">
+        <source> Zurücksetzen </source>
+        <target> Zurücksetzen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.save">
+      <segment state="initial">
+        <source> Übernehmen </source>
+        <target> Übernehmen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.holding">
+      <segment state="initial">
+        <source>Halten</source>
+        <target>Halten</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.paused">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.ready">
+      <segment state="initial">
+        <source>Bereit</source>
+        <target>Bereit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.plank">
+      <segment state="initial">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimerAria">
+      <segment state="initial">
+        <source>Halteübungs-Timer öffnen</source>
+        <target>Halteübungs-Timer öffnen</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <segment state="initial">
+        <source>Plank‑Timer</source>
+        <target>Plank‑Timer</target>
+      </segment>
+    </unit>
+</file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -8494,5 +8494,131 @@
         <target>Ringe</target>
       </segment>
     </unit>
-  </file>
+      <unit id="exerciseTimer.title">
+      <segment state="initial">
+        <source>Halteübung-Timer</source>
+        <target>Halteübung-Timer</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <segment state="initial">
+        <source>Übung wählen</source>
+        <target>Übung wählen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraMode">
+      <segment state="initial">
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+        <target> Kamera: Start/Ende automatisch erkennen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraStarting">
+      <segment state="initial">
+        <source>Kamera startet …</source>
+        <target>Kamera startet …</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraUnavailable">
+      <segment state="initial">
+        <source> Kamera nicht verfügbar </source>
+        <target> Kamera nicht verfügbar </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <segment state="initial">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Form-Check anzeigen oder ausblenden</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.angle">
+      <segment state="initial">
+        <source>Winkel</source>
+        <target>Winkel</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <segment state="initial">
+        <source>Sicherheit</source>
+        <target>Sicherheit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.pause">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.start">
+      <segment state="initial">
+        <source>Start</source>
+        <target>Start</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraHint">
+      <segment state="initial">
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.reset">
+      <segment state="initial">
+        <source> Zurücksetzen </source>
+        <target> Zurücksetzen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.save">
+      <segment state="initial">
+        <source> Übernehmen </source>
+        <target> Übernehmen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.holding">
+      <segment state="initial">
+        <source>Halten</source>
+        <target>Halten</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.paused">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.ready">
+      <segment state="initial">
+        <source>Bereit</source>
+        <target>Bereit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.plank">
+      <segment state="initial">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimerAria">
+      <segment state="initial">
+        <source>Halteübungs-Timer öffnen</source>
+        <target>Halteübungs-Timer öffnen</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <segment state="initial">
+        <source>Plank‑Timer</source>
+        <target>Plank‑Timer</target>
+      </segment>
+    </unit>
+</file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -8494,5 +8494,131 @@
         <target>Ringe</target>
       </segment>
     </unit>
-  </file>
+      <unit id="exerciseTimer.title">
+      <segment state="initial">
+        <source>Halteübung-Timer</source>
+        <target>Halteübung-Timer</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <segment state="initial">
+        <source>Übung wählen</source>
+        <target>Übung wählen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraMode">
+      <segment state="initial">
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+        <target> Kamera: Start/Ende automatisch erkennen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraStarting">
+      <segment state="initial">
+        <source>Kamera startet …</source>
+        <target>Kamera startet …</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraUnavailable">
+      <segment state="initial">
+        <source> Kamera nicht verfügbar </source>
+        <target> Kamera nicht verfügbar </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <segment state="initial">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Form-Check anzeigen oder ausblenden</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.angle">
+      <segment state="initial">
+        <source>Winkel</source>
+        <target>Winkel</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <segment state="initial">
+        <source>Sicherheit</source>
+        <target>Sicherheit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.pause">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.start">
+      <segment state="initial">
+        <source>Start</source>
+        <target>Start</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraHint">
+      <segment state="initial">
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.reset">
+      <segment state="initial">
+        <source> Zurücksetzen </source>
+        <target> Zurücksetzen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.save">
+      <segment state="initial">
+        <source> Übernehmen </source>
+        <target> Übernehmen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.holding">
+      <segment state="initial">
+        <source>Halten</source>
+        <target>Halten</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.paused">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.ready">
+      <segment state="initial">
+        <source>Bereit</source>
+        <target>Bereit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.plank">
+      <segment state="initial">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimerAria">
+      <segment state="initial">
+        <source>Halteübungs-Timer öffnen</source>
+        <target>Halteübungs-Timer öffnen</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <segment state="initial">
+        <source>Plank‑Timer</source>
+        <target>Plank‑Timer</target>
+      </segment>
+    </unit>
+</file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -8494,5 +8494,131 @@
         <target>Ringe</target>
       </segment>
     </unit>
-  </file>
+      <unit id="exerciseTimer.title">
+      <segment state="initial">
+        <source>Halteübung-Timer</source>
+        <target>Halteübung-Timer</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <segment state="initial">
+        <source>Übung wählen</source>
+        <target>Übung wählen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraMode">
+      <segment state="initial">
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+        <target> Kamera: Start/Ende automatisch erkennen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraStarting">
+      <segment state="initial">
+        <source>Kamera startet …</source>
+        <target>Kamera startet …</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraUnavailable">
+      <segment state="initial">
+        <source> Kamera nicht verfügbar </source>
+        <target> Kamera nicht verfügbar </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <segment state="initial">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Form-Check anzeigen oder ausblenden</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.angle">
+      <segment state="initial">
+        <source>Winkel</source>
+        <target>Winkel</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <segment state="initial">
+        <source>Sicherheit</source>
+        <target>Sicherheit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.pause">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.start">
+      <segment state="initial">
+        <source>Start</source>
+        <target>Start</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraHint">
+      <segment state="initial">
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.reset">
+      <segment state="initial">
+        <source> Zurücksetzen </source>
+        <target> Zurücksetzen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.save">
+      <segment state="initial">
+        <source> Übernehmen </source>
+        <target> Übernehmen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.holding">
+      <segment state="initial">
+        <source>Halten</source>
+        <target>Halten</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.paused">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.ready">
+      <segment state="initial">
+        <source>Bereit</source>
+        <target>Bereit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.plank">
+      <segment state="initial">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimerAria">
+      <segment state="initial">
+        <source>Halteübungs-Timer öffnen</source>
+        <target>Halteübungs-Timer öffnen</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <segment state="initial">
+        <source>Plank‑Timer</source>
+        <target>Plank‑Timer</target>
+      </segment>
+    </unit>
+</file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -7754,5 +7754,131 @@ Deine Position: # ·  Reps        </source>
         <target>Ringe</target>
       </segment>
     </unit>
-  </file>
+      <unit id="exerciseTimer.title">
+      <segment state="initial">
+        <source>Halteübung-Timer</source>
+        <target>Halteübung-Timer</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <segment state="initial">
+        <source>Übung wählen</source>
+        <target>Übung wählen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraMode">
+      <segment state="initial">
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+        <target> Kamera: Start/Ende automatisch erkennen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraStarting">
+      <segment state="initial">
+        <source>Kamera startet …</source>
+        <target>Kamera startet …</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraUnavailable">
+      <segment state="initial">
+        <source> Kamera nicht verfügbar </source>
+        <target> Kamera nicht verfügbar </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <segment state="initial">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Form-Check anzeigen oder ausblenden</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.angle">
+      <segment state="initial">
+        <source>Winkel</source>
+        <target>Winkel</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <segment state="initial">
+        <source>Sicherheit</source>
+        <target>Sicherheit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.pause">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.start">
+      <segment state="initial">
+        <source>Start</source>
+        <target>Start</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraHint">
+      <segment state="initial">
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.reset">
+      <segment state="initial">
+        <source> Zurücksetzen </source>
+        <target> Zurücksetzen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.save">
+      <segment state="initial">
+        <source> Übernehmen </source>
+        <target> Übernehmen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.holding">
+      <segment state="initial">
+        <source>Halten</source>
+        <target>Halten</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.paused">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.ready">
+      <segment state="initial">
+        <source>Bereit</source>
+        <target>Bereit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.plank">
+      <segment state="initial">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimerAria">
+      <segment state="initial">
+        <source>Halteübungs-Timer öffnen</source>
+        <target>Halteübungs-Timer öffnen</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <segment state="initial">
+        <source>Plank‑Timer</source>
+        <target>Plank‑Timer</target>
+      </segment>
+    </unit>
+</file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -8346,5 +8346,110 @@
         <source>Detailseite öffnen</source>
       </segment>
     </unit>
-  </file>
+      <unit id="exerciseTimer.title">
+      <segment>
+        <source>Halteübung-Timer</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <segment>
+        <source>Übung wählen</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraMode">
+      <segment>
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraStarting">
+      <segment>
+        <source>Kamera startet …</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraUnavailable">
+      <segment>
+        <source> Kamera nicht verfügbar </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <segment>
+        <source>Form-Check anzeigen oder ausblenden</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.angle">
+      <segment>
+        <source>Winkel</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <segment>
+        <source>Sicherheit</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.pause">
+      <segment>
+        <source>Pause</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.start">
+      <segment>
+        <source>Start</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraHint">
+      <segment>
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.reset">
+      <segment>
+        <source> Zurücksetzen </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cancel">
+      <segment>
+        <source> Abbrechen </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.save">
+      <segment>
+        <source> Übernehmen </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.holding">
+      <segment>
+        <source>Halten</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.paused">
+      <segment>
+        <source>Pause</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.ready">
+      <segment>
+        <source>Bereit</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.plank">
+      <segment>
+        <source>Plank</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <segment>
+        <source>Hollow Hold</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimerAria">
+      <segment>
+        <source>Halteübungs-Timer öffnen</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <segment>
+        <source>Plank‑Timer</source>
+      </segment>
+    </unit>
+</file>
 </xliff>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -8112,5 +8112,131 @@
         <target>Ringe</target>
       </segment>
     </unit>
-  </file>
+      <unit id="exerciseTimer.title">
+      <segment state="initial">
+        <source>Halteübung-Timer</source>
+        <target>Halteübung-Timer</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <segment state="initial">
+        <source>Übung wählen</source>
+        <target>Übung wählen</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraMode">
+      <segment state="initial">
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+        <target> Kamera: Start/Ende automatisch erkennen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraStarting">
+      <segment state="initial">
+        <source>Kamera startet …</source>
+        <target>Kamera startet …</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraUnavailable">
+      <segment state="initial">
+        <source> Kamera nicht verfügbar </source>
+        <target> Kamera nicht verfügbar </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <segment state="initial">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Form-Check anzeigen oder ausblenden</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.angle">
+      <segment state="initial">
+        <source>Winkel</source>
+        <target>Winkel</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <segment state="initial">
+        <source>Sicherheit</source>
+        <target>Sicherheit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.pause">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.start">
+      <segment state="initial">
+        <source>Start</source>
+        <target>Start</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraHint">
+      <segment state="initial">
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.reset">
+      <segment state="initial">
+        <source> Zurücksetzen </source>
+        <target> Zurücksetzen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.save">
+      <segment state="initial">
+        <source> Übernehmen </source>
+        <target> Übernehmen </target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.holding">
+      <segment state="initial">
+        <source>Halten</source>
+        <target>Halten</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.paused">
+      <segment state="initial">
+        <source>Pause</source>
+        <target>Pause</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.ready">
+      <segment state="initial">
+        <source>Bereit</source>
+        <target>Bereit</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.plank">
+      <segment state="initial">
+        <source>Plank</source>
+        <target>Plank</target>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <segment state="initial">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimerAria">
+      <segment state="initial">
+        <source>Halteübungs-Timer öffnen</source>
+        <target>Halteübungs-Timer öffnen</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <segment state="initial">
+        <source>Plank‑Timer</source>
+        <target>Plank‑Timer</target>
+      </segment>
+    </unit>
+</file>
 </xliff>


### PR DESCRIPTION
## Summary

Adds a counter for time-based exercises like plank, mirroring the existing rep-counter flow. The new dialog runs in **manual stopwatch mode** by default and offers an optional **camera mode** that auto-starts/pauses the timer via pose detection — when the user enters a flat-body plank position the timer runs; sustained hip sag or standing up pauses it.

### Domain (`libs/auto-count`)

- `HoldStateMachine` — pure, frame-by-frame hold detector with hysteresis (separate `in`/`out` angle thresholds), debounce for both entering and leaving the pose, and inter-sample gap capping so a dropped camera frame can't silently add seconds.
- `ExerciseHoldProfile` + `PLANK_HOLD_PROFILE` / `HOLLOWHOLD_PROFILE` — tuning constants per exercise (hip-flexion triplet, 160°/140° thresholds, 600/800 ms debounce).
- `PoseHoldTimerService` — signal-based service, browser-only, ties the state machine to the existing MediaPipe detector + frame source.

### Web (`web/src/app/auto-count`)

- `ExerciseTimerDialogComponent` — manual stopwatch + camera-assist toggle, exercise picker (plank / hollow hold). Reuses the camera service and pose-detector providers that already back the rep counter.
- `QuickAddOrchestrationService.openExerciseTimer` — lazy-imports the new dialog (MediaPipe stays out of the initial bundle) and chains into the standard training-entry dialog so the user can confirm/adjust `durationSec` before persisting via `ExerciseFirestoreService`.
- `QuickAddFab` — new "Plank-Timer" dial item that routes to the launcher.

## Test plan

- [x] `pnpm nx test auto-count` — 76 tests green incl. new `hold-state-machine`, `pose-hold-timer.service`, `exercise-hold-profile` specs
- [x] `pnpm nx affected -t lint,test` — 12 projects green
- [x] `pnpm nx run web:build --configuration=development` — green
- [ ] Manual smoke: open dialog → manual mode → start → pause → save flows back through training-entry dialog with `durationSec` prefilled
- [ ] Manual smoke: open dialog → toggle camera → enter plank → confirm timer starts → leave pose → confirm timer pauses

https://claude.ai/code/session_01KHxE2S8wTtA22Q4DLNm9L6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHxE2S8wTtA22Q4DLNm9L6)_