### PR TITLE
feat(landing): refresh hero, feature copy & order for current state

### DIFF
--- a/web/src/app/app.routes.ts
+++ b/web/src/app/app.routes.ts
@@ -13,7 +13,7 @@ export const appRoutes: Routes = [
     pathMatch: 'full',
     data: {
       seoTitle: $localize`:@@seo.landing.title:Liegestütze Tracker: Trainingsplan, Streaks & Bestenliste`,
-      seoDescription: $localize`:@@seo.landing.description:Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.`,
+      seoDescription: $localize`:@@seo.landing.description:Kostenlose Web-App für Liegestütze und mehr: Reps per Kamera-KI im Browser automatisch zählen, plus Trainingspläne, 30-Tage-Challenge, Heatmap, Streaks, Tagesziele und Bestenliste – auch für Sit-ups, Kniebeugen, Klimmzüge, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.`,
     },
     loadComponent: () =>
       import('./marketing/shell/landing-page.component').then(

--- a/web/src/app/marketing/shell/landing-page.component.html
+++ b/web/src/app/marketing/shell/landing-page.component.html
@@ -14,8 +14,9 @@
       <span class="free-badge" i18n="@@landing.free.badge">kostenlos</span>
       <h1 i18n="@@landing.title">Dein Training. Klar visualisiert.</h1>
       <p class="subtitle" i18n="@@landing.subtitle">
-        Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync.
-        Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst.
+        Reps live per Kamera-KI zählen – Liegestütze, Kniebeugen, Klimmzüge,
+        Sit-ups sowie Halte-Timer für Plank & Hollow-Hold. Dazu Trainingspläne,
+        Heatmap, Streaks, Tagesziele und Live-Sync auf allen Geräten.
       </p>
 
       <div class="cta-row">
@@ -217,106 +218,12 @@
         >
       </mat-card-header>
       <mat-card-content i18n="@@landing.feature.autoCount.body"
-        >Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze,
-        Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in
-        Echtzeit direkt im Browser und zählt automatisch mit. Der
-        Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt,
-        dass die Zählung sauber läuft.</mat-card-content
-      >
-    </mat-card>
-
-    <mat-card class="feature-card feature-card--visual">
-      <div class="feature-visual feature-visual--multiset" aria-hidden="true">
-        <svg viewBox="0 0 320 160" xmlns="http://www.w3.org/2000/svg">
-          <defs>
-            <linearGradient id="lp-set-bar" x1="0" y1="0" x2="1" y2="0">
-              <stop offset="0%" class="lp-bar-from" />
-              <stop offset="100%" class="lp-bar-to" />
-            </linearGradient>
-          </defs>
-          <rect width="320" height="160" rx="14" class="lp-bg" />
-          <rect
-            x="14"
-            y="14"
-            width="190"
-            height="132"
-            rx="10"
-            class="lp-card"
-          />
-          <rect
-            x="28"
-            y="44"
-            width="138"
-            height="10"
-            rx="5"
-            class="lp-bar-bg"
-          />
-          <rect
-            x="28"
-            y="44"
-            width="120"
-            height="10"
-            rx="5"
-            fill="url(#lp-set-bar)"
-          />
-          <text x="172" y="53" class="lp-reps">12</text>
-          <rect
-            x="28"
-            y="82"
-            width="138"
-            height="10"
-            rx="5"
-            class="lp-bar-bg"
-          />
-          <rect
-            x="28"
-            y="82"
-            width="100"
-            height="10"
-            rx="5"
-            fill="url(#lp-set-bar)"
-          />
-          <text x="172" y="91" class="lp-reps">10</text>
-          <rect
-            x="28"
-            y="120"
-            width="138"
-            height="10"
-            rx="5"
-            class="lp-bar-bg"
-          />
-          <rect
-            x="28"
-            y="120"
-            width="80"
-            height="10"
-            rx="5"
-            fill="url(#lp-set-bar)"
-          />
-          <text x="172" y="129" class="lp-reps">8</text>
-          <rect
-            x="216"
-            y="14"
-            width="90"
-            height="132"
-            rx="10"
-            class="lp-card"
-          />
-          <text x="261" y="86" text-anchor="middle" class="lp-total-value">
-            30
-          </text>
-        </svg>
-      </div>
-      <mat-card-header class="key-features-header">
-        <mat-icon aria-hidden="true">layers</mat-icon>
-        <mat-card-title i18n="@@landing.feature.multiset.title"
-          >Multi-Set Tracking</mat-card-title
-        >
-      </mat-card-header>
-      <mat-card-content i18n="@@landing.feature.multiset.body"
-        >Erfasse jeden Satz einzeln – z.&#x202F;B.
-        12&nbsp;+&nbsp;10&nbsp;+&nbsp;8. Die App summiert automatisch und zeigt
-        deine durchschnittliche Set-Größe.</mat-card-content
+        >Stell das Handy hin, öffne den Auto-Zähler und leg los: Die KI erkennt
+        Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit direkt im
+        Browser und zählt jede saubere Wiederholung mit. Für Plank und
+        Hollow-Hold läuft stattdessen ein automatischer Halte-Timer. Der
+        Live-Form-Check zeigt Winkel, Phase und Erkennungs-Sicherheit – ohne
+        Cloud, ganz ohne Daten-Upload.</mat-card-content
       >
     </mat-card>
 
@@ -383,9 +290,11 @@
         >
       </mat-card-header>
       <mat-card-content i18n="@@landing.feature.analytics.body"
-        >Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten
-        (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit
-        frei wählbarem Zeitraum.</mat-card-content
+        >Tabbed Analyse mit Verlaufsdiagrammen, KPI-Karten und
+        Kategorie-Vergleich: Liegestütz-Varianten (Standard, Wide, Diamond),
+        Klimmzüge, Sit-ups, Kniebeugen, Plank-Zeiten und Laufen inkl. Pace –
+        jede Übung mit ihrer eigenen Maßeinheit, Zeitraum frei
+        wählbar.</mat-card-content
       >
     </mat-card>
 
@@ -485,9 +394,10 @@
         >
       </mat-card-header>
       <mat-card-content i18n="@@landing.feature.goals.body"
-        >Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige
-        belohnt dranbleiben, Konfetti feiert dein erreichtes
-        Tagesziel.</mat-card-content
+        >Dreifacher Fortschrittsbalken hält dich auf Kurs – Tages-, Wochen- und
+        Monatsziel auf einen Blick. Läuft gerade ein Trainingsplan, übernimmt
+        der das Tagesziel automatisch. Die Streak-Anzeige belohnt Dranbleiben,
+        Konfetti feiert dein erreichtes Ziel.</mat-card-content
       >
     </mat-card>
 
@@ -539,6 +449,103 @@
       >
     </mat-card>
 
+    <mat-card class="feature-card feature-card--visual">
+      <div class="feature-visual feature-visual--multiset" aria-hidden="true">
+        <svg viewBox="0 0 320 160" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="lp-set-bar" x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" class="lp-bar-from" />
+              <stop offset="100%" class="lp-bar-to" />
+            </linearGradient>
+          </defs>
+          <rect width="320" height="160" rx="14" class="lp-bg" />
+          <rect
+            x="14"
+            y="14"
+            width="190"
+            height="132"
+            rx="10"
+            class="lp-card"
+          />
+          <rect
+            x="28"
+            y="44"
+            width="138"
+            height="10"
+            rx="5"
+            class="lp-bar-bg"
+          />
+          <rect
+            x="28"
+            y="44"
+            width="120"
+            height="10"
+            rx="5"
+            fill="url(#lp-set-bar)"
+          />
+          <text x="172" y="53" class="lp-reps">12</text>
+          <rect
+            x="28"
+            y="82"
+            width="138"
+            height="10"
+            rx="5"
+            class="lp-bar-bg"
+          />
+          <rect
+            x="28"
+            y="82"
+            width="100"
+            height="10"
+            rx="5"
+            fill="url(#lp-set-bar)"
+          />
+          <text x="172" y="91" class="lp-reps">10</text>
+          <rect
+            x="28"
+            y="120"
+            width="138"
+            height="10"
+            rx="5"
+            class="lp-bar-bg"
+          />
+          <rect
+            x="28"
+            y="120"
+            width="80"
+            height="10"
+            rx="5"
+            fill="url(#lp-set-bar)"
+          />
+          <text x="172" y="129" class="lp-reps">8</text>
+          <rect
+            x="216"
+            y="14"
+            width="90"
+            height="132"
+            rx="10"
+            class="lp-card"
+          />
+          <text x="261" y="86" text-anchor="middle" class="lp-total-value">
+            30
+          </text>
+        </svg>
+      </div>
+      <mat-card-header class="key-features-header">
+        <mat-icon aria-hidden="true">layers</mat-icon>
+        <mat-card-title i18n="@@landing.feature.multiset.title"
+          >Sätze & Intervalle</mat-card-title
+        >
+      </mat-card-header>
+      <mat-card-content i18n="@@landing.feature.multiset.body"
+        >Erfasse jeden Satz einzeln – z.&#x202F;B.
+        12&nbsp;+&nbsp;10&nbsp;+&nbsp;8. Die App summiert automatisch, zeigt
+        deine Set-Verteilung und vergleicht den Aufbau über Wochen. Für Lauf-
+        und Ausdauer-Workouts trägst du genauso einfach Intervalle samt Pace
+        ein.</mat-card-content
+      >
+    </mat-card>
+
     <mat-card class="feature-card">
       <mat-card-header class="key-features-header">
         <mat-icon aria-hidden="true">bolt</mat-icon>
@@ -547,9 +554,10 @@
         >
       </mat-card-header>
       <mat-card-content i18n="@@landing.feature.quick.body"
-        >Eintrag in 2 Sekunden über den Floating Action Button oder
-        Schnellaktionen direkt im Dashboard – ganz ohne
-        Dialog.</mat-card-content
+        >Ein Tap auf den Floating Action Button oder eine Schnellaktion im
+        Dashboard – Eintrag in zwei Sekunden, komplett ohne Dialog. Detaillierte
+        Erfassung mit Sätzen, Intervallen, Dauer oder Distanz erreichst du auf
+        Wunsch im selben Flow.</mat-card-content
       >
     </mat-card>
 
@@ -562,8 +570,9 @@
       </mat-card-header>
       <mat-card-content i18n="@@landing.feature.adaptive.body"
         >Die Schnellaktionen lernen aus deiner Historie und schlagen passende
-        Wiederholungen vor – oder du konfigurierst eigene
-        Buttons.</mat-card-content
+        Wiederholungen vor. Du willst eigene Presets? Konfiguriere bis zu sechs
+        Buttons pro Übung selbst – inklusive Standard-Variante für den
+        FAB.</mat-card-content
       >
     </mat-card>
 
@@ -576,8 +585,9 @@
       </mat-card-header>
       <mat-card-content i18n="@@landing.feature.pwa.body"
         >Direkt aus dem Browser als App installieren – mit Echtzeit-Sync
-        zwischen allen Geräten und Tagesergebnis per
-        Teilen-Button.</mat-card-content
+        zwischen allen Geräten, Offline-Eintrag dank Service Worker und
+        Tagesergebnis per Teilen-Button. Updates kommen
+        automatisch.</mat-card-content
       >
       @if (isStandalone()) {
         <mat-card-actions class="install-actions">
@@ -617,7 +627,8 @@
         >
       </mat-card-header>
       <mat-card-content i18n="@@landing.feature.privacy.body"
-        >DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der
+        >DSGVO-konform mit anpassbarer Cookie-Zustimmung. Reps werden lokal im
+        Browser ausgewertet – kein Video verlässt dein Gerät. Dein Name auf der
         Bestenliste? Nur wenn du es willst. Kein Abo, keine
         Kreditkarte.</mat-card-content
       >

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -1643,8 +1643,8 @@
       <notes>
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
-      <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+      <segment state="needs-translation">
+        <source>Kostenlose Web-App für Liegestütze und mehr: Reps per Kamera-KI im Browser automatisch zählen, plus Trainingspläne, 30-Tage-Challenge, Heatmap, Streaks, Tagesziele und Bestenliste – auch für Sit-ups, Kniebeugen, Klimmzüge, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
         <target>Κατέγραψε τις κάμψεις με δωρεάν web-app: προγράμματα προπόνησης, πρόκληση 30 ημερών, ημερήσιος στόχος, σερί και πίνακας κατάταξης — τώρα και με sit-ups, καθίσματα, plank και τρέξιμο. Mobile, χωρίς δίκτυο, με live συγχρονισμό.</target>
       </segment>
     </unit>
@@ -2636,8 +2636,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
-      <segment state="translated">
-        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+      <segment state="needs-translation">
+        <source> Reps live per Kamera-KI zählen – Liegestütze, Kniebeugen, Klimmzüge, Sit-ups sowie Halte-Timer für Plank &amp; Hollow-Hold. Dazu Trainingspläne, Heatmap, Streaks, Tagesziele und Live-Sync auf allen Geräten. </source>
         <target> Κατέγραψε τις κάμψεις σου σε δευτερόλεπτα — με τάσεις, σερί και live συγχρονισμό. Επιπλέον sit-ups, καθίσματα, plank και τρέξιμο όταν θέλεις περισσότερα. </target>
       </segment>
     </unit>
@@ -2819,8 +2819,8 @@
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.body">
-      <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+      <segment state="needs-translation">
+        <source>Stell das Handy hin, öffne den Auto-Zähler und leg los: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit direkt im Browser und zählt jede saubere Wiederholung mit. Für Plank und Hollow-Hold läuft stattdessen ein automatischer Halte-Timer. Der Live-Form-Check zeigt Winkel, Phase und Erkennungs-Sicherheit – ohne Cloud, ganz ohne Daten-Upload.</source>
         <target>Στήσε το κινητό, άνοιξε την αυτόματη μέτρηση και ξεκίνα τις κάμψεις, τα καθίσματα, τις έλξεις ή τους κοιλιακούς – η τεχνητή νοημοσύνη μας αναγνωρίζει την κίνησή σου σε πραγματικό χρόνο, απευθείας στον περιηγητή, και μετράει αυτόματα. Το ζωντανό Form Check δείχνει γωνία και αξιοπιστία ώστε να ξέρεις ότι η μέτρηση είναι καθαρή.</target>
       </segment>
     </unit>
@@ -2837,8 +2837,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:284,286</note>
       </notes>
-      <segment state="translated">
-        <source>Multi-Set Tracking</source>
+      <segment state="needs-translation">
+        <source>Sätze &amp; Intervalle</source>
         <target>Παρακολούθηση πολλαπλών συνόλων</target>
       </segment>
     </unit>
@@ -2846,8 +2846,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:288,290</note>
       </notes>
-      <segment state="translated">
-        <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
+      <segment state="needs-translation">
+        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch, zeigt deine Set-Verteilung und vergleicht den Aufbau über Wochen. Für Lauf- und Ausdauer-Workouts trägst du genauso einfach Intervalle samt Pace ein.</source>
         <target>Καταγράψτε κάθε πρόταση ξεχωριστά – π.χ. Π.χ. 12 + 10 + 8. Η εφαρμογή αθροίζει αυτόματα και εμφανίζει το μέσο μέγεθος του συνόλου σας.</target>
       </segment>
     </unit>
@@ -2864,8 +2864,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
-      <segment state="translated">
-        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+      <segment state="needs-translation">
+        <source>Tabbed Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich: Liegestütz-Varianten (Standard, Wide, Diamond), Klimmzüge, Sit-ups, Kniebeugen, Plank-Zeiten und Laufen inkl. Pace – jede Übung mit ihrer eigenen Maßeinheit, Zeitraum frei wählbar.</source>
         <target>Γραφήματα τάσεων και κάρτες KPI για κάθε άσκηση: παραλλαγές κάμψεων (Standard, Wide, Diamond), sit-ups, καθίσματα, plank και τρέξιμο — με ελεύθερα επιλέξιμη περίοδο.</target>
       </segment>
     </unit>
@@ -2882,8 +2882,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:458,461</note>
       </notes>
-      <segment state="translated">
-        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
+      <segment state="needs-translation">
+        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs – Tages-, Wochen- und Monatsziel auf einen Blick. Läuft gerade ein Trainingsplan, übernimmt der das Tagesziel automatisch. Die Streak-Anzeige belohnt Dranbleiben, Konfetti feiert dein erreichtes Ziel.</source>
         <target>Η τριπλή γραμμή προόδου σας κρατά σε καλό δρόμο. Το Streak Display σάς ανταμείβει που το τηρείτε, το κομφετί γιορτάζει τον καθημερινό σας στόχο που επιτύχατε.</target>
       </segment>
     </unit>
@@ -2918,8 +2918,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:520,523</note>
       </notes>
-      <segment state="translated">
-        <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
+      <segment state="needs-translation">
+        <source>Ein Tap auf den Floating Action Button oder eine Schnellaktion im Dashboard – Eintrag in zwei Sekunden, komplett ohne Dialog. Detaillierte Erfassung mit Sätzen, Intervallen, Dauer oder Distanz erreichst du auf Wunsch im selben Flow.</source>
         <target>Είσοδος σε 2 δευτερόλεπτα χρησιμοποιώντας το κουμπί αιωρούμενης ενέργειας ή γρήγορες ενέργειες απευθείας στον πίνακα ελέγχου - χωρίς κανένα παράθυρο διαλόγου.</target>
       </segment>
     </unit>
@@ -2936,8 +2936,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:534,538</note>
       </notes>
-      <segment state="translated">
-        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
+      <segment state="needs-translation">
+        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor. Du willst eigene Presets? Konfiguriere bis zu sechs Buttons pro Übung selbst – inklusive Standard-Variante für den FAB.</source>
         <target>Οι γρήγορες ενέργειες μαθαίνουν από το ιστορικό σας και προτείνουν κατάλληλες επαναλήψεις - ή μπορείτε να διαμορφώσετε τα δικά σας κουμπιά.</target>
       </segment>
     </unit>
@@ -2954,8 +2954,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:548,551</note>
       </notes>
-      <segment state="translated">
-        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
+      <segment state="needs-translation">
+        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten, Offline-Eintrag dank Service Worker und Tagesergebnis per Teilen-Button. Updates kommen automatisch.</source>
         <target>Εγκατάσταση απευθείας από τον περιηγητή σαν εφαρμογή – με συγχρονισμό σε πραγματικό χρόνο σε όλες τις συσκευές και κοινοποίηση του ημερήσιου αποτελέσματος με ένα κουμπί.</target>
       </segment>
     </unit>
@@ -2999,8 +2999,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:562,566</note>
       </notes>
-      <segment state="translated">
-        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
+      <segment state="needs-translation">
+        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Reps werden lokal im Browser ausgewertet – kein Video verlässt dein Gerät. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
         <target>Συμβατό με το GDPR με συναίνεση για προσαρμοσμένα cookie. Το όνομά σας στο leaderboard; Μόνο αν το θέλεις. Χωρίς συνδρομή, χωρίς πιστωτική κάρτα.</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1954,8 +1954,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
-        <target>Trend charts and KPI cards for every exercise: push-up variants (Standard, Wide, Diamond), sit-ups, squats, planks and running – with a freely selectable time range.</target>
+        <source>Tabbed Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich: Liegestütz-Varianten (Standard, Wide, Diamond), Klimmzüge, Sit-ups, Kniebeugen, Plank-Zeiten und Laufen inkl. Pace – jede Übung mit ihrer eigenen Maßeinheit, Zeitraum frei wählbar.</source>
+        <target>Tabbed analysis with trend charts, KPI cards and category comparison: push-up variants (Standard, Wide, Diamond), pull-ups, sit-ups, squats, plank durations and running with pace – each exercise in its own unit, time range freely selectable.</target>
             </segment>
         </unit>
     <unit id="landing.feature.analytics.title">
@@ -1972,8 +1972,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Multi-Set Tracking</source>
-        <target>Multi-set tracking</target>
+        <source>Sätze &amp; Intervalle</source>
+        <target>Sets &amp; intervals</target>
             </segment>
         </unit>
     <unit id="landing.feature.multiset.body">
@@ -1981,8 +1981,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
-        <target>Log every set individually – e.g. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. The app sums them up automatically and shows your average set size.</target>
+        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch, zeigt deine Set-Verteilung und vergleicht den Aufbau über Wochen. Für Lauf- und Ausdauer-Workouts trägst du genauso einfach Intervalle samt Pace ein.</source>
+        <target>Log every set individually – e.g. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. The app totals it up automatically, shows your set distribution and compares the build over weeks. For running and endurance workouts you log intervals with pace in the same flow.</target>
             </segment>
         </unit>
     <unit id="landing.feature.goals.title">
@@ -1999,8 +1999,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
-        <target>Triple progress bar keeps you on track. The streak counter rewards consistency and confetti celebrates each daily goal you hit.</target>
+        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs – Tages-, Wochen- und Monatsziel auf einen Blick. Läuft gerade ein Trainingsplan, übernimmt der das Tagesziel automatisch. Die Streak-Anzeige belohnt Dranbleiben, Konfetti feiert dein erreichtes Ziel.</source>
+        <target>A triple progress bar keeps you on track – daily, weekly and monthly goal at a glance. When a training plan is active it takes over the daily goal automatically. The streak counter rewards consistency and confetti celebrates each goal you hit.</target>
             </segment>
         </unit>
     <unit id="landing.feature.heatmap.title">
@@ -2026,8 +2026,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
-        <target>Log an entry in 2 seconds via the floating action button or quick actions directly on the dashboard – no dialog needed.</target>
+        <source>Ein Tap auf den Floating Action Button oder eine Schnellaktion im Dashboard – Eintrag in zwei Sekunden, komplett ohne Dialog. Detaillierte Erfassung mit Sätzen, Intervallen, Dauer oder Distanz erreichst du auf Wunsch im selben Flow.</source>
+        <target>One tap on the floating action button or a quick action on the dashboard – an entry in two seconds, no dialog at all. Detailed logging with sets, intervals, duration or distance is one step further in the same flow.</target>
             </segment>
         </unit>
     <unit id="landing.feature.quick.title">
@@ -2053,8 +2053,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
-        <target>Install it as an app straight from the browser – with real-time sync across all your devices and your daily result a share button away.</target>
+        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten, Offline-Eintrag dank Service Worker und Tagesergebnis per Teilen-Button. Updates kommen automatisch.</source>
+        <target>Install it as an app straight from the browser – with real-time sync across all your devices, offline logging thanks to the service worker and your daily result one tap of the share button away. Updates roll out automatically.</target>
             </segment>
         </unit>
     <unit id="landing.feature.pwa.installed">
@@ -2098,8 +2098,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
-        <target>GDPR-friendly with customisable cookie consent. Your name on the leaderboard? Only if you want it there. No subscription, no credit card.</target>
+        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Reps werden lokal im Browser ausgewertet – kein Video verlässt dein Gerät. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
+        <target>GDPR-friendly with customisable cookie consent. Reps are analysed locally in the browser – no video ever leaves your device. Your name on the leaderboard? Only if you want it there. No subscription, no credit card.</target>
             </segment>
         </unit>
     <unit id="landing.feature.autoCount.imageAlt">
@@ -2116,8 +2116,8 @@ Active:         </target>
     </unit>
     <unit id="landing.feature.autoCount.body">
       <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
-        <target>Prop up your phone, open the auto-counter and start your push-ups, squats, pull-ups or sit-ups – our AI recognises your motion in real time, right in your browser, and counts along automatically. The live Form Check shows angle and confidence so you always know the count is clean.</target>
+        <source>Stell das Handy hin, öffne den Auto-Zähler und leg los: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit direkt im Browser und zählt jede saubere Wiederholung mit. Für Plank und Hollow-Hold läuft stattdessen ein automatischer Halte-Timer. Der Live-Form-Check zeigt Winkel, Phase und Erkennungs-Sicherheit – ohne Cloud, ganz ohne Daten-Upload.</source>
+        <target>Prop up your phone, open the auto-counter and get going: the AI recognises push-ups, squats, pull-ups and sit-ups in real time right in your browser and counts every clean rep. For planks and hollow holds an automatic hold timer kicks in instead. The live Form Check shows angle, phase and detection confidence – on-device, with zero data leaving your phone.</target>
       </segment>
     </unit>
     <unit id="landing.features.aria">
@@ -2414,8 +2414,8 @@ Deine Position: # ·  Reps        </source>
 
             </notes>
       <segment state="translated">
-        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
-        <target> Track push-ups in seconds — with trends, streaks and live sync. Plus sit-ups, squats, planks and running when you want more. </target>
+        <source> Reps live per Kamera-KI zählen – Liegestütze, Kniebeugen, Klimmzüge, Sit-ups sowie Halte-Timer für Plank &amp; Hollow-Hold. Dazu Trainingspläne, Heatmap, Streaks, Tagesziele und Live-Sync auf allen Geräten. </source>
+        <target> Count reps live with camera-AI — push-ups, squats, pull-ups, sit-ups plus a hold timer for planks &amp; hollow holds. With training plans, heatmap, streaks, daily goals and live sync across every device. </target>
 
 
 
@@ -3644,8 +3644,8 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="seo.landing.description">
       <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
-        <target>Track push-ups with a free web app: training plans, 30-day challenge, daily goal, streaks and global leaderboard – now also with sit-ups, squats, planks and running. Mobile, offline-capable, live-synced.</target>
+        <source>Kostenlose Web-App für Liegestütze und mehr: Reps per Kamera-KI im Browser automatisch zählen, plus Trainingspläne, 30-Tage-Challenge, Heatmap, Streaks, Tagesziele und Bestenliste – auch für Sit-ups, Kniebeugen, Klimmzüge, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+        <target>Free web app for push-ups and more: count reps automatically with camera-AI in your browser, plus training plans, 30-day challenge, heatmap, streaks, daily goals and global leaderboard – also with sit-ups, squats, pull-ups, planks and running. Mobile, offline-capable, live-synced.</target>
 
 
 
@@ -5542,8 +5542,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="landing.feature.adaptive.body">
       <segment state="translated">
-        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
-        <target>The quick actions learn from your history and suggest fitting rep counts – or you configure your own buttons.</target>
+        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor. Du willst eigene Presets? Konfiguriere bis zu sechs Buttons pro Übung selbst – inklusive Standard-Variante für den FAB.</source>
+        <target>The quick actions learn from your history and suggest matching rep counts. Want your own presets? Configure up to six buttons per exercise yourself – including the default the FAB uses.</target>
       </segment>
     </unit>
     <unit id="dashboard.analysisTeaserAriaLabel">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -1643,8 +1643,8 @@
       <notes>
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
-      <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+      <segment state="needs-translation">
+        <source>Kostenlose Web-App für Liegestütze und mehr: Reps per Kamera-KI im Browser automatisch zählen, plus Trainingspläne, 30-Tage-Challenge, Heatmap, Streaks, Tagesziele und Bestenliste – auch für Sit-ups, Kniebeugen, Klimmzüge, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
         <target>Registra tus flexiones con una web-app gratuita: planes de entrenamiento, reto de 30 días, objetivo diario, rachas y clasificación — ahora también con abdominales, sentadillas, plancha y carrera. Móvil, sin conexión, sincronización en vivo.</target>
       </segment>
     </unit>
@@ -2636,8 +2636,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
-      <segment state="translated">
-        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+      <segment state="needs-translation">
+        <source> Reps live per Kamera-KI zählen – Liegestütze, Kniebeugen, Klimmzüge, Sit-ups sowie Halte-Timer für Plank &amp; Hollow-Hold. Dazu Trainingspläne, Heatmap, Streaks, Tagesziele und Live-Sync auf allen Geräten. </source>
         <target> Registra tus flexiones en segundos — con tendencias, rachas y sincronización en vivo. Además abdominales, sentadillas, plancha y carrera cuando quieras más. </target>
       </segment>
     </unit>
@@ -2819,8 +2819,8 @@
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.body">
-      <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+      <segment state="needs-translation">
+        <source>Stell das Handy hin, öffne den Auto-Zähler und leg los: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit direkt im Browser und zählt jede saubere Wiederholung mit. Für Plank und Hollow-Hold läuft stattdessen ein automatischer Halte-Timer. Der Live-Form-Check zeigt Winkel, Phase und Erkennungs-Sicherheit – ohne Cloud, ganz ohne Daten-Upload.</source>
         <target>Coloca el teléfono, abre el conteo automático y empieza tus flexiones, sentadillas, dominadas o abdominales: nuestra IA reconoce tu movimiento en tiempo real, directamente en el navegador, y cuenta automáticamente por ti. El Form Check en vivo muestra ángulo y confianza para que sepas que el conteo es limpio.</target>
       </segment>
     </unit>
@@ -2837,8 +2837,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:284,286</note>
       </notes>
-      <segment state="translated">
-        <source>Multi-Set Tracking</source>
+      <segment state="needs-translation">
+        <source>Sätze &amp; Intervalle</source>
         <target>Seguimiento de conjuntos múltiples</target>
       </segment>
     </unit>
@@ -2846,8 +2846,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:288,290</note>
       </notes>
-      <segment state="translated">
-        <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
+      <segment state="needs-translation">
+        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch, zeigt deine Set-Verteilung und vergleicht den Aufbau über Wochen. Für Lauf- und Ausdauer-Workouts trägst du genauso einfach Intervalle samt Pace ein.</source>
         <target>Registre cada oración individualmente – p.e. P.ej. 12 + 10 + 8. La aplicación suma y muestra automáticamente el tamaño promedio del conjunto.</target>
       </segment>
     </unit>
@@ -2864,8 +2864,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
-      <segment state="translated">
-        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+      <segment state="needs-translation">
+        <source>Tabbed Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich: Liegestütz-Varianten (Standard, Wide, Diamond), Klimmzüge, Sit-ups, Kniebeugen, Plank-Zeiten und Laufen inkl. Pace – jede Übung mit ihrer eigenen Maßeinheit, Zeitraum frei wählbar.</source>
         <target>Gráficos de tendencia y tarjetas KPI para cada ejercicio: variantes de flexión (Standard, Wide, Diamond), abdominales, sentadillas, plancha y carrera — con un periodo libremente seleccionable.</target>
       </segment>
     </unit>
@@ -2882,8 +2882,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:458,461</note>
       </notes>
-      <segment state="translated">
-        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
+      <segment state="needs-translation">
+        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs – Tages-, Wochen- und Monatsziel auf einen Blick. Läuft gerade ein Trainingsplan, übernimmt der das Tagesziel automatisch. Die Streak-Anzeige belohnt Dranbleiben, Konfetti feiert dein erreichtes Ziel.</source>
         <target>La triple barra de progreso te mantiene encaminado. La visualización de rachas te recompensa por seguir adelante, el confeti celebra tu objetivo diario alcanzado.</target>
       </segment>
     </unit>
@@ -2918,8 +2918,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:520,523</note>
       </notes>
-      <segment state="translated">
-        <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
+      <segment state="needs-translation">
+        <source>Ein Tap auf den Floating Action Button oder eine Schnellaktion im Dashboard – Eintrag in zwei Sekunden, komplett ohne Dialog. Detaillierte Erfassung mit Sätzen, Intervallen, Dauer oder Distanz erreichst du auf Wunsch im selben Flow.</source>
         <target>Entrada en 2 segundos usando el botón de acción flotante o acciones rápidas directamente en el tablero, sin ningún diálogo.</target>
       </segment>
     </unit>
@@ -2936,8 +2936,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:534,538</note>
       </notes>
-      <segment state="translated">
-        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
+      <segment state="needs-translation">
+        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor. Du willst eigene Presets? Konfiguriere bis zu sechs Buttons pro Übung selbst – inklusive Standard-Variante für den FAB.</source>
         <target>Las acciones rápidas aprenden de su historial y sugieren repeticiones adecuadas, o puede configurar sus propios botones.</target>
       </segment>
     </unit>
@@ -2954,8 +2954,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:548,551</note>
       </notes>
-      <segment state="translated">
-        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
+      <segment state="needs-translation">
+        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten, Offline-Eintrag dank Service Worker und Tagesergebnis per Teilen-Button. Updates kommen automatisch.</source>
         <target>Instálala directamente desde el navegador como una app, con sincronización en tiempo real entre todos tus dispositivos y comparte tu resultado diario con un solo botón.</target>
       </segment>
     </unit>
@@ -2999,8 +2999,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:562,566</note>
       </notes>
-      <segment state="translated">
-        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
+      <segment state="needs-translation">
+        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Reps werden lokal im Browser ausgewertet – kein Video verlässt dein Gerät. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
         <target>Cumple con GDPR con consentimiento de cookies personalizable. ¿Tu nombre en la clasificación? Sólo si lo deseas. Sin suscripción, sin tarjeta de crédito.</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -1643,8 +1643,8 @@
       <notes>
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
-      <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+      <segment state="needs-translation">
+        <source>Kostenlose Web-App für Liegestütze und mehr: Reps per Kamera-KI im Browser automatisch zählen, plus Trainingspläne, 30-Tage-Challenge, Heatmap, Streaks, Tagesziele und Bestenliste – auch für Sit-ups, Kniebeugen, Klimmzüge, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
         <target>Suivez vos pompes avec une web-app gratuite : plans d'entraînement, défi 30 jours, objectif quotidien, séries et classement mondial — désormais aussi avec abdos, squats, gainage et course. Mobile, hors-ligne, sync en direct.</target>
       </segment>
     </unit>
@@ -2636,8 +2636,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
-      <segment state="translated">
-        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+      <segment state="needs-translation">
+        <source> Reps live per Kamera-KI zählen – Liegestütze, Kniebeugen, Klimmzüge, Sit-ups sowie Halte-Timer für Plank &amp; Hollow-Hold. Dazu Trainingspläne, Heatmap, Streaks, Tagesziele und Live-Sync auf allen Geräten. </source>
         <target> Suis tes pompes en quelques secondes — avec tendances, séries et synchronisation en direct. Plus des abdos, squats, gainage et course quand tu en veux plus. </target>
       </segment>
     </unit>
@@ -2819,8 +2819,8 @@
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.body">
-      <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+      <segment state="needs-translation">
+        <source>Stell das Handy hin, öffne den Auto-Zähler und leg los: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit direkt im Browser und zählt jede saubere Wiederholung mit. Für Plank und Hollow-Hold läuft stattdessen ein automatischer Halte-Timer. Der Live-Form-Check zeigt Winkel, Phase und Erkennungs-Sicherheit – ohne Cloud, ganz ohne Daten-Upload.</source>
         <target>Pose ton téléphone, ouvre le comptage automatique et fais tes pompes, squats, tractions ou abdominaux – notre IA détecte ton mouvement en temps réel, directement dans le navigateur, et compte automatiquement pour toi. Le Form Check en direct affiche l'angle et la confiance pour que tu saches que le décompte est propre.</target>
       </segment>
     </unit>
@@ -2837,8 +2837,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:284,286</note>
       </notes>
-      <segment state="translated">
-        <source>Multi-Set Tracking</source>
+      <segment state="needs-translation">
+        <source>Sätze &amp; Intervalle</source>
         <target>Suivi multi-ensembles</target>
       </segment>
     </unit>
@@ -2846,8 +2846,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:288,290</note>
       </notes>
-      <segment state="translated">
-        <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
+      <segment state="needs-translation">
+        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch, zeigt deine Set-Verteilung und vergleicht den Aufbau über Wochen. Für Lauf- und Ausdauer-Workouts trägst du genauso einfach Intervalle samt Pace ein.</source>
         <target>Enregistrez chaque phrase individuellement – par ex. Par ex. 12 + 10 + 8. L'application totalise automatiquement et affiche la taille moyenne de votre ensemble.</target>
       </segment>
     </unit>
@@ -2864,8 +2864,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
-      <segment state="translated">
-        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+      <segment state="needs-translation">
+        <source>Tabbed Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich: Liegestütz-Varianten (Standard, Wide, Diamond), Klimmzüge, Sit-ups, Kniebeugen, Plank-Zeiten und Laufen inkl. Pace – jede Übung mit ihrer eigenen Maßeinheit, Zeitraum frei wählbar.</source>
         <target>Graphiques de tendance et cartes KPI pour chaque exercice : variantes de pompes (Standard, Wide, Diamond), abdos, squats, gainage et course — avec une période librement sélectionnable.</target>
       </segment>
     </unit>
@@ -2882,8 +2882,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:458,461</note>
       </notes>
-      <segment state="translated">
-        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
+      <segment state="needs-translation">
+        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs – Tages-, Wochen- und Monatsziel auf einen Blick. Läuft gerade ein Trainingsplan, übernimmt der das Tagesziel automatisch. Die Streak-Anzeige belohnt Dranbleiben, Konfetti feiert dein erreichtes Ziel.</source>
         <target>La triple barre de progression vous permet de rester sur la bonne voie. L'affichage Streak vous récompense pour votre persévérance, les confettis célèbrent votre objectif quotidien atteint.</target>
       </segment>
     </unit>
@@ -2918,8 +2918,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:520,523</note>
       </notes>
-      <segment state="translated">
-        <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
+      <segment state="needs-translation">
+        <source>Ein Tap auf den Floating Action Button oder eine Schnellaktion im Dashboard – Eintrag in zwei Sekunden, komplett ohne Dialog. Detaillierte Erfassung mit Sätzen, Intervallen, Dauer oder Distanz erreichst du auf Wunsch im selben Flow.</source>
         <target>Saisie en 2 secondes à l'aide du bouton d'action flottant ou d'actions rapides directement dans le tableau de bord - sans aucune boîte de dialogue.</target>
       </segment>
     </unit>
@@ -2936,8 +2936,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:534,538</note>
       </notes>
-      <segment state="translated">
-        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
+      <segment state="needs-translation">
+        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor. Du willst eigene Presets? Konfiguriere bis zu sechs Buttons pro Übung selbst – inklusive Standard-Variante für den FAB.</source>
         <target>Les actions rapides apprennent de votre historique et suggèrent des répétitions appropriées - ou vous pouvez configurer vos propres boutons.</target>
       </segment>
     </unit>
@@ -2954,8 +2954,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:548,551</note>
       </notes>
-      <segment state="translated">
-        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
+      <segment state="needs-translation">
+        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten, Offline-Eintrag dank Service Worker und Tagesergebnis per Teilen-Button. Updates kommen automatisch.</source>
         <target>Installe-la directement depuis le navigateur comme une app, avec synchronisation en temps réel entre tous tes appareils et partage de ton résultat du jour en un clic.</target>
       </segment>
     </unit>
@@ -2999,8 +2999,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:562,566</note>
       </notes>
-      <segment state="translated">
-        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
+      <segment state="needs-translation">
+        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Reps werden lokal im Browser ausgewertet – kein Video verlässt dein Gerät. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
         <target>Conforme RGPD avec consentement aux cookies personnalisable. Votre nom dans le classement? Seulement si tu le veux. Pas d'abonnement, pas de carte bancaire.</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -1643,8 +1643,8 @@
       <notes>
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
-      <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+      <segment state="needs-translation">
+        <source>Kostenlose Web-App für Liegestütze und mehr: Reps per Kamera-KI im Browser automatisch zählen, plus Trainingspläne, 30-Tage-Challenge, Heatmap, Streaks, Tagesziele und Bestenliste – auch für Sit-ups, Kniebeugen, Klimmzüge, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
         <target>Traccia i piegamenti con una web-app gratuita: piani di allenamento, sfida di 30 giorni, obiettivo giornaliero, streak e classifica — ora anche con sit-up, squat, plank e corsa. Mobile, offline, sincronizzazione live.</target>
       </segment>
     </unit>
@@ -2636,8 +2636,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
-      <segment state="translated">
-        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+      <segment state="needs-translation">
+        <source> Reps live per Kamera-KI zählen – Liegestütze, Kniebeugen, Klimmzüge, Sit-ups sowie Halte-Timer für Plank &amp; Hollow-Hold. Dazu Trainingspläne, Heatmap, Streaks, Tagesziele und Live-Sync auf allen Geräten. </source>
         <target> Traccia i piegamenti in pochi secondi — con tendenze, streak e sincronizzazione live. Più sit-up, squat, plank e corsa quando vuoi di più. </target>
       </segment>
     </unit>
@@ -2819,8 +2819,8 @@
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.body">
-      <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+      <segment state="needs-translation">
+        <source>Stell das Handy hin, öffne den Auto-Zähler und leg los: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit direkt im Browser und zählt jede saubere Wiederholung mit. Für Plank und Hollow-Hold läuft stattdessen ein automatischer Halte-Timer. Der Live-Form-Check zeigt Winkel, Phase und Erkennungs-Sicherheit – ohne Cloud, ganz ohne Daten-Upload.</source>
         <target>Appoggia il telefono, apri il conteggio automatico e fai le flessioni, gli squat, le trazioni o gli addominali – la nostra IA riconosce il tuo movimento in tempo reale, direttamente nel browser, e conta automaticamente per te. Il Form Check in tempo reale mostra angolo e affidabilità così sai che il conteggio è preciso.</target>
       </segment>
     </unit>
@@ -2837,8 +2837,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:284,286</note>
       </notes>
-      <segment state="translated">
-        <source>Multi-Set Tracking</source>
+      <segment state="needs-translation">
+        <source>Sätze &amp; Intervalle</source>
         <target>Monitoraggio di più set</target>
       </segment>
     </unit>
@@ -2846,8 +2846,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:288,290</note>
       </notes>
-      <segment state="translated">
-        <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
+      <segment state="needs-translation">
+        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch, zeigt deine Set-Verteilung und vergleicht den Aufbau über Wochen. Für Lauf- und Ausdauer-Workouts trägst du genauso einfach Intervalle samt Pace ein.</source>
         <target>Registra ogni frase individualmente – ad es. Per esempio. 12 + 10 + 8. L'app calcola automaticamente il totale e mostra la dimensione media del tuo set.</target>
       </segment>
     </unit>
@@ -2864,8 +2864,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
-      <segment state="translated">
-        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+      <segment state="needs-translation">
+        <source>Tabbed Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich: Liegestütz-Varianten (Standard, Wide, Diamond), Klimmzüge, Sit-ups, Kniebeugen, Plank-Zeiten und Laufen inkl. Pace – jede Übung mit ihrer eigenen Maßeinheit, Zeitraum frei wählbar.</source>
         <target>Grafici di tendenza e schede KPI per ogni esercizio: varianti di piegamento (Standard, Wide, Diamond), sit-up, squat, plank e corsa — con periodo a scelta.</target>
       </segment>
     </unit>
@@ -2882,8 +2882,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:458,461</note>
       </notes>
-      <segment state="translated">
-        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
+      <segment state="needs-translation">
+        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs – Tages-, Wochen- und Monatsziel auf einen Blick. Läuft gerade ein Trainingsplan, übernimmt der das Tagesziel automatisch. Die Streak-Anzeige belohnt Dranbleiben, Konfetti feiert dein erreichtes Ziel.</source>
         <target>La tripla barra di avanzamento ti mantiene in pista. La visualizzazione delle strisce ti premia per aver continuato a seguirla, i coriandoli celebrano il tuo obiettivo quotidiano raggiunto.</target>
       </segment>
     </unit>
@@ -2918,8 +2918,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:520,523</note>
       </notes>
-      <segment state="translated">
-        <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
+      <segment state="needs-translation">
+        <source>Ein Tap auf den Floating Action Button oder eine Schnellaktion im Dashboard – Eintrag in zwei Sekunden, komplett ohne Dialog. Detaillierte Erfassung mit Sätzen, Intervallen, Dauer oder Distanz erreichst du auf Wunsch im selben Flow.</source>
         <target>Inserimento in 2 secondi utilizzando il pulsante di azione mobile o azioni rapide direttamente nel dashboard - senza alcuna finestra di dialogo.</target>
       </segment>
     </unit>
@@ -2936,8 +2936,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:534,538</note>
       </notes>
-      <segment state="translated">
-        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
+      <segment state="needs-translation">
+        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor. Du willst eigene Presets? Konfiguriere bis zu sechs Buttons pro Übung selbst – inklusive Standard-Variante für den FAB.</source>
         <target>Le azioni rapide imparano dalla tua cronologia e suggeriscono ripetizioni adeguate, oppure puoi configurare i tuoi pulsanti.</target>
       </segment>
     </unit>
@@ -2954,8 +2954,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:548,551</note>
       </notes>
-      <segment state="translated">
-        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
+      <segment state="needs-translation">
+        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten, Offline-Eintrag dank Service Worker und Tagesergebnis per Teilen-Button. Updates kommen automatisch.</source>
         <target>Installala direttamente dal browser come app, con sincronizzazione in tempo reale tra tutti i tuoi dispositivi e condivisione del risultato giornaliero con un solo tocco.</target>
       </segment>
     </unit>
@@ -2999,8 +2999,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:562,566</note>
       </notes>
-      <segment state="translated">
-        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
+      <segment state="needs-translation">
+        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Reps werden lokal im Browser ausgewertet – kein Video verlässt dein Gerät. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
         <target>GDPR conforme con consenso cookie personalizzabile. Il tuo nome in classifica? Solo se lo vuoi. Nessun abbonamento, nessuna carta di credito.</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -1643,8 +1643,8 @@
       <notes>
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
-      <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+      <segment state="needs-translation">
+        <source>Kostenlose Web-App für Liegestütze und mehr: Reps per Kamera-KI im Browser automatisch zählen, plus Trainingspläne, 30-Tage-Challenge, Heatmap, Streaks, Tagesziele und Bestenliste – auch für Sit-ups, Kniebeugen, Klimmzüge, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
         <target>Pressiones cum gratuita applicatione interretiali metiri: rationes exercitii, certamen XXX dierum, propositum cotidianum, series et tabula primorum — nunc etiam cum sedationibus, genuflexionibus, planca et cursu. Mobile, sine rete, cum synchronia viva.</target>
       </segment>
     </unit>
@@ -2636,8 +2636,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
-      <segment state="translated">
-        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+      <segment state="needs-translation">
+        <source> Reps live per Kamera-KI zählen – Liegestütze, Kniebeugen, Klimmzüge, Sit-ups sowie Halte-Timer für Plank &amp; Hollow-Hold. Dazu Trainingspläne, Heatmap, Streaks, Tagesziele und Live-Sync auf allen Geräten. </source>
         <target> Pressiones in secundis metiri – cum tendentiis, seriebus et synchronia viva. Praeterea sedationes, genuflexiones, planca et cursus, cum plura velis. </target>
       </segment>
     </unit>
@@ -2819,8 +2819,8 @@
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.body">
-      <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+      <segment state="needs-translation">
+        <source>Stell das Handy hin, öffne den Auto-Zähler und leg los: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit direkt im Browser und zählt jede saubere Wiederholung mit. Für Plank und Hollow-Hold läuft stattdessen ein automatischer Halte-Timer. Der Live-Form-Check zeigt Winkel, Phase und Erkennungs-Sicherheit – ohne Cloud, ganz ohne Daten-Upload.</source>
         <target>Telephonum pone, numeratorem automaticum aperi et pulsus, genuflexiones, tractus aut sessiones fac – intellegentia artificialis nostra motum tuum tempore vero in navigatro ipso cognoscit et automatice numerat. Form-Check vivus angulum et fiduciam monstrat, ut scias numerationem mundam esse.</target>
       </segment>
     </unit>
@@ -2837,8 +2837,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:284,286</note>
       </notes>
-      <segment state="translated">
-        <source>Multi-Set Tracking</source>
+      <segment state="needs-translation">
+        <source>Sätze &amp; Intervalle</source>
         <target>Multi-parant Semita</target>
       </segment>
     </unit>
@@ -2846,8 +2846,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:288,290</note>
       </notes>
-      <segment state="translated">
-        <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
+      <segment state="needs-translation">
+        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch, zeigt deine Set-Verteilung und vergleicht den Aufbau über Wochen. Für Lauf- und Ausdauer-Workouts trägst du genauso einfach Intervalle samt Pace ein.</source>
         <target>Record each sentence individually – e.g. E.g. 12 + 10 + 8. Summa app automatice demonstrat ac magnitudinem tuam mediocris statuta ostendit.</target>
       </segment>
     </unit>
@@ -2864,8 +2864,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
-      <segment state="translated">
-        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+      <segment state="needs-translation">
+        <source>Tabbed Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich: Liegestütz-Varianten (Standard, Wide, Diamond), Klimmzüge, Sit-ups, Kniebeugen, Plank-Zeiten und Laufen inkl. Pace – jede Übung mit ihrer eigenen Maßeinheit, Zeitraum frei wählbar.</source>
         <target>Diagrammata tendentiarum et tabellae KPI pro omni exercitatione: varietates pressionum (Standard, Wide, Diamond), sedationes, genuflexiones, planca et cursus — cum tempore libere eligendo.</target>
       </segment>
     </unit>
@@ -2882,8 +2882,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:458,461</note>
       </notes>
-      <segment state="translated">
-        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
+      <segment state="needs-translation">
+        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs – Tages-, Wochen- und Monatsziel auf einen Blick. Läuft gerade ein Trainingsplan, übernimmt der das Tagesziel automatisch. Die Streak-Anzeige belohnt Dranbleiben, Konfetti feiert dein erreichtes Ziel.</source>
         <target>Triple progress bar keeps you on track. Streak display rewards you for sticking with it, confetti celebrates your daily goal achieved.</target>
       </segment>
     </unit>
@@ -2918,8 +2918,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:520,523</note>
       </notes>
-      <segment state="translated">
-        <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
+      <segment state="needs-translation">
+        <source>Ein Tap auf den Floating Action Button oder eine Schnellaktion im Dashboard – Eintrag in zwei Sekunden, komplett ohne Dialog. Detaillierte Erfassung mit Sätzen, Intervallen, Dauer oder Distanz erreichst du auf Wunsch im selben Flow.</source>
         <target>Entry in 2 seconds using the floating action button or quick actions directly in the dashboard - without any dialog.</target>
       </segment>
     </unit>
@@ -2936,8 +2936,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:534,538</note>
       </notes>
-      <segment state="translated">
-        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
+      <segment state="needs-translation">
+        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor. Du willst eigene Presets? Konfiguriere bis zu sechs Buttons pro Übung selbst – inklusive Standard-Variante für den FAB.</source>
         <target>The quick actions learn from your history and suggest suitable repetitions - or you can configure your own buttons.</target>
       </segment>
     </unit>
@@ -2954,8 +2954,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:548,551</note>
       </notes>
-      <segment state="translated">
-        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
+      <segment state="needs-translation">
+        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten, Offline-Eintrag dank Service Worker und Tagesergebnis per Teilen-Button. Updates kommen automatisch.</source>
         <target>Eam directe e navigatro tamquam applicationem installa – cum synchronia tempore reali inter omnia instrumenta et eventu cotidiano per buttonem communicatum.</target>
       </segment>
     </unit>
@@ -2999,8 +2999,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:562,566</note>
       </notes>
-      <segment state="translated">
-        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
+      <segment state="needs-translation">
+        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Reps werden lokal im Browser ausgewertet – kein Video verlässt dein Gerät. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
         <target>GDPR compliant with customizable cookie consent. Nomen tuum in ducisboard? Si vis tantum. Nulla subscriptio, nulla scidula.</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -1643,8 +1643,8 @@
       <notes>
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
-      <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+      <segment state="needs-translation">
+        <source>Kostenlose Web-App für Liegestütze und mehr: Reps per Kamera-KI im Browser automatisch zählen, plus Trainingspläne, 30-Tage-Challenge, Heatmap, Streaks, Tagesziele und Bestenliste – auch für Sit-ups, Kniebeugen, Klimmzüge, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
         <target>Volg je push-ups met een gratis web-app: trainingsplannen, 30-daagse uitdaging, dagdoel, streaks en ranglijst — nu ook met sit-ups, squats, plank en hardlopen. Mobiel, offline en met live-sync.</target>
       </segment>
     </unit>
@@ -2636,8 +2636,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
-      <segment state="translated">
-        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+      <segment state="needs-translation">
+        <source> Reps live per Kamera-KI zählen – Liegestütze, Kniebeugen, Klimmzüge, Sit-ups sowie Halte-Timer für Plank &amp; Hollow-Hold. Dazu Trainingspläne, Heatmap, Streaks, Tagesziele und Live-Sync auf allen Geräten. </source>
         <target> Volg je push-ups in seconden — met trends, streaks en live-sync. Plus sit-ups, squats, plank en hardlopen wanneer je meer wilt. </target>
       </segment>
     </unit>
@@ -2819,8 +2819,8 @@
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.body">
-      <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+      <segment state="needs-translation">
+        <source>Stell das Handy hin, öffne den Auto-Zähler und leg los: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit direkt im Browser und zählt jede saubere Wiederholung mit. Für Plank und Hollow-Hold läuft stattdessen ein automatischer Halte-Timer. Der Live-Form-Check zeigt Winkel, Phase und Erkennungs-Sicherheit – ohne Cloud, ganz ohne Daten-Upload.</source>
         <target>Zet de telefoon neer, open de auto-teller en doe je push-ups, squats, pull-ups of sit-ups – onze AI herkent je beweging in realtime, direct in de browser, en telt automatisch mee. De live Form Check toont hoek en zekerheid, zodat je weet dat de telling klopt.</target>
       </segment>
     </unit>
@@ -2837,8 +2837,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:284,286</note>
       </notes>
-      <segment state="translated">
-        <source>Multi-Set Tracking</source>
+      <segment state="needs-translation">
+        <source>Sätze &amp; Intervalle</source>
         <target>Tracking van meerdere sets</target>
       </segment>
     </unit>
@@ -2846,8 +2846,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:288,290</note>
       </notes>
-      <segment state="translated">
-        <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
+      <segment state="needs-translation">
+        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch, zeigt deine Set-Verteilung und vergleicht den Aufbau über Wochen. Für Lauf- und Ausdauer-Workouts trägst du genauso einfach Intervalle samt Pace ein.</source>
         <target>Neem elke zin afzonderlijk op – b.v. Bijvoorbeeld 12 + 10 + 8. De app telt automatisch uw gemiddelde setgrootte op en toont deze.</target>
       </segment>
     </unit>
@@ -2864,8 +2864,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:357,360</note>
       </notes>
-      <segment state="translated">
-        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+      <segment state="needs-translation">
+        <source>Tabbed Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich: Liegestütz-Varianten (Standard, Wide, Diamond), Klimmzüge, Sit-ups, Kniebeugen, Plank-Zeiten und Laufen inkl. Pace – jede Übung mit ihrer eigenen Maßeinheit, Zeitraum frei wählbar.</source>
         <target>Trendgrafieken en KPI-kaarten voor elke oefening: push-up-varianten (Standard, Wide, Diamond), sit-ups, squats, plank en hardlopen — met vrij te kiezen periode.</target>
       </segment>
     </unit>
@@ -2882,8 +2882,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:458,461</note>
       </notes>
-      <segment state="translated">
-        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
+      <segment state="needs-translation">
+        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs – Tages-, Wochen- und Monatsziel auf einen Blick. Läuft gerade ein Trainingsplan, übernimmt der das Tagesziel automatisch. Die Streak-Anzeige belohnt Dranbleiben, Konfetti feiert dein erreichtes Ziel.</source>
         <target>Drievoudige voortgangsbalk houdt u op het goede spoor. Streak-display beloont je als je je eraan houdt, confetti viert je dagelijkse doel dat je hebt bereikt.</target>
       </segment>
     </unit>
@@ -2918,8 +2918,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:520,523</note>
       </notes>
-      <segment state="translated">
-        <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
+      <segment state="needs-translation">
+        <source>Ein Tap auf den Floating Action Button oder eine Schnellaktion im Dashboard – Eintrag in zwei Sekunden, komplett ohne Dialog. Detaillierte Erfassung mit Sätzen, Intervallen, Dauer oder Distanz erreichst du auf Wunsch im selben Flow.</source>
         <target>Invoer in 2 seconden via de zwevende actieknop of snelle acties direct in het dashboard - zonder enige dialoog.</target>
       </segment>
     </unit>
@@ -2936,8 +2936,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:534,538</note>
       </notes>
-      <segment state="translated">
-        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
+      <segment state="needs-translation">
+        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor. Du willst eigene Presets? Konfiguriere bis zu sechs Buttons pro Übung selbst – inklusive Standard-Variante für den FAB.</source>
         <target>De snelle acties leren van je geschiedenis en stellen geschikte herhalingen voor - of je kunt je eigen knoppen configureren.</target>
       </segment>
     </unit>
@@ -2954,8 +2954,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:548,551</note>
       </notes>
-      <segment state="translated">
-        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
+      <segment state="needs-translation">
+        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten, Offline-Eintrag dank Service Worker und Tagesergebnis per Teilen-Button. Updates kommen automatisch.</source>
         <target>Installeer hem rechtstreeks vanuit de browser als app, met realtime synchronisatie tussen al je apparaten en deel je dagresultaat met één knop.</target>
       </segment>
     </unit>
@@ -2999,8 +2999,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:562,566</note>
       </notes>
-      <segment state="translated">
-        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
+      <segment state="needs-translation">
+        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Reps werden lokal im Browser ausgewertet – kein Video verlässt dein Gerät. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
         <target>AVG-conform met aanpasbare toestemming voor cookies. Jouw naam op het scorebord? Alleen als jij het wilt. Geen abonnement, geen creditcard.</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -1599,8 +1599,8 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
-      <segment state="translated">
-        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+      <segment state="needs-translation">
+        <source>Tabbed Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich: Liegestütz-Varianten (Standard, Wide, Diamond), Klimmzüge, Sit-ups, Kniebeugen, Plank-Zeiten und Laufen inkl. Pace – jede Übung mit ihrer eigenen Maßeinheit, Zeitraum frei wählbar.</source>
         <target>Trenddiagrammer og KPI-kort for hver øvelse: push-up-varianter (Standard, Wide, Diamond), sit-ups, knebøy, plank og løping — med fritt valgt tidsrom.</target>
             </segment>
         </unit>
@@ -1617,8 +1617,8 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
-      <segment state="translated">
-        <source>Multi-Set Tracking</source>
+      <segment state="needs-translation">
+        <source>Sätze &amp; Intervalle</source>
         <target>Flersett-sporing</target>
             </segment>
         </unit>
@@ -1626,8 +1626,8 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
-      <segment state="translated">
-        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
+      <segment state="needs-translation">
+        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch, zeigt deine Set-Verteilung und vergleicht den Aufbau über Wochen. Für Lauf- und Ausdauer-Workouts trägst du genauso einfach Intervalle samt Pace ein.</source>
         <target>Logg hver sett enkeltvis – f.eks. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Appen summerer automatisk og viser gjennomsnittlig setstørrelse.</target>
             </segment>
         </unit>
@@ -1644,8 +1644,8 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
-      <segment state="translated">
-        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
+      <segment state="needs-translation">
+        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs – Tages-, Wochen- und Monatsziel auf einen Blick. Läuft gerade ein Trainingsplan, übernimmt der das Tagesziel automatisch. Die Streak-Anzeige belohnt Dranbleiben, Konfetti feiert dein erreichtes Ziel.</source>
         <target>Trippel fremgangsindikator holder deg på sporet. Streak-telleren belønner konsistens og konfetti feirer hvert daglige mål du oppnår.</target>
             </segment>
         </unit>
@@ -1671,8 +1671,8 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
-      <segment state="translated">
-        <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
+      <segment state="needs-translation">
+        <source>Ein Tap auf den Floating Action Button oder eine Schnellaktion im Dashboard – Eintrag in zwei Sekunden, komplett ohne Dialog. Detaillierte Erfassung mit Sätzen, Intervallen, Dauer oder Distanz erreichst du auf Wunsch im selben Flow.</source>
         <target>Logg en oppføring på 2 sekunder via flytende handlingsknapp eller hurtighandlinger direkte i dashbordet – ingen dialog nødvendig.</target>
             </segment>
         </unit>
@@ -1698,8 +1698,8 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
-      <segment state="translated">
-        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
+      <segment state="needs-translation">
+        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten, Offline-Eintrag dank Service Worker und Tagesergebnis per Teilen-Button. Updates kommen automatisch.</source>
         <target>Installer den rett fra nettleseren som app, med sanntidssynkronisering mellom alle enhetene dine, og del dagsresultatet med én knapp.</target>
             </segment>
         </unit>
@@ -1743,8 +1743,8 @@ Aktiv:         </target>
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
-      <segment state="translated">
-        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
+      <segment state="needs-translation">
+        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Reps werden lokal im Browser ausgewertet – kein Video verlässt dein Gerät. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
         <target>GDPR-kompatibel med tilpassbar informasjonskapsel-samtykke. Ditt navn på leaderboard? Bare hvis du ønsker det. Ingen abonnement, intet kredittkort.</target>
             </segment>
         </unit>
@@ -1761,8 +1761,8 @@ Aktiv:         </target>
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.body">
-      <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+      <segment state="needs-translation">
+        <source>Stell das Handy hin, öffne den Auto-Zähler und leg los: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit direkt im Browser und zählt jede saubere Wiederholung mit. Für Plank und Hollow-Hold läuft stattdessen ein automatischer Halte-Timer. Der Live-Form-Check zeigt Winkel, Phase und Erkennungs-Sicherheit – ohne Cloud, ganz ohne Daten-Upload.</source>
         <target>Sett mobilen ned, åpne auto-tellingen og gjør armhevinger, knebøy, kroppshevinger eller sit-ups – KI-en vår gjenkjenner bevegelsen din i sanntid, rett i nettleseren, og teller automatisk for deg. Live Form Check viser vinkel og sikkerhet slik at du vet at tellingen er ren.</target>
       </segment>
     </unit>
@@ -2038,8 +2038,8 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
 
             </notes>
-      <segment state="translated">
-        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+      <segment state="needs-translation">
+        <source> Reps live per Kamera-KI zählen – Liegestütze, Kniebeugen, Klimmzüge, Sit-ups sowie Halte-Timer für Plank &amp; Hollow-Hold. Dazu Trainingspläne, Heatmap, Streaks, Tagesziele und Live-Sync auf allen Geräten. </source>
         <target> Spor push-ups på sekunder — med trender, streaks og live-sync. Pluss sit-ups, knebøy, plank og løping når du vil ha mer. </target>
 
             </segment>
@@ -3046,8 +3046,8 @@ Deine Position: # ·  Reps        </source>
 
         </unit>
     <unit id="seo.landing.description">
-      <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+      <segment state="needs-translation">
+        <source>Kostenlose Web-App für Liegestütze und mehr: Reps per Kamera-KI im Browser automatisch zählen, plus Trainingspläne, 30-Tage-Challenge, Heatmap, Streaks, Tagesziele und Bestenliste – auch für Sit-ups, Kniebeugen, Klimmzüge, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
         <target>Spor push-ups med en gratis nettapp: treningsplaner, 30-dagers utfordring, daglig mål, streaks og topplister — nå også med sit-ups, knebøy, plank og løping. Mobil, offline, live-sync.</target>
 
             </segment>
@@ -4642,8 +4642,8 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="landing.feature.adaptive.body">
-      <segment state="translated">
-        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
+      <segment state="needs-translation">
+        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor. Du willst eigene Presets? Konfiguriere bis zu sechs Buttons pro Übung selbst – inklusive Standard-Variante für den FAB.</source>
         <target>Hurtighandlingene lærer fra historikken din og foreslår passende repetisjoner – eller du konfigurerer dine egne knapper.</target>
       </segment>
     </unit>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -641,9 +641,25 @@
         <source>Auto‑Zählen</source>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.customValueAria">
+    <unit id="quickAdd.fab.exerciseTimerAria">
       <notes>
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:34,35</note>
+      </notes>
+      <segment>
+        <source>Halteübungs-Timer öffnen</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <notes>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:39,41</note>
+      </notes>
+      <segment>
+        <source>Plank‑Timer</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.customValueAria">
+      <notes>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:46,47</note>
       </notes>
       <segment>
         <source>Eigenen Wert eingeben</source>
@@ -651,7 +667,7 @@
     </unit>
     <unit id="quickAdd.fab.customValue">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:39,41</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:51,53</note>
       </notes>
       <segment>
         <source>Eigener Wert</source>
@@ -659,7 +675,7 @@
     </unit>
     <unit id="quickAdd.fab.fillToGoal">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:57,58</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:69,70</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> bis zum Ziel</source>
@@ -667,7 +683,7 @@
     </unit>
     <unit id="quickAdd.fab.quickAddReps">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:71,72</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:83,84</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> Reps</source>
@@ -675,7 +691,7 @@
     </unit>
     <unit id="quickAdd.fab.open">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:70</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:78</note>
       </notes>
       <segment>
         <source>Schnellerfassung öffnen</source>
@@ -683,7 +699,7 @@
     </unit>
     <unit id="quickAdd.fab.close">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:71</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:79</note>
       </notes>
       <segment>
         <source>Schnellerfassung schließen</source>
@@ -691,7 +707,7 @@
     </unit>
     <unit id="quickAdd.fab.goalReached">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:72</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:80</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -699,7 +715,7 @@
     </unit>
     <unit id="quickAdd.fab.goalReachedAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:73</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:81</note>
       </notes>
       <segment>
         <source>Tagesziel bereits erreicht</source>
@@ -707,7 +723,7 @@
     </unit>
     <unit id="quickAdd.fab.repAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:76</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:84</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
@@ -715,7 +731,7 @@
     </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:80</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:88</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="GAP" disp="gap"/> Liegestütze bis zum Tagesziel hinzufügen</source>
@@ -2321,7 +2337,7 @@
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
       <segment>
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+        <source>Kostenlose Web-App für Liegestütze und mehr: Reps per Kamera-KI im Browser automatisch zählen, plus Trainingspläne, 30-Tage-Challenge, Heatmap, Streaks, Tagesziele und Bestenliste – auch für Sit-ups, Kniebeugen, Klimmzüge, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
       </segment>
     </unit>
     <unit id="seo.dashboard.title">
@@ -2598,7 +2614,7 @@
     </unit>
     <unit id="toolbarDailyGoal.replayAria">
       <notes>
-        <note category="location">web/src/app/app.ts:386</note>
+        <note category="location">web/src/app/app.ts:390</note>
       </notes>
       <segment>
         <source>Tagesziel-Animation erneut abspielen</source>
@@ -2606,7 +2622,7 @@
     </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:415</note>
+        <note category="location">web/src/app/app.ts:419</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -2614,7 +2630,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:422</note>
+        <note category="location">web/src/app/app.ts:426</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>
@@ -2788,6 +2804,160 @@
         <source>Sit-ups</source>
       </segment>
     </unit>
+    <unit id="exerciseTimer.title">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:1,3</note>
+      </notes>
+      <segment>
+        <source>Halteübung-Timer</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:8,9</note>
+      </notes>
+      <segment>
+        <source>Übung wählen</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraMode">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:25,28</note>
+      </notes>
+      <segment>
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraStarting">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:42,45</note>
+      </notes>
+      <segment>
+        <source>Kamera startet …</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraUnavailable">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:49,51</note>
+      </notes>
+      <segment>
+        <source> Kamera nicht verfügbar </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:67,68</note>
+      </notes>
+      <segment>
+        <source>Form-Check anzeigen oder ausblenden</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.angle">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:77,79</note>
+      </notes>
+      <segment>
+        <source>Winkel</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:87,89</note>
+      </notes>
+      <segment>
+        <source>Sicherheit</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.pause">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:111,113</note>
+      </notes>
+      <segment>
+        <source>Pause</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.start">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:113,116</note>
+      </notes>
+      <segment>
+        <source>Start</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cameraHint">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:119,124</note>
+      </notes>
+      <segment>
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.reset">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:132,134</note>
+      </notes>
+      <segment>
+        <source> Zurücksetzen </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.cancel">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:135,138</note>
+      </notes>
+      <segment>
+        <source> Abbrechen </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.save">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.html:144,146</note>
+      </notes>
+      <segment>
+        <source> Übernehmen </source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.holding">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.ts:109</note>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.ts:117</note>
+      </notes>
+      <segment>
+        <source>Halten</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.paused">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.ts:111</note>
+      </notes>
+      <segment>
+        <source>Pause</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.phase.ready">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.ts:113</note>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.ts:118</note>
+      </notes>
+      <segment>
+        <source>Bereit</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.plank">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.ts:126</note>
+      </notes>
+      <segment>
+        <source>Plank</source>
+      </segment>
+    </unit>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <notes>
+        <note category="location">web/src/app/auto-count/exercise-timer-dialog.component.ts:131</note>
+      </notes>
+      <segment>
+        <source>Hollow Hold</source>
+      </segment>
+    </unit>
     <unit id="blog.article.back">
       <notes>
         <note category="location">web/src/app/blog/blog-article.component.ts:40,42</note>
@@ -2919,8 +3089,8 @@
     </unit>
     <unit id="quickAdd.success.create">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:75</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:264</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:91</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:334</note>
       </notes>
       <segment>
         <source>Eintrag gespeichert.</source>
@@ -2928,9 +3098,9 @@
     </unit>
     <unit id="quickAdd.error.create">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:87</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:126</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:280</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:103</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:142</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:350</note>
       </notes>
       <segment>
         <source>Eintrag konnte nicht gespeichert werden.</source>
@@ -2938,7 +3108,7 @@
     </unit>
     <unit id="quickAdd.success.goalReached">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:113</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:129</note>
       </notes>
       <segment>
         <source>Tagesziel erreicht 🎉</source>
@@ -3437,15 +3607,15 @@
     </unit>
     <unit id="landing.subtitle">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:17,21</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:17,20</note>
       </notes>
       <segment>
-        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+        <source> Reps live per Kamera-KI zählen – Liegestütze, Kniebeugen, Klimmzüge, Sit-ups sowie Halte-Timer für Plank &amp; Hollow-Hold. Dazu Trainingspläne, Heatmap, Streaks, Tagesziele und Live-Sync auf allen Geräten. </source>
       </segment>
     </unit>
     <unit id="landing.cta.dashboard">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:30,32</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:31,33</note>
       </notes>
       <segment>
         <source>Zum Dashboard</source>
@@ -3453,8 +3623,8 @@
     </unit>
     <unit id="landing.cta.signup">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:40,43</note>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:52,55</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:41,44</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:53,56</note>
       </notes>
       <segment>
         <source>Konto erstellen</source>
@@ -3462,7 +3632,7 @@
     </unit>
     <unit id="landing.cta.login">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:60,62</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:61,63</note>
       </notes>
       <segment>
         <source>Einloggen</source>
@@ -3470,7 +3640,7 @@
     </unit>
     <unit id="landing.cta.guest">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:68,70</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:69,71</note>
       </notes>
       <segment>
         <source> Als Gast ausprobieren </source>
@@ -3478,7 +3648,7 @@
     </unit>
     <unit id="landing.cta.hint">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:73,76</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:74,77</note>
       </notes>
       <segment>
         <source> Kostenlos · Kein Abo · Jederzeit kündbar </source>
@@ -3486,7 +3656,7 @@
     </unit>
     <unit id="landing.plans.eyebrow">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:84,86</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:85,87</note>
       </notes>
       <segment>
         <source>Strukturiert trainieren</source>
@@ -3494,7 +3664,7 @@
     </unit>
     <unit id="landing.plans.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:87,89</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:88,90</note>
       </notes>
       <segment>
         <source> Liegestütz-Trainingspläne, die wirklich funktionieren </source>
@@ -3502,7 +3672,7 @@
     </unit>
     <unit id="landing.plans.subtitle">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:90,94</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:91,95</note>
       </notes>
       <segment>
         <source> Vom Einsteiger zum 100er-Set: Geführte Pläne mit Tagesziel, Sätzen und automatischer Fortschrittsverfolgung. Stöbere kostenlos — starten und tracken kannst du mit einem kostenlosen Konto. </source>
@@ -3510,7 +3680,7 @@
     </unit>
     <unit id="landing.plans.recruit.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:101,103</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:102,104</note>
       </notes>
       <segment>
         <source>Von 0 auf 100 — 6 Wochen</source>
@@ -3518,7 +3688,7 @@
     </unit>
     <unit id="landing.plans.recruit.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:105,107</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:106,108</note>
       </notes>
       <segment>
         <source> Einsteigerfreundlich: 3 Trainingstage pro Woche, progressiver Aufbau und ein Maximaltest in Woche 6. </source>
@@ -3526,9 +3696,9 @@
     </unit>
     <unit id="landing.plans.viewPlan">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:114,116</note>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:136,138</note>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:158,160</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:115,117</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:137,139</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:159,161</note>
       </notes>
       <segment>
         <source>Plan ansehen</source>
@@ -3536,7 +3706,7 @@
     </unit>
     <unit id="landing.plans.challenge.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:123,125</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:124,126</note>
       </notes>
       <segment>
         <source>30-Tage-Challenge</source>
@@ -3544,7 +3714,7 @@
     </unit>
     <unit id="landing.plans.challenge.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:127,129</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:128,130</note>
       </notes>
       <segment>
         <source> 30 Tage Pushups mit gezielten Ruhetagen. Tag 1 ist der Maximaltest, Tag 30 der Endtest. </source>
@@ -3552,7 +3722,7 @@
     </unit>
     <unit id="landing.plans.over40.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:145,147</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:146,148</note>
       </notes>
       <segment>
         <source>Liegestütze ab 40 — 4 Wochen</source>
@@ -3560,7 +3730,7 @@
     </unit>
     <unit id="landing.plans.over40.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:149,151</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:150,152</note>
       </notes>
       <segment>
         <source> Schonender Plan mit Fokus auf saubere Technik, ausreichend Pause und langsames Tempo. </source>
@@ -3568,7 +3738,7 @@
     </unit>
     <unit id="landing.plans.cta.overview">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:171,173</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:172,174</note>
       </notes>
       <segment>
         <source>Alle Pläne ansehen</source>
@@ -3576,7 +3746,7 @@
     </unit>
     <unit id="landing.plans.cta.signup">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:180,184</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:181,185</note>
       </notes>
       <segment>
         <source>Konto erstellen &amp; Plan starten</source>
@@ -3584,7 +3754,7 @@
     </unit>
     <unit id="landing.trust.bar">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:193,197</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:194,198</note>
       </notes>
       <segment>
         <source> ✓ Kostenlos · ✓ Kein Abo · ✓ Keine Kreditkarte · ✓ Datenschutz first </source>
@@ -3592,7 +3762,7 @@
     </unit>
     <unit id="landing.features.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:198,199</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:199,200</note>
       </notes>
       <segment>
         <source>Funktionen</source>
@@ -3600,7 +3770,7 @@
     </unit>
     <unit id="landing.feature.autoCount.imageAlt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:205,206</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:206,207</note>
       </notes>
       <segment>
         <source>Sportlerin bei einer sauberen Liegestütze auf Holzboden</source>
@@ -3608,7 +3778,7 @@
     </unit>
     <unit id="landing.feature.autoCount.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:216,218</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:217,219</note>
       </notes>
       <segment>
         <source>Reps automatisch zählen</source>
@@ -3616,31 +3786,15 @@
     </unit>
     <unit id="landing.feature.autoCount.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:220,224</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:221,226</note>
       </notes>
       <segment>
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
-      </segment>
-    </unit>
-    <unit id="landing.feature.multiset.title">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:313,315</note>
-      </notes>
-      <segment>
-        <source>Multi-Set Tracking</source>
-      </segment>
-    </unit>
-    <unit id="landing.feature.multiset.body">
-      <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:317,319</note>
-      </notes>
-      <segment>
-        <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
+        <source>Stell das Handy hin, öffne den Auto-Zähler und leg los: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit direkt im Browser und zählt jede saubere Wiederholung mit. Für Plank und Hollow-Hold läuft stattdessen ein automatischer Halte-Timer. Der Live-Form-Check zeigt Winkel, Phase und Erkennungs-Sicherheit – ohne Cloud, ganz ohne Daten-Upload.</source>
       </segment>
     </unit>
     <unit id="landing.feature.analytics.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:382,384</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:289,291</note>
       </notes>
       <segment>
         <source>Charts, Trends &amp; alle Übungen</source>
@@ -3648,15 +3802,15 @@
     </unit>
     <unit id="landing.feature.analytics.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:386,390</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:293,297</note>
       </notes>
       <segment>
-        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+        <source>Tabbed Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich: Liegestütz-Varianten (Standard, Wide, Diamond), Klimmzüge, Sit-ups, Kniebeugen, Plank-Zeiten und Laufen inkl. Pace – jede Übung mit ihrer eigenen Maßeinheit, Zeitraum frei wählbar.</source>
       </segment>
     </unit>
     <unit id="landing.feature.goals.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:484,486</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:393,395</note>
       </notes>
       <segment>
         <source>Tages-, Wochen- &amp; Monatsziele</source>
@@ -3664,15 +3818,15 @@
     </unit>
     <unit id="landing.feature.goals.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:488,491</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:397,400</note>
       </notes>
       <segment>
-        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
+        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs – Tages-, Wochen- und Monatsziel auf einen Blick. Läuft gerade ein Trainingsplan, übernimmt der das Tagesziel automatisch. Die Streak-Anzeige belohnt Dranbleiben, Konfetti feiert dein erreichtes Ziel.</source>
       </segment>
     </unit>
     <unit id="landing.feature.heatmap.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:532,534</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:442,444</note>
       </notes>
       <segment>
         <source>Heatmap-Kalender</source>
@@ -3680,15 +3834,31 @@
     </unit>
     <unit id="landing.feature.heatmap.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:536,540</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:446,450</note>
       </notes>
       <segment>
         <source>Sieh auf einen Blick, an welchen Tagen du wie hart trainiert hast. Lücken werden sichtbar – Konsistenz wird zur Gewohnheit.</source>
       </segment>
     </unit>
+    <unit id="landing.feature.multiset.title">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:537,539</note>
+      </notes>
+      <segment>
+        <source>Sätze &amp; Intervalle</source>
+      </segment>
+    </unit>
+    <unit id="landing.feature.multiset.body">
+      <notes>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:541,544</note>
+      </notes>
+      <segment>
+        <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch, zeigt deine Set-Verteilung und vergleicht den Aufbau über Wochen. Für Lauf- und Ausdauer-Workouts trägst du genauso einfach Intervalle samt Pace ein.</source>
+      </segment>
+    </unit>
     <unit id="landing.feature.quick.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:546,548</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:553,555</note>
       </notes>
       <segment>
         <source>Quick Logging mit FAB</source>
@@ -3696,15 +3866,15 @@
     </unit>
     <unit id="landing.feature.quick.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:550,553</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:557,560</note>
       </notes>
       <segment>
-        <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
+        <source>Ein Tap auf den Floating Action Button oder eine Schnellaktion im Dashboard – Eintrag in zwei Sekunden, komplett ohne Dialog. Detaillierte Erfassung mit Sätzen, Intervallen, Dauer oder Distanz erreichst du auf Wunsch im selben Flow.</source>
       </segment>
     </unit>
     <unit id="landing.feature.adaptive.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:560,562</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:568,570</note>
       </notes>
       <segment>
         <source>Adaptive Vorschläge</source>
@@ -3712,15 +3882,15 @@
     </unit>
     <unit id="landing.feature.adaptive.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:564,568</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:572,576</note>
       </notes>
       <segment>
-        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
+        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor. Du willst eigene Presets? Konfiguriere bis zu sechs Buttons pro Übung selbst – inklusive Standard-Variante für den FAB.</source>
       </segment>
     </unit>
     <unit id="landing.feature.pwa.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:574,576</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:583,585</note>
       </notes>
       <segment>
         <source>App-Installation, Live-Sync &amp; Teilen</source>
@@ -3728,15 +3898,15 @@
     </unit>
     <unit id="landing.feature.pwa.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:578,581</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:587,590</note>
       </notes>
       <segment>
-        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
+        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten, Offline-Eintrag dank Service Worker und Tagesergebnis per Teilen-Button. Updates kommen automatisch.</source>
       </segment>
     </unit>
     <unit id="landing.feature.pwa.installed">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:585,587</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:594,596</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">check_circle</pc> Du nutzt bereits die installierte App </source>
@@ -3744,7 +3914,7 @@
     </unit>
     <unit id="landing.feature.pwa.install">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:598,600</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:607,609</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">download</pc> Jetzt als App installieren </source>
@@ -3752,7 +3922,7 @@
     </unit>
     <unit id="landing.feature.pwa.iosHint">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:605,608</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:614,617</note>
       </notes>
       <segment>
         <source> Auf iPhone &amp; iPad: Teilen-Symbol antippen und „Zum Home-Bildschirm“ wählen. </source>
@@ -3760,7 +3930,7 @@
     </unit>
     <unit id="landing.feature.privacy.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:616,618</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:625,627</note>
       </notes>
       <segment>
         <source>Privacy first &amp; 100 % kostenlos</source>
@@ -3768,15 +3938,15 @@
     </unit>
     <unit id="landing.feature.privacy.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:620,624</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:629,633</note>
       </notes>
       <segment>
-        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
+        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Reps werden lokal im Browser ausgewertet – kein Video verlässt dein Gerät. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
       </segment>
     </unit>
     <unit id="ads.landing.aria">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:626</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:636</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -3784,7 +3954,7 @@
     </unit>
     <unit id="landing.preview.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:635,637</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:645,647</note>
       </notes>
       <segment>
         <source> Deine Statistik auf einen Blick </source>
@@ -3792,7 +3962,7 @@
     </unit>
     <unit id="landing.preview.alt">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:642,643</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:652,653</note>
       </notes>
       <segment>
         <source>Vorschau der Statistikansicht</source>
@@ -3800,7 +3970,7 @@
     </unit>
     <unit id="landing.discover.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:783,784</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:793,794</note>
       </notes>
       <segment>
         <source>Mehr entdecken</source>
@@ -3808,7 +3978,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:789,791</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:799,801</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3816,7 +3986,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:793,796</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:803,806</note>
       </notes>
       <segment>
         <source> Vergleiche dich mit der Community: Top-Reps für heute, die letzten 7 Tage und die letzten 30 Tage. Privacy first – dein Name erscheint nur, wenn du es willst. </source>
@@ -3824,7 +3994,7 @@
     </unit>
     <unit id="landing.discover.leaderboard.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:803,806</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:813,816</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -3832,7 +4002,7 @@
     </unit>
     <unit id="landing.discover.blog.title">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:812,814</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:822,824</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3840,7 +4010,7 @@
     </unit>
     <unit id="landing.discover.blog.body">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:816,819</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:826,829</note>
       </notes>
       <segment>
         <source> Tipps, Hintergrundwissen und Motivation rund um Liegestütze – von Einsteiger bis Fortgeschritten. Viele Artikel verlinken direkt auf den passenden Trainingsplan. </source>
@@ -3848,7 +4018,7 @@
     </unit>
     <unit id="landing.discover.blog.cta">
       <notes>
-        <note category="location">web/src/app/marketing/shell/landing-page.component.html:826,828</note>
+        <note category="location">web/src/app/marketing/shell/landing-page.component.html:836,838</note>
       </notes>
       <segment>
         <source>Zum Blog</source>
@@ -5083,22 +5253,6 @@
       </notes>
       <segment>
         <source> Keine Sets-Daten vorhanden </source>
-      </segment>
-    </unit>
-    <unit id="intervalsDistribution.noData">
-      <notes>
-        <note category="location">web/src/app/stats/components/intervals-distribution/intervals-distribution.component.ts</note>
-      </notes>
-      <segment>
-        <source> Keine Intervall-Daten vorhanden </source>
-      </segment>
-    </unit>
-    <unit id="intervalsDistribution.listLabel">
-      <notes>
-        <note category="location">web/src/app/stats/components/intervals-distribution/intervals-distribution.component.ts</note>
-      </notes>
-      <segment>
-        <source>Intervall-Verteilung</source>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">
@@ -8354,110 +8508,5 @@
         <source>Detailseite öffnen</source>
       </segment>
     </unit>
-      <unit id="exerciseTimer.title">
-      <segment>
-        <source>Halteübung-Timer</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.exercisePickerAria">
-      <segment>
-        <source>Übung wählen</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.cameraMode">
-      <segment>
-        <source> Kamera: Start/Ende automatisch erkennen </source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.cameraStarting">
-      <segment>
-        <source>Kamera startet …</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.cameraUnavailable">
-      <segment>
-        <source> Kamera nicht verfügbar </source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.formCheck.toggleAria">
-      <segment>
-        <source>Form-Check anzeigen oder ausblenden</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.formCheck.angle">
-      <segment>
-        <source>Winkel</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.formCheck.confidence">
-      <segment>
-        <source>Sicherheit</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.pause">
-      <segment>
-        <source>Pause</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.start">
-      <segment>
-        <source>Start</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.cameraHint">
-      <segment>
-        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.reset">
-      <segment>
-        <source> Zurücksetzen </source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.cancel">
-      <segment>
-        <source> Abbrechen </source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.save">
-      <segment>
-        <source> Übernehmen </source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.phase.holding">
-      <segment>
-        <source>Halten</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.phase.paused">
-      <segment>
-        <source>Pause</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.phase.ready">
-      <segment>
-        <source>Bereit</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.exercise.plank">
-      <segment>
-        <source>Plank</source>
-      </segment>
-    </unit>
-    <unit id="exerciseTimer.exercise.hollowhold">
-      <segment>
-        <source>Hollow Hold</source>
-      </segment>
-    </unit>
-    <unit id="quickAdd.fab.exerciseTimerAria">
-      <segment>
-        <source>Halteübungs-Timer öffnen</source>
-      </segment>
-    </unit>
-    <unit id="quickAdd.fab.exerciseTimer">
-      <segment>
-        <source>Plank‑Timer</source>
-      </segment>
-    </unit>
-</file>
+  </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -5709,6 +5709,22 @@
         <source>Weiteres Intervall hinzufügen</source>
       </segment>
     </unit>
+    <unit id="intervalsDistribution.listLabel">
+      <notes>
+        <note category="location">web/src/app/stats/components/intervals-distribution/intervals-distribution.component.ts:28</note>
+      </notes>
+      <segment>
+        <source>Intervall-Verteilung</source>
+      </segment>
+    </unit>
+    <unit id="intervalsDistribution.noData">
+      <notes>
+        <note category="location">web/src/app/stats/components/intervals-distribution/intervals-distribution.component.ts:47,49</note>
+      </notes>
+      <segment>
+        <source> Keine Intervall-Daten vorhanden </source>
+      </segment>
+    </unit>
     <unit id="entryDialog.overCapDuration">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:585,586</note>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -2441,8 +2441,8 @@
       <notes>
         <note category="location">web/src/app/app.routes.ts:16</note>
       </notes>
-      <segment state="translated">
-        <source>Liegestütze tracken mit kostenloser Web-App: Trainingspläne, 30-Tage-Challenge, Tagesziel, Streaks und Bestenliste – jetzt auch mit Sit-ups, Kniebeugen, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
+      <segment state="needs-translation">
+        <source>Kostenlose Web-App für Liegestütze und mehr: Reps per Kamera-KI im Browser automatisch zählen, plus Trainingspläne, 30-Tage-Challenge, Heatmap, Streaks, Tagesziele und Bestenliste – auch für Sit-ups, Kniebeugen, Klimmzüge, Plank und Laufen. Mobil, offline-fähig, mit Live-Sync.</source>
       <target>用免费网页应用追踪俯卧撑：训练计划、30 天挑战、每日目标、连续天数与排行榜 — 现在也支持仰卧起坐、深蹲、平板支撑与跑步。手机端、离线可用、实时同步。</target></segment>
     </unit>
     <unit id="seo.dashboard.title">
@@ -3344,8 +3344,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:19,23</note>
       </notes>
-      <segment state="translated">
-        <source> Liegestütze tracken in Sekunden – mit Trends, Streaks und Live-Sync. Plus Sit-ups, Kniebeugen, Plank und Laufen, wenn du mehr willst. </source>
+      <segment state="needs-translation">
+        <source> Reps live per Kamera-KI zählen – Liegestütze, Kniebeugen, Klimmzüge, Sit-ups sowie Halte-Timer für Plank &amp; Hollow-Hold. Dazu Trainingspläne, Heatmap, Streaks, Tagesziele und Live-Sync auf allen Geräten. </source>
       <target> 几秒钟记录俯卧撑 — 提供趋势、连续天数与实时同步。需要更多时还可记录仰卧起坐、深蹲、平板支撑和跑步。</target></segment>
     </unit>
     <unit id="landing.cta.dashboard">
@@ -3508,8 +3508,8 @@
       </segment>
     </unit>
     <unit id="landing.feature.autoCount.body">
-      <segment state="translated">
-        <source>Stell das Handy hin, öffne die Auto-Zählung und mach deine Liegestütze, Kniebeugen, Klimmzüge oder Sit-ups – unsere KI erkennt deine Bewegung in Echtzeit direkt im Browser und zählt automatisch mit. Der Live-Form-Check zeigt Winkel und Sicherheit, damit du jederzeit weißt, dass die Zählung sauber läuft.</source>
+      <segment state="needs-translation">
+        <source>Stell das Handy hin, öffne den Auto-Zähler und leg los: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit direkt im Browser und zählt jede saubere Wiederholung mit. Für Plank und Hollow-Hold läuft stattdessen ein automatischer Halte-Timer. Der Live-Form-Check zeigt Winkel, Phase und Erkennungs-Sicherheit – ohne Cloud, ganz ohne Daten-Upload.</source>
         <target>把手机放好,打开自动计数,然后开始做俯卧撑、深蹲、引体向上或仰卧起坐——我们的 AI 直接在浏览器中实时识别你的动作并自动计数。实时动作检查显示角度和置信度,让你随时知道计数是否准确。</target>
       </segment>
     </unit>
@@ -3525,16 +3525,16 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:288,290</note>
       </notes>
-      <segment state="translated">
-        <source>Multi-Set Tracking</source>
+      <segment state="needs-translation">
+        <source>Sätze &amp; Intervalle</source>
       <target>多组次数追踪</target></segment>
     </unit>
     <unit id="landing.feature.multiset.body">
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:292,294</note>
       </notes>
-      <segment state="translated">
-        <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
+      <segment state="needs-translation">
+        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch, zeigt deine Set-Verteilung und vergleicht den Aufbau über Wochen. Für Lauf- und Ausdauer-Workouts trägst du genauso einfach Intervalle samt Pace ein.</source>
       <target>逐组记录每一组 — 例如 12 + 10 + 8 次。应用会自动求和，并计算你的平均每组次数。</target></segment>
     </unit>
     <unit id="landing.feature.analytics.title">
@@ -3549,8 +3549,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:361,364</note>
       </notes>
-      <segment state="translated">
-        <source>Verlaufsdiagramme und KPI-Karten für jede Übung: Liegestütz-Varianten (Standard, Wide, Diamond), Sit-ups, Kniebeugen, Plank und Laufen – mit frei wählbarem Zeitraum.</source>
+      <segment state="needs-translation">
+        <source>Tabbed Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich: Liegestütz-Varianten (Standard, Wide, Diamond), Klimmzüge, Sit-ups, Kniebeugen, Plank-Zeiten und Laufen inkl. Pace – jede Übung mit ihrer eigenen Maßeinheit, Zeitraum frei wählbar.</source>
       <target>为每项练习提供趋势图与 KPI 卡片：俯卧撑变体(Standard、Wide、Diamond)、仰卧起坐、深蹲、平板支撑与跑步 — 可自由选择时间范围。</target></segment>
     </unit>
     <unit id="landing.feature.goals.title">
@@ -3565,8 +3565,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:462,465</note>
       </notes>
-      <segment state="translated">
-        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs. Streak-Anzeige belohnt dranbleiben, Konfetti feiert dein erreichtes Tagesziel.</source>
+      <segment state="needs-translation">
+        <source>Dreifacher Fortschrittsbalken hält dich auf Kurs – Tages-, Wochen- und Monatsziel auf einen Blick. Läuft gerade ein Trainingsplan, übernimmt der das Tagesziel automatisch. Die Streak-Anzeige belohnt Dranbleiben, Konfetti feiert dein erreichtes Ziel.</source>
       <target>三重进度条让你保持正轨。连续记录显示会显示你的坚持情况，达成每日目标时还有彩纸庆祝。</target></segment>
     </unit>
     <unit id="landing.feature.heatmap.title">
@@ -3597,8 +3597,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:524,527</note>
       </notes>
-      <segment state="translated">
-        <source>Eintrag in 2 Sekunden über den Floating Action Button oder Schnellaktionen direkt im Dashboard – ganz ohne Dialog.</source>
+      <segment state="needs-translation">
+        <source>Ein Tap auf den Floating Action Button oder eine Schnellaktion im Dashboard – Eintrag in zwei Sekunden, komplett ohne Dialog. Detaillierte Erfassung mit Sätzen, Intervallen, Dauer oder Distanz erreichst du auf Wunsch im selben Flow.</source>
       <target>通过悬浮操作按钮或仪表板快速操作，只需2秒就能记录一次训练 — 无需打开对话框。</target></segment>
     </unit>
     <unit id="landing.feature.adaptive.title">
@@ -3613,8 +3613,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:538,542</note>
       </notes>
-      <segment state="translated">
-        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor – oder du konfigurierst eigene Buttons.</source>
+      <segment state="needs-translation">
+        <source>Die Schnellaktionen lernen aus deiner Historie und schlagen passende Wiederholungen vor. Du willst eigene Presets? Konfiguriere bis zu sechs Buttons pro Übung selbst – inklusive Standard-Variante für den FAB.</source>
       <target>快速操作按钮会学习你的历史数据并推荐合适的次数 — 或者你可以自定义按钮。</target></segment>
     </unit>
     <unit id="landing.feature.pwa.title">
@@ -3629,8 +3629,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:552,555</note>
       </notes>
-      <segment state="translated">
-        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten und Tagesergebnis per Teilen-Button.</source>
+      <segment state="needs-translation">
+        <source>Direkt aus dem Browser als App installieren – mit Echtzeit-Sync zwischen allen Geräten, Offline-Eintrag dank Service Worker und Tagesergebnis per Teilen-Button. Updates kommen automatisch.</source>
       <target>直接从浏览器作为应用安装 — 在所有设备之间实时同步,并通过分享按钮发送当日成绩。</target></segment>
     </unit>
     <unit id="landing.feature.pwa.installed">
@@ -3672,8 +3672,8 @@
       <notes>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html:566,570</note>
       </notes>
-      <segment state="translated">
-        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
+      <segment state="needs-translation">
+        <source>DSGVO-konform mit anpassbarer Cookie-Zustimmung. Reps werden lokal im Browser ausgewertet – kein Video verlässt dein Gerät. Dein Name auf der Bestenliste? Nur wenn du es willst. Kein Abo, keine Kreditkarte.</source>
       <target>符合GDPR标准，可自定义Cookie同意设置。想要你的名字出现在排行榜上？只有在你同意时才会显示。无需订阅，无需信用卡。</target></segment>
     </unit>
     <unit id="ads.landing.aria">


### PR DESCRIPTION
Lead with the camera-KI rep counter and the hold timer for plank/hollow-hold
since those are the freshest features. Reorder the feature grid so the
visually-rich cards (auto-count → analytics → goals → heatmap) appear first,
push multi-set/intervals down, and update each body to match what the app
actually does today: tabbed measurement-aware analysis with pace, plan-aware
daily goal, offline-capable PWA install, on-device pose inference.