### PR TITLE
feat(analysis): heatmap respects measurement type for time/distance exercises

### DIFF
--- a/web/src/app/stats/components/heatmap/heatmap.component.spec.ts
+++ b/web/src/app/stats/components/heatmap/heatmap.component.spec.ts
@@ -145,8 +145,10 @@ describe('HeatmapComponent', () => {
     const tooltip = opts.plugins.tooltip.callbacks.label({
       raw: { x: 'Mo', y: '08', v: 150 },
     });
-    expect(tooltip).toContain('2:30');
-    expect(tooltip).toContain('min');
+    // The formatter already embeds the unit ("min"); the component
+    // must not append it a second time — regression: previously
+    // `2:30 min min`.
+    expect(tooltip).toBe('Mo 08:00 - 2:30 min');
 
     const datalabel = opts.plugins.datalabels.formatter({
       x: 'Mo',
@@ -178,7 +180,9 @@ describe('HeatmapComponent', () => {
     const tooltip = opts.plugins.tooltip.callbacks.label({
       raw: { x: 'Mo', y: '08', v: 5000 },
     });
-    expect(tooltip).toContain('5.00 km');
+    // Tooltip must not append "Strecke" after the unit-bearing
+    // formatted value (regression: previously `5.00 km Strecke`).
+    expect(tooltip).toBe('Mo 08:00 - 5.0 km');
 
     const datalabel = opts.plugins.datalabels.formatter({
       x: 'Mo',
@@ -212,6 +216,6 @@ describe('HeatmapComponent', () => {
     const tooltip = opts.plugins.tooltip.callbacks.label({
       raw: { x: 'Mo', y: '08', v: 3 },
     });
-    expect(tooltip).toContain('Einträge');
+    expect(tooltip).toBe('Mo 08:00 - 3 Einträge');
   });
 });

--- a/web/src/app/stats/components/heatmap/heatmap.component.spec.ts
+++ b/web/src/app/stats/components/heatmap/heatmap.component.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HeatmapComponent } from './heatmap.component';
+import { HeatmapComponent, type HeatmapEntry } from './heatmap.component';
 
 describe('HeatmapComponent', () => {
   let fixture: ComponentFixture<HeatmapComponent>;
@@ -15,14 +15,9 @@ describe('HeatmapComponent', () => {
 
   it('builds heatmap chart data with top-down hours and correct values', async () => {
     fixture.componentRef.setInput('entries', [
-      { _id: '1', timestamp: '2026-02-09T08:00:00', reps: 10, source: 'wa' }, // Mo
-      { _id: '2', timestamp: '2026-02-10T23:00:00', reps: 12, source: 'web' }, // Di
-    ] as Array<{
-      _id: string;
-      timestamp: string;
-      reps: number;
-      source: string;
-    }>);
+      { timestamp: '2026-02-09T08:00:00', reps: 10 }, // Mo
+      { timestamp: '2026-02-10T23:00:00', reps: 12 }, // Di
+    ] as HeatmapEntry[]);
 
     await fixture.whenStable();
 
@@ -52,13 +47,8 @@ describe('HeatmapComponent', () => {
 
   it('shows datalabels only for non-zero heatmap cells', async () => {
     fixture.componentRef.setInput('entries', [
-      { _id: '1', timestamp: '2026-02-09T08:00:00', reps: 10, source: 'wa' },
-    ] as Array<{
-      _id: string;
-      timestamp: string;
-      reps: number;
-      source: string;
-    }>);
+      { timestamp: '2026-02-09T08:00:00', reps: 10 },
+    ] as HeatmapEntry[]);
 
     await fixture.whenStable();
 
@@ -87,30 +77,24 @@ describe('HeatmapComponent', () => {
     expect(dl.formatter(points[zeroIndex])).toBe('');
   });
 
-  it('aggregates set count in sets mode and uses correct tooltip unit', async () => {
+  it('aggregates set count in breakdown mode and uses correct tooltip unit', async () => {
     fixture.componentRef.setInput('entries', [
       {
-        _id: '1',
         timestamp: '2026-02-09T08:00:00',
         reps: 30,
         sets: [10, 10, 10],
-        source: 'wa',
-      }, // Mo
+      },
       {
-        _id: '2',
         timestamp: '2026-02-09T08:30:00',
         reps: 20,
         sets: [10, 10],
-        source: 'web',
-      }, // Mo, same hour
+      },
       {
-        _id: '3',
         timestamp: '2026-02-10T23:00:00',
         reps: 12,
-        source: 'web',
-      }, // Di, no sets
-    ] as any[]);
-    fixture.componentRef.setInput('mode', 'sets');
+      },
+    ] as HeatmapEntry[]);
+    fixture.componentRef.setInput('mode', 'breakdown');
 
     await fixture.whenStable();
 
@@ -126,16 +110,108 @@ describe('HeatmapComponent', () => {
     const mo8 = points.find((p) => p.x === 'Mo' && p.y === '08');
     expect(mo8?.v).toBe(5);
 
-    // Di 23: no sets → 0
     const di23 = points.find((p) => p.x === 'Di' && p.y === '23');
     expect(di23?.v).toBe(0);
 
-    // Tooltip should show 'Sets' not 'Reps'
     const opts = component.chartOptions() as any;
     const label = opts.plugins.tooltip.callbacks.label({
       raw: { x: 'Mo', y: '08', v: 5 },
     });
     expect(label).toContain('Sätze');
     expect(label).not.toContain('Wiederholungen');
+  });
+
+  it('sums durationSec and formats mm:ss in tooltip when measurement is "time"', async () => {
+    fixture.componentRef.setInput('entries', [
+      { timestamp: '2026-02-09T08:00:00', durationSec: 60 }, // Mo
+      { timestamp: '2026-02-09T08:30:00', durationSec: 90 }, // Mo same hour
+    ] as HeatmapEntry[]);
+    fixture.componentRef.setInput('measurement', 'time');
+
+    await fixture.whenStable();
+
+    const component = fixture.componentInstance;
+    const data = component.chartData();
+    const points = data.datasets[0].data as Array<{
+      x: string;
+      y: string;
+      v: number;
+    }>;
+
+    const mo8 = points.find((p) => p.x === 'Mo' && p.y === '08');
+    expect(mo8?.v).toBe(150);
+
+    const opts = component.chartOptions() as any;
+    const tooltip = opts.plugins.tooltip.callbacks.label({
+      raw: { x: 'Mo', y: '08', v: 150 },
+    });
+    expect(tooltip).toContain('2:30');
+    expect(tooltip).toContain('min');
+
+    const datalabel = opts.plugins.datalabels.formatter({
+      x: 'Mo',
+      y: '08',
+      v: 150,
+    });
+    expect(datalabel).toBe('2:30');
+  });
+
+  it('sums distanceM and formats km in tooltip when measurement is "distance-time"', async () => {
+    fixture.componentRef.setInput('entries', [
+      { timestamp: '2026-02-09T08:00:00', distanceM: 5000, durationSec: 1500 },
+    ] as HeatmapEntry[]);
+    fixture.componentRef.setInput('measurement', 'distance-time');
+
+    await fixture.whenStable();
+
+    const component = fixture.componentInstance;
+    const data = component.chartData();
+    const points = data.datasets[0].data as Array<{
+      x: string;
+      y: string;
+      v: number;
+    }>;
+    const mo8 = points.find((p) => p.x === 'Mo' && p.y === '08');
+    expect(mo8?.v).toBe(5000);
+
+    const opts = component.chartOptions() as any;
+    const tooltip = opts.plugins.tooltip.callbacks.label({
+      raw: { x: 'Mo', y: '08', v: 5000 },
+    });
+    expect(tooltip).toContain('5.00 km');
+
+    const datalabel = opts.plugins.datalabels.formatter({
+      x: 'Mo',
+      y: '08',
+      v: 5000,
+    });
+    expect(datalabel).toBe('5.0 km');
+  });
+
+  it('counts entries when measurement is "mixed"', async () => {
+    fixture.componentRef.setInput('entries', [
+      { timestamp: '2026-02-09T08:00:00', reps: 30 },
+      { timestamp: '2026-02-09T08:30:00', durationSec: 60 },
+      { timestamp: '2026-02-09T08:45:00', reps: 20 },
+    ] as HeatmapEntry[]);
+    fixture.componentRef.setInput('measurement', 'mixed');
+
+    await fixture.whenStable();
+
+    const component = fixture.componentInstance;
+    const data = component.chartData();
+    const points = data.datasets[0].data as Array<{
+      x: string;
+      y: string;
+      v: number;
+    }>;
+    const mo8 = points.find((p) => p.x === 'Mo' && p.y === '08');
+    expect(mo8?.v).toBe(3);
+
+    const opts = component.chartOptions() as any;
+    const tooltip = opts.plugins.tooltip.callbacks.label({
+      raw: { x: 'Mo', y: '08', v: 3 },
+    });
+    expect(tooltip).toContain('Einträge');
   });
 });

--- a/web/src/app/stats/components/heatmap/heatmap.component.ts
+++ b/web/src/app/stats/components/heatmap/heatmap.component.ts
@@ -88,11 +88,13 @@ export class HeatmapComponent {
       return $localize`:@@heatmap.unit.intervals:Intervalle`;
     }
     switch (m) {
+      // `formatHeatmapTooltipValue` already embeds the unit for time
+      // (`2:30 min`, `1:02:05 h`) and distance (`750 m`, `5.00 km`) —
+      // appending another suffix would render `2:30 min min`.
       case 'time':
-        return $localize`:@@heatmap.unit.minutes:min`;
       case 'distance':
       case 'distance-time':
-        return $localize`:@@heatmap.unit.distance:Strecke`;
+        return '';
       case 'mixed':
         return $localize`:@@heatmap.unit.entries:Einträge`;
       case 'reps':
@@ -162,7 +164,8 @@ export class HeatmapComponent {
                 measurement,
                 mode,
               });
-              return `${v?.x ?? ''} ${v?.y ?? ''}:00 - ${formatted} ${unit}`;
+              const suffix = unit ? ` ${unit}` : '';
+              return `${v?.x ?? ''} ${v?.y ?? ''}:00 - ${formatted}${suffix}`;
             },
           },
         },

--- a/web/src/app/stats/components/heatmap/heatmap.component.ts
+++ b/web/src/app/stats/components/heatmap/heatmap.component.ts
@@ -7,7 +7,11 @@ import {
   buildHeatmapCells,
   defaultHeatmapDays,
   defaultHeatmapHoursTopDown,
+  formatHeatmapCellLabel,
+  formatHeatmapTooltipValue,
   heatmapCellColor,
+  type HeatmapMeasurement,
+  type HeatmapMode,
 } from './heatmap.utils';
 
 /** Minimal shape the heatmap reads — narrower than `PushupRecord` or
@@ -15,8 +19,11 @@ import {
  *  caller. `buildHeatmapCells` already requires only these fields. */
 export interface HeatmapEntry {
   timestamp: string;
-  reps: number;
+  reps?: number;
+  durationSec?: number;
+  distanceM?: number;
   sets?: number[];
+  intervals?: number[];
 }
 
 ensureHeatmapChartRegistered();
@@ -24,7 +31,7 @@ ensureHeatmapChartRegistered();
 export interface HeatmapCell {
   x: string; // weekday label
   y: string; // hour label
-  v: number; // reps
+  v: number; // aggregated value (reps / durationSec / distanceM / count)
 }
 
 @Component({
@@ -61,28 +68,48 @@ export interface HeatmapCell {
 })
 export class HeatmapComponent {
   readonly entries = input<ReadonlyArray<HeatmapEntry>>([]);
-  readonly mode = input<'reps' | 'sets'>('reps');
+  readonly measurement = input<HeatmapMeasurement | null>('reps');
+  readonly mode = input<HeatmapMode>('primary');
 
   readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   private readonly days = defaultHeatmapDays;
   private readonly hoursTopDown = defaultHeatmapHoursTopDown;
 
-  private readonly unitLabel = computed(() =>
-    this.mode() === 'sets'
-      ? $localize`:@@heatmap.unit.sets:Sätze`
-      : $localize`:@@heatmap.unit.reps:Wiederholungen`
-  );
+  private readonly unitLabel = computed(() => {
+    const m = this.measurement() ?? 'mixed';
+    if (this.mode() === 'breakdown') {
+      if (m === 'reps' || m === 'weight') {
+        return $localize`:@@heatmap.unit.sets:Sätze`;
+      }
+      if (m === 'mixed') {
+        return $localize`:@@heatmap.unit.entries:Einträge`;
+      }
+      return $localize`:@@heatmap.unit.intervals:Intervalle`;
+    }
+    switch (m) {
+      case 'time':
+        return $localize`:@@heatmap.unit.minutes:min`;
+      case 'distance':
+      case 'distance-time':
+        return $localize`:@@heatmap.unit.distance:Strecke`;
+      case 'mixed':
+        return $localize`:@@heatmap.unit.entries:Einträge`;
+      case 'reps':
+      case 'weight':
+        return $localize`:@@heatmap.unit.reps:Wiederholungen`;
+    }
+  });
 
   // Matrix chart typing is tricky with string category axes; keep this loosely typed.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly chartData = computed<any>(() => {
-    const currentMode = this.mode();
     const data = buildHeatmapCells({
       entries: this.entries(),
       days: this.days,
       hoursTopDown: this.hoursTopDown,
-      mode: currentMode,
+      measurement: this.measurement() ?? 'mixed',
+      mode: this.mode(),
     });
 
     const max = Math.max(0, ...data.map((d) => d.v)) || 1;
@@ -90,7 +117,7 @@ export class HeatmapComponent {
     return {
       datasets: [
         {
-          label: 'Pushups',
+          label: 'Heatmap',
           data,
           backgroundColor: (context: unknown) => {
             const raw = (context as { raw?: HeatmapCell }).raw;
@@ -118,6 +145,8 @@ export class HeatmapComponent {
   // Keeping this in the component to avoid leaking Chart.js typing complexity into page components.
   readonly chartOptions = computed<ChartConfiguration['options']>(() => {
     const unit = this.unitLabel();
+    const measurement = this.measurement() ?? 'mixed';
+    const mode = this.mode();
     return {
       responsive: true,
       maintainAspectRatio: false,
@@ -128,7 +157,12 @@ export class HeatmapComponent {
             title: () => '',
             label: (context: unknown) => {
               const v = (context as { raw?: HeatmapCell }).raw;
-              return `${v?.x ?? ''} ${v?.y ?? ''}:00 - ${v?.v ?? 0} ${unit}`;
+              const formatted = formatHeatmapTooltipValue({
+                value: v?.v ?? 0,
+                measurement,
+                mode,
+              });
+              return `${v?.x ?? ''} ${v?.y ?? ''}:00 - ${formatted} ${unit}`;
             },
           },
         },
@@ -140,7 +174,12 @@ export class HeatmapComponent {
             )?.dataset?.data?.[(ctx as { dataIndex: number }).dataIndex];
             return !!raw && typeof raw.v === 'number' && raw.v > 0;
           },
-          formatter: (value: HeatmapCell) => (value?.v ? String(value.v) : ''),
+          formatter: (value: HeatmapCell) =>
+            formatHeatmapCellLabel({
+              value: value?.v ?? 0,
+              measurement,
+              mode,
+            }),
           anchor: 'center',
           align: 'center',
           clamp: true,

--- a/web/src/app/stats/components/heatmap/heatmap.utils.spec.ts
+++ b/web/src/app/stats/components/heatmap/heatmap.utils.spec.ts
@@ -163,6 +163,10 @@ describe('heatmap.utils', () => {
     };
     expect(entryHeatmapValue(repsEntry, 'reps', 'primary')).toBe(30);
     expect(entryHeatmapValue(repsEntry, 'reps', 'breakdown')).toBe(3);
+    // Weight uses `reps` for the primary value (sets × reps with a load
+    // companion); the breakdown count still comes from the sets array.
+    expect(entryHeatmapValue(repsEntry, 'weight', 'primary')).toBe(30);
+    expect(entryHeatmapValue(repsEntry, 'weight', 'breakdown')).toBe(3);
 
     const timeEntry: HeatmapValueEntry = {
       timestamp: '2026-02-09T08:00:00',
@@ -179,6 +183,37 @@ describe('heatmap.utils', () => {
     expect(entryHeatmapValue(distanceEntry, 'distance-time', 'primary')).toBe(
       5000
     );
+    expect(entryHeatmapValue(distanceEntry, 'distance', 'primary')).toBe(5000);
+  });
+
+  it('entryHeatmapValue falls back to entry-count when measurement is null/undefined', () => {
+    const entry: HeatmapValueEntry = {
+      timestamp: '2026-02-09T08:00:00',
+      reps: 30,
+    };
+    expect(entryHeatmapValue(entry, null, 'primary')).toBe(1);
+    expect(entryHeatmapValue(entry, undefined, 'primary')).toBe(1);
+    // Mixed has no meaningful breakdown — defensive fallback is still 1.
+    expect(entryHeatmapValue(entry, null, 'breakdown')).toBe(1);
+    expect(entryHeatmapValue(entry, 'mixed', 'breakdown')).toBe(1);
+  });
+
+  it('entryHeatmapValue returns 0 when the primary value field is absent', () => {
+    // e.g. a time-measured entry with no durationSec, or a reps-measured
+    // entry with no reps — the cell should not get a phantom 1.
+    expect(
+      entryHeatmapValue({ timestamp: '2026-02-09T08:00:00' }, 'time', 'primary')
+    ).toBe(0);
+    expect(
+      entryHeatmapValue({ timestamp: '2026-02-09T08:00:00' }, 'reps', 'primary')
+    ).toBe(0);
+    expect(
+      entryHeatmapValue(
+        { timestamp: '2026-02-09T08:00:00' },
+        'distance',
+        'primary'
+      )
+    ).toBe(0);
   });
 
   describe('formatHeatmapCellLabel', () => {
@@ -266,13 +301,15 @@ describe('heatmap.utils', () => {
           mode: 'primary',
         })
       ).toBe('1:02:05 h');
+      // One decimal place — matches the compact cell label so the
+      // tooltip and the cell don't read as inconsistent precisions.
       expect(
         formatHeatmapTooltipValue({
           value: 5000,
           measurement: 'distance-time',
           mode: 'primary',
         })
-      ).toBe('5.00 km');
+      ).toBe('5.0 km');
       expect(
         formatHeatmapTooltipValue({
           value: 250,
@@ -280,6 +317,33 @@ describe('heatmap.utils', () => {
           mode: 'primary',
         })
       ).toBe('250 m');
+    });
+
+    it('returns plain integers (no unit) for breakdown and mixed modes', () => {
+      // The component appends the localized unit ("Intervalle"/"Sätze"/
+      // "Einträge") after this value — embedding a second unit here
+      // would render "4 min Intervalle".
+      expect(
+        formatHeatmapTooltipValue({
+          value: 4,
+          measurement: 'time',
+          mode: 'breakdown',
+        })
+      ).toBe('4');
+      expect(
+        formatHeatmapTooltipValue({
+          value: 3,
+          measurement: 'reps',
+          mode: 'breakdown',
+        })
+      ).toBe('3');
+      expect(
+        formatHeatmapTooltipValue({
+          value: 2,
+          measurement: 'mixed',
+          mode: 'primary',
+        })
+      ).toBe('2');
     });
   });
 

--- a/web/src/app/stats/components/heatmap/heatmap.utils.spec.ts
+++ b/web/src/app/stats/components/heatmap/heatmap.utils.spec.ts
@@ -2,16 +2,17 @@ import {
   buildHeatmapCells,
   defaultHeatmapDays,
   defaultHeatmapHoursTopDown,
+  entryHeatmapValue,
+  formatHeatmapCellLabel,
+  formatHeatmapTooltipValue,
   heatmapCellColor,
   hourTopDownLabels,
+  type HeatmapValueEntry,
 } from './heatmap.utils';
-
-// minimal shape used by the utils
-type Entry = { timestamp: string; reps: number; sets?: number[] };
 
 describe('heatmap.utils', () => {
   it('generates 24*7 cells and aggregates reps by weekday+hour', () => {
-    const entries: Entry[] = [
+    const entries: HeatmapValueEntry[] = [
       { timestamp: '2026-02-09T08:00:00', reps: 10 }, // Mon
       { timestamp: '2026-02-09T08:30:00', reps: 5 }, // Mon, same hour
       { timestamp: '2026-02-10T23:00:00', reps: 12 }, // Tue
@@ -25,15 +26,11 @@ describe('heatmap.utils', () => {
 
     expect(cells).toHaveLength(24 * 7);
 
-    const mo8 = cells.find(
-      (c: { x: string; y: string; v: number }) => c.x === 'Mo' && c.y === '08'
-    );
+    const mo8 = cells.find((c) => c.x === 'Mo' && c.y === '08');
     expect(mo8).toBeDefined();
     expect(mo8?.v).toBe(15);
 
-    const di23 = cells.find(
-      (c: { x: string; y: string; v: number }) => c.x === 'Di' && c.y === '23'
-    );
+    const di23 = cells.find((c) => c.x === 'Di' && c.y === '23');
     expect(di23).toBeDefined();
     expect(di23?.v).toBe(12);
   });
@@ -54,8 +51,8 @@ describe('heatmap.utils', () => {
     expect(c.startsWith('rgba(69, 137, 255,')).toBe(true);
   });
 
-  it('aggregates set count instead of reps when mode is "sets"', () => {
-    const entries: Entry[] = [
+  it('aggregates set count in breakdown mode for reps measurement', () => {
+    const entries: HeatmapValueEntry[] = [
       { timestamp: '2026-02-09T08:00:00', reps: 10, sets: [5, 5] }, // Mon
       { timestamp: '2026-02-09T08:30:00', reps: 15, sets: [5, 5, 5] }, // Mon, same hour
       { timestamp: '2026-02-10T23:00:00', reps: 12 }, // Tue, no sets
@@ -65,20 +62,225 @@ describe('heatmap.utils', () => {
       entries,
       days: defaultHeatmapDays,
       hoursTopDown: defaultHeatmapHoursTopDown,
-      mode: 'sets',
+      measurement: 'reps',
+      mode: 'breakdown',
     });
 
     // Mon 08: 2 sets + 3 sets = 5
-    const mo8 = cells.find(
-      (c: { x: string; y: string; v: number }) => c.x === 'Mo' && c.y === '08'
-    );
+    const mo8 = cells.find((c) => c.x === 'Mo' && c.y === '08');
     expect(mo8?.v).toBe(5);
 
     // Tue 23: no sets → 0
-    const di23 = cells.find(
-      (c: { x: string; y: string; v: number }) => c.x === 'Di' && c.y === '23'
-    );
+    const di23 = cells.find((c) => c.x === 'Di' && c.y === '23');
     expect(di23?.v).toBe(0);
+  });
+
+  it('sums durationSec when measurement is "time" (regression: planks no longer surface as zero cells)', () => {
+    const entries: HeatmapValueEntry[] = [
+      { timestamp: '2026-02-09T08:00:00', reps: 0, durationSec: 60 }, // Mon
+      { timestamp: '2026-02-09T08:30:00', reps: 0, durationSec: 90 }, // Mon same hour
+    ];
+
+    const cells = buildHeatmapCells({
+      entries,
+      days: defaultHeatmapDays,
+      hoursTopDown: defaultHeatmapHoursTopDown,
+      measurement: 'time',
+    });
+
+    const mo8 = cells.find((c) => c.x === 'Mo' && c.y === '08');
+    expect(mo8?.v).toBe(150);
+  });
+
+  it('counts intervals in breakdown mode for time-measured entries', () => {
+    const entries: HeatmapValueEntry[] = [
+      {
+        timestamp: '2026-02-09T08:00:00',
+        durationSec: 90,
+        intervals: [30, 30, 30],
+      },
+      {
+        timestamp: '2026-02-09T08:30:00',
+        durationSec: 60,
+        intervals: [30, 30],
+      },
+    ];
+
+    const cells = buildHeatmapCells({
+      entries,
+      days: defaultHeatmapDays,
+      hoursTopDown: defaultHeatmapHoursTopDown,
+      measurement: 'time',
+      mode: 'breakdown',
+    });
+
+    const mo8 = cells.find((c) => c.x === 'Mo' && c.y === '08');
+    expect(mo8?.v).toBe(5);
+  });
+
+  it('sums distanceM when measurement is "distance-time" (cardio runs)', () => {
+    const entries: HeatmapValueEntry[] = [
+      { timestamp: '2026-02-09T08:00:00', distanceM: 5000, durationSec: 1500 },
+      { timestamp: '2026-02-09T08:30:00', distanceM: 3000, durationSec: 900 },
+    ];
+
+    const cells = buildHeatmapCells({
+      entries,
+      days: defaultHeatmapDays,
+      hoursTopDown: defaultHeatmapHoursTopDown,
+      measurement: 'distance-time',
+    });
+
+    const mo8 = cells.find((c) => c.x === 'Mo' && c.y === '08');
+    expect(mo8?.v).toBe(8000);
+  });
+
+  it('counts each entry once when measurement is "mixed"', () => {
+    // Mixed view (e.g. core with planks + sit-ups, or overview): summing
+    // seconds + reps would be nonsense; we render entry count instead.
+    const entries: HeatmapValueEntry[] = [
+      { timestamp: '2026-02-09T08:00:00', reps: 30 }, // sit-ups
+      { timestamp: '2026-02-09T08:30:00', durationSec: 60 }, // plank
+      { timestamp: '2026-02-09T08:45:00', reps: 20 }, // sit-ups
+    ];
+
+    const cells = buildHeatmapCells({
+      entries,
+      days: defaultHeatmapDays,
+      hoursTopDown: defaultHeatmapHoursTopDown,
+      measurement: 'mixed',
+    });
+
+    const mo8 = cells.find((c) => c.x === 'Mo' && c.y === '08');
+    expect(mo8?.v).toBe(3);
+  });
+
+  it('entryHeatmapValue picks the right field per measurement type', () => {
+    const repsEntry: HeatmapValueEntry = {
+      timestamp: '2026-02-09T08:00:00',
+      reps: 30,
+      sets: [10, 10, 10],
+    };
+    expect(entryHeatmapValue(repsEntry, 'reps', 'primary')).toBe(30);
+    expect(entryHeatmapValue(repsEntry, 'reps', 'breakdown')).toBe(3);
+
+    const timeEntry: HeatmapValueEntry = {
+      timestamp: '2026-02-09T08:00:00',
+      durationSec: 90,
+      intervals: [30, 30, 30],
+    };
+    expect(entryHeatmapValue(timeEntry, 'time', 'primary')).toBe(90);
+    expect(entryHeatmapValue(timeEntry, 'time', 'breakdown')).toBe(3);
+
+    const distanceEntry: HeatmapValueEntry = {
+      timestamp: '2026-02-09T08:00:00',
+      distanceM: 5000,
+    };
+    expect(entryHeatmapValue(distanceEntry, 'distance-time', 'primary')).toBe(
+      5000
+    );
+  });
+
+  describe('formatHeatmapCellLabel', () => {
+    it('returns empty string for zero/negative values', () => {
+      expect(
+        formatHeatmapCellLabel({
+          value: 0,
+          measurement: 'reps',
+          mode: 'primary',
+        })
+      ).toBe('');
+    });
+
+    it('renders reps/weight as plain integers', () => {
+      expect(
+        formatHeatmapCellLabel({
+          value: 45,
+          measurement: 'reps',
+          mode: 'primary',
+        })
+      ).toBe('45');
+    });
+
+    it('renders time as m:ss for sub-hour values', () => {
+      expect(
+        formatHeatmapCellLabel({
+          value: 150,
+          measurement: 'time',
+          mode: 'primary',
+        })
+      ).toBe('2:30');
+    });
+
+    it('renders time as h:mm for >= 1 hour values', () => {
+      expect(
+        formatHeatmapCellLabel({
+          value: 3720, // 1h 02m
+          measurement: 'time',
+          mode: 'primary',
+        })
+      ).toBe('1:02h');
+    });
+
+    it('renders distance in meters below 1 km, km above', () => {
+      expect(
+        formatHeatmapCellLabel({
+          value: 750,
+          measurement: 'distance-time',
+          mode: 'primary',
+        })
+      ).toBe('750 m');
+      expect(
+        formatHeatmapCellLabel({
+          value: 5000,
+          measurement: 'distance-time',
+          mode: 'primary',
+        })
+      ).toBe('5.0 km');
+    });
+
+    it('renders breakdown values as plain integers regardless of measurement', () => {
+      expect(
+        formatHeatmapCellLabel({
+          value: 3,
+          measurement: 'time',
+          mode: 'breakdown',
+        })
+      ).toBe('3');
+    });
+  });
+
+  describe('formatHeatmapTooltipValue', () => {
+    it('includes units for time and distance', () => {
+      expect(
+        formatHeatmapTooltipValue({
+          value: 150,
+          measurement: 'time',
+          mode: 'primary',
+        })
+      ).toBe('2:30 min');
+      expect(
+        formatHeatmapTooltipValue({
+          value: 3725, // 1h 02m 05s
+          measurement: 'time',
+          mode: 'primary',
+        })
+      ).toBe('1:02:05 h');
+      expect(
+        formatHeatmapTooltipValue({
+          value: 5000,
+          measurement: 'distance-time',
+          mode: 'primary',
+        })
+      ).toBe('5.00 km');
+      expect(
+        formatHeatmapTooltipValue({
+          value: 250,
+          measurement: 'distance',
+          mode: 'primary',
+        })
+      ).toBe('250 m');
+    });
   });
 
   it('exposes day/hour constants', () => {

--- a/web/src/app/stats/components/heatmap/heatmap.utils.ts
+++ b/web/src/app/stats/components/heatmap/heatmap.utils.ts
@@ -231,5 +231,5 @@ function formatDistanceCompact(meters: number): string {
 function formatDistanceLong(meters: number): string {
   const v = Math.max(0, meters);
   if (v < 1000) return `${Math.round(v)} m`;
-  return `${(v / 1000).toFixed(2)} km`;
+  return `${(v / 1000).toFixed(1)} km`;
 }

--- a/web/src/app/stats/components/heatmap/heatmap.utils.ts
+++ b/web/src/app/stats/components/heatmap/heatmap.utils.ts
@@ -24,13 +24,84 @@ function weekdayLabel(date: Date): HeatmapDay {
   return defaultHeatmapDays[dayIndex];
 }
 
+/**
+ * Measurement bucket the heatmap consumes. Mirrors {@link MeasurementType}
+ * with two additions:
+ *   - `'mixed'`     — used by the overview / category-overlap views where
+ *                     summing different units is meaningless; the heatmap
+ *                     then counts entries per cell instead.
+ *   - `null` / `undefined` — same fallback (entry count).
+ */
+export type HeatmapMeasurement =
+  | 'reps'
+  | 'time'
+  | 'distance'
+  | 'distance-time'
+  | 'weight'
+  | 'mixed';
+
+/**
+ * Aggregation mode:
+ *   - `'primary'`   — sum each entry's primary value
+ *                     (reps for reps/weight, durationSec for time,
+ *                     distanceM for distance/distance-time, entry count
+ *                     for mixed).
+ *   - `'breakdown'` — count of the per-entry breakdown (sets for
+ *                     reps/weight, intervals for time/distance).
+ *                     Not meaningful for `'mixed'`.
+ */
+export type HeatmapMode = 'primary' | 'breakdown';
+
+export interface HeatmapValueEntry {
+  timestamp: string;
+  reps?: number;
+  durationSec?: number;
+  distanceM?: number;
+  sets?: number[];
+  intervals?: number[];
+}
+
+export function entryHeatmapValue(
+  entry: HeatmapValueEntry,
+  measurement: HeatmapMeasurement | null | undefined,
+  mode: HeatmapMode
+): number {
+  const m = measurement ?? 'mixed';
+  if (mode === 'breakdown') {
+    // `mixed` has no meaningful breakdown — toggle is hidden in the UI
+    // but be defensive: fall back to entry-count.
+    if (m === 'mixed') return 1;
+    if (m === 'reps' || m === 'weight') return entry.sets?.length ?? 0;
+    return entry.intervals?.length ?? 0;
+  }
+  switch (m) {
+    case 'reps':
+    case 'weight':
+      return entry.reps ?? 0;
+    case 'time':
+      return entry.durationSec ?? 0;
+    case 'distance':
+    case 'distance-time':
+      return entry.distanceM ?? 0;
+    case 'mixed':
+      return 1;
+  }
+}
+
 export function buildHeatmapCells(params: {
-  entries: ReadonlyArray<{ timestamp: string; reps: number; sets?: number[] }>;
+  entries: ReadonlyArray<HeatmapValueEntry>;
   days: ReadonlyArray<string>;
   hoursTopDown: ReadonlyArray<string>;
-  mode?: 'reps' | 'sets';
+  measurement?: HeatmapMeasurement | null;
+  mode?: HeatmapMode;
 }): HeatmapCell[] {
-  const { entries, days, hoursTopDown, mode = 'reps' } = params;
+  const {
+    entries,
+    days,
+    hoursTopDown,
+    measurement = 'reps',
+    mode = 'primary',
+  } = params;
 
   const base: HeatmapCell[] = [];
   for (const day of days) {
@@ -45,7 +116,7 @@ export function buildHeatmapCells(params: {
     const dayLabel = weekdayLabel(date);
     const hourLabel = String(date.getHours()).padStart(2, '0');
     const key = `${dayLabel}-${hourLabel}`;
-    const value = mode === 'sets' ? (row.sets?.length ?? 0) : row.reps;
+    const value = entryHeatmapValue(row, measurement, mode);
     map.set(key, (map.get(key) ?? 0) + value);
   }
 
@@ -71,4 +142,94 @@ export function heatmapCellColor(params: {
   const t = Math.pow(ratio, 0.6);
   const alpha = 0.2 + t * 0.8;
   return `rgba(69, 137, 255, ${alpha})`;
+}
+
+/**
+ * Cell-label formatter — what the datalabel plugin prints on the cell.
+ * Kept short so it fits inside the cell at every zoom level:
+ *
+ *   - reps/weight: plain integer (e.g. `45`)
+ *   - time: `m:ss` for sub-hour, `h:mm` for >= 1 h (drops seconds so
+ *           the label stays inside the cell)
+ *   - distance: `750 m` or `1.5 km` (one decimal for km)
+ *   - breakdown / mixed: plain integer
+ */
+export function formatHeatmapCellLabel(params: {
+  value: number;
+  measurement: HeatmapMeasurement | null | undefined;
+  mode: HeatmapMode;
+}): string {
+  const { value, measurement, mode } = params;
+  if (value <= 0) return '';
+  const m = measurement ?? 'mixed';
+  if (mode === 'breakdown' || m === 'mixed' || m === 'reps' || m === 'weight') {
+    return String(Math.round(value));
+  }
+  if (m === 'time') return formatDurationCompact(value);
+  // distance / distance-time
+  return formatDistanceCompact(value);
+}
+
+/**
+ * Tooltip label — longer than the cell label; includes the unit so the
+ * user knows what they're looking at.
+ */
+export function formatHeatmapTooltipValue(params: {
+  value: number;
+  measurement: HeatmapMeasurement | null | undefined;
+  mode: HeatmapMode;
+}): string {
+  const { value, measurement, mode } = params;
+  const m = measurement ?? 'mixed';
+  if (mode === 'breakdown') {
+    return String(Math.round(value));
+  }
+  switch (m) {
+    case 'time':
+      return formatDurationLong(value);
+    case 'distance':
+    case 'distance-time':
+      return formatDistanceLong(value);
+    case 'reps':
+    case 'weight':
+    case 'mixed':
+      return String(Math.round(value));
+  }
+}
+
+function formatDurationCompact(totalSec: number): string {
+  const s = Math.max(0, Math.round(totalSec));
+  if (s < 3600) {
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return `${m}:${String(sec).padStart(2, '0')}`;
+  }
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  return `${h}:${String(m).padStart(2, '0')}h`;
+}
+
+function formatDurationLong(totalSec: number): string {
+  const s = Math.max(0, Math.round(totalSec));
+  if (s < 3600) {
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return `${m}:${String(sec).padStart(2, '0')} min`;
+  }
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  return `${h}:${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')} h`;
+}
+
+function formatDistanceCompact(meters: number): string {
+  const v = Math.max(0, meters);
+  if (v < 1000) return `${Math.round(v)} m`;
+  return `${(v / 1000).toFixed(1)} km`;
+}
+
+function formatDistanceLong(meters: number): string {
+  const v = Math.max(0, meters);
+  if (v < 1000) return `${Math.round(v)} m`;
+  return `${(v / 1000).toFixed(2)} km`;
 }

--- a/web/src/app/stats/shell/analysis-group-view.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.spec.ts
@@ -409,6 +409,77 @@ describe('AnalysisGroupViewComponent', () => {
     expect(store.viewPaceSeries()).toEqual([]);
   });
 
+  it('heatmap toggle shows Reps/Sets for reps-measured views', async () => {
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'abs.situps',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        reps: 30,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('core');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const groupView =
+      groupViewEl.componentInstance as AnalysisGroupViewComponent;
+    expect(groupView.heatmapMeasurement()).toBe('reps');
+    expect(groupView.heatmapToggleLabels()).toEqual({
+      primary: 'Reps',
+      breakdown: 'Sets',
+    });
+
+    const host: HTMLElement = fixture.nativeElement;
+    const toggle = host.querySelector('.heatmap-toggle');
+    expect(toggle?.textContent).toContain('Reps');
+    expect(toggle?.textContent).toContain('Sets');
+  });
+
+  it('heatmap toggle shows Strecke/Intervalle for distance-time views', async () => {
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'cardio.running',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        distanceM: 5000,
+        durationSec: 1500,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('cardio');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const groupView =
+      groupViewEl.componentInstance as AnalysisGroupViewComponent;
+    expect(groupView.heatmapMeasurement()).toBe('distance-time');
+    expect(groupView.heatmapToggleLabels()).toEqual({
+      primary: 'Strecke',
+      breakdown: 'Intervalle',
+    });
+
+    const host: HTMLElement = fixture.nativeElement;
+    const toggle = host.querySelector('.heatmap-toggle');
+    expect(toggle?.textContent).toContain('Strecke');
+    expect(toggle?.textContent).toContain('Intervalle');
+  });
+
   it('heatmap toggle switches to Zeit/Intervalle for time-measured views', async () => {
     liveExerciseEntries.set([
       {

--- a/web/src/app/stats/shell/analysis-group-view.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.spec.ts
@@ -25,7 +25,8 @@ import { SetsDistributionComponent } from '../components/sets-distribution/sets-
 })
 class MockHeatmapComponent {
   readonly entries = input<unknown[]>([]);
-  readonly mode = input<string>('reps');
+  readonly measurement = input<unknown>(null);
+  readonly mode = input<string>('primary');
 }
 
 @Component({
@@ -191,7 +192,7 @@ describe('AnalysisGroupViewComponent', () => {
     ).toBeTruthy();
   });
 
-  it('places the heatmap reps/sets toggle inside the heatmap card header so the mobile stacked layout applies', () => {
+  it('places the heatmap mode toggle inside the heatmap card header so the mobile stacked layout applies', () => {
     const host: HTMLElement = fixture.nativeElement;
 
     const heatmapCard = host.querySelector('.heatmap-full');
@@ -406,6 +407,81 @@ describe('AnalysisGroupViewComponent', () => {
     await fixture.whenStable();
 
     expect(store.viewPaceSeries()).toEqual([]);
+  });
+
+  it('heatmap toggle switches to Zeit/Intervalle for time-measured views', async () => {
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'plank.standard',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        durationSec: 60,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('core');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const groupView =
+      groupViewEl.componentInstance as AnalysisGroupViewComponent;
+    expect(groupView.heatmapMeasurement()).toBe('time');
+    expect(groupView.heatmapToggleLabels()).toEqual({
+      primary: 'Zeit',
+      breakdown: 'Intervalle',
+    });
+
+    const host: HTMLElement = fixture.nativeElement;
+    const toggle = host.querySelector('.heatmap-toggle');
+    expect(toggle?.textContent).toContain('Zeit');
+    expect(toggle?.textContent).toContain('Intervalle');
+  });
+
+  it('heatmap toggle is hidden for mixed-measurement views', async () => {
+    liveExerciseEntries.set([
+      {
+        _id: 'e1',
+        userId: 'u1',
+        exerciseId: 'abs.situps',
+        timestamp: '2026-02-10T08:00:00.000Z',
+        reps: 30,
+        source: 'web',
+      } as ExerciseEntry,
+      {
+        _id: 'e2',
+        userId: 'u1',
+        exerciseId: 'plank.standard',
+        timestamp: '2026-02-11T08:00:00.000Z',
+        durationSec: 60,
+        source: 'web',
+      } as ExerciseEntry,
+    ]);
+    const groupViewEl = fixture.debugElement.query(
+      By.directive(AnalysisGroupViewComponent)
+    );
+    const store = groupViewEl.injector.get(AnalysisStore);
+    store.setRange('2026-02-09', '2026-02-15');
+    store.setActiveView('core');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const groupView =
+      groupViewEl.componentInstance as AnalysisGroupViewComponent;
+    expect(groupView.heatmapMeasurement()).toBe('mixed');
+    expect(groupView.heatmapToggleLabels()).toBeNull();
+
+    const host: HTMLElement = fixture.nativeElement;
+    const heatmapCard = host.querySelector('.heatmap-full');
+    const toggle = heatmapCard?.querySelector('.heatmap-toggle');
+    expect(toggle).toBeNull();
   });
 
   it('viewChartEntries surfaces durationSec on `reps` for time-measured rows so the stacked-bar layer also sees the volume', async () => {

--- a/web/src/app/stats/shell/analysis-group-view.component.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.ts
@@ -6,6 +6,10 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { type UnifiedEntryFilterKey } from '@pu-stats/models';
 import { HeatmapComponent } from '../components/heatmap/heatmap.component';
+import type {
+  HeatmapMeasurement,
+  HeatmapMode,
+} from '../components/heatmap/heatmap.utils';
 import { SetsDistributionComponent } from '../components/sets-distribution/sets-distribution.component';
 import { StatsChartComponent } from '../components/stats-chart/stats-chart.component';
 import { TypePieComponent } from '../components/type-pie/type-pie.component';
@@ -154,25 +158,28 @@ import { kindDisplayName } from '../i18n/exercise-display-names';
           <mat-card-title i18n="@@analysis.heatmapTitle"
             >Heatmap (Wochentag/Uhrzeit)</mat-card-title
           >
-          <mat-button-toggle-group
-            [value]="heatmapMode()"
-            (change)="heatmapMode.set($event.value)"
-            class="heatmap-toggle"
-            aria-label="Heatmap-Modus auswählen"
-            i18n-aria-label="@@analysis.heatmapToggleAriaLabel"
-          >
-            <mat-button-toggle value="reps" i18n="@@analysis.heatmapReps"
-              >Reps</mat-button-toggle
+          @if (heatmapToggleLabels(); as labels) {
+            <mat-button-toggle-group
+              [value]="heatmapMode()"
+              (change)="heatmapMode.set($event.value)"
+              class="heatmap-toggle"
+              aria-label="Heatmap-Modus auswählen"
+              i18n-aria-label="@@analysis.heatmapToggleAriaLabel"
             >
-            <mat-button-toggle value="sets" i18n="@@analysis.heatmapSets"
-              >Sets</mat-button-toggle
-            >
-          </mat-button-toggle-group>
+              <mat-button-toggle value="primary">{{
+                labels.primary
+              }}</mat-button-toggle>
+              <mat-button-toggle value="breakdown">{{
+                labels.breakdown
+              }}</mat-button-toggle>
+            </mat-button-toggle-group>
+          }
         </mat-card-header>
         <mat-card-content class="heatmap-wrap">
           @defer (hydrate on viewport) {
             <app-heatmap
               [entries]="store.viewFilteredRows()"
+              [measurement]="heatmapMeasurement()"
               [mode]="heatmapMode()"
             />
           }
@@ -364,7 +371,52 @@ import { kindDisplayName } from '../i18n/exercise-display-names';
 export class AnalysisGroupViewComponent {
   readonly store = inject(AnalysisStore);
   readonly trendColumnsWithSets = ['label', 'total', 'avgSetsPerEntry'];
-  readonly heatmapMode = signal<'reps' | 'sets'>('reps');
+  readonly heatmapMode = signal<HeatmapMode>('primary');
+
+  /**
+   * Heatmap measurement bucket, derived from the analysis view's
+   * dominant measurement. `null` (no entries) collapses into `'mixed'`
+   * so the heatmap renders entry-count rather than empty cells.
+   */
+  readonly heatmapMeasurement = computed<HeatmapMeasurement>(() => {
+    const m = this.store.viewMeasurement();
+    return m ?? 'mixed';
+  });
+
+  /**
+   * Toggle labels switch with the measurement so users see "Reps/Sätze"
+   * for strength views, "Zeit/Intervalle" for time-measured views (e.g.
+   * planks, holds), and "Strecke/Intervalle" for distance/cardio. Mixed
+   * views (overview, multi-measurement categories like `core`) hide the
+   * toggle — the heatmap then counts entries per cell.
+   */
+  readonly heatmapToggleLabels = computed<{
+    primary: string;
+    breakdown: string;
+  } | null>(() => {
+    const measurement = this.heatmapMeasurement();
+    switch (measurement) {
+      case 'reps':
+      case 'weight':
+        return {
+          primary: $localize`:@@analysis.heatmapReps:Reps`,
+          breakdown: $localize`:@@analysis.heatmapSets:Sets`,
+        };
+      case 'time':
+        return {
+          primary: $localize`:@@analysis.heatmapTime:Zeit`,
+          breakdown: $localize`:@@analysis.heatmapIntervals:Intervalle`,
+        };
+      case 'distance':
+      case 'distance-time':
+        return {
+          primary: $localize`:@@analysis.heatmapDistance:Strecke`,
+          breakdown: $localize`:@@analysis.heatmapIntervals:Intervalle`,
+        };
+      case 'mixed':
+        return null;
+    }
+  });
 
   /**
    * True for per-category tabs whose currently-selected range contains

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -4563,6 +4563,30 @@
         <target>Επαναλήψεις</target>
       </segment>
     </unit>
+    <unit id="heatmap.unit.minutes">
+      <segment state="translated">
+        <source>min</source>
+        <target>λεπτά</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.distance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Απόσταση</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.intervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Διαστήματα</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.entries">
+      <segment state="translated">
+        <source>Einträge</source>
+        <target>Καταχωρήσεις</target>
+      </segment>
+    </unit>
     <unit id="previewBanner.text">
       <notes>
         <note category="location">web/src/app/stats/components/preview-banner/preview-banner.component.ts:23,26</note>
@@ -5313,6 +5337,24 @@
       <segment state="translated">
         <source>Sets</source>
         <target>σετ</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapTime">
+      <segment state="translated">
+        <source>Zeit</source>
+        <target>Χρόνος</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapDistance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Απόσταση</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapIntervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Διαστήματα</target>
       </segment>
     </unit>
     <unit id="entries.title">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -511,6 +511,24 @@ Active:         </target>
         <target>Sets</target>
       </segment>
     </unit>
+    <unit id="analysis.heatmapTime">
+      <segment state="translated">
+        <source>Zeit</source>
+        <target>Time</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapDistance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distance</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapIntervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervals</target>
+      </segment>
+    </unit>
     <unit id="heatmap.unit.sets">
       <segment state="translated">
         <source>Sätze</source>
@@ -521,6 +539,30 @@ Active:         </target>
       <segment state="translated">
         <source>Wiederholungen</source>
         <target>Reps</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.minutes">
+      <segment state="translated">
+        <source>min</source>
+        <target>min</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.distance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distance</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.intervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervals</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.entries">
+      <segment state="translated">
+        <source>Einträge</source>
+        <target>Entries</target>
       </segment>
     </unit>
     <unit id="setsDistribution.noData">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -4563,6 +4563,30 @@
         <target>Repeticiones</target>
       </segment>
     </unit>
+    <unit id="heatmap.unit.minutes">
+      <segment state="translated">
+        <source>min</source>
+        <target>min</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.distance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distancia</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.intervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervalos</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.entries">
+      <segment state="translated">
+        <source>Einträge</source>
+        <target>Entradas</target>
+      </segment>
+    </unit>
     <unit id="previewBanner.text">
       <notes>
         <note category="location">web/src/app/stats/components/preview-banner/preview-banner.component.ts:23,26</note>
@@ -5313,6 +5337,24 @@
       <segment state="translated">
         <source>Sets</source>
         <target>conjuntos</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapTime">
+      <segment state="translated">
+        <source>Zeit</source>
+        <target>Tiempo</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapDistance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distancia</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapIntervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervalos</target>
       </segment>
     </unit>
     <unit id="entries.title">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -4563,6 +4563,30 @@
         <target>Répétitions</target>
       </segment>
     </unit>
+    <unit id="heatmap.unit.minutes">
+      <segment state="translated">
+        <source>min</source>
+        <target>min</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.distance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distance</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.intervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervalles</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.entries">
+      <segment state="translated">
+        <source>Einträge</source>
+        <target>Entrées</target>
+      </segment>
+    </unit>
     <unit id="previewBanner.text">
       <notes>
         <note category="location">web/src/app/stats/components/preview-banner/preview-banner.component.ts:23,26</note>
@@ -5313,6 +5337,24 @@
       <segment state="translated">
         <source>Sets</source>
         <target>ensembles</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapTime">
+      <segment state="translated">
+        <source>Zeit</source>
+        <target>Temps</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapDistance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distance</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapIntervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervalles</target>
       </segment>
     </unit>
     <unit id="entries.title">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -4563,6 +4563,30 @@
         <target>Ripetizioni</target>
       </segment>
     </unit>
+    <unit id="heatmap.unit.minutes">
+      <segment state="translated">
+        <source>min</source>
+        <target>min</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.distance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distanza</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.intervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervalli</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.entries">
+      <segment state="translated">
+        <source>Einträge</source>
+        <target>Voci</target>
+      </segment>
+    </unit>
     <unit id="previewBanner.text">
       <notes>
         <note category="location">web/src/app/stats/components/preview-banner/preview-banner.component.ts:23,26</note>
@@ -5313,6 +5337,24 @@
       <segment state="translated">
         <source>Sets</source>
         <target>imposta</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapTime">
+      <segment state="translated">
+        <source>Zeit</source>
+        <target>Tempo</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapDistance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distanza</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapIntervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervalli</target>
       </segment>
     </unit>
     <unit id="entries.title">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -4563,6 +4563,30 @@
         <target>Repetitiones</target>
       </segment>
     </unit>
+    <unit id="heatmap.unit.minutes">
+      <segment state="translated">
+        <source>min</source>
+        <target>min</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.distance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distantia</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.intervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervalla</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.entries">
+      <segment state="translated">
+        <source>Einträge</source>
+        <target>Inscriptiones</target>
+      </segment>
+    </unit>
     <unit id="previewBanner.text">
       <notes>
         <note category="location">web/src/app/stats/components/preview-banner/preview-banner.component.ts:23,26</note>
@@ -5313,6 +5337,24 @@
       <segment state="translated">
         <source>Sets</source>
         <target>sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapTime">
+      <segment state="translated">
+        <source>Zeit</source>
+        <target>Tempus</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapDistance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distantia</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapIntervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervalla</target>
       </segment>
     </unit>
     <unit id="entries.title">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -4584,7 +4584,7 @@
     <unit id="heatmap.unit.entries">
       <segment state="translated">
         <source>Einträge</source>
-        <target>Items</target>
+        <target>Vermeldingen</target>
       </segment>
     </unit>
     <unit id="previewBanner.text">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -4563,6 +4563,30 @@
         <target>Herhalingen</target>
       </segment>
     </unit>
+    <unit id="heatmap.unit.minutes">
+      <segment state="translated">
+        <source>min</source>
+        <target>min</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.distance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Afstand</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.intervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervallen</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.entries">
+      <segment state="translated">
+        <source>Einträge</source>
+        <target>Items</target>
+      </segment>
+    </unit>
     <unit id="previewBanner.text">
       <notes>
         <note category="location">web/src/app/stats/components/preview-banner/preview-banner.component.ts:23,26</note>
@@ -5313,6 +5337,24 @@
       <segment state="translated">
         <source>Sets</source>
         <target>sets</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapTime">
+      <segment state="translated">
+        <source>Zeit</source>
+        <target>Tijd</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapDistance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Afstand</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapIntervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervallen</target>
       </segment>
     </unit>
     <unit id="entries.title">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -399,6 +399,24 @@ Aktiv:         </target>
         <target>Serier</target>
       </segment>
     </unit>
+    <unit id="analysis.heatmapTime">
+      <segment state="translated">
+        <source>Zeit</source>
+        <target>Tid</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapDistance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distanse</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapIntervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervaller</target>
+      </segment>
+    </unit>
     <unit id="heatmap.unit.sets">
       <segment state="translated">
         <source>Sätze</source>
@@ -409,6 +427,30 @@ Aktiv:         </target>
       <segment state="translated">
         <source>Wiederholungen</source>
         <target>Repetisjoner</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.minutes">
+      <segment state="translated">
+        <source>min</source>
+        <target>min</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.distance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>Distanse</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.intervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervaller</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.entries">
+      <segment state="translated">
+        <source>Einträge</source>
+        <target>Oppføringer</target>
       </segment>
     </unit>
     <unit id="setsDistribution.noData">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -6121,6 +6121,38 @@
         <source>Wiederholungen</source>
       </segment>
     </unit>
+    <unit id="heatmap.unit.minutes">
+      <notes>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:82</note>
+      </notes>
+      <segment>
+        <source>min</source>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.distance">
+      <notes>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:84</note>
+      </notes>
+      <segment>
+        <source>Strecke</source>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.intervals">
+      <notes>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:91</note>
+      </notes>
+      <segment>
+        <source>Intervalle</source>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.entries">
+      <notes>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:86</note>
+      </notes>
+      <segment>
+        <source>Einträge</source>
+      </segment>
+    </unit>
     <unit id="previewBanner.text">
       <notes>
         <note category="location">web/src/app/stats/components/preview-banner/preview-banner.component.ts:23,26</note>
@@ -7845,6 +7877,30 @@
       </notes>
       <segment>
         <source>Sets</source>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapTime">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:421</note>
+      </notes>
+      <segment>
+        <source>Zeit</source>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapDistance">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:428</note>
+      </notes>
+      <segment>
+        <source>Strecke</source>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapIntervals">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:422</note>
+      </notes>
+      <segment>
+        <source>Intervalle</source>
       </segment>
     </unit>
     <unit id="analysis.weekTrendTitle">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -5153,6 +5153,30 @@
         <source>Wiederholungen</source>
       <target>重复次数</target></segment>
     </unit>
+    <unit id="heatmap.unit.minutes">
+      <segment state="translated">
+        <source>min</source>
+        <target>分</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.distance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>距离</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.intervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>区间</target>
+      </segment>
+    </unit>
+    <unit id="heatmap.unit.entries">
+      <segment state="translated">
+        <source>Einträge</source>
+        <target>记录</target>
+      </segment>
+    </unit>
     <unit id="previewBanner.text">
       <notes>
         <note category="location">web/src/app/stats/components/preview-banner/preview-banner.component.ts:23,26</note>
@@ -5844,6 +5868,24 @@
       <segment state="translated">
         <source>Sets</source>
       <target>组数</target></segment>
+    </unit>
+    <unit id="analysis.heatmapTime">
+      <segment state="translated">
+        <source>Zeit</source>
+        <target>时间</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapDistance">
+      <segment state="translated">
+        <source>Strecke</source>
+        <target>距离</target>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapIntervals">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>区间</target>
+      </segment>
     </unit>
     <unit id="entries.title">
       <notes>


### PR DESCRIPTION
The heatmap on the Analysis page summed `reps` unconditionally, so
time-measured exercises (plank, hollow hold) and distance-measured
ones (runs, carries) surfaced as zero — even when entries existed in
the selected range.

The heatmap now consumes the view's `viewMeasurement()` and aggregates
the matching primary value per cell: `reps` for reps/weight,
`durationSec` for time, `distanceM` for distance/distance-time, and
entry count for mixed views. The mode toggle adapts its labels per
measurement (Reps/Sätze, Zeit/Intervalle, Strecke/Intervalle) and is
hidden in mixed views.

Tooltip and cell labels format values with appropriate units: mm:ss
(or h:mm:ss past one hour) for time, and m / km (one decimal) for
distance.

https://claude.ai/code/session_01Ldph54ncE5jZNeeXUs8XUV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Heatmap visualizations now support multiple measurement types: time, distance, and entry counts in addition to repetitions.
  * Added breakdown mode for enhanced data analysis alongside the primary view option.
  * Improved formatting for cell labels and tooltips with measurement-specific units (minutes, kilometers, intervals).
  * Expanded internationalization support across all supported languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->