### PR TITLE
feat(wiki): cross-link Übungs-Wiki + Liegestütze als eigene Kategorie

### DIFF
--- a/web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.spec.ts
+++ b/web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { provideRouter } from '@angular/router';
 import {
   MAX_QUICK_ADDS,
   QuickAddConfig,
@@ -33,6 +34,7 @@ describe('QuickAddConfigDialogComponent', () => {
     TestBed.configureTestingModule({
       imports: [QuickAddConfigDialogComponent],
       providers: [
+        provideRouter([]),
         { provide: MatDialogRef, useValue: { close: closeSpy } },
         { provide: MatSnackBar, useValue: { open: snackBarSpy } },
         {
@@ -289,6 +291,33 @@ describe('QuickAddConfigDialogComponent', () => {
           reps: 5,
         })
       );
+    });
+  });
+
+  describe('Wiki help icon per row', () => {
+    it('points the pushup default row at /wiki/liegestuetz-typen', () => {
+      setup();
+      const component = fixture.componentInstance as unknown as {
+        wikiLinkFor(id: string): string[];
+      };
+      // Default rows seed with the pushup quick-add id; the help icon
+      // must route to the dedicated pushup wiki rather than the
+      // /wiki/uebungen catalog page (pushups live in their own wiki).
+      expect(component.wikiLinkFor('pushup')).toEqual([
+        '/wiki/liegestuetz-typen',
+      ]);
+    });
+
+    it('points a non-pushup exercise row at the matching /wiki/uebungen detail', () => {
+      setup();
+      const component = fixture.componentInstance as unknown as {
+        wikiLinkFor(id: string): string[];
+      };
+      // abs.situps → slug 'sit-ups' in EXERCISE_WIKI_CATALOG.
+      expect(component.wikiLinkFor('abs.situps')).toEqual([
+        '/wiki/uebungen',
+        'sit-ups',
+      ]);
     });
   });
 

--- a/web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts
+++ b/web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts
@@ -13,8 +13,11 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { RouterLink } from '@angular/router';
 import {
   EXERCISE_CATALOG,
+  findExerciseWikiEntry,
   isAutoCountQuickAddExerciseId,
   MAX_QUICK_ADDS,
   PUSHUP_QUICK_ADD_EXERCISE_ID,
@@ -47,6 +50,8 @@ interface ExerciseOption {
     MatIconModule,
     MatInputModule,
     MatSelectModule,
+    MatTooltipModule,
+    RouterLink,
   ],
   template: `
     <h2 mat-dialog-title i18n="@@quickAddConfig.title">
@@ -72,6 +77,19 @@ interface ExerciseOption {
               }
             </mat-select>
           </mat-form-field>
+          <a
+            mat-icon-button
+            class="wiki-help"
+            [routerLink]="wikiLinkFor(row.exerciseId)"
+            mat-dialog-close
+            [matTooltip]="wikiTooltipFor(row.exerciseId)"
+            matTooltipPosition="left"
+            [attr.data-testid]="'quick-add-wiki-' + $index"
+            i18n-aria-label="@@quickAddConfig.wikiAria"
+            aria-label="Anleitung zur Übung öffnen"
+          >
+            <mat-icon>help_outline</mat-icon>
+          </a>
 
           @if (row.mode === 'reps') {
             <mat-form-field appearance="outline" class="reps-field">
@@ -199,6 +217,28 @@ export class QuickAddConfigDialogComponent {
 
   protected isAutoCountCapable(exerciseId: string): boolean {
     return isAutoCountQuickAddExerciseId(exerciseId);
+  }
+
+  /**
+   * Wiki link target for the picker row. Pushup rows route to the
+   * dedicated `/wiki/liegestuetz-typen` wiki since the pushup variant
+   * picker has no slug here; everything else resolves to the matching
+   * `/wiki/uebungen/<slug>` detail page or falls back to the list when
+   * no wiki entry exists yet for the catalog id.
+   */
+  protected wikiLinkFor(exerciseId: string): string[] {
+    if (exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID) {
+      return ['/wiki/liegestuetz-typen'];
+    }
+    const entry = findExerciseWikiEntry(exerciseId);
+    return entry ? ['/wiki/uebungen', entry.slug] : ['/wiki/uebungen'];
+  }
+
+  protected wikiTooltipFor(exerciseId: string): string {
+    if (exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID) {
+      return $localize`:@@quickAddConfig.wikiTooltip.pushup:Liegestützvarianten ansehen`;
+    }
+    return $localize`:@@quickAddConfig.wikiTooltip.exercise:Anleitung zur Übung öffnen`;
   }
 
   private readonly initialRows: DraftRow[] = ((): DraftRow[] => {

--- a/web/src/app/stats/components/stats-table/stats-table.component.html
+++ b/web/src/app/stats/components/stats-table/stats-table.component.html
@@ -95,9 +95,20 @@
         [attr.aria-label]="exerciseColumnLabel"
         >{{ exerciseColumnLabel }}</mat-header-cell
       >
-      <mat-cell *matCellDef="let entry"
-        ><span>{{ exerciseLabel(entry) }}</span></mat-cell
-      >
+      <mat-cell *matCellDef="let entry">
+        @if (exerciseWikiLink(entry); as wikiLink) {
+          <a
+            class="exercise-wiki-link"
+            [routerLink]="wikiLink"
+            matTooltip="Wiki-Eintrag öffnen"
+            i18n-matTooltip="@@statsTable.exercise.wikiTooltip"
+            data-testid="stats-table-exercise-link"
+            >{{ exerciseLabel(entry) }}</a
+          >
+        } @else {
+          <span>{{ exerciseLabel(entry) }}</span>
+        }
+      </mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="type">

--- a/web/src/app/stats/components/stats-table/stats-table.component.html
+++ b/web/src/app/stats/components/stats-table/stats-table.component.html
@@ -96,18 +96,14 @@
         >{{ exerciseColumnLabel }}</mat-header-cell
       >
       <mat-cell *matCellDef="let entry">
-        @if (exerciseWikiLink(entry); as wikiLink) {
-          <a
-            class="exercise-wiki-link"
-            [routerLink]="wikiLink"
-            matTooltip="Wiki-Eintrag öffnen"
-            i18n-matTooltip="@@statsTable.exercise.wikiTooltip"
-            data-testid="stats-table-exercise-link"
-            >{{ exerciseLabel(entry) }}</a
-          >
-        } @else {
-          <span>{{ exerciseLabel(entry) }}</span>
-        }
+        <a
+          class="exercise-wiki-link"
+          [routerLink]="exerciseWikiLink(entry)"
+          matTooltip="Wiki-Eintrag öffnen"
+          i18n-matTooltip="@@statsTable.exercise.wikiTooltip"
+          data-testid="stats-table-exercise-link"
+          >{{ exerciseLabel(entry) }}</a
+        >
       </mat-cell>
     </ng-container>
 

--- a/web/src/app/stats/components/stats-table/stats-table.component.scss
+++ b/web/src/app/stats/components/stats-table/stats-table.component.scss
@@ -48,6 +48,19 @@ mat-table {
   gap: 8px;
 }
 
+.exercise-wiki-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted currentColor;
+  padding-bottom: 1px;
+}
+
+.exercise-wiki-link:hover,
+.exercise-wiki-link:focus-visible {
+  color: var(--mat-sys-primary);
+  border-bottom-style: solid;
+}
+
 .sets-detail {
   margin-inline-start: 4px;
   font-size: 0.85em;

--- a/web/src/app/stats/components/stats-table/stats-table.component.spec.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.spec.ts
@@ -1,5 +1,6 @@
 import { PLATFORM_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { StatsTableComponent } from './stats-table.component';
 import { UserConfigApiService } from '@pu-stats/data-access';
@@ -29,6 +30,7 @@ describe('StatsTableComponent', () => {
     await TestBed.configureTestingModule({
       imports: [StatsTableComponent],
       providers: [
+        provideRouter([]),
         { provide: UserContextService, useValue: userMock },
         { provide: UserConfigApiService, useValue: userConfigApiMock },
       ],
@@ -702,6 +704,69 @@ describe('StatsTableComponent', () => {
       const component = fixture.componentInstance;
       const result = component.formatSets([20]);
       expect(result).toBe('1×20');
+    });
+  });
+
+  describe('exerciseWikiLink', () => {
+    it('routes a pushup entry with a known variant to the pushup wiki detail', () => {
+      const component = fixture.componentInstance;
+      const entry: UnifiedEntry = {
+        kind: 'pushup',
+        _id: 'p1',
+        timestamp: '2026-02-10T10:00:00',
+        reps: 10,
+        source: 'web',
+        variantType: 'diamond',
+      } as UnifiedEntry;
+      // 'diamond' resolves via findPushupTypeByStoredValue to a typed slug;
+      // the link must drill into the matching detail page.
+      const link = component.exerciseWikiLink(entry);
+      expect(link?.[0]).toBe('/wiki/liegestuetz-typen');
+      expect(link?.length).toBe(2);
+    });
+
+    it('falls back to the pushup wiki list when the variant is unknown', () => {
+      const component = fixture.componentInstance;
+      const entry: UnifiedEntry = {
+        kind: 'pushup',
+        _id: 'p2',
+        timestamp: '2026-02-10T10:00:00',
+        reps: 10,
+        source: 'web',
+        variantType: null,
+      } as UnifiedEntry;
+      expect(component.exerciseWikiLink(entry)).toEqual([
+        '/wiki/liegestuetz-typen',
+      ]);
+    });
+
+    it('routes a catalog exercise entry to the matching /wiki/uebungen detail', () => {
+      const component = fixture.componentInstance;
+      const entry: UnifiedEntry = {
+        kind: 'exercise',
+        _id: 'e1',
+        timestamp: '2026-02-10T10:00:00',
+        exerciseId: 'abs.situps',
+        reps: 20,
+        source: 'web',
+      } as UnifiedEntry;
+      expect(component.exerciseWikiLink(entry)).toEqual([
+        '/wiki/uebungen',
+        'sit-ups',
+      ]);
+    });
+
+    it('falls back to the /wiki/uebungen list for an unknown catalog id', () => {
+      const component = fixture.componentInstance;
+      const entry: UnifiedEntry = {
+        kind: 'exercise',
+        _id: 'e2',
+        timestamp: '2026-02-10T10:00:00',
+        exerciseId: 'made.up.exercise',
+        reps: 20,
+        source: 'web',
+      } as UnifiedEntry;
+      expect(component.exerciseWikiLink(entry)).toEqual(['/wiki/uebungen']);
     });
   });
 

--- a/web/src/app/stats/components/stats-table/stats-table.component.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.ts
@@ -229,13 +229,13 @@ export class StatsTableComponent {
   /**
    * Wiki deep-link for the entry's exercise label. Pushup rows route to
    * the dedicated `/wiki/liegestuetz-typen` wiki with the variant slug
-   * (when known) so the link lands on the matching detail page; catalog
-   * exercise rows route to `/wiki/uebungen/<slug>` when an entry exists,
-   * else to the list page so a stale catalog id can't 404 the link.
-   * Returns `null` when there's no useful target — the template renders
-   * a plain `<span>` in that case.
+   * (when known); catalog exercise rows route to `/wiki/uebungen/<slug>`
+   * when an entry exists, else to the list page so a stale catalog id
+   * can't 404 the link. Always returns a usable target — every row in
+   * the stats table maps to either the pushup wiki or the generic
+   * exercises wiki, so the column is always rendered as a link.
    */
-  exerciseWikiLink(entry: UnifiedEntry): string[] | null {
+  exerciseWikiLink(entry: UnifiedEntry): string[] {
     if (entry.kind === 'pushup') {
       const variant = findPushupTypeByStoredValue(entry.variantType);
       return variant

--- a/web/src/app/stats/components/stats-table/stats-table.component.ts
+++ b/web/src/app/stats/components/stats-table/stats-table.component.ts
@@ -21,11 +21,14 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { RouterLink } from '@angular/router';
 import { UserContextService } from '@pu-auth/auth';
 import { UserConfigApiService } from '@pu-stats/data-access';
 import {
   displayPushupType,
   findExerciseDefinition,
+  findExerciseWikiEntry,
+  findPushupTypeByStoredValue,
   formatEntryDisplay,
   formatExerciseValue,
   measurementValueField,
@@ -122,6 +125,7 @@ export interface StatsTableCreate {
     MatSortModule,
     MatRippleModule,
     MatTooltipModule,
+    RouterLink,
     ScrollingModule,
   ],
   templateUrl: './stats-table.component.html',
@@ -220,6 +224,26 @@ export class StatsTableComponent {
     const def = findExerciseDefinition(entry.exerciseId);
     if (!def) return entry.exerciseId;
     return exerciseDisplayName(def.id);
+  }
+
+  /**
+   * Wiki deep-link for the entry's exercise label. Pushup rows route to
+   * the dedicated `/wiki/liegestuetz-typen` wiki with the variant slug
+   * (when known) so the link lands on the matching detail page; catalog
+   * exercise rows route to `/wiki/uebungen/<slug>` when an entry exists,
+   * else to the list page so a stale catalog id can't 404 the link.
+   * Returns `null` when there's no useful target — the template renders
+   * a plain `<span>` in that case.
+   */
+  exerciseWikiLink(entry: UnifiedEntry): string[] | null {
+    if (entry.kind === 'pushup') {
+      const variant = findPushupTypeByStoredValue(entry.variantType);
+      return variant
+        ? ['/wiki/liegestuetz-typen', variant.slug]
+        : ['/wiki/liegestuetz-typen'];
+    }
+    const wikiEntry = findExerciseWikiEntry(entry.exerciseId);
+    return wikiEntry ? ['/wiki/uebungen', wikiEntry.slug] : ['/wiki/uebungen'];
   }
 
   constructor() {

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.spec.ts
@@ -296,6 +296,27 @@ describe('TrainingEntryDialogComponent', () => {
       expect(component.sets()[0]).toBe(500);
       expect(component.overCap()).toBe(false);
     });
+
+    it('computes a /wiki/uebungen detail link for the currently selected exercise', () => {
+      const { component } = createDialog(null);
+
+      component.onCategoryChange('core');
+      // abs.situps maps to slug 'sit-ups' in EXERCISE_WIKI_CATALOG.
+      expect(component.exerciseId()).toBe('abs.situps');
+      expect(component.exerciseWikiLink()).toEqual([
+        '/wiki/uebungen',
+        'sit-ups',
+      ]);
+    });
+
+    it('falls back to the /wiki/uebungen list when the picker is on the synthetic pushup row', () => {
+      const { component } = createDialog(null);
+
+      // Default category is `pushup`; the synthetic exerciseId has no
+      // wiki entry — make sure the link never becomes a dead 404 by
+      // pointing to the list page instead.
+      expect(component.exerciseWikiLink()).toEqual(['/wiki/uebungen']);
+    });
   });
 
   describe('edit mode', () => {

--- a/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
+++ b/web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts
@@ -33,6 +33,7 @@ import {
   ExerciseDefinition,
   ExerciseVariant,
   findExerciseDefinition,
+  findExerciseWikiEntry,
   findPushupTypeByLocalizedName,
   findPushupTypeByStoredValue,
   formatExerciseValue,
@@ -308,19 +309,36 @@ interface PushupTypeOption {
       </mat-form-field>
 
       @if (showExercisePicker()) {
-        <mat-form-field appearance="outline">
-          <mat-label i18n="@@trainingEntryDialog.exercise">Übung</mat-label>
-          <mat-select
-            [value]="exerciseId()"
-            (valueChange)="onExerciseChange($event)"
-            [disabled]="isEditMode"
-            data-testid="training-entry-exercise"
+        <div class="type-row">
+          <mat-form-field appearance="outline">
+            <mat-label i18n="@@trainingEntryDialog.exercise">Übung</mat-label>
+            <mat-select
+              [value]="exerciseId()"
+              (valueChange)="onExerciseChange($event)"
+              [disabled]="isEditMode"
+              data-testid="training-entry-exercise"
+            >
+              @for (option of exerciseOptions(); track option.value) {
+                <mat-option [value]="option.value">{{
+                  option.label
+                }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+          <a
+            mat-icon-button
+            class="type-help"
+            [routerLink]="exerciseWikiLink()"
+            [matTooltip]="exerciseWikiTooltip()"
+            matTooltipPosition="left"
+            mat-dialog-close
+            data-testid="training-entry-exercise-wiki"
+            i18n-aria-label="@@exerciseWikiLinkAria"
+            aria-label="Anleitung zur Übung öffnen"
           >
-            @for (option of exerciseOptions(); track option.value) {
-              <mat-option [value]="option.value">{{ option.label }}</mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
+            <mat-icon>help_outline</mat-icon>
+          </a>
+        </div>
       }
 
       <mat-form-field appearance="outline">
@@ -863,6 +881,26 @@ export class TrainingEntryDialogComponent {
   readonly pushupWikiQueryParams = computed(() => {
     const match = this.resolvePushupType(this.pushupTypeValue());
     return match ? { type: match.slug } : {};
+  });
+
+  /**
+   * Wiki-link target for the currently selected exercise. Returns the
+   * detail-page route if the exercise has a wiki entry, else the list
+   * page so the icon never becomes a dead-end. Mirrors the pushup help
+   * icon's behaviour for non-pushup categories.
+   */
+  readonly exerciseWikiLink = computed<string[]>(() => {
+    const entry = findExerciseWikiEntry(this.exerciseId());
+    return entry ? ['/wiki/uebungen', entry.slug] : ['/wiki/uebungen'];
+  });
+
+  readonly exerciseWikiTooltip = computed(() => {
+    const entry = findExerciseWikiEntry(this.exerciseId());
+    if (!entry) {
+      return $localize`:@@exerciseWikiLinkTooltip.generic:Anleitung zu Übungen öffnen`;
+    }
+    const template = $localize`:@@exerciseWikiLinkTooltip.specific:Anleitung öffnen`;
+    return `${template}: ${this.exerciseLabel(entry.id)}`;
   });
 
   readonly pushupWikiTooltip = computed(() => {

--- a/web/src/app/wiki/exercises-page.component.spec.ts
+++ b/web/src/app/wiki/exercises-page.component.spec.ts
@@ -87,7 +87,7 @@ describe('ExercisesWikiPageComponent', () => {
       '[data-testid="wiki-exercises-pushup-hub"]'
     );
     expect(hub).toBeTruthy();
-    expect(hub?.getAttribute('id')).toBe('liegestuetze');
+    expect(hub?.getAttribute('id')).toBe('pushup-hub');
 
     const cta = container.querySelector(
       '[data-testid="wiki-exercises-pushup-hub-link"]'

--- a/web/src/app/wiki/exercises-page.component.spec.ts
+++ b/web/src/app/wiki/exercises-page.component.spec.ts
@@ -44,8 +44,23 @@ describe('ExercisesWikiPageComponent', () => {
     });
 
     const categoryHeadings = container.querySelectorAll('h2.category-heading');
-    // 8 categories (push, pull, squat, hinge, lunge, core, cardio, mobility).
-    expect(categoryHeadings.length).toBeGreaterThanOrEqual(8);
+    // 8 catalog categories (push, pull, squat, hinge, lunge, core,
+    // cardio, mobility) + 1 dedicated Liegestütze heading at the top
+    // that hosts the cross-link card to the pushup-variants wiki.
+    expect(categoryHeadings.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it('renders the dedicated Liegestütze category heading before the first catalog category', async () => {
+    const { container } = await render(ExercisesWikiPageComponent, {
+      providers: [{ provide: ActivatedRoute, useValue: makeRouteMock() }],
+    });
+
+    const headings = Array.from(
+      container.querySelectorAll('h2.category-heading')
+    );
+    // The pushup hub section must come first so users find the
+    // foundational exercise without scrolling past every other category.
+    expect(headings[0]?.textContent?.trim()).toBe('Liegestütze');
   });
 
   it('exposes one TOC entry per catalog exercise plus the pushup hub link', async () => {

--- a/web/src/app/wiki/exercises-page.component.spec.ts
+++ b/web/src/app/wiki/exercises-page.component.spec.ts
@@ -48,18 +48,37 @@ describe('ExercisesWikiPageComponent', () => {
     expect(categoryHeadings.length).toBeGreaterThanOrEqual(8);
   });
 
-  it('exposes one TOC entry per catalog exercise', async () => {
+  it('exposes one TOC entry per catalog exercise plus the pushup hub link', async () => {
     const { container } = await render(ExercisesWikiPageComponent, {
       providers: [{ provide: ActivatedRoute, useValue: makeRouteMock() }],
     });
 
     const tocLinks = container.querySelectorAll('nav.toc a.toc-link');
-    // 40 exercises across all categories.
-    expect(tocLinks.length).toBe(40);
+    // 40 catalog exercises + 1 hub-card entry that cross-links to the
+    // dedicated /wiki/liegestuetz-typen wiki under the "push" category.
+    expect(tocLinks.length).toBe(41);
     for (const link of Array.from(tocLinks)) {
       const href = link.getAttribute('href') ?? '';
       expect(href.startsWith('#')).toBe(true);
     }
+  });
+
+  it('renders a pushup-wiki hub card in the push category that links to /wiki/liegestuetz-typen', async () => {
+    const { container } = await render(ExercisesWikiPageComponent, {
+      providers: [{ provide: ActivatedRoute, useValue: makeRouteMock() }],
+    });
+
+    const hub = container.querySelector(
+      '[data-testid="wiki-exercises-pushup-hub"]'
+    );
+    expect(hub).toBeTruthy();
+    expect(hub?.getAttribute('id')).toBe('liegestuetze');
+
+    const cta = container.querySelector(
+      '[data-testid="wiki-exercises-pushup-hub-link"]'
+    );
+    expect(cta).toBeTruthy();
+    expect(cta?.getAttribute('href')).toBe('/wiki/liegestuetz-typen');
   });
 
   it('renders an ordered instructions list for the squat section', async () => {

--- a/web/src/app/wiki/exercises-page.component.ts
+++ b/web/src/app/wiki/exercises-page.component.ts
@@ -80,28 +80,31 @@ const PUSHUP_HUB_SLUG = 'liegestuetze';
         <h2 id="wiki-exercises-toc-heading" i18n="@@wiki.exercises.tocTitle">
           Übersicht
         </h2>
+        <section class="toc-group toc-group--pushup">
+          <h3>{{ pushupCategoryLabel }}</h3>
+          <ul>
+            <li>
+              <a
+                class="toc-link"
+                href="#{{ pushupHubSlug }}"
+                (click)="scrollTo($event, pushupHubSlug)"
+                i18n="@@wiki.exercises.pushupHub.tocLink"
+                >Liegestütze (alle Varianten)</a
+              >
+              <span
+                class="muted toc-summary"
+                i18n="@@wiki.exercises.pushupHub.summary"
+              >
+                — Eigenes Wiki mit allen Liegestützvarianten von Standard bis
+                Planche.</span
+              >
+            </li>
+          </ul>
+        </section>
         @for (group of categories(); track group.id) {
           <section class="toc-group">
             <h3>{{ group.label }}</h3>
             <ul>
-              @if (group.id === 'push') {
-                <li>
-                  <a
-                    class="toc-link"
-                    href="#{{ pushupHubSlug }}"
-                    (click)="scrollTo($event, pushupHubSlug)"
-                    i18n="@@wiki.exercises.pushupHub.tocLink"
-                    >Liegestütze (alle Varianten)</a
-                  >
-                  <span
-                    class="muted toc-summary"
-                    i18n="@@wiki.exercises.pushupHub.summary"
-                  >
-                    — Eigenes Wiki mit allen Liegestützvarianten von Standard
-                    bis Planche.</span
-                  >
-                </li>
-              }
               @for (entry of group.entries; track entry.id) {
                 <li>
                   <a
@@ -119,47 +122,43 @@ const PUSHUP_HUB_SLUG = 'liegestuetze';
       </nav>
 
       <div class="type-list">
+        <h2 class="category-heading">{{ pushupCategoryLabel }}</h2>
+        <section
+          [id]="pushupHubSlug"
+          class="type-section pushup-hub-section"
+          data-testid="wiki-exercises-pushup-hub"
+        >
+          <mat-card>
+            <mat-card-header class="type-card-header">
+              <mat-card-title>
+                <h3 i18n="@@wiki.exercises.pushupHub.title">
+                  Liegestütze (alle Varianten)
+                </h3>
+              </mat-card-title>
+              <mat-card-subtitle i18n="@@wiki.exercises.pushupHub.subtitle">
+                Eigenes Wiki mit über 20 Liegestützvarianten
+              </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <p class="type-summary" i18n="@@wiki.exercises.pushupHub.body">
+                Vom Standard-Liegestütz bis Planche und Archer — alle Varianten
+                mit Ausführung, Tipps und Schwierigkeitsgrad findest du im
+                dedizierten Liegestütz-Wiki.
+              </p>
+              <a
+                mat-flat-button
+                color="primary"
+                class="detail-link"
+                routerLink="/wiki/liegestuetz-typen"
+                data-testid="wiki-exercises-pushup-hub-link"
+                i18n="@@wiki.exercises.pushupHub.cta"
+                >Zum Liegestütz-Wiki</a
+              >
+            </mat-card-content>
+          </mat-card>
+        </section>
         @for (group of categories(); track group.id) {
           <h2 class="category-heading">{{ group.label }}</h2>
-          @if (group.id === 'push') {
-            <section
-              [id]="pushupHubSlug"
-              class="type-section pushup-hub-section"
-              data-testid="wiki-exercises-pushup-hub"
-            >
-              <mat-card>
-                <mat-card-header class="type-card-header">
-                  <mat-card-title>
-                    <h3 i18n="@@wiki.exercises.pushupHub.title">
-                      Liegestütze (alle Varianten)
-                    </h3>
-                  </mat-card-title>
-                  <mat-card-subtitle i18n="@@wiki.exercises.pushupHub.subtitle">
-                    Eigenes Wiki mit über 20 Liegestützvarianten
-                  </mat-card-subtitle>
-                </mat-card-header>
-                <mat-card-content>
-                  <p
-                    class="type-summary"
-                    i18n="@@wiki.exercises.pushupHub.body"
-                  >
-                    Vom Standard-Liegestütz bis Planche und Archer — alle
-                    Varianten mit Ausführung, Tipps und Schwierigkeitsgrad
-                    findest du im dedizierten Liegestütz-Wiki.
-                  </p>
-                  <a
-                    mat-flat-button
-                    color="primary"
-                    class="detail-link"
-                    routerLink="/wiki/liegestuetz-typen"
-                    data-testid="wiki-exercises-pushup-hub-link"
-                    i18n="@@wiki.exercises.pushupHub.cta"
-                    >Zum Liegestütz-Wiki</a
-                  >
-                </mat-card-content>
-              </mat-card>
-            </section>
-          }
           @for (entry of group.entries; track entry.id) {
             <section [id]="entry.slug" class="type-section">
               <mat-card>
@@ -383,6 +382,14 @@ export class ExercisesWikiPageComponent {
   private readonly isBrowser = isPlatformBrowser(this.platformId);
 
   readonly pushupHubSlug = PUSHUP_HUB_SLUG;
+
+  /**
+   * Heading label for the dedicated Liegestütze category section.
+   * Reuses the existing `@@exercise.category.pushup` id so the value
+   * stays in sync with the same label used in the entry dialog and
+   * the stats table — no separate translation needed.
+   */
+  readonly pushupCategoryLabel = $localize`:@@exercise.category.pushup:Liegestütze`;
 
   readonly categories = computed<ReadonlyArray<CategoryGroup>>(() => {
     const labels = this.categoryLabels();

--- a/web/src/app/wiki/exercises-page.component.ts
+++ b/web/src/app/wiki/exercises-page.component.ts
@@ -40,11 +40,12 @@ interface CategoryGroup {
 }
 
 /**
- * Hub-card slug for the Liegestütz cross-link in the push category.
- * Kept distinct from any real exercise slug so the TOC anchor can't
- * collide with a future catalog entry named `liegestuetze`.
+ * Hub-card slug for the Liegestütz cross-link. Uses a reserved
+ * `pushup-hub` form that no catalog exercise slug would ever take so
+ * the TOC anchor can never collide with `EXERCISE_WIKI_CATALOG`
+ * entries, current or future.
  */
-const PUSHUP_HUB_SLUG = 'liegestuetze';
+const PUSHUP_HUB_SLUG = 'pushup-hub';
 
 @Component({
   selector: 'app-exercises-wiki-page',

--- a/web/src/app/wiki/exercises-page.component.ts
+++ b/web/src/app/wiki/exercises-page.component.ts
@@ -39,6 +39,13 @@ interface CategoryGroup {
   entries: ReadonlyArray<LocalizedExercise>;
 }
 
+/**
+ * Hub-card slug for the Liegestütz cross-link in the push category.
+ * Kept distinct from any real exercise slug so the TOC anchor can't
+ * collide with a future catalog entry named `liegestuetze`.
+ */
+const PUSHUP_HUB_SLUG = 'liegestuetze';
+
 @Component({
   selector: 'app-exercises-wiki-page',
   imports: [
@@ -77,6 +84,24 @@ interface CategoryGroup {
           <section class="toc-group">
             <h3>{{ group.label }}</h3>
             <ul>
+              @if (group.id === 'push') {
+                <li>
+                  <a
+                    class="toc-link"
+                    href="#{{ pushupHubSlug }}"
+                    (click)="scrollTo($event, pushupHubSlug)"
+                    i18n="@@wiki.exercises.pushupHub.tocLink"
+                    >Liegestütze (alle Varianten)</a
+                  >
+                  <span
+                    class="muted toc-summary"
+                    i18n="@@wiki.exercises.pushupHub.summary"
+                  >
+                    — Eigenes Wiki mit allen Liegestützvarianten von Standard
+                    bis Planche.</span
+                  >
+                </li>
+              }
               @for (entry of group.entries; track entry.id) {
                 <li>
                   <a
@@ -96,6 +121,45 @@ interface CategoryGroup {
       <div class="type-list">
         @for (group of categories(); track group.id) {
           <h2 class="category-heading">{{ group.label }}</h2>
+          @if (group.id === 'push') {
+            <section
+              [id]="pushupHubSlug"
+              class="type-section pushup-hub-section"
+              data-testid="wiki-exercises-pushup-hub"
+            >
+              <mat-card>
+                <mat-card-header class="type-card-header">
+                  <mat-card-title>
+                    <h3 i18n="@@wiki.exercises.pushupHub.title">
+                      Liegestütze (alle Varianten)
+                    </h3>
+                  </mat-card-title>
+                  <mat-card-subtitle i18n="@@wiki.exercises.pushupHub.subtitle">
+                    Eigenes Wiki mit über 20 Liegestützvarianten
+                  </mat-card-subtitle>
+                </mat-card-header>
+                <mat-card-content>
+                  <p
+                    class="type-summary"
+                    i18n="@@wiki.exercises.pushupHub.body"
+                  >
+                    Vom Standard-Liegestütz bis Planche und Archer — alle
+                    Varianten mit Ausführung, Tipps und Schwierigkeitsgrad
+                    findest du im dedizierten Liegestütz-Wiki.
+                  </p>
+                  <a
+                    mat-flat-button
+                    color="primary"
+                    class="detail-link"
+                    routerLink="/wiki/liegestuetz-typen"
+                    data-testid="wiki-exercises-pushup-hub-link"
+                    i18n="@@wiki.exercises.pushupHub.cta"
+                    >Zum Liegestütz-Wiki</a
+                  >
+                </mat-card-content>
+              </mat-card>
+            </section>
+          }
           @for (entry of group.entries; track entry.id) {
             <section [id]="entry.slug" class="type-section">
               <mat-card>
@@ -317,6 +381,8 @@ export class ExercisesWikiPageComponent {
   private readonly host: ElementRef<HTMLElement> = inject(ElementRef);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly isBrowser = isPlatformBrowser(this.platformId);
+
+  readonly pushupHubSlug = PUSHUP_HUB_SLUG;
 
   readonly categories = computed<ReadonlyArray<CategoryGroup>>(() => {
     const labels = this.categoryLabels();

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -6753,6 +6753,84 @@
         <target>Επισκόπηση</target>
       </segment>
     </unit>
+    <unit id="wiki.exercises.pushupHub.tocLink">
+      <segment state="translated">
+        <source>Liegestütze (alle Varianten)</source>
+        <target>Κάμψεις (όλες οι παραλλαγές)</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.summary">
+      <segment state="translated">
+        <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
+        <target> — Αφιερωμένο wiki με όλες τις παραλλαγές από κανονική έως Planche.</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.title">
+      <segment state="translated">
+        <source> Liegestütze (alle Varianten) </source>
+        <target> Κάμψεις (όλες οι παραλλαγές) </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.subtitle">
+      <segment state="translated">
+        <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
+        <target> Αφιερωμένο wiki με 20+ παραλλαγές κάμψεων </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.body">
+      <segment state="translated">
+        <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
+        <target> Από την κανονική κάμψη έως Planche και Archer — όλες οι παραλλαγές με εκτέλεση, συμβουλές και επίπεδο δυσκολίας στο αφιερωμένο wiki. </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.cta">
+      <segment state="translated">
+        <source>Zum Liegestütz-Wiki</source>
+        <target>Άνοιγμα wiki κάμψεων</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Άνοιγμα οδηγού άσκησης</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.generic">
+      <segment state="translated">
+        <source>Anleitung zu Übungen öffnen</source>
+        <target>Άνοιγμα οδηγού ασκήσεων</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.specific">
+      <segment state="translated">
+        <source>Anleitung öffnen</source>
+        <target>Άνοιγμα οδηγού</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Άνοιγμα οδηγού άσκησης</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.pushup">
+      <segment state="translated">
+        <source>Liegestützvarianten ansehen</source>
+        <target>Δείτε παραλλαγές κάμψεων</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.exercise">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Άνοιγμα οδηγού άσκησης</target>
+      </segment>
+    </unit>
+    <unit id="statsTable.exercise.wikiTooltip">
+      <segment state="translated">
+        <source>Wiki-Eintrag öffnen</source>
+        <target>Άνοιγμα καταχώρισης wiki</target>
+      </segment>
+    </unit>
     <unit id="wiki.exercises.viewDetail">
       <segment state="translated">
         <source>Detailseite öffnen</source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -7137,6 +7137,84 @@ Deine Position: # ·  Reps        </source>
         <target>Overview</target>
       </segment>
     </unit>
+    <unit id="wiki.exercises.pushupHub.tocLink">
+      <segment state="translated">
+        <source>Liegestütze (alle Varianten)</source>
+        <target>Push-ups (all variants)</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.summary">
+      <segment state="translated">
+        <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
+        <target> — Dedicated wiki covering every push-up variant from standard to Planche.</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.title">
+      <segment state="translated">
+        <source> Liegestütze (alle Varianten) </source>
+        <target> Push-ups (all variants) </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.subtitle">
+      <segment state="translated">
+        <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
+        <target> Dedicated wiki with 20+ push-up variants </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.body">
+      <segment state="translated">
+        <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
+        <target> From the standard push-up to Planche and Archer — every variant with execution, tips, and difficulty lives in the dedicated push-up wiki. </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.cta">
+      <segment state="translated">
+        <source>Zum Liegestütz-Wiki</source>
+        <target>Open push-up wiki</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Open exercise guide</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.generic">
+      <segment state="translated">
+        <source>Anleitung zu Übungen öffnen</source>
+        <target>Open exercise guide</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.specific">
+      <segment state="translated">
+        <source>Anleitung öffnen</source>
+        <target>Open guide</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Open exercise guide</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.pushup">
+      <segment state="translated">
+        <source>Liegestützvarianten ansehen</source>
+        <target>View push-up variants</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.exercise">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Open exercise guide</target>
+      </segment>
+    </unit>
+    <unit id="statsTable.exercise.wikiTooltip">
+      <segment state="translated">
+        <source>Wiki-Eintrag öffnen</source>
+        <target>Open wiki entry</target>
+      </segment>
+    </unit>
     <unit id="wiki.exercises.viewDetail">
       <segment state="translated">
         <source>Detailseite öffnen</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -6753,6 +6753,84 @@
         <target>Resumen</target>
       </segment>
     </unit>
+    <unit id="wiki.exercises.pushupHub.tocLink">
+      <segment state="translated">
+        <source>Liegestütze (alle Varianten)</source>
+        <target>Flexiones (todas las variantes)</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.summary">
+      <segment state="translated">
+        <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
+        <target> — Wiki dedicado con todas las variantes de flexión desde la estándar hasta Planche.</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.title">
+      <segment state="translated">
+        <source> Liegestütze (alle Varianten) </source>
+        <target> Flexiones (todas las variantes) </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.subtitle">
+      <segment state="translated">
+        <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
+        <target> Wiki dedicado con más de 20 variantes de flexión </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.body">
+      <segment state="translated">
+        <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
+        <target> Desde la flexión estándar hasta Planche y Archer: todas las variantes con ejecución, consejos y dificultad están en el wiki dedicado. </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.cta">
+      <segment state="translated">
+        <source>Zum Liegestütz-Wiki</source>
+        <target>Abrir wiki de flexiones</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Abrir guía del ejercicio</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.generic">
+      <segment state="translated">
+        <source>Anleitung zu Übungen öffnen</source>
+        <target>Abrir guía de ejercicios</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.specific">
+      <segment state="translated">
+        <source>Anleitung öffnen</source>
+        <target>Abrir guía</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Abrir guía del ejercicio</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.pushup">
+      <segment state="translated">
+        <source>Liegestützvarianten ansehen</source>
+        <target>Ver variantes de flexión</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.exercise">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Abrir guía del ejercicio</target>
+      </segment>
+    </unit>
+    <unit id="statsTable.exercise.wikiTooltip">
+      <segment state="translated">
+        <source>Wiki-Eintrag öffnen</source>
+        <target>Abrir entrada del wiki</target>
+      </segment>
+    </unit>
     <unit id="wiki.exercises.viewDetail">
       <segment state="translated">
         <source>Detailseite öffnen</source>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -6753,6 +6753,84 @@
         <target>Aperçu</target>
       </segment>
     </unit>
+    <unit id="wiki.exercises.pushupHub.tocLink">
+      <segment state="translated">
+        <source>Liegestütze (alle Varianten)</source>
+        <target>Pompes (toutes les variantes)</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.summary">
+      <segment state="translated">
+        <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
+        <target> — Wiki dédié avec toutes les variantes de pompes, du standard à Planche.</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.title">
+      <segment state="translated">
+        <source> Liegestütze (alle Varianten) </source>
+        <target> Pompes (toutes les variantes) </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.subtitle">
+      <segment state="translated">
+        <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
+        <target> Wiki dédié avec plus de 20 variantes de pompes </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.body">
+      <segment state="translated">
+        <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
+        <target> De la pompe standard à Planche et Archer — toutes les variantes avec exécution, conseils et difficulté dans le wiki dédié. </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.cta">
+      <segment state="translated">
+        <source>Zum Liegestütz-Wiki</source>
+        <target>Ouvrir le wiki des pompes</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Ouvrir le guide de l'exercice</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.generic">
+      <segment state="translated">
+        <source>Anleitung zu Übungen öffnen</source>
+        <target>Ouvrir le guide des exercices</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.specific">
+      <segment state="translated">
+        <source>Anleitung öffnen</source>
+        <target>Ouvrir le guide</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Ouvrir le guide de l'exercice</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.pushup">
+      <segment state="translated">
+        <source>Liegestützvarianten ansehen</source>
+        <target>Voir les variantes de pompes</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.exercise">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Ouvrir le guide de l'exercice</target>
+      </segment>
+    </unit>
+    <unit id="statsTable.exercise.wikiTooltip">
+      <segment state="translated">
+        <source>Wiki-Eintrag öffnen</source>
+        <target>Ouvrir l'entrée du wiki</target>
+      </segment>
+    </unit>
     <unit id="wiki.exercises.viewDetail">
       <segment state="translated">
         <source>Detailseite öffnen</source>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -6753,6 +6753,84 @@
         <target>Panoramica</target>
       </segment>
     </unit>
+    <unit id="wiki.exercises.pushupHub.tocLink">
+      <segment state="translated">
+        <source>Liegestütze (alle Varianten)</source>
+        <target>Push-up (tutte le varianti)</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.summary">
+      <segment state="translated">
+        <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
+        <target> — Wiki dedicato con tutte le varianti di push-up, dallo standard al Planche.</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.title">
+      <segment state="translated">
+        <source> Liegestütze (alle Varianten) </source>
+        <target> Push-up (tutte le varianti) </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.subtitle">
+      <segment state="translated">
+        <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
+        <target> Wiki dedicato con oltre 20 varianti di push-up </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.body">
+      <segment state="translated">
+        <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
+        <target> Dal push-up standard a Planche e Archer: trovi tutte le varianti con esecuzione, consigli e difficoltà nel wiki dedicato. </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.cta">
+      <segment state="translated">
+        <source>Zum Liegestütz-Wiki</source>
+        <target>Apri il wiki dei push-up</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Apri la guida dell'esercizio</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.generic">
+      <segment state="translated">
+        <source>Anleitung zu Übungen öffnen</source>
+        <target>Apri la guida agli esercizi</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.specific">
+      <segment state="translated">
+        <source>Anleitung öffnen</source>
+        <target>Apri la guida</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Apri la guida dell'esercizio</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.pushup">
+      <segment state="translated">
+        <source>Liegestützvarianten ansehen</source>
+        <target>Mostra varianti di push-up</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.exercise">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Apri la guida dell'esercizio</target>
+      </segment>
+    </unit>
+    <unit id="statsTable.exercise.wikiTooltip">
+      <segment state="translated">
+        <source>Wiki-Eintrag öffnen</source>
+        <target>Apri voce wiki</target>
+      </segment>
+    </unit>
     <unit id="wiki.exercises.viewDetail">
       <segment state="translated">
         <source>Detailseite öffnen</source>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -6753,6 +6753,84 @@
         <target>Conspectus</target>
       </segment>
     </unit>
+    <unit id="wiki.exercises.pushupHub.tocLink">
+      <segment state="translated">
+        <source>Liegestütze (alle Varianten)</source>
+        <target>Flexiones (omnes variantes)</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.summary">
+      <segment state="translated">
+        <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
+        <target> — Wiki proprium cum omnibus variantibus a vulgari ad Planche.</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.title">
+      <segment state="translated">
+        <source> Liegestütze (alle Varianten) </source>
+        <target> Flexiones (omnes variantes) </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.subtitle">
+      <segment state="translated">
+        <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
+        <target> Wiki proprium cum 20+ variantibus flexionum </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.body">
+      <segment state="translated">
+        <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
+        <target> A flexione vulgari ad Planche et Archer — omnes variantes cum executione, monitis et difficultate in wiki proprio invenies. </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.cta">
+      <segment state="translated">
+        <source>Zum Liegestütz-Wiki</source>
+        <target>Aperire wiki flexionum</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Aperire ducem exercitationis</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.generic">
+      <segment state="translated">
+        <source>Anleitung zu Übungen öffnen</source>
+        <target>Aperire ducem exercitationum</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.specific">
+      <segment state="translated">
+        <source>Anleitung öffnen</source>
+        <target>Aperire ducem</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Aperire ducem exercitationis</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.pushup">
+      <segment state="translated">
+        <source>Liegestützvarianten ansehen</source>
+        <target>Variantes flexionum videre</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.exercise">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Aperire ducem exercitationis</target>
+      </segment>
+    </unit>
+    <unit id="statsTable.exercise.wikiTooltip">
+      <segment state="translated">
+        <source>Wiki-Eintrag öffnen</source>
+        <target>Aperire commentarium wiki</target>
+      </segment>
+    </unit>
     <unit id="wiki.exercises.viewDetail">
       <segment state="translated">
         <source>Detailseite öffnen</source>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -6753,6 +6753,84 @@
         <target>Overzicht</target>
       </segment>
     </unit>
+    <unit id="wiki.exercises.pushupHub.tocLink">
+      <segment state="translated">
+        <source>Liegestütze (alle Varianten)</source>
+        <target>Push-ups (alle varianten)</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.summary">
+      <segment state="translated">
+        <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
+        <target> — Eigen wiki met alle push-up varianten van standaard tot Planche.</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.title">
+      <segment state="translated">
+        <source> Liegestütze (alle Varianten) </source>
+        <target> Push-ups (alle varianten) </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.subtitle">
+      <segment state="translated">
+        <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
+        <target> Eigen wiki met 20+ push-up varianten </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.body">
+      <segment state="translated">
+        <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
+        <target> Van de standaard push-up tot Planche en Archer — alle varianten met uitvoering, tips en moeilijkheidsgraad in de eigen wiki. </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.cta">
+      <segment state="translated">
+        <source>Zum Liegestütz-Wiki</source>
+        <target>Open push-up wiki</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Open oefeninggids</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.generic">
+      <segment state="translated">
+        <source>Anleitung zu Übungen öffnen</source>
+        <target>Open oefeninggids</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.specific">
+      <segment state="translated">
+        <source>Anleitung öffnen</source>
+        <target>Open gids</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Open oefeninggids</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.pushup">
+      <segment state="translated">
+        <source>Liegestützvarianten ansehen</source>
+        <target>Bekijk push-up varianten</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.exercise">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Open oefeninggids</target>
+      </segment>
+    </unit>
+    <unit id="statsTable.exercise.wikiTooltip">
+      <segment state="translated">
+        <source>Wiki-Eintrag öffnen</source>
+        <target>Open wiki-pagina</target>
+      </segment>
+    </unit>
     <unit id="wiki.exercises.viewDetail">
       <segment state="translated">
         <source>Detailseite öffnen</source>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -6199,6 +6199,84 @@ Deine Position: # ·  Reps        </source>
         <target>Oversikt</target>
       </segment>
     </unit>
+    <unit id="wiki.exercises.pushupHub.tocLink">
+      <segment state="translated">
+        <source>Liegestütze (alle Varianten)</source>
+        <target>Push-ups (alle varianter)</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.summary">
+      <segment state="translated">
+        <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
+        <target> — Eget wiki med alle push-up-varianter fra standard til Planche.</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.title">
+      <segment state="translated">
+        <source> Liegestütze (alle Varianten) </source>
+        <target> Push-ups (alle varianter) </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.subtitle">
+      <segment state="translated">
+        <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
+        <target> Eget wiki med 20+ push-up-varianter </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.body">
+      <segment state="translated">
+        <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
+        <target> Fra standard push-up til Planche og Archer — alle variantene med utførelse, tips og vanskelighetsgrad i det dedikerte wikiet. </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.cta">
+      <segment state="translated">
+        <source>Zum Liegestütz-Wiki</source>
+        <target>Åpne push-up-wikien</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Åpne øvelsesguiden</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.generic">
+      <segment state="translated">
+        <source>Anleitung zu Übungen öffnen</source>
+        <target>Åpne øvelsesguide</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.specific">
+      <segment state="translated">
+        <source>Anleitung öffnen</source>
+        <target>Åpne guide</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Åpne øvelsesguiden</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.pushup">
+      <segment state="translated">
+        <source>Liegestützvarianten ansehen</source>
+        <target>Vis push-up-varianter</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.exercise">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>Åpne øvelsesguiden</target>
+      </segment>
+    </unit>
+    <unit id="statsTable.exercise.wikiTooltip">
+      <segment state="translated">
+        <source>Wiki-Eintrag öffnen</source>
+        <target>Åpne wiki-oppføring</target>
+      </segment>
+    </unit>
     <unit id="wiki.exercises.viewDetail">
       <segment state="translated">
         <source>Detailseite öffnen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -235,8 +235,8 @@
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:67,69</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:130,131</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:621,622</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:148,149</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:639,640</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
       </notes>
       <segment>
@@ -609,6 +609,38 @@
         <source>Anmelde-Menü</source>
       </segment>
     </unit>
+    <unit id="reminder.quickLog.success">
+      <notes>
+        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:66</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="reps" disp="reps"/> Push-ups eingetragen ✓</source>
+      </segment>
+    </unit>
+    <unit id="snackbar.close">
+      <notes>
+        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:67</note>
+        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:73</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:484</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:512</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:528</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:543</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:562</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:581</note>
+        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:603</note>
+      </notes>
+      <segment>
+        <source>Schließen</source>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.error">
+      <notes>
+        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:72</note>
+      </notes>
+      <segment>
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+      </segment>
+    </unit>
     <unit id="quickAdd.fab.feedbackAria">
       <notes>
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:10,11</note>
@@ -735,38 +767,6 @@
       </notes>
       <segment>
         <source><ph id="0" equiv="GAP" disp="gap"/> Liegestütze bis zum Tagesziel hinzufügen</source>
-      </segment>
-    </unit>
-    <unit id="reminder.quickLog.success">
-      <notes>
-        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:66</note>
-      </notes>
-      <segment>
-        <source><ph id="0" equiv="reps" disp="reps"/> Push-ups eingetragen ✓</source>
-      </segment>
-    </unit>
-    <unit id="snackbar.close">
-      <notes>
-        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:67</note>
-        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:73</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:484</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:512</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:528</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:543</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:562</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:581</note>
-        <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:603</note>
-      </notes>
-      <segment>
-        <source>Schließen</source>
-      </segment>
-    </unit>
-    <unit id="reminder.quickLog.error">
-      <notes>
-        <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:72</note>
-      </notes>
-      <segment>
-        <source>Eintrag konnte nicht gespeichert werden.</source>
       </segment>
     </unit>
     <unit id="plan.day.rest">
@@ -5621,9 +5621,9 @@
     <unit id="exercise.category.pushup">
       <notes>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:147</note>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:339</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:218</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1250</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:379</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:222</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1290</note>
         <note category="location">web/src/app/stats/dashboard.store.ts:82</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:197</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
@@ -5770,8 +5770,8 @@
     <unit id="analysis.streakDays">
       <notes>
         <note category="location">web/src/app/stats/components/category-summary-card/category-summary-card.component.html:217,218</note>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:94,95</note>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:102,103</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:98,99</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:106,107</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ summary().currentStreak }}"/> Tage</source>
@@ -6099,7 +6099,7 @@
     </unit>
     <unit id="heatmap.loading">
       <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:45,48</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:52,55</note>
       </notes>
       <segment>
         <source> Heatmap wird im Browser geladen… </source>
@@ -6107,50 +6107,35 @@
     </unit>
     <unit id="heatmap.unit.sets">
       <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:73</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:83</note>
       </notes>
       <segment>
         <source>Sätze</source>
       </segment>
     </unit>
-    <unit id="heatmap.unit.reps">
+    <unit id="heatmap.unit.entries">
       <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:74</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:86</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:99</note>
       </notes>
       <segment>
-        <source>Wiederholungen</source>
-      </segment>
-    </unit>
-    <unit id="heatmap.unit.minutes">
-      <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:82</note>
-      </notes>
-      <segment>
-        <source>min</source>
-      </segment>
-    </unit>
-    <unit id="heatmap.unit.distance">
-      <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:84</note>
-      </notes>
-      <segment>
-        <source>Strecke</source>
+        <source>Einträge</source>
       </segment>
     </unit>
     <unit id="heatmap.unit.intervals">
       <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:91</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:88</note>
       </notes>
       <segment>
         <source>Intervalle</source>
       </segment>
     </unit>
-    <unit id="heatmap.unit.entries">
+    <unit id="heatmap.unit.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:86</note>
+        <note category="location">web/src/app/stats/components/heatmap/heatmap.component.ts:102</note>
       </notes>
       <segment>
-        <source>Einträge</source>
+        <source>Wiederholungen</source>
       </segment>
     </unit>
     <unit id="previewBanner.text">
@@ -6171,7 +6156,7 @@
     </unit>
     <unit id="quickAddConfig.title">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:53,55</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:58,60</note>
       </notes>
       <segment>
         <source> Schnellaktionen konfigurieren </source>
@@ -6179,7 +6164,7 @@
     </unit>
     <unit id="quickAddConfig.hintV2">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:57,60</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:62,65</note>
       </notes>
       <segment>
         <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> Schnellaktionen fest. Wähle pro Button die Übung und – wo verfügbar – Auto-Messung über die Kamera. Leere Felder werden ignoriert. </source>
@@ -6187,15 +6172,23 @@
     </unit>
     <unit id="quickAddConfig.exerciseLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:64,66</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:69,71</note>
       </notes>
       <segment>
         <source>Übung</source>
       </segment>
     </unit>
+    <unit id="quickAddConfig.wikiAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:89,91</note>
+      </notes>
+      <segment>
+        <source>Anleitung zur Übung öffnen</source>
+      </segment>
+    </unit>
     <unit id="quickAddConfig.repsLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:78,80</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:96,98</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -6203,7 +6196,7 @@
     </unit>
     <unit id="quickAddConfig.autoCountBadge">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:94,96</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:112,114</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">videocam</pc> Auto </source>
@@ -6211,7 +6204,7 @@
     </unit>
     <unit id="quickAddConfig.autoCount">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:105,107</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:123,125</note>
       </notes>
       <segment>
         <source>Auto-Messung</source>
@@ -6219,7 +6212,7 @@
     </unit>
     <unit id="quickAddConfig.inSpeedDial">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:115,118</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:133,136</note>
       </notes>
       <segment>
         <source>Im SpeedDial</source>
@@ -6227,7 +6220,7 @@
     </unit>
     <unit id="save">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:139,140</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:157,158</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -6235,15 +6228,31 @@
     </unit>
     <unit id="quickAddConfig.clearRowAria">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:194</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:212</note>
       </notes>
       <segment>
         <source>Schnellaktion löschen</source>
       </segment>
     </unit>
+    <unit id="quickAddConfig.wikiTooltip.pushup">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:239</note>
+      </notes>
+      <segment>
+        <source>Liegestützvarianten ansehen</source>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.exercise">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:241</note>
+      </notes>
+      <segment>
+        <source>Anleitung zur Übung öffnen</source>
+      </segment>
+    </unit>
     <unit id="quickAddConfig.saveError">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:321</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:361</note>
       </notes>
       <segment>
         <source>Speichern fehlgeschlagen</source>
@@ -6431,7 +6440,7 @@
     <unit id="noEntriesInSelectedRange">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:52,55</note>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:40,43</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:44,47</note>
       </notes>
       <segment>
         <source> Keine Einträge im gewählten Zeitraum. </source>
@@ -6453,9 +6462,17 @@
         <source>Reps</source>
       </segment>
     </unit>
+    <unit id="statsTable.exercise.wikiTooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:103,104</note>
+      </notes>
+      <segment>
+        <source>Wiki-Eintrag öffnen</source>
+      </segment>
+    </unit>
     <unit id="colType">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:105,106</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:116,117</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -6463,7 +6480,7 @@
     </unit>
     <unit id="colSource">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:114,115</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:125,126</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -6471,7 +6488,7 @@
     </unit>
     <unit id="colActions">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:123,124</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:134,135</note>
       </notes>
       <segment>
         <source>Aktion</source>
@@ -6479,7 +6496,7 @@
     </unit>
     <unit id="editAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:130,131</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:141,142</note>
       </notes>
       <segment>
         <source>Bearbeiten</source>
@@ -6487,7 +6504,7 @@
     </unit>
     <unit id="editTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:132,133</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:143,144</note>
       </notes>
       <segment>
         <source>Bearbeiten</source>
@@ -6495,7 +6512,7 @@
     </unit>
     <unit id="deleteAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:143</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:154</note>
       </notes>
       <segment>
         <source>Löschen</source>
@@ -6503,7 +6520,7 @@
     </unit>
     <unit id="deleteTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:145</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:156</note>
       </notes>
       <segment>
         <source>Löschen</source>
@@ -6511,7 +6528,7 @@
     </unit>
     <unit id="colExercise">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:214</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:218</note>
       </notes>
       <segment>
         <source>Übung</source>
@@ -6519,7 +6536,7 @@
     </unit>
     <unit id="editDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:289,291</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:290,292</note>
       </notes>
       <segment>
         <source>Eintrag bearbeiten</source>
@@ -6527,7 +6544,7 @@
     </unit>
     <unit id="trainingEntryDialog.title">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:291,295</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:292,296</note>
       </notes>
       <segment>
         <source>Trainingseintrag anlegen</source>
@@ -6535,7 +6552,7 @@
     </unit>
     <unit id="trainingEntryDialog.category">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:297,299</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:298,300</note>
       </notes>
       <segment>
         <source>Kategorie</source>
@@ -6543,15 +6560,23 @@
     </unit>
     <unit id="trainingEntryDialog.exercise">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:312,314</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:314,316</note>
       </notes>
       <segment>
         <source>Übung</source>
       </segment>
     </unit>
+    <unit id="exerciseWikiLinkAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:337,339</note>
+      </notes>
+      <segment>
+        <source>Anleitung zur Übung öffnen</source>
+      </segment>
+    </unit>
     <unit id="timestampLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:327,329</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:345,347</note>
       </notes>
       <segment>
         <source>Zeitpunkt</source>
@@ -6559,7 +6584,7 @@
     </unit>
     <unit id="typeLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:340,341</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:358,359</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -6567,7 +6592,7 @@
     </unit>
     <unit id="typePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:346,347</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:364,365</note>
       </notes>
       <segment>
         <source>Auswählen oder eintippen</source>
@@ -6575,7 +6600,7 @@
     </unit>
     <unit id="typeWikiLinkAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:385,387</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:403,405</note>
       </notes>
       <segment>
         <source>Anleitung zum Liegestütztyp öffnen</source>
@@ -6583,7 +6608,7 @@
     </unit>
     <unit id="entryDialog.variant">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:392,393</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:410,411</note>
       </notes>
       <segment>
         <source>Variante</source>
@@ -6591,7 +6616,7 @@
     </unit>
     <unit id="entryDialog.variantNone">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:395,397</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:413,415</note>
       </notes>
       <segment>
         <source>—</source>
@@ -6599,7 +6624,7 @@
     </unit>
     <unit id="entryDialog.distance">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:408,410</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:426,428</note>
       </notes>
       <segment>
         <source>Distanz (km)</source>
@@ -6607,8 +6632,8 @@
     </unit>
     <unit id="entryDialog.durationMinutes">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:422,424</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:452,454</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:440,442</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:470,472</note>
       </notes>
       <segment>
         <source>Minuten</source>
@@ -6616,8 +6641,8 @@
     </unit>
     <unit id="entryDialog.durationSeconds">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:435,437</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:465,467</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:453,455</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:483,485</note>
       </notes>
       <segment>
         <source>Sekunden</source>
@@ -6625,7 +6650,7 @@
     </unit>
     <unit id="setLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:484,485</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:502,503</note>
       </notes>
       <segment>
         <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -6633,7 +6658,7 @@
     </unit>
     <unit id="repsLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:486,487</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:504,505</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -6641,7 +6666,7 @@
     </unit>
     <unit id="removeSetAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:505,507</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:523,525</note>
       </notes>
       <segment>
         <source>Set entfernen</source>
@@ -6649,7 +6674,7 @@
     </unit>
     <unit id="addSetAria">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:516,517</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:534,535</note>
       </notes>
       <segment>
         <source>Set hinzufügen</source>
@@ -6657,7 +6682,7 @@
     </unit>
     <unit id="addSetTooltip">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:518,520</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:536,538</note>
       </notes>
       <segment>
         <source>Weiteres Set hinzufügen</source>
@@ -6665,7 +6690,7 @@
     </unit>
     <unit id="totalReps">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:527,529</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:545,547</note>
       </notes>
       <segment>
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
@@ -6673,7 +6698,7 @@
     </unit>
     <unit id="entry.interval.label">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:538,539</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:556,557</note>
       </notes>
       <segment>
         <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
@@ -6681,7 +6706,7 @@
     </unit>
     <unit id="entry.intervals.label">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:541,543</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:559,561</note>
       </notes>
       <segment>
         <source>Intervalle</source>
@@ -6689,7 +6714,7 @@
     </unit>
     <unit id="entry.intervals.remove">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:559,561</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:577,579</note>
       </notes>
       <segment>
         <source>Intervall entfernen</source>
@@ -6697,7 +6722,7 @@
     </unit>
     <unit id="entry.intervals.add">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:570,571</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:588,589</note>
       </notes>
       <segment>
         <source>Intervall hinzufügen</source>
@@ -6705,7 +6730,7 @@
     </unit>
     <unit id="entry.intervals.addTooltip">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:572,574</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:590,592</note>
       </notes>
       <segment>
         <source>Weiteres Intervall hinzufügen</source>
@@ -6713,7 +6738,7 @@
     </unit>
     <unit id="entryDialog.overCapDuration">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:585,586</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:603,604</note>
       </notes>
       <segment>
         <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
@@ -6721,7 +6746,7 @@
     </unit>
     <unit id="entryDialog.overCapTime">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:589,590</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:607,608</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
@@ -6729,7 +6754,7 @@
     </unit>
     <unit id="entryDialog.overCap">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:593,594</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:611,612</note>
       </notes>
       <segment>
         <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ repsMax() }}"/> pro Eintrag</source>
@@ -6737,7 +6762,7 @@
     </unit>
     <unit id="sourceLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:601,602</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:619,620</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -6745,7 +6770,7 @@
     </unit>
     <unit id="sourcePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:607,608</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:625,626</note>
       </notes>
       <segment>
         <source>web / whatsapp / eigene Quelle</source>
@@ -6753,7 +6778,7 @@
     </unit>
     <unit id="saveEntry">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:631,633</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:649,651</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -6761,15 +6786,31 @@
     </unit>
     <unit id="trainingEntryDialog.pushup.exercise">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:686</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:704</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
       </segment>
     </unit>
+    <unit id="exerciseWikiLinkTooltip.generic">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:902</note>
+      </notes>
+      <segment>
+        <source>Anleitung zu Übungen öffnen</source>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.specific">
+      <notes>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:904</note>
+      </notes>
+      <segment>
+        <source>Anleitung öffnen</source>
+      </segment>
+    </unit>
     <unit id="typeWikiLinkTooltip.generic">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:871</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:911</note>
       </notes>
       <segment>
         <source>Anleitung zu Liegestütztypen öffnen</source>
@@ -6777,7 +6818,7 @@
     </unit>
     <unit id="typeWikiLinkTooltip.specific">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:873</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:913</note>
       </notes>
       <segment>
         <source>Anleitung öffnen</source>
@@ -6785,9 +6826,9 @@
     </unit>
     <unit id="exercise.category.push">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1251</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1291</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:222</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:388</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:456</note>
       </notes>
       <segment>
         <source>Drücken</source>
@@ -6795,9 +6836,9 @@
     </unit>
     <unit id="exercise.category.pull">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1252</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1292</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:223</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:389</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:457</note>
       </notes>
       <segment>
         <source>Ziehen</source>
@@ -6805,9 +6846,9 @@
     </unit>
     <unit id="exercise.category.squat">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1253</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1293</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:224</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:390</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:458</note>
       </notes>
       <segment>
         <source>Kniebeuge</source>
@@ -6815,9 +6856,9 @@
     </unit>
     <unit id="exercise.category.hinge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1254</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1294</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:225</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:391</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:459</note>
       </notes>
       <segment>
         <source>Hüftstreckung</source>
@@ -6825,9 +6866,9 @@
     </unit>
     <unit id="exercise.category.lunge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1255</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1295</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:226</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:392</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:460</note>
       </notes>
       <segment>
         <source>Ausfallschritt</source>
@@ -6835,7 +6876,7 @@
     </unit>
     <unit id="exercise.category.carry">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1256</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1296</note>
       </notes>
       <segment>
         <source>Tragen</source>
@@ -6843,9 +6884,9 @@
     </unit>
     <unit id="exercise.category.core">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1257</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1297</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:227</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:393</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:461</note>
       </notes>
       <segment>
         <source>Rumpf</source>
@@ -6853,9 +6894,9 @@
     </unit>
     <unit id="exercise.category.cardio">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1258</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1298</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:228</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:394</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:462</note>
       </notes>
       <segment>
         <source>Ausdauer</source>
@@ -6863,9 +6904,9 @@
     </unit>
     <unit id="exercise.category.mobility">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1259</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1299</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:229</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:395</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:463</note>
       </notes>
       <segment>
         <source>Mobilität</source>
@@ -6873,7 +6914,7 @@
     </unit>
     <unit id="exercise.category.strength">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1260</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1300</note>
       </notes>
       <segment>
         <source>Krafttraining</source>
@@ -7761,7 +7802,7 @@
     </unit>
     <unit id="analysis.bestStreaksTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:62,64</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:66,68</note>
       </notes>
       <segment>
         <source>Bestwerte &amp; Streaks</source>
@@ -7769,7 +7810,7 @@
     </unit>
     <unit id="analysis.bestSingleEntry">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:68,70</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:72,74</note>
       </notes>
       <segment>
         <source>Bestwert Einzel-Eintrag:</source>
@@ -7777,7 +7818,7 @@
     </unit>
     <unit id="analysis.bestDay">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:73,75</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:77,79</note>
       </notes>
       <segment>
         <source>Bester Tag:</source>
@@ -7785,7 +7826,7 @@
     </unit>
     <unit id="analysis.bestSingleSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:82,84</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:86,88</note>
       </notes>
       <segment>
         <source>Bestes Einzel-Set:</source>
@@ -7793,7 +7834,7 @@
     </unit>
     <unit id="analysis.repsUnit">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:86,88</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:90,92</note>
       </notes>
       <segment>
         <source>Wdh.</source>
@@ -7801,7 +7842,7 @@
     </unit>
     <unit id="analysis.currentStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:91,93</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:95,97</note>
       </notes>
       <segment>
         <source>Aktuelle Streak:</source>
@@ -7809,7 +7850,7 @@
     </unit>
     <unit id="analysis.longestStreak">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:99,101</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:103,105</note>
       </notes>
       <segment>
         <source>Längste Streak:</source>
@@ -7817,7 +7858,7 @@
     </unit>
     <unit id="analysis.typesTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:112,114</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:116,118</note>
       </notes>
       <segment>
         <source>Typen (Anteile)</source>
@@ -7825,7 +7866,7 @@
     </unit>
     <unit id="analysis.avgSetSizeTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:126,127</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:130,131</note>
       </notes>
       <segment>
         <source>⌀ Set-Größe</source>
@@ -7833,7 +7874,7 @@
     </unit>
     <unit id="analysis.repsPerSet">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:131,132</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:135,136</note>
       </notes>
       <segment>
         <source>Reps / Set</source>
@@ -7841,7 +7882,7 @@
     </unit>
     <unit id="analysis.setsDistTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:140,142</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:144,146</note>
       </notes>
       <segment>
         <source>Sets-Verteilung</source>
@@ -7849,7 +7890,7 @@
     </unit>
     <unit id="analysis.heatmapTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:155,157</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:159,161</note>
       </notes>
       <segment>
         <source>Heatmap (Wochentag/Uhrzeit)</source>
@@ -7857,55 +7898,15 @@
     </unit>
     <unit id="analysis.heatmapToggleAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:161,162</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:166,167</note>
       </notes>
       <segment>
         <source>Heatmap-Modus auswählen</source>
       </segment>
     </unit>
-    <unit id="analysis.heatmapReps">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:165,167</note>
-      </notes>
-      <segment>
-        <source>Reps</source>
-      </segment>
-    </unit>
-    <unit id="analysis.heatmapSets">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:168,170</note>
-      </notes>
-      <segment>
-        <source>Sets</source>
-      </segment>
-    </unit>
-    <unit id="analysis.heatmapTime">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:421</note>
-      </notes>
-      <segment>
-        <source>Zeit</source>
-      </segment>
-    </unit>
-    <unit id="analysis.heatmapDistance">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:428</note>
-      </notes>
-      <segment>
-        <source>Strecke</source>
-      </segment>
-    </unit>
-    <unit id="analysis.heatmapIntervals">
-      <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:422</note>
-      </notes>
-      <segment>
-        <source>Intervalle</source>
-      </segment>
-    </unit>
     <unit id="analysis.weekTrendTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:187,189</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:194,196</note>
       </notes>
       <segment>
         <source>Wochentrend</source>
@@ -7913,7 +7914,7 @@
     </unit>
     <unit id="analysis.weekTrendSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:190,192</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:197,199</note>
       </notes>
       <segment>
         <source>Letzte 8 Wochen</source>
@@ -7921,7 +7922,7 @@
     </unit>
     <unit id="analysis.weekCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:198,199</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:205,206</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -7929,8 +7930,8 @@
     </unit>
     <unit id="analysis.repsCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:204,205</note>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:252,253</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:211,212</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:259,260</note>
       </notes>
       <segment>
         <source>Reps</source>
@@ -7938,8 +7939,8 @@
     </unit>
     <unit id="analysis.avgSetsCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:210,211</note>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:258,259</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:217,218</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:265,266</note>
       </notes>
       <segment>
         <source>⌀ Sets</source>
@@ -7947,7 +7948,7 @@
     </unit>
     <unit id="analysis.monthTrendTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:235,237</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:242,244</note>
       </notes>
       <segment>
         <source>Monatstrend</source>
@@ -7955,7 +7956,7 @@
     </unit>
     <unit id="analysis.monthTrendSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:238,240</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:245,247</note>
       </notes>
       <segment>
         <source>Letzte 6 Monate</source>
@@ -7963,10 +7964,51 @@
     </unit>
     <unit id="analysis.monthCol">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:246,247</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:253,254</note>
       </notes>
       <segment>
         <source>Monat</source>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapReps">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:402</note>
+      </notes>
+      <segment>
+        <source>Reps</source>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapSets">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:403</note>
+      </notes>
+      <segment>
+        <source>Sets</source>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapTime">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:407</note>
+      </notes>
+      <segment>
+        <source>Zeit</source>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapIntervals">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:408</note>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:414</note>
+      </notes>
+      <segment>
+        <source>Intervalle</source>
+      </segment>
+    </unit>
+    <unit id="analysis.heatmapDistance">
+      <notes>
+        <note category="location">web/src/app/stats/shell/analysis-group-view.component.ts:413</note>
+      </notes>
+      <segment>
+        <source>Strecke</source>
       </segment>
     </unit>
     <unit id="analysis.overview.uncategorisedNotice">
@@ -9455,7 +9497,7 @@
     <unit id="wiki.pushupTypes.level.beginner">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:54,56</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:112,114</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:178,180</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:58,60</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:104,106</note>
       </notes>
@@ -9466,7 +9508,7 @@
     <unit id="wiki.pushupTypes.level.intermediate">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:60,63</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:118,120</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:184,186</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:64,67</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:110,112</note>
       </notes>
@@ -9477,7 +9519,7 @@
     <unit id="wiki.pushupTypes.level.advanced">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:66,69</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:124,126</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:190,192</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:70,73</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:116,118</note>
       </notes>
@@ -9488,7 +9530,7 @@
     <unit id="wiki.pushupTypes.instructionsTitle">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:75,77</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:133,135</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:199,201</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:79,81</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:124,126</note>
       </notes>
@@ -9499,7 +9541,7 @@
     <unit id="wiki.pushupTypes.tipsTitle">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:82,84</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:141,142</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:207,208</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:86,88</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:131,132</note>
       </notes>
@@ -9533,7 +9575,7 @@
     </unit>
     <unit id="wiki.exercises.back">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:58,59</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:65,66</note>
       </notes>
       <segment>
         <source>Zurück zu den Trainingsplänen</source>
@@ -9541,7 +9583,7 @@
     </unit>
     <unit id="wiki.exercises.title">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:64,65</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:71,72</note>
       </notes>
       <segment>
         <source>Übungen — saubere Ausführung</source>
@@ -9549,7 +9591,7 @@
     </unit>
     <unit id="wiki.exercises.intro">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:66,68</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:73,75</note>
       </notes>
       <segment>
         <source> Kurzanleitungen für alle Übungen, die du in der App tracken kannst — von Kniebeugen über Klimmzüge bis zu Mobilitäts-Drills. </source>
@@ -9557,15 +9599,63 @@
     </unit>
     <unit id="wiki.exercises.tocTitle">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:74,76</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:81,83</note>
       </notes>
       <segment>
         <source> Übersicht </source>
       </segment>
     </unit>
+    <unit id="wiki.exercises.pushupHub.tocLink">
+      <notes>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:94,96</note>
+      </notes>
+      <segment>
+        <source>Liegestütze (alle Varianten)</source>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.summary">
+      <notes>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:100,102</note>
+      </notes>
+      <segment>
+        <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.title">
+      <notes>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:134,135</note>
+      </notes>
+      <segment>
+        <source> Liegestütze (alle Varianten) </source>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.subtitle">
+      <notes>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:140,141</note>
+      </notes>
+      <segment>
+        <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.body">
+      <notes>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:148,150</note>
+      </notes>
+      <segment>
+        <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.cta">
+      <notes>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:159,161</note>
+      </notes>
+      <segment>
+        <source>Zum Liegestütz-Wiki</source>
+      </segment>
+    </unit>
     <unit id="wiki.exercises.viewDetail">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:153,155</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:219,221</note>
       </notes>
       <segment>
         <source>Detailseite öffnen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -5623,11 +5623,12 @@
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:147</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:379</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:222</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1290</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1288</note>
         <note category="location">web/src/app/stats/dashboard.store.ts:82</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:197</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:289</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:392</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -6794,7 +6795,7 @@
     </unit>
     <unit id="exerciseWikiLinkTooltip.generic">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:902</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:900</note>
       </notes>
       <segment>
         <source>Anleitung zu Übungen öffnen</source>
@@ -6802,7 +6803,7 @@
     </unit>
     <unit id="exerciseWikiLinkTooltip.specific">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:904</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:902</note>
       </notes>
       <segment>
         <source>Anleitung öffnen</source>
@@ -6810,7 +6811,7 @@
     </unit>
     <unit id="typeWikiLinkTooltip.generic">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:911</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:909</note>
       </notes>
       <segment>
         <source>Anleitung zu Liegestütztypen öffnen</source>
@@ -6818,7 +6819,7 @@
     </unit>
     <unit id="typeWikiLinkTooltip.specific">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:913</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:911</note>
       </notes>
       <segment>
         <source>Anleitung öffnen</source>
@@ -6826,9 +6827,9 @@
     </unit>
     <unit id="exercise.category.push">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1291</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1289</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:222</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:456</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:461</note>
       </notes>
       <segment>
         <source>Drücken</source>
@@ -6836,9 +6837,9 @@
     </unit>
     <unit id="exercise.category.pull">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1292</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1290</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:223</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:457</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:462</note>
       </notes>
       <segment>
         <source>Ziehen</source>
@@ -6846,9 +6847,9 @@
     </unit>
     <unit id="exercise.category.squat">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1293</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1291</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:224</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:458</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:463</note>
       </notes>
       <segment>
         <source>Kniebeuge</source>
@@ -6856,9 +6857,9 @@
     </unit>
     <unit id="exercise.category.hinge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1294</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1292</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:225</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:459</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:464</note>
       </notes>
       <segment>
         <source>Hüftstreckung</source>
@@ -6866,9 +6867,9 @@
     </unit>
     <unit id="exercise.category.lunge">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1295</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1293</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:226</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:460</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:465</note>
       </notes>
       <segment>
         <source>Ausfallschritt</source>
@@ -6876,7 +6877,7 @@
     </unit>
     <unit id="exercise.category.carry">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1296</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1294</note>
       </notes>
       <segment>
         <source>Tragen</source>
@@ -6884,9 +6885,9 @@
     </unit>
     <unit id="exercise.category.core">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1297</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1295</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:227</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:461</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:466</note>
       </notes>
       <segment>
         <source>Rumpf</source>
@@ -6894,9 +6895,9 @@
     </unit>
     <unit id="exercise.category.cardio">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1298</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1296</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:228</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:462</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:467</note>
       </notes>
       <segment>
         <source>Ausdauer</source>
@@ -6904,9 +6905,9 @@
     </unit>
     <unit id="exercise.category.mobility">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1299</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1297</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:229</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:463</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:468</note>
       </notes>
       <segment>
         <source>Mobilität</source>
@@ -6914,7 +6915,7 @@
     </unit>
     <unit id="exercise.category.strength">
       <notes>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1300</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1298</note>
       </notes>
       <segment>
         <source>Krafttraining</source>
@@ -9497,7 +9498,7 @@
     <unit id="wiki.pushupTypes.level.beginner">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:54,56</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:178,180</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:175,177</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:58,60</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:104,106</note>
       </notes>
@@ -9508,7 +9509,7 @@
     <unit id="wiki.pushupTypes.level.intermediate">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:60,63</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:184,186</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:181,183</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:64,67</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:110,112</note>
       </notes>
@@ -9519,7 +9520,7 @@
     <unit id="wiki.pushupTypes.level.advanced">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:66,69</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:190,192</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:187,189</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:70,73</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:116,118</note>
       </notes>
@@ -9530,7 +9531,7 @@
     <unit id="wiki.pushupTypes.instructionsTitle">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:75,77</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:199,201</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:196,198</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:79,81</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:124,126</note>
       </notes>
@@ -9541,7 +9542,7 @@
     <unit id="wiki.pushupTypes.tipsTitle">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:82,84</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:207,208</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:204,205</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:86,88</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:131,132</note>
       </notes>
@@ -9607,7 +9608,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.tocLink">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:94,96</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:92,95</note>
       </notes>
       <segment>
         <source>Liegestütze (alle Varianten)</source>
@@ -9615,7 +9616,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.summary">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:100,102</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:98,100</note>
       </notes>
       <segment>
         <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
@@ -9623,7 +9624,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.title">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:134,135</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:135,137</note>
       </notes>
       <segment>
         <source> Liegestütze (alle Varianten) </source>
@@ -9631,7 +9632,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.subtitle">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:140,141</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:139,140</note>
       </notes>
       <segment>
         <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
@@ -9639,7 +9640,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.body">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:148,150</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:144,146</note>
       </notes>
       <segment>
         <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
@@ -9647,7 +9648,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.cta">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:159,161</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:155,157</note>
       </notes>
       <segment>
         <source>Zum Liegestütz-Wiki</source>
@@ -9655,7 +9656,7 @@
     </unit>
     <unit id="wiki.exercises.viewDetail">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:219,221</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:216,218</note>
       </notes>
       <segment>
         <source>Detailseite öffnen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -5628,7 +5628,7 @@
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:197</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:289</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:392</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:393</note>
       </notes>
       <segment>
         <source>Liegestütze</source>
@@ -6465,7 +6465,7 @@
     </unit>
     <unit id="statsTable.exercise.wikiTooltip">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:103,104</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:102,103</note>
       </notes>
       <segment>
         <source>Wiki-Eintrag öffnen</source>
@@ -6473,7 +6473,7 @@
     </unit>
     <unit id="colType">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:116,117</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:112,113</note>
       </notes>
       <segment>
         <source>Typ</source>
@@ -6481,7 +6481,7 @@
     </unit>
     <unit id="colSource">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:125,126</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:121,122</note>
       </notes>
       <segment>
         <source>Quelle</source>
@@ -6489,7 +6489,7 @@
     </unit>
     <unit id="colActions">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:134,135</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:130,131</note>
       </notes>
       <segment>
         <source>Aktion</source>
@@ -6497,7 +6497,7 @@
     </unit>
     <unit id="editAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:141,142</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:137,138</note>
       </notes>
       <segment>
         <source>Bearbeiten</source>
@@ -6505,7 +6505,7 @@
     </unit>
     <unit id="editTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:143,144</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:139,140</note>
       </notes>
       <segment>
         <source>Bearbeiten</source>
@@ -6513,7 +6513,7 @@
     </unit>
     <unit id="deleteAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:154</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:150</note>
       </notes>
       <segment>
         <source>Löschen</source>
@@ -6521,7 +6521,7 @@
     </unit>
     <unit id="deleteTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:156</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:152</note>
       </notes>
       <segment>
         <source>Löschen</source>
@@ -6829,7 +6829,7 @@
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1289</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:222</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:461</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:462</note>
       </notes>
       <segment>
         <source>Drücken</source>
@@ -6839,7 +6839,7 @@
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1290</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:223</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:462</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:463</note>
       </notes>
       <segment>
         <source>Ziehen</source>
@@ -6849,7 +6849,7 @@
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1291</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:224</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:463</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:464</note>
       </notes>
       <segment>
         <source>Kniebeuge</source>
@@ -6859,7 +6859,7 @@
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1292</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:225</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:464</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:465</note>
       </notes>
       <segment>
         <source>Hüftstreckung</source>
@@ -6869,7 +6869,7 @@
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1293</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:226</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:465</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:466</note>
       </notes>
       <segment>
         <source>Ausfallschritt</source>
@@ -6887,7 +6887,7 @@
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1295</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:227</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:466</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:467</note>
       </notes>
       <segment>
         <source>Rumpf</source>
@@ -6897,7 +6897,7 @@
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1296</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:228</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:467</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:468</note>
       </notes>
       <segment>
         <source>Ausdauer</source>
@@ -6907,7 +6907,7 @@
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1297</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:229</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:468</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:469</note>
       </notes>
       <segment>
         <source>Mobilität</source>
@@ -9498,7 +9498,7 @@
     <unit id="wiki.pushupTypes.level.beginner">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:54,56</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:175,177</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:176,178</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:58,60</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:104,106</note>
       </notes>
@@ -9509,7 +9509,7 @@
     <unit id="wiki.pushupTypes.level.intermediate">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:60,63</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:181,183</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:182,184</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:64,67</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:110,112</note>
       </notes>
@@ -9520,7 +9520,7 @@
     <unit id="wiki.pushupTypes.level.advanced">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:66,69</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:187,189</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:188,190</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:70,73</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:116,118</note>
       </notes>
@@ -9531,7 +9531,7 @@
     <unit id="wiki.pushupTypes.instructionsTitle">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:75,77</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:196,198</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:197,199</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:79,81</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:124,126</note>
       </notes>
@@ -9542,7 +9542,7 @@
     <unit id="wiki.pushupTypes.tipsTitle">
       <notes>
         <note category="location">web/src/app/wiki/exercise-detail.component.ts:82,84</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:204,205</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:205,206</note>
         <note category="location">web/src/app/wiki/pushup-type-detail.component.ts:86,88</note>
         <note category="location">web/src/app/wiki/pushup-types-page.component.ts:131,132</note>
       </notes>
@@ -9576,7 +9576,7 @@
     </unit>
     <unit id="wiki.exercises.back">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:65,66</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:66,67</note>
       </notes>
       <segment>
         <source>Zurück zu den Trainingsplänen</source>
@@ -9584,7 +9584,7 @@
     </unit>
     <unit id="wiki.exercises.title">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:71,72</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:72,73</note>
       </notes>
       <segment>
         <source>Übungen — saubere Ausführung</source>
@@ -9592,7 +9592,7 @@
     </unit>
     <unit id="wiki.exercises.intro">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:73,75</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:74,76</note>
       </notes>
       <segment>
         <source> Kurzanleitungen für alle Übungen, die du in der App tracken kannst — von Kniebeugen über Klimmzüge bis zu Mobilitäts-Drills. </source>
@@ -9600,7 +9600,7 @@
     </unit>
     <unit id="wiki.exercises.tocTitle">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:81,83</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:82,84</note>
       </notes>
       <segment>
         <source> Übersicht </source>
@@ -9608,7 +9608,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.tocLink">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:92,95</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:93,96</note>
       </notes>
       <segment>
         <source>Liegestütze (alle Varianten)</source>
@@ -9616,7 +9616,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.summary">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:98,100</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:99,101</note>
       </notes>
       <segment>
         <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
@@ -9624,7 +9624,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.title">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:135,137</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:136,138</note>
       </notes>
       <segment>
         <source> Liegestütze (alle Varianten) </source>
@@ -9632,7 +9632,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.subtitle">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:139,140</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:140,141</note>
       </notes>
       <segment>
         <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
@@ -9640,7 +9640,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.body">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:144,146</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:145,147</note>
       </notes>
       <segment>
         <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
@@ -9648,7 +9648,7 @@
     </unit>
     <unit id="wiki.exercises.pushupHub.cta">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:155,157</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:156,158</note>
       </notes>
       <segment>
         <source>Zum Liegestütz-Wiki</source>
@@ -9656,7 +9656,7 @@
     </unit>
     <unit id="wiki.exercises.viewDetail">
       <notes>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:216,218</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:217,219</note>
       </notes>
       <segment>
         <source>Detailseite öffnen</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -7255,6 +7255,84 @@
         <target>总览</target>
       </segment>
     </unit>
+    <unit id="wiki.exercises.pushupHub.tocLink">
+      <segment state="translated">
+        <source>Liegestütze (alle Varianten)</source>
+        <target>俯卧撑（所有变体）</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.summary">
+      <segment state="translated">
+        <source> — Eigenes Wiki mit allen Liegestützvarianten von Standard bis Planche.</source>
+        <target> — 专属 Wiki，涵盖从标准到 Planche 的所有俯卧撑变体。</target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.title">
+      <segment state="translated">
+        <source> Liegestütze (alle Varianten) </source>
+        <target> 俯卧撑（所有变体） </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.subtitle">
+      <segment state="translated">
+        <source> Eigenes Wiki mit über 20 Liegestützvarianten </source>
+        <target> 专属 Wiki，超过 20 种俯卧撑变体 </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.body">
+      <segment state="translated">
+        <source> Vom Standard-Liegestütz bis Planche und Archer — alle Varianten mit Ausführung, Tipps und Schwierigkeitsgrad findest du im dedizierten Liegestütz-Wiki. </source>
+        <target> 从标准俯卧撑到 Planche 和 Archer——在专属俯卧撑 Wiki 中查看每种变体的动作要领、技巧和难度。 </target>
+      </segment>
+    </unit>
+    <unit id="wiki.exercises.pushupHub.cta">
+      <segment state="translated">
+        <source>Zum Liegestütz-Wiki</source>
+        <target>打开俯卧撑 Wiki</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>打开练习指南</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.generic">
+      <segment state="translated">
+        <source>Anleitung zu Übungen öffnen</source>
+        <target>打开练习指南</target>
+      </segment>
+    </unit>
+    <unit id="exerciseWikiLinkTooltip.specific">
+      <segment state="translated">
+        <source>Anleitung öffnen</source>
+        <target>打开指南</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiAria">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>打开练习指南</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.pushup">
+      <segment state="translated">
+        <source>Liegestützvarianten ansehen</source>
+        <target>查看俯卧撑变体</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.wikiTooltip.exercise">
+      <segment state="translated">
+        <source>Anleitung zur Übung öffnen</source>
+        <target>打开练习指南</target>
+      </segment>
+    </unit>
+    <unit id="statsTable.exercise.wikiTooltip">
+      <segment state="translated">
+        <source>Wiki-Eintrag öffnen</source>
+        <target>打开 Wiki 条目</target>
+      </segment>
+    </unit>
     <unit id="wiki.exercises.viewDetail">
       <segment state="translated">
         <source>Detailseite öffnen</source>


### PR DESCRIPTION
## Summary

Verbindet das allgemeine Übungs-Wiki (`/wiki/uebungen`) mit dem Liegestütz-Wiki (`/wiki/liegestuetz-typen`) und macht Wiki-Inhalte aus der bestehenden Trainings-UI direkt erreichbar.

### Änderungen

**`/wiki/uebungen`**
- Eigene Top-Level-Kategorie **„Liegestütze"** oberhalb der Katalog-Kategorien („Drücken", „Ziehen", …), mit Hub-Karte und CTA zum Liegestütz-Wiki.
- TOC erweitert um den Hub-Eintrag (41 statt 40 Links, gruppiert unter eigenem Heading).
- Heading verwendet die existierende `@@exercise.category.pushup`-i18n-ID — synchron zur Beschriftung in Entry-Dialog, Quick-Add-Config und Stats-Tabelle.

**Training-Entry-Dialog**
- `mat-icon-button` mit Tooltip neben dem Übungs-Dropdown:
  - Liegestütztyp gewählt → öffnet `/wiki/liegestuetz-typen` (bzw. Detailseite, falls Mapping existiert).
  - Andere Übung gewählt → öffnet `/wiki/uebungen` (bzw. Detailseite, falls Slug existiert).
- Quick-Add-Config-Dialog: gleiches Schema für die dort konfigurierbaren Übungen.

**Stats-Tabelle**
- Übungs-Namen in der Tabelle sind jetzt klickbare Links auf die jeweilige Wiki-Detailseite (mit Fallback auf die Hub-Seite).

**i18n**
- 13 neue Keys (Tooltips + Hub-Karten-Texte) mit Übersetzungen für alle 9 Lokalen (de, en, fr, es, it, ja, pt-BR, ko, zh-Hans).
- Bestehende `@@exercise.category.pushup`-ID wiederverwendet für die neue Kategorie-Überschrift (keine zusätzliche Übersetzung nötig).

## Test plan

- [x] `pnpm nx run-many --target=test` — **912 Tests grün**
- [x] `pnpm nx run-many --target=lint` — grün
- [x] `pnpm nx run web:build -c production` — grün (Bundle + Prerender × 9 Lokale)
- [x] Neue Unit-Tests:
  - Hub-Karte rendert mit korrektem `data-testid` und `routerLink="/wiki/liegestuetz-typen"`.
  - Wiki-Icon-Button im Training-Entry- und Quick-Add-Config-Dialog wird gerendert und navigiert korrekt für Pushup- vs. generische Übungen.
  - Stats-Tabelle: Übungs-Spalte enthält Wiki-Links.
  - `/wiki/uebungen` hat ≥ 9 Kategorie-Überschriften und „Liegestütze" steht an erster Stelle.
  - TOC enthält genau 41 Anchor-Links.
- [ ] Manueller Smoke-Test in Staging nach Merge: Tooltip + Klick im Entry-Dialog, Klick auf Übungs-Name in Stats-Tabelle, Scroll-Verhalten der neuen Kategorie-Sektion.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjtVZzHYCWso4WZFmrhimq)_