### PR TITLE
i18n: translate exercise & UI strings across all locales

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -4692,7 +4692,7 @@
     <unit id="entry.interval.label">
       <segment state="translated">
         <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
+        <target>Διάστημα <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
       </segment>
     </unit>
     <unit id="entry.intervals.label">
@@ -8094,13 +8094,13 @@
     <unit id="exercise.category.hinge">
       <segment state="translated">
         <source>Hüftstreckung</source>
-        <target>Εκτέλεση του ισχίου</target>
+        <target>Έκταση ισχίου</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">
       <segment state="translated">
         <source>Ausfallschritt</source>
-        <target>Αιχμές</target>
+        <target>Προβολές</target>
       </segment>
     </unit>
     <unit id="exercise.category.carry">
@@ -8286,7 +8286,7 @@
     <unit id="exercise.mobility.catcow.name">
       <segment state="translated">
         <source>Katze-Kuh</source>
-        <target>Κάτω-Αγελάδα</target>
+        <target>Γάτα-Αγελάδα</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.hipopener.name">
@@ -8664,7 +8664,7 @@
     <unit id="exerciseTimer.cameraMode">
       <segment state="translated">
         <source> Kamera: Start/Ende automatisch erkennen </source>
-        <target> Kamera: Start/Ende automatisch erkennen </target>
+        <target> Κάμερα: αυτόματη ανίχνευση έναρξης/λήξης </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraStarting">
@@ -8676,7 +8676,7 @@
     <unit id="exerciseTimer.cameraUnavailable">
       <segment state="translated">
         <source> Kamera nicht verfügbar </source>
-        <target> Kamera nicht verfügbar </target>
+        <target> Η κάμερα δεν είναι διαθέσιμη </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.toggleAria">
@@ -8712,25 +8712,25 @@
     <unit id="exerciseTimer.cameraHint">
       <segment state="translated">
         <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
-        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+        <target> Τοποθέτησε την κάμερα ώστε να φαίνονται ώμος, ισχίο και γόνατο. Ο χρονομετρητής ξεκινά αυτόματα μόλις πάρεις θέση και κάνει παύση όταν φύγεις από τη θέση. </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.reset">
       <segment state="translated">
         <source> Zurücksetzen </source>
-        <target> Zurücksetzen </target>
+        <target> Επαναφορά </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cancel">
       <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Ακύρωση </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.save">
       <segment state="translated">
         <source> Übernehmen </source>
-        <target> Übernehmen </target>
+        <target> Εφαρμογή </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.holding">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -2947,7 +2947,7 @@
       </notes>
       <segment state="translated">
         <source>App-Installation, Live-Sync &amp; Teilen</source>
-        <target>Εγκατάσταση εφαρμογής, ζωντανός συγχρονισμός & κοινή χρήση</target>
+        <target>Εγκατάσταση εφαρμογής, ζωντανός συγχρονισμός &amp; κοινή χρήση</target>
       </segment>
     </unit>
     <unit id="landing.feature.pwa.body">
@@ -2983,7 +2983,7 @@
       </notes>
       <segment state="translated">
         <source> Auf iPhone &amp; iPad: Teilen-Symbol antippen und „Zum Home-Bildschirm“ wählen. </source>
-        <target> Σε iPhone & iPad: άγγιξε το εικονίδιο κοινής χρήσης και επίλεξε «Στην οθόνη Αφετηρίας». </target>
+        <target> Σε iPhone &amp; iPad: άγγιξε το εικονίδιο κοινής χρήσης και επίλεξε «Στην οθόνη Αφετηρίας». </target>
       </segment>
     </unit>
     <unit id="landing.feature.privacy.title">
@@ -4678,45 +4678,45 @@
       </segment>
     </unit>
     <unit id="intervalsDistribution.noData">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Intervall-Daten vorhanden</source>
-        <target>Keine Intervall-Daten vorhanden</target>
+        <target>Δεν υπάρχουν διαθέσιμα δεδομένα διαστήματος</target>
       </segment>
     </unit>
     <unit id="intervalsDistribution.listLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Verteilung</source>
-        <target>Intervall-Verteilung</target>
+        <target>Κατανομή διαστήματος</target>
       </segment>
     </unit>
     <unit id="entry.interval.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
         <target>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
       </segment>
     </unit>
     <unit id="entry.intervals.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervalle</source>
-        <target>Intervalle</target>
+        <target>Διαστήματα</target>
       </segment>
     </unit>
     <unit id="entry.intervals.remove">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall entfernen</source>
-        <target>Intervall entfernen</target>
+        <target>Κατάργηση διαστήματος</target>
       </segment>
     </unit>
     <unit id="entry.intervals.add">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall hinzufügen</source>
-        <target>Intervall hinzufügen</target>
+        <target>Προσθήκη διαστήματος</target>
       </segment>
     </unit>
     <unit id="entry.intervals.addTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Weiteres Intervall hinzufügen</source>
-        <target>Weiteres Intervall hinzufügen</target>
+        <target>Προσθήκη επιπλέον διαστήματος</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.reps">
@@ -8074,705 +8074,705 @@
       </segment>
     </unit>
       <unit id="exercise.category.push">
-      <segment state="initial">
+      <segment state="translated">
         <source>Drücken</source>
-        <target>Drücken</target>
+        <target>Ώθηση</target>
       </segment>
     </unit>
     <unit id="exercise.category.pull">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziehen</source>
-        <target>Ziehen</target>
+        <target>Έλξη</target>
       </segment>
     </unit>
     <unit id="exercise.category.squat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kniebeuge</source>
-        <target>Kniebeuge</target>
+        <target>Καθίσματα</target>
       </segment>
     </unit>
     <unit id="exercise.category.hinge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftstreckung</source>
-        <target>Hüftstreckung</target>
+        <target>Εκτέλεση του ισχίου</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausfallschritt</source>
-        <target>Ausfallschritt</target>
+        <target>Αιχμές</target>
       </segment>
     </unit>
     <unit id="exercise.category.carry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tragen</source>
-        <target>Tragen</target>
+        <target>Μεταφορά</target>
       </segment>
     </unit>
     <unit id="exercise.category.core">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rumpf</source>
-        <target>Rumpf</target>
+        <target>Κορμός</target>
       </segment>
     </unit>
     <unit id="exercise.category.mobility">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mobilität</source>
-        <target>Mobilität</target>
+        <target>Κινητικότητα</target>
       </segment>
     </unit>
     <unit id="exercise.category.strength">
-      <segment state="initial">
+      <segment state="translated">
         <source>Krafttraining</source>
-        <target>Krafttraining</target>
+        <target>Εκπαίδευση δύναμης</target>
       </segment>
     </unit>
     <unit id="exercise.core.deadbug.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Bug</source>
         <target>Dead Bug</target>
       </segment>
     </unit>
     <unit id="exercise.core.hollowhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
         <target>Hollow Hold</target>
       </segment>
     </unit>
     <unit id="exercise.squat.wallsit.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wandsitz</source>
-        <target>Wandsitz</target>
+        <target>Wall Sit</target>
       </segment>
     </unit>
     <unit id="exercise.squat.boxjump.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Box Jumps</source>
         <target>Box Jumps</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.singlelegRdl.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeiniges Kreuzheben</source>
-        <target>Einbeiniges Kreuzheben</target>
+        <target>Μονοσκελές Deadlift</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.goodmorning.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Good Morning</source>
         <target>Good Morning</target>
       </segment>
     </unit>
     <unit id="exercise.lunge.stepup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Step-ups</source>
         <target>Step-ups</target>
       </segment>
     </unit>
     <unit id="exercise.pull.pullups.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Klimmzüge</source>
-        <target>Klimmzüge</target>
+        <target>Έλξεις</target>
       </segment>
     </unit>
     <unit id="exercise.pull.rows.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ruderzug</source>
-        <target>Ruderzug</target>
+        <target>Σειρές</target>
       </segment>
     </unit>
     <unit id="exercise.pull.deadhang.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Hang</source>
         <target>Dead Hang</target>
       </segment>
     </unit>
     <unit id="exercise.pull.facepull.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Face Pull</source>
         <target>Face Pull</target>
       </segment>
     </unit>
     <unit id="exercise.carry.farmer.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Farmer&apos;s Walk</source>
         <target>Farmer&apos;s Walk</target>
       </segment>
     </unit>
     <unit id="exercise.carry.suitcase.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Suitcase Carry</source>
         <target>Suitcase Carry</target>
       </segment>
     </unit>
     <unit id="exercise.carry.overhead.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Overhead Carry</source>
         <target>Overhead Carry</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.walking.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gehen</source>
-        <target>Gehen</target>
+        <target>Περπάτημα</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.cycling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Radfahren</source>
-        <target>Radfahren</target>
+        <target>Ποδηλασία</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.rowing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rudern</source>
-        <target>Rudern</target>
+        <target>Κωπηλασία</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.swimming.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schwimmen</source>
-        <target>Schwimmen</target>
+        <target>Κολύμβηση</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumprope.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seilspringen</source>
-        <target>Seilspringen</target>
+        <target>Jump Rope</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.burpees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Burpees</source>
         <target>Burpees</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumpingjacks.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hampelmänner</source>
-        <target>Hampelmänner</target>
+        <target>Jumping Jacks</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.highknees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>High Knees</source>
         <target>High Knees</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.stretching.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dehnen</source>
-        <target>Dehnen</target>
+        <target>Διατάσεις</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.yoga.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Yoga</source>
-        <target>Yoga</target>
+        <target>Γιόγκα</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.foamrolling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Faszienrolle</source>
-        <target>Faszienrolle</target>
+        <target>Foam Roller</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dynamisches Aufwärmen</source>
-        <target>Dynamisches Aufwärmen</target>
+        <target>Δυναμικό προθέρμανση</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.catcow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Katze-Kuh</source>
-        <target>Katze-Kuh</target>
+        <target>Κάτω-Αγελάδα</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.hipopener.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftöffner</source>
-        <target>Hüftöffner</target>
+        <target>Ανοίγματα ισχίου</target>
       </segment>
     </unit>
     <unit id="exercise.strength.benchpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdrücken</source>
-        <target>Bankdrücken</target>
+        <target>Bench Press</target>
       </segment>
     </unit>
     <unit id="exercise.strength.overheadpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schulterdrücken</source>
-        <target>Schulterdrücken</target>
+        <target>Shoulder Press</target>
       </segment>
     </unit>
     <unit id="exercise.strength.deadlift.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kreuzheben</source>
-        <target>Kreuzheben</target>
+        <target>Deadlifts</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellsquat.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel-Kniebeuge</source>
-        <target>Langhantel-Kniebeuge</target>
+        <target>Barbell Squat</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellrow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantelrudern</source>
-        <target>Langhantelrudern</target>
+        <target>Barbell Row</target>
       </segment>
     </unit>
     <unit id="exercise.strength.kettlebellswing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kettlebell Swing</source>
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
       <unit id="exercise.variant.situps.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source>Decline</source>
         <target>Decline</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Με πρόσθετο βάρος</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reverse Crunches</source>
         <target>Reverse Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.bicycle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bicycle Crunches</source>
         <target>Bicycle Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.oblique">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schräge Crunches</source>
-        <target>Schräge Crunches</target>
+        <target>Oblique Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.lying">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegend</source>
-        <target>Liegend</target>
+        <target>Ξαπλωμένος</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-knee">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (Knie)</source>
-        <target>Hängend (Knie)</target>
+        <target>Κρεμαστά (γόνατα)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-straight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (gestreckt)</source>
-        <target>Hängend (gestreckt)</target>
+        <target>Κρεμαστά (τεντωμένα)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Ίδιο βάρος</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Με πρόσθετο βάρος</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.cross-body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Cross-Body</source>
         <target>Cross-Body</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.forearm">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unterarmstütz</source>
-        <target>Unterarmstütz</target>
+        <target>Forearm Plank</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.side">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Πλευρικός</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Umgekehrt</source>
-        <target>Umgekehrt</target>
+        <target>Ανάποδος</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Ίδιο βάρος</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.sumo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sumo</source>
         <target>Sumo</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.goblet">
-      <segment state="initial">
+      <segment state="translated">
         <source>Goblet</source>
         <target>Goblet</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bulgarian-split">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bulgarian Split</source>
         <target>Bulgarian Split</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.pistol">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pistol</source>
-        <target>Pistol</target>
+        <target>Πιστόλι</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>Μονοσκελές</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.seated">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sitzend</source>
-        <target>Sitzend</target>
+        <target>Κάθεται</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>Μονοσκελές</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.hip-thrust">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hip Thrust</source>
         <target>Hip Thrust</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.march">
-      <segment state="initial">
+      <segment state="translated">
         <source>Marching</source>
         <target>Marching</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.forward">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorwärts</source>
-        <target>Vorwärts</target>
+        <target>Εμπρός</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückwärts</source>
-        <target>Rückwärts</target>
+        <target>Πίσω</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.walking">
-      <segment state="initial">
+      <segment state="translated">
         <source>Walking</source>
-        <target>Walking</target>
+        <target>Περπάτημα</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.lateral">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Πλευρικός</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.curtsy">
-      <segment state="initial">
+      <segment state="translated">
         <source>Curtsy</source>
         <target>Curtsy</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.jumping">
-      <segment state="initial">
+      <segment state="translated">
         <source>Jumping</source>
-        <target>Jumping</target>
+        <target>Άλμα</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.chin-up">
-      <segment state="initial">
+      <segment state="translated">
         <source>Chin-up</source>
         <target>Chin-up</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.wide-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Breiter Griff</source>
-        <target>Breiter Griff</target>
+        <target>Φαρδιά λαβή</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.neutral-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neutraler Griff</source>
-        <target>Neutraler Griff</target>
+        <target>Ουδέτερη λαβή</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.negative">
-      <segment state="initial">
+      <segment state="translated">
         <source>Negativ</source>
-        <target>Negativ</target>
+        <target>Αρνητικό</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.assisted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Assistiert</source>
-        <target>Assistiert</target>
+        <target>Με βοήθεια</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.archer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Archer</source>
-        <target>Archer</target>
+        <target>Τοξότης</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.inverted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Inverted Row</source>
         <target>Inverted Row</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.australian">
-      <segment state="initial">
+      <segment state="translated">
         <source>Australian Row</source>
         <target>Australian Row</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.dumbbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kurzhantel</source>
-        <target>Kurzhantel</target>
+        <target>Αλτήρι</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.barbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel</source>
-        <target>Langhantel</target>
+        <target>Barbell</target>
       </segment>
     </unit>
     <unit id="exercise.push.dips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dips</source>
         <target>Dips</target>
       </segment>
     </unit>
     <unit id="exercise.push.benchdips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdips</source>
-        <target>Bankdips</target>
+        <target>Bench Dips</target>
       </segment>
     </unit>
     <unit id="exercise.push.handstandhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Handstand-Hold</source>
         <target>Handstand-Hold</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.parallel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Barren</source>
-        <target>Barren</target>
+        <target>Ράβδοι παραλλήλων</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.straight-bar">
-      <segment state="initial">
+      <segment state="translated">
         <source>Stange</source>
-        <target>Stange</target>
+        <target>Μπάρα</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.ring">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ringe</source>
-        <target>Ringe</target>
+        <target>Δακτύλιοι</target>
       </segment>
     </unit>
       <unit id="exerciseTimer.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübung-Timer</source>
-        <target>Halteübung-Timer</target>
+        <target>Τimer κράτησης</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercisePickerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung wählen</source>
-        <target>Übung wählen</target>
+        <target>Επιλέξτε άσκηση</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraMode">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera: Start/Ende automatisch erkennen </source>
         <target> Kamera: Start/Ende automatisch erkennen </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraStarting">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kamera startet …</source>
-        <target>Kamera startet …</target>
+        <target>Κάμερα εκκίνησης…</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraUnavailable">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera nicht verfügbar </source>
         <target> Kamera nicht verfügbar </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.toggleAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Form-Check anzeigen oder ausblenden</source>
-        <target>Form-Check anzeigen oder ausblenden</target>
+        <target>Εμφάνιση ή απόκρυψη ελέγχου φόρμας</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.angle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Winkel</source>
-        <target>Winkel</target>
+        <target>Γωνία</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.confidence">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sicherheit</source>
-        <target>Sicherheit</target>
+        <target>Ασφάλεια</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.pause">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
+        <target>Παύση</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.start">
-      <segment state="initial">
+      <segment state="translated">
         <source>Start</source>
-        <target>Start</target>
+        <target>Έναρξη</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
         <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurücksetzen </source>
         <target> Zurücksetzen </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
         <target> Abbrechen </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Übernehmen </source>
         <target> Übernehmen </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.holding">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halten</source>
-        <target>Halten</target>
+        <target>Κρατήστε</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.paused">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
+        <target>Παύση</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.ready">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bereit</source>
-        <target>Bereit</target>
+        <target>Έτοιμο</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercise.plank">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank</source>
         <target>Plank</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercise.hollowhold">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
         <target>Hollow Hold</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübungs-Timer öffnen</source>
-        <target>Halteübungs-Timer öffnen</target>
+        <target>Άνοιγμα χρονόμετρου κράτησης</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank‑Timer</source>
-        <target>Plank‑Timer</target>
+        <target>Plank-Timer</target>
       </segment>
     </unit>
     <unit id="quickAddConfig.hintV2">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -3998,7 +3998,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="settings.deleteDialogPhraseHint">
       <segment state="translated">
         <source />
-        <target>Please enter exactly "löscchen".</target>
+        <target>Please enter exactly "löschen".</target>
       </segment>
     </unit>
     <unit id="settings.deleteDialogPhraseLabel">
@@ -4720,7 +4720,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="admin.bulk.hint">
       <segment state="translated">
         <source> Löscht anonyme Benutzer ohne Pushups in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays }}" /> Tagen. </source>
-        <target>Deletes anonymous users without pushups in the last  days.</target>
+        <target>Deletes anonymous users without pushups in the last <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays }}" /> days.</target>
       </segment>
     </unit>
     <unit id="admin.bulk.button">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="de" trgLang="en">
+<?xml version='1.0' encoding='utf-8'?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="de" trgLang="en">
   <file id="ngi18n" original="ng.template">
     <unit id="1713004850888488155">
       <notes>
@@ -54,7 +54,7 @@
         </unit>
     <unit id="2721806142807617942">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Register </target>
       </segment>
     </unit>
@@ -77,7 +77,7 @@
         </unit>
     <unit id="6031063121455734122">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Back </target>
       </segment>
     </unit>
@@ -106,10 +106,10 @@
             </notes>
       <segment state="translated">
         <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ activeUserId() }}"/>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ activeUserId() }}" />
 Aktiv:         </source>
         <target>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ activeUserId() }}"/>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ activeUserId() }}" />
 Active:         </target>
 
         
@@ -392,10 +392,10 @@ Active:         </target>
             </notes>
       <segment state="translated">
         <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ currentStreak() }}"/>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ currentStreak() }}" />
  Tage        </source>
         <target>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ currentStreak() }}"/>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ currentStreak() }}" />
  days        </target>
 
         
@@ -459,8 +459,8 @@ Active:         </target>
     </unit>
     <unit id="analysis.avgSetsCol">
       <segment state="translated">
-        <source>&#x2300; Sets</source>
-        <target>&#x2300; Sets</target>
+        <source>⌀ Sets</source>
+        <target>⌀ Sets</target>
       </segment>
     </unit>
     <unit id="analysis.bestSingleSet">
@@ -471,8 +471,8 @@ Active:         </target>
     </unit>
     <unit id="analysis.avgSetSizeTitle">
       <segment state="translated">
-        <source>&#x2300; Set-Gr&#x00F6;&#x00DF;e</source>
-        <target>&#x2300; Set size</target>
+        <source>⌀ Set-Größe</source>
+        <target>⌀ Set size</target>
       </segment>
     </unit>
     <unit id="analysis.repsPerSet">
@@ -585,8 +585,8 @@ Active:         </target>
     </unit>
     <unit id="entry.interval.label">
       <segment state="translated">
-        <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Interval <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
+        <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></source>
+        <target>Interval <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></target>
       </segment>
     </unit>
     <unit id="entry.intervals.label">
@@ -624,8 +624,8 @@ Active:         </target>
     </unit>
     <unit id="pie.avgSetSize">
       <segment state="translated">
-        <source>&#x2300; Set-Gr&#x00F6;&#x00DF;e</source>
-        <target>&#x2300; Set size</target>
+        <source>⌀ Set-Größe</source>
+        <target>⌀ Set size</target>
       </segment>
     </unit>
     <unit id="chart.modeToggleAria">
@@ -660,8 +660,8 @@ Active:         </target>
     </unit>
     <unit id="chart.avgSetSize">
       <segment state="translated">
-        <source>&#x2300; Set-Gr&#x00F6;&#x00DF;e</source>
-        <target>&#x2300; Set size</target>
+        <source>⌀ Set-Größe</source>
+        <target>⌀ Set size</target>
       </segment>
     </unit>
     <unit id="app.title">
@@ -685,265 +685,265 @@ Active:         </target>
         </unit>
     <unit id="auth.email">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Email</target>
       </segment>
     </unit>
     <unit id="auth.error.emailInUse">
       <segment state="translated">
-        <source/>
+        <source />
         <target>An account already exists for this email.</target>
       </segment>
     </unit>
     <unit id="auth.error.generic">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Login failed. Please try again.</target>
       </segment>
     </unit>
     <unit id="auth.error.internalError">
       <segment state="translated">
-        <source/>
+        <source />
         <target>A technical error occurred. Please try again shortly.</target>
       </segment>
     </unit>
     <unit id="auth.error.invalidCredential">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Email or password is incorrect.</target>
       </segment>
     </unit>
     <unit id="auth.error.invalidEmail">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Please enter a valid email address.</target>
       </segment>
     </unit>
     <unit id="auth.error.network">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Network error. Please check your internet connection and try again.</target>
       </segment>
     </unit>
     <unit id="auth.error.popupBlocked">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Popup was blocked. Please allow popups and try again.</target>
       </segment>
     </unit>
     <unit id="auth.error.popupClosed">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Google sign-in was canceled. The sign-in window was closed.</target>
       </segment>
     </unit>
     <unit id="auth.error.tooManyRequests">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Too many attempts. Please wait a moment and try again.</target>
       </segment>
     </unit>
     <unit id="auth.error.userDisabled">
       <segment state="translated">
-        <source/>
+        <source />
         <target>This account is disabled.</target>
       </segment>
     </unit>
     <unit id="auth.error.userNotFound">
       <segment state="translated">
-        <source/>
+        <source />
         <target>No account found for this email.</target>
       </segment>
     </unit>
     <unit id="auth.error.weakPassword">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Password is too weak (at least 6 characters).</target>
       </segment>
     </unit>
     <unit id="auth.error.wrongPassword">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Email or password is incorrect.</target>
       </segment>
     </unit>
     <unit id="auth.google.signin">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Sign in with Google </target>
       </segment>
     </unit>
     <unit id="auth.google.signup">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Sign up with Google </target>
       </segment>
     </unit>
     <unit id="auth.login.loading">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Signing in...</target>
       </segment>
     </unit>
     <unit id="auth.login.submit">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Sign in</target>
       </segment>
     </unit>
     <unit id="auth.login.subtitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Please sign in</target>
       </segment>
     </unit>
     <unit id="auth.login.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Welcome to PushUp Stats</target>
       </segment>
     </unit>
     <unit id="auth.next">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Next </target>
       </segment>
     </unit>
     <unit id="auth.onboarding.google.consent.checkbox">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Grant consent </target>
       </segment>
     </unit>
     <unit id="auth.onboarding.google.consent.text">
       <segment state="translated">
-        <source/>
+        <source />
         <target> I consent to data processing for technically required data collection, statistical analysis, and personalized advertising. </target>
       </segment>
     </unit>
     <unit id="auth.onboarding.google.error.consentRequired">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Please consent to data processing.</target>
       </segment>
     </unit>
     <unit id="auth.onboarding.google.error.noUser">
       <segment state="translated">
-        <source/>
+        <source />
         <target>No logged-in user found.</target>
       </segment>
     </unit>
     <unit id="auth.onboarding.google.error.saveFailed">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Onboarding could not be saved. Please try again.</target>
       </segment>
     </unit>
     <unit id="auth.onboarding.google.finish">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Finish </target>
       </segment>
     </unit>
     <unit id="auth.onboarding.google.goal">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Daily goal</target>
       </segment>
     </unit>
     <unit id="auth.onboarding.google.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Complete setup </target>
       </segment>
     </unit>
     <unit id="auth.onboarding.google.username">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Username</target>
       </segment>
     </unit>
     <unit id="auth.onboarding.google.username.hint">
       <segment state="translated">
-        <source/>
+        <source />
         <target>At least 2 characters.</target>
       </segment>
     </unit>
     <unit id="auth.or">
       <segment state="translated">
-        <source/>
+        <source />
         <target>or</target>
       </segment>
     </unit>
     <unit id="auth.password">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Password</target>
       </segment>
     </unit>
     <unit id="auth.register.back">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Back </target>
       </segment>
     </unit>
     <unit id="auth.register.finalizing">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Creating account and saving profile...</target>
       </segment>
     </unit>
     <unit id="auth.register.google.skipPassword">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Password step skipped (Google registration). </target>
       </segment>
     </unit>
     <unit id="auth.register.noAccount">
       <segment state="translated">
-        <source/>
+        <source />
         <target>No account yet?</target>
       </segment>
     </unit>
     <unit id="auth.register.password.hint">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Min. 8 characters, 1 number, and 1 special character.</target>
       </segment>
     </unit>
     <unit id="auth.register.password.invalid">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Password does not meet requirements.</target>
       </segment>
     </unit>
     <unit id="auth.register.password.repeat">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Repeat password</target>
       </segment>
     </unit>
     <unit id="auth.register.password.repeat.invalid">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Passwords do not match.</target>
       </segment>
     </unit>
     <unit id="auth.register.processing">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Preparing registration...</target>
       </segment>
     </unit>
     <unit id="auth.register.submit">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Register </target>
       </segment>
     </unit>
     <unit id="auth.register.subtitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Create your account</target>
       </segment>
     </unit>
@@ -967,25 +967,25 @@ Active:         </target>
     </unit>
     <unit id="auth.register.success.dashboard">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Go to dashboard </target>
       </segment>
     </unit>
     <unit id="auth.register.success.text">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Your account is ready. Time for the first push-ups 💪 </target>
       </segment>
     </unit>
     <unit id="auth.register.success.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Done! 🎉</target>
       </segment>
     </unit>
     <unit id="auth.register.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Registration</target>
       </segment>
     </unit>
@@ -1518,19 +1518,19 @@ Active:         </target>
         </unit>
     <unit id="dayChartMode14h">
       <segment state="translated">
-        <source/>
+        <source />
         <target>14h Day Mode</target>
       </segment>
     </unit>
     <unit id="dayChartMode24h">
       <segment state="translated">
-        <source/>
+        <source />
         <target>24h</target>
       </segment>
     </unit>
     <unit id="dayChartModeLabel">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Day view</target>
       </segment>
     </unit>
@@ -1816,10 +1816,10 @@ Active:         </target>
             </notes>
       <segment state="translated">
         <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}" />
  Einträge        </source>
         <target>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}" />
  entries        </target>
 
         
@@ -2023,8 +2023,8 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Erfasse jeden Satz einzeln – z.&#x202F;B. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
-        <target>Log every set individually – e.g. 12&#xA0;+&#xA0;10&#xA0;+&#xA0;8. The app sums them up automatically and shows your average set size.</target>
+        <source>Erfasse jeden Satz einzeln – z. B. 12 + 10 + 8. Die App summiert automatisch und zeigt deine durchschnittliche Set-Größe.</source>
+        <target>Log every set individually – e.g. 12 + 10 + 8. The app sums them up automatically and shows your average set size.</target>
             </segment>
         </unit>
     <unit id="landing.feature.goals.title">
@@ -2123,7 +2123,7 @@ Active:         </target>
             </notes>
       <segment state="translated">
         <source> Auf iPhone &amp; iPad: Teilen-Symbol antippen und „Zum Home-Bildschirm“ wählen. </source>
-        <target> On iPhone &amp; iPad: tap the Share icon and choose &quot;Add to Home Screen&quot;. </target>
+        <target> On iPhone &amp; iPad: tap the Share icon and choose "Add to Home Screen". </target>
             </segment>
         </unit>
     <unit id="landing.feature.privacy.title">
@@ -2131,7 +2131,7 @@ Active:         </target>
         <note category="location">web/src/app/marketing/shell/landing-page.component.html</note>
             </notes>
       <segment state="translated">
-        <source>Privacy first &amp; 100&#xA0;% kostenlos</source>
+        <source>Privacy first &amp; 100 % kostenlos</source>
         <target>Privacy first &amp; 100% free</target>
             </segment>
         </unit>
@@ -2285,8 +2285,8 @@ Active:         </target>
             </notes>
       <segment state="translated">
         <source>
-          <x id="INTERPOLATION" equiv-text="{{ me.rank }}"/>
-          <x id="INTERPOLATION_1" equiv-text="{{ me.reps }}"/>
+          <x id="INTERPOLATION" equiv-text="{{ me.rank }}" />
+          <x id="INTERPOLATION_1" equiv-text="{{ me.reps }}" />
 Deine Position: # ·  Reps        </source>
         <target> Your position: #{$INTERPOLATION} · {$INTERPOLATION_1} reps </target>
 
@@ -2508,12 +2508,12 @@ Deine Position: # ·  Reps        </source>
             </notes>
       <segment state="translated">
         <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/>
-          <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}" />
+          <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || 'Standard' }}" />
   Reps ·          </source>
         <target>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/>
-          <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}" />
+          <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || 'Standard' }}" />
   reps ·          </target>
 
         
@@ -2525,13 +2525,13 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="leaderboard.page.subtitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Today · Last 7 days · Last 30 days</target>
       </segment>
     </unit>
     <unit id="leaderboard.page.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Leaderboard</target>
       </segment>
     </unit>
@@ -2543,10 +2543,10 @@ Deine Position: # ·  Reps        </source>
             </notes>
       <segment state="translated">
         <source>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;verbunden&apos; : &apos;getrennt&apos; }}"/>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? 'verbunden' : 'getrennt' }}" />
  Live:          </source>
         <target>
-          <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;connected&apos; : &apos;disconnected&apos; }}"/>
+          <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? 'connected' : 'disconnected' }}" />
  Live:          </target>
 
         
@@ -2711,7 +2711,7 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="nav.leaderboard">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Leaderboard</target>
       </segment>
     </unit>
@@ -3005,8 +3005,8 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html</note>
       </notes>
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ vm.reps }}"/> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ vm.reps }}"/> reps</target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ vm.reps }}" /> Reps</source>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ vm.reps }}" /> reps</target>
       </segment>
     </unit>
     <unit id="dashboard.quickAdd.autoPrefix">
@@ -3041,8 +3041,8 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
       </notes>
       <segment state="translated">
-        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> eigene Reps-Buttons fest. Leere Felder werden ignoriert. </source>
-        <target> Define up to <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> custom rep buttons. Empty fields are ignored. </target>
+        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> eigene Reps-Buttons fest. Leere Felder werden ignoriert. </source>
+        <target> Define up to <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> custom rep buttons. Empty fields are ignored. </target>
       </segment>
     </unit>
     <unit id="quickAddConfig.repsLabel">
@@ -3068,8 +3068,8 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
       </notes>
       <segment state="translated">
-        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> Schnellaktionen fest. Wähle pro Button die Übung und – wo verfügbar – Auto-Messung über die Kamera. Leere Felder werden ignoriert. </source>
-        <target> Configure up to <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> quick actions. Pick the exercise per button and — where available — auto-count via the camera. Empty fields are ignored. </target>
+        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> Schnellaktionen fest. Wähle pro Button die Übung und – wo verfügbar – Auto-Messung über die Kamera. Leere Felder werden ignoriert. </source>
+        <target> Configure up to <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> quick actions. Pick the exercise per button and — where available — auto-count via the camera. Empty fields are ignored. </target>
       </segment>
     </unit>
     <unit id="quickAddConfig.exerciseLabel">
@@ -3356,8 +3356,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="setLabel">
       <segment state="translated">
-        <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
+        <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></source>
+        <target>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></target>
       </segment>
     </unit>
     <unit id="removeSetAria">
@@ -3368,8 +3368,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="totalReps">
       <segment state="translated">
-        <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
-        <target> Total: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> reps </target>
+        <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}" /> Reps </source>
+        <target> Total: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}" /> reps </target>
       </segment>
     </unit>
     <unit id="saveChanges">
@@ -3380,14 +3380,14 @@ Deine Position: # ·  Reps        </source>
             </notes>
       <segment state="translated">
         <source>
-          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (editingId() &amp;&amp; isBusy(&apos;update&apos;, editBusyId())) {" dispEnd="}">
-            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"/>
+          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (editingId() &amp;&amp; isBusy('update', editBusyId())) {" dispEnd="}">
+            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;" />
           </pc>
           <pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Speichern </pc>
         </source>
         <target>
-          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (editingId() &amp;&amp; isBusy(&apos;update&apos;, editBusyId())) {" dispEnd="}">
-            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"/>
+          <pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (editingId() &amp;&amp; isBusy('update', editBusyId())) {" dispEnd="}">
+            <pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;14&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;" />
           </pc>
           <pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Save </pc>
         </target>
@@ -3428,14 +3428,14 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="entryDialog.overCapDuration">
       <segment state="translated">
-        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
-        <target>Maximum duration: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}" /></source>
+        <target>Maximum duration: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}" /></target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
-        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
-        <target>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}" /></source>
+        <target>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}" /></target>
       </segment>
     </unit>
     <unit id="exercise.category.plank">
@@ -3476,8 +3476,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="entryDialog.overCap">
       <segment state="translated">
-        <source> Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> pro Eintrag </source>
-        <target> Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> per entry </target>
+        <source> Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}" /> pro Eintrag </source>
+        <target> Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}" /> per entry </target>
       </segment>
     </unit>
     <unit id="exerciseSection.lastEntry">
@@ -3841,13 +3841,13 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="settings.adsConsentHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Controls whether ad slots may be loaded on the dashboard. </target>
       </segment>
     </unit>
     <unit id="settings.adsConsentOptIn">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Enable personalized ads </target>
       </segment>
     </unit>
@@ -3949,7 +3949,7 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="settings.dangerZoneBody">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Deleting your account removes your account. Training data remains anonymized for statistical analysis. </target>
       </segment>
     </unit>
@@ -3973,85 +3973,85 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="settings.dangerZoneTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Danger Zone</target>
       </segment>
     </unit>
     <unit id="settings.deleteAccount">
       <segment state="translated">
-        <source/>
+        <source />
         <target>{$START_TAG_MAT_ICON}warning{$CLOSE_TAG_MAT_ICON} Delete account </target>
       </segment>
     </unit>
     <unit id="settings.deleteConfirmFinal">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Final delete </target>
       </segment>
     </unit>
     <unit id="settings.deleteDialogInfo">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Your account will be deleted. Training data remains anonymized for statistical analysis. </target>
       </segment>
     </unit>
     <unit id="settings.deleteDialogPhraseHint">
       <segment state="translated">
-        <source/>
-        <target>Please enter exactly &quot;löscchen&quot;.</target>
+        <source />
+        <target>Please enter exactly "löscchen".</target>
       </segment>
     </unit>
     <unit id="settings.deleteDialogPhraseLabel">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Enter confirmation word</target>
       </segment>
     </unit>
     <unit id="settings.deleteDialogTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Really delete account? </target>
       </segment>
     </unit>
     <unit id="settings.deleteDialogWarning">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Warning: This action cannot be undone. </target>
       </segment>
     </unit>
     <unit id="settings.deletingAccount">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Deleting account…</target>
       </segment>
     </unit>
     <unit id="settings.displayNameHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target>May be shown on the leaderboard.</target>
       </segment>
     </unit>
     <unit id="settings.goalHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Shown prominently in the toolbar.</target>
       </segment>
     </unit>
     <unit id="settings.leaderboardOptIn">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Show in leaderboard </target>
       </segment>
     </unit>
     <unit id="settings.leaderboardOptOutHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> If disabled, your profile will not be shown in the leaderboard. </target>
       </segment>
     </unit>
     <unit id="settings.leaderboardRequiresPublicProfile">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Only profiles with Public profile enabled appear on the leaderboard. Enable “Public profile” below to use this option. </target>
       </segment>
     </unit>
@@ -4098,16 +4098,12 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source>
           <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">
-            <ph id="1" equiv="INTERPOLATION" disp="{{
-        showSourceColumn() ? &apos;visibility&apos; : &apos;visibility_off&apos;
-      }}"/>
+            <ph id="1" equiv="INTERPOLATION" disp="{{         showSourceColumn() ? 'visibility' : 'visibility_off'       }}" />
           </pc>
  Quelle         </source>
         <target>
           <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">
-            <ph id="1" equiv="INTERPOLATION" disp="{{
-        showSourceColumn() ? &apos;visibility&apos; : &apos;visibility_off&apos;
-      }}"/>
+            <ph id="1" equiv="INTERPOLATION" disp="{{         showSourceColumn() ? 'visibility' : 'visibility_off'       }}" />
           </pc>
  Source         </target>
 
@@ -4221,7 +4217,7 @@ Deine Position: # ·  Reps        </source>
             </notes>
       <segment state="translated">
         <source>Tagesfokus</source>
-        <target>Today&apos;s focus</target>
+        <target>Today's focus</target>
 
         
         
@@ -4232,7 +4228,7 @@ Deine Position: # ·  Reps        </source>
         </unit>
     <unit id="toolbarDailyGoal">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Daily goal</target>
       </segment>
     </unit>
@@ -4723,7 +4719,7 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="admin.bulk.hint">
       <segment state="translated">
-        <source> Löscht anonyme Benutzer ohne Pushups in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays }}"/> Tagen. </source>
+        <source> Löscht anonyme Benutzer ohne Pushups in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays }}" /> Tagen. </source>
         <target>Deletes anonymous users without pushups in the last  days.</target>
       </segment>
     </unit>
@@ -4813,8 +4809,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="admin.row.detailsAria">
       <segment state="translated">
-        <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Open details for <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier" /></source>
+        <target>Open details for <ph id="0" equiv="identifier" disp="identifier" /></target>
       </segment>
     </unit>
     <unit id="admin.details.uid">
@@ -4999,8 +4995,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="blog.article.readingTime">
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}"/> Min. Lesezeit</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}"/> min read</target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}" /> Min. Lesezeit</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}" /> min read</target>
       </segment>
     </unit>
     <unit id="blog.article.updated">
@@ -5287,8 +5283,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="reminder.quickLog.success">
       <segment state="translated">
-        <source><ph id="0" equiv="reps" disp="reps"/> Push-ups eingetragen ✓</source>
-        <target><ph id="0" equiv="reps" disp="reps"/> push-ups logged ✓</target>
+        <source><ph id="0" equiv="reps" disp="reps" /> Push-ups eingetragen ✓</source>
+        <target><ph id="0" equiv="reps" disp="reps" /> push-ups logged ✓</target>
       </segment>
     </unit>
     <unit id="reminder.quickLog.error">
@@ -5419,8 +5415,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="push.device.count">
       <segment state="translated">
-        <source>Aktiv auf <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}"/> Geräten</source>
-        <target>Active on <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}"/> devices</target>
+        <source>Aktiv auf <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}" /> Geräten</source>
+        <target>Active on <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}" /> devices</target>
       </segment>
     </unit>
     <unit id="push.cta.desc">
@@ -5599,14 +5595,14 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="quickAdd.fab.quickAddReps">
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> Reps</target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> Reps</source>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> Reps</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.repAria">
       <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
-        <target>Add <ph id="0" equiv="REPS" disp="reps"/> push-ups</target>
+        <source><ph id="0" equiv="REPS" disp="reps" /> Liegestütze hinzufügen</source>
+        <target>Add <ph id="0" equiv="REPS" disp="reps" /> push-ups</target>
       </segment>
     </unit>
     <unit id="quickAdd.success.create">
@@ -5656,8 +5652,8 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Streak: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}"/> Tage</source>
-        <target>Streak: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}"/> days</target>
+        <source>Streak: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}" /> Tage</source>
+        <target>Streak: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}" /> days</target>
       </segment>
     </unit>
     <unit id="dashboard.analysisTeaserWeekReps">
@@ -5665,8 +5661,8 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts</note>
       </notes>
       <segment state="translated">
-        <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> Reps</source>
-        <target>This week: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> reps</target>
+        <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}" /> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}" /> Reps</source>
+        <target>This week: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}" /> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}" /> reps</target>
       </segment>
     </unit>
     <unit id="dashboard.analysisTeaserError">
@@ -5731,8 +5727,8 @@ Deine Position: # ·  Reps        </source>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:110</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="label" disp="label"/> in der Historie öffnen</source>
-        <target>Open <ph id="0" equiv="label" disp="label"/> in history</target>
+        <source><ph id="0" equiv="label" disp="label" /> in der Historie öffnen</source>
+        <target>Open <ph id="0" equiv="label" disp="label" /> in history</target>
       </segment>
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
@@ -5786,7 +5782,7 @@ Deine Position: # ·  Reps        </source>
         <target>Dark theme active. Click to switch</target>
       </segment>
     </unit>
-    <!-- Footer -->
+    
     <unit id="footer.aria">
       <segment state="translated">
         <source>Rechtliches</source>
@@ -5824,7 +5820,7 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
 
-    <!-- Cookie Consent Banner -->
+    
     <unit id="consent.banner.aria">
       <segment state="translated">
         <source>Cookie-Einstellungen</source>
@@ -5856,7 +5852,7 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
 
-    <!-- SEO: Legal pages -->
+    
     <unit id="seo.impressum.title">
       <segment state="translated">
         <source>Impressum – Pushup Tracker</source>
@@ -5882,7 +5878,7 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
 
-    <!-- Impressum page -->
+    
     <unit id="impressum.title">
       <segment state="translated">
         <source>Impressum</source>
@@ -5950,7 +5946,7 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
 
-    <!-- Datenschutz page -->
+    
     <unit id="datenschutz.title">
       <segment state="translated">
         <source>Datenschutzerklärung</source>
@@ -6277,14 +6273,14 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="quickAdd.fab.fillToGoal">
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> bis zum Ziel</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> to goal</target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> bis zum Ziel</source>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> to goal</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <segment state="translated">
-        <source><ph id="0" equiv="GAP" disp="gap"/> Liegestütze bis zum Tagesziel hinzufügen</source>
-        <target>Add <ph id="0" equiv="GAP" disp="gap"/> pushups to reach the daily goal</target>
+        <source><ph id="0" equiv="GAP" disp="gap" /> Liegestütze bis zum Tagesziel hinzufügen</source>
+        <target>Add <ph id="0" equiv="GAP" disp="gap" /> pushups to reach the daily goal</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalReached">
@@ -6307,8 +6303,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="dashboard.goalFill.fill">
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> bis zum Ziel</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> to goal</target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}" /> bis zum Ziel</source>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}" /> to goal</target>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.reached">
@@ -6685,8 +6681,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="trainingPlans.jumped">
       <segment state="translated">
-        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
-        <target>Jumped to day <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex" /> gesprungen.</source>
+        <target>Jumped to day <ph id="0" equiv="INTERPOLATION" disp="dayIndex" />.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.back">
@@ -6721,8 +6717,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="goalReached.share.daily.text">
       <segment state="translated">
-        <source>Heute mein Tagesziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Hit my daily goal of <ph id="0" equiv="goal" disp="goal"/> push-ups today! 💪 Track your stats for free:</target>
+        <source>Heute mein Tagesziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen geschafft! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Hit my daily goal of <ph id="0" equiv="goal" disp="goal" /> push-ups today! 💪 Track your stats for free:</target>
       </segment>
     </unit>
     <unit id="goalReached.share.weekly.title">
@@ -6733,8 +6729,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="goalReached.share.weekly.text">
       <segment state="translated">
-        <source>Wochenziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Hit my weekly goal of <ph id="0" equiv="goal" disp="goal"/> push-ups – <ph id="1" equiv="total" disp="total"/> total! 💪 Track your stats for free:</target>
+        <source>Wochenziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen geschafft – <ph id="1" equiv="total" disp="total" /> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Hit my weekly goal of <ph id="0" equiv="goal" disp="goal" /> push-ups – <ph id="1" equiv="total" disp="total" /> total! 💪 Track your stats for free:</target>
       </segment>
     </unit>
     <unit id="goalReached.share.monthly.title">
@@ -6745,8 +6741,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="goalReached.share.monthly.text">
       <segment state="translated">
-        <source>Monatsziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Hit my monthly goal of <ph id="0" equiv="goal" disp="goal"/> push-ups – <ph id="1" equiv="total" disp="total"/> total! 💪 Track your stats for free:</target>
+        <source>Monatsziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen geschafft – <ph id="1" equiv="total" disp="total" /> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Hit my monthly goal of <ph id="0" equiv="goal" disp="goal" /> push-ups – <ph id="1" equiv="total" disp="total" /> total! 💪 Track your stats for free:</target>
       </segment>
     </unit>
     <unit id="goalReached.share.plan.title">
@@ -6757,8 +6753,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="goalReached.share.plan.text">
       <segment state="translated">
-        <source>Heute mein Trainingsplan-Ziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen erreicht – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Hit today's training plan goal of <ph id="0" equiv="goal" disp="goal"/> push-ups – <ph id="1" equiv="total" disp="total"/> total! 💪 Track your stats for free:</target>
+        <source>Heute mein Trainingsplan-Ziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen erreicht – <ph id="1" equiv="total" disp="total" /> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Hit today's training plan goal of <ph id="0" equiv="goal" disp="goal" /> push-ups – <ph id="1" equiv="total" disp="total" /> total! 💪 Track your stats for free:</target>
       </segment>
     </unit>
     <unit id="dashboard.share">
@@ -6781,26 +6777,26 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="dashboard.share.text.simple">
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Already <ph id="0" equiv="total" disp="total"/> push-ups today! 💪 Track your stats for free:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Already <ph id="0" equiv="total" disp="total" /> push-ups today! 💪 Track your stats for free:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.streak">
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
-        <target>Already <ph id="0" equiv="total" disp="total"/> push-ups today – streak: <ph id="1" equiv="streak" disp="streak"/> days 🔥 Track your stats for free:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak" /> Tage 🔥 Tracke deine Stats kostenlos:</source>
+        <target>Already <ph id="0" equiv="total" disp="total" /> push-ups today – streak: <ph id="1" equiv="streak" disp="streak" /> days 🔥 Track your stats for free:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.simple">
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
-        <target>Already <ph id="0" equiv="total" disp="total"/> push-ups today! 💪 Check out my profile:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
+        <target>Already <ph id="0" equiv="total" disp="total" /> push-ups today! 💪 Check out my profile:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.streak">
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Schau dir mein Profil an:</source>
-        <target>Already <ph id="0" equiv="total" disp="total"/> push-ups today – streak: <ph id="1" equiv="streak" disp="streak"/> days 🔥 Check out my profile:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak" /> Tage 🔥 Schau dir mein Profil an:</source>
+        <target>Already <ph id="0" equiv="total" disp="total" /> push-ups today – streak: <ph id="1" equiv="streak" disp="streak" /> days 🔥 Check out my profile:</target>
       </segment>
     </unit>
     <unit id="share.success.clipboard">
@@ -6859,8 +6855,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="publicProfile.seo.imageAlt">
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="name"/> auf Pushup Tracker</source>
-        <target><ph id="0" equiv="name" disp="name"/> on Pushup Tracker</target>
+        <source><ph id="0" equiv="name" disp="name" /> auf Pushup Tracker</source>
+        <target><ph id="0" equiv="name" disp="name" /> on Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="publicProfile.notFound.title">
@@ -6961,8 +6957,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="publicProfile.share.text">
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="name"/> hat <ph id="1" equiv="total" disp="total"/> Liegestütze auf Pushup Tracker geschafft 💪 Schau's dir an:</source>
-        <target><ph id="0" equiv="name" disp="name"/> hit <ph id="1" equiv="total" disp="total"/> push-ups on Pushup Tracker 💪 Check it out:</target>
+        <source><ph id="0" equiv="name" disp="name" /> hat <ph id="1" equiv="total" disp="total" /> Liegestütze auf Pushup Tracker geschafft 💪 Schau's dir an:</source>
+        <target><ph id="0" equiv="name" disp="name" /> hit <ph id="1" equiv="total" disp="total" /> push-ups on Pushup Tracker 💪 Check it out:</target>
       </segment>
     </unit>
     <unit id="publicProfile.share.title">
@@ -6985,14 +6981,14 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="publicProfile.seo.title">
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="name"/> – <ph id="1" equiv="total" disp="total"/> Liegestütze · Streak <ph id="2" equiv="streak" disp="streak"/> · Pushup Tracker</source>
-        <target><ph id="0" equiv="name" disp="name"/> – <ph id="1" equiv="total" disp="total"/> push-ups · streak <ph id="2" equiv="streak" disp="streak"/> · Pushup Tracker</target>
+        <source><ph id="0" equiv="name" disp="name" /> – <ph id="1" equiv="total" disp="total" /> Liegestütze · Streak <ph id="2" equiv="streak" disp="streak" /> · Pushup Tracker</source>
+        <target><ph id="0" equiv="name" disp="name" /> – <ph id="1" equiv="total" disp="total" /> push-ups · streak <ph id="2" equiv="streak" disp="streak" /> · Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="publicProfile.seo.description">
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="name"/> hat <ph id="1" equiv="total" disp="total"/> Liegestütze in <ph id="2" equiv="days" disp="days"/> aktiven Tagen geschafft – aktuelle Streak: <ph id="3" equiv="streak" disp="streak"/> Tage. Tracke selbst kostenlos auf pushup-stats.com.</source>
-        <target><ph id="0" equiv="name" disp="name"/> hit <ph id="1" equiv="total" disp="total"/> push-ups across <ph id="2" equiv="days" disp="days"/> active days – current streak: <ph id="3" equiv="streak" disp="streak"/> days. Start tracking free at pushup-stats.com.</target>
+        <source><ph id="0" equiv="name" disp="name" /> hat <ph id="1" equiv="total" disp="total" /> Liegestütze in <ph id="2" equiv="days" disp="days" /> aktiven Tagen geschafft – aktuelle Streak: <ph id="3" equiv="streak" disp="streak" /> Tage. Tracke selbst kostenlos auf pushup-stats.com.</source>
+        <target><ph id="0" equiv="name" disp="name" /> hit <ph id="1" equiv="total" disp="total" /> push-ups across <ph id="2" equiv="days" disp="days" /> active days – current streak: <ph id="3" equiv="streak" disp="streak" /> days. Start tracking free at pushup-stats.com.</target>
       </segment>
     </unit>
     <unit id="settings.publicProfile.toggle">
@@ -7026,7 +7022,7 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
 
-    <!-- Pushup-types wiki page -->
+    
     <unit id="seo.wiki.pushupTypes.title">
       <segment state="translated">
         <source>Liegestütztypen erklärt – Pushup Tracker</source>
@@ -7094,7 +7090,7 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
 
-    <!-- Exercises wiki page -->
+    
     <unit id="seo.wiki.exercises.title">
       <segment state="translated">
         <source>Übungen erklärt – Pushup Tracker</source>
@@ -7978,268 +7974,268 @@ Deine Position: # ·  Reps        </source>
         <target>User management, feedback and clean-up.</target>
       </segment>
     </unit>
-    <!-- Cross-reference links -->
+    
     <unit id="dashboard.noPlanTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>No active training plan yet</target>
       </segment>
     </unit>
     <unit id="dashboard.noPlanSubtitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Pick a plan to have your daily goal set automatically. </target>
       </segment>
     </unit>
     <unit id="dashboard.noPlanCta">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Pick a plan </target>
       </segment>
     </unit>
     <unit id="dashboard.goalEditAria">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Open daily goal in settings</target>
       </segment>
     </unit>
     <unit id="dashboard.lastEntryLinkAria">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Open last entry in history</target>
       </segment>
     </unit>
     <unit id="settings.displayNameHint.leaderboardLink">
       <segment state="translated">
-        <source/>
+        <source />
         <target>View leaderboard</target>
       </segment>
     </unit>
     <unit id="settings.publicProfile.previewCta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">visibility</pc> Preview</target>
       </segment>
     </unit>
     <unit id="settings.goals.planOverrideHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> An active training plan sets your daily goal automatically. Manual values only apply once the plan ends. </target>
       </segment>
     </unit>
     <unit id="settings.goals.openActivePlan">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Open active plan</target>
       </segment>
     </unit>
     <unit id="settings.adsConsent.privacyLink">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Privacy policy</target>
       </segment>
     </unit>
     <unit id="leaderboard.visibilityHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Want to change your visibility or display name? </target>
       </segment>
     </unit>
     <unit id="leaderboard.visibilityHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Open settings</target>
       </segment>
     </unit>
     <unit id="leaderboard.loginHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Want to compete and show up here? </target>
       </segment>
     </unit>
     <unit id="leaderboard.loginHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Sign in</target>
       </segment>
     </unit>
     <unit id="trainingPlans.goalOverrideHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Your daily goal is set by the plan. </target>
       </segment>
     </unit>
     <unit id="trainingPlans.goalOverrideHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Adjust manual goals</target>
       </segment>
     </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>No entries yet.</target>
       </segment>
     </unit>
     <unit id="entries.empty.body">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Add your first training entry — your history will appear here. </target>
       </segment>
     </unit>
     <unit id="entries.empty.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc> Create entry</target>
       </segment>
     </unit>
     <unit id="analysis.empty.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>No data to analyse yet.</target>
       </segment>
     </unit>
     <unit id="analysis.empty.body">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Start a training plan or log your first set — we'll show trends and streaks here. </target>
       </segment>
     </unit>
     <unit id="analysis.empty.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Pick a training plan</target>
       </segment>
     </unit>
     <unit id="analysis.tabs.overview">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Overview</target>
       </segment>
     </unit>
     <unit id="analysis.overview.empty">
       <segment state="translated">
-        <source/>
+        <source />
         <target>No entries in the current date range yet.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.uncategorisedNotice">
       <segment state="translated">
-        <source/>
+        <source />
         <target>These entries don't belong to a known category — aggregate below.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Comparison by exercise group</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
-        <source/>
+        <source />
         <target>No data in the current date range.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalReps">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Total reps</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Today</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Best day</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Streak</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metricLabel">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Training sessions</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.repsTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Reps</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalSets">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Total sets</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.timeTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Time</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalTime">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Total time</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayTime">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Today</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.distanceTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Distance</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalDistance">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Total distance</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayDistance">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Today</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.distanceTimeTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Distance &amp; Time</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.entries">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Training sessions</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <segment state="translated">
-        <source/>
+        <source />
         <target>View details</target>
       </segment>
     </unit>
     <unit id="dashboard.allTimeBadges.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Open analysis</target>
       </segment>
     </unit>
@@ -8274,579 +8270,579 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
       <unit id="exercise.category.push">
-      <segment state="initial">
+      <segment state="translated">
         <source>Drücken</source>
-        <target>Drücken</target>
+        <target>Push</target>
       </segment>
     </unit>
     <unit id="exercise.category.pull">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziehen</source>
-        <target>Ziehen</target>
+        <target>Pull</target>
       </segment>
     </unit>
     <unit id="exercise.category.squat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kniebeuge</source>
-        <target>Kniebeuge</target>
+        <target>Squat</target>
       </segment>
     </unit>
     <unit id="exercise.category.hinge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftstreckung</source>
-        <target>Hüftstreckung</target>
+        <target>Hinge</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausfallschritt</source>
-        <target>Ausfallschritt</target>
+        <target>Lunge</target>
       </segment>
     </unit>
     <unit id="exercise.category.carry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tragen</source>
-        <target>Tragen</target>
+        <target>Carry</target>
       </segment>
     </unit>
     <unit id="exercise.category.core">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rumpf</source>
-        <target>Rumpf</target>
+        <target>Core</target>
       </segment>
     </unit>
     <unit id="exercise.category.mobility">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mobilität</source>
-        <target>Mobilität</target>
+        <target>Mobility</target>
       </segment>
     </unit>
     <unit id="exercise.category.strength">
-      <segment state="initial">
+      <segment state="translated">
         <source>Krafttraining</source>
-        <target>Krafttraining</target>
+        <target>Strength</target>
       </segment>
     </unit>
     <unit id="exercise.core.deadbug.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Bug</source>
         <target>Dead Bug</target>
       </segment>
     </unit>
     <unit id="exercise.core.hollowhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
         <target>Hollow Hold</target>
       </segment>
     </unit>
     <unit id="exercise.squat.wallsit.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wandsitz</source>
-        <target>Wandsitz</target>
+        <target>Wall Sit</target>
       </segment>
     </unit>
     <unit id="exercise.squat.boxjump.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Box Jumps</source>
         <target>Box Jumps</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.singlelegRdl.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeiniges Kreuzheben</source>
-        <target>Einbeiniges Kreuzheben</target>
+        <target>Single-Leg Deadlift</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.goodmorning.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Good Morning</source>
         <target>Good Morning</target>
       </segment>
     </unit>
     <unit id="exercise.lunge.stepup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Step-ups</source>
         <target>Step-ups</target>
       </segment>
     </unit>
     <unit id="exercise.pull.pullups.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Klimmzüge</source>
-        <target>Klimmzüge</target>
+        <target>Pull-ups</target>
       </segment>
     </unit>
     <unit id="exercise.pull.rows.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ruderzug</source>
-        <target>Ruderzug</target>
+        <target>Rows</target>
       </segment>
     </unit>
     <unit id="exercise.pull.deadhang.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Hang</source>
         <target>Dead Hang</target>
       </segment>
     </unit>
     <unit id="exercise.pull.facepull.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Face Pull</source>
         <target>Face Pull</target>
       </segment>
     </unit>
     <unit id="exercise.carry.farmer.name">
-      <segment state="initial">
-        <source>Farmer&apos;s Walk</source>
-        <target>Farmer&apos;s Walk</target>
+      <segment state="translated">
+        <source>Farmer's Walk</source>
+        <target>Farmer's Walk</target>
       </segment>
     </unit>
     <unit id="exercise.carry.suitcase.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Suitcase Carry</source>
         <target>Suitcase Carry</target>
       </segment>
     </unit>
     <unit id="exercise.carry.overhead.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Overhead Carry</source>
         <target>Overhead Carry</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.walking.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gehen</source>
-        <target>Gehen</target>
+        <target>Walking</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.cycling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Radfahren</source>
-        <target>Radfahren</target>
+        <target>Cycling</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.rowing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rudern</source>
-        <target>Rudern</target>
+        <target>Rowing</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.swimming.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schwimmen</source>
-        <target>Schwimmen</target>
+        <target>Swimming</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumprope.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seilspringen</source>
-        <target>Seilspringen</target>
+        <target>Jump Rope</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.burpees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Burpees</source>
         <target>Burpees</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumpingjacks.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hampelmänner</source>
-        <target>Hampelmänner</target>
+        <target>Jumping Jacks</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.highknees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>High Knees</source>
         <target>High Knees</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.stretching.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dehnen</source>
-        <target>Dehnen</target>
+        <target>Stretching</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.yoga.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Yoga</source>
         <target>Yoga</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.foamrolling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Faszienrolle</source>
-        <target>Faszienrolle</target>
+        <target>Foam Rolling</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dynamisches Aufwärmen</source>
-        <target>Dynamisches Aufwärmen</target>
+        <target>Dynamic Warm-up</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.catcow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Katze-Kuh</source>
-        <target>Katze-Kuh</target>
+        <target>Cat-Cow</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.hipopener.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftöffner</source>
-        <target>Hüftöffner</target>
+        <target>Hip Opener</target>
       </segment>
     </unit>
     <unit id="exercise.strength.benchpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdrücken</source>
-        <target>Bankdrücken</target>
+        <target>Bench Press</target>
       </segment>
     </unit>
     <unit id="exercise.strength.overheadpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schulterdrücken</source>
-        <target>Schulterdrücken</target>
+        <target>Overhead Press</target>
       </segment>
     </unit>
     <unit id="exercise.strength.deadlift.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kreuzheben</source>
-        <target>Kreuzheben</target>
+        <target>Deadlift</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellsquat.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel-Kniebeuge</source>
-        <target>Langhantel-Kniebeuge</target>
+        <target>Barbell Squat</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellrow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantelrudern</source>
-        <target>Langhantelrudern</target>
+        <target>Barbell Row</target>
       </segment>
     </unit>
     <unit id="exercise.strength.kettlebellswing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kettlebell Swing</source>
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
       <unit id="exercise.variant.situps.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source>Decline</source>
         <target>Decline</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Weighted</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reverse Crunches</source>
         <target>Reverse Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.bicycle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bicycle Crunches</source>
         <target>Bicycle Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.oblique">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schräge Crunches</source>
-        <target>Schräge Crunches</target>
+        <target>Oblique Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.lying">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegend</source>
-        <target>Liegend</target>
+        <target>Lying</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-knee">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (Knie)</source>
-        <target>Hängend (Knie)</target>
+        <target>Hanging (Knee)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-straight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (gestreckt)</source>
-        <target>Hängend (gestreckt)</target>
+        <target>Hanging (Straight)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Bodyweight</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Weighted</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.cross-body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Cross-Body</source>
         <target>Cross-Body</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.forearm">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unterarmstütz</source>
-        <target>Unterarmstütz</target>
+        <target>Forearm Plank</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.side">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Side</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Umgekehrt</source>
-        <target>Umgekehrt</target>
+        <target>Reverse</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Bodyweight</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.sumo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sumo</source>
         <target>Sumo</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.goblet">
-      <segment state="initial">
+      <segment state="translated">
         <source>Goblet</source>
         <target>Goblet</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bulgarian-split">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bulgarian Split</source>
         <target>Bulgarian Split</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.pistol">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pistol</source>
         <target>Pistol</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>Single-Leg</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.seated">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sitzend</source>
-        <target>Sitzend</target>
+        <target>Seated</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>Single-Leg</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.hip-thrust">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hip Thrust</source>
         <target>Hip Thrust</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.march">
-      <segment state="initial">
+      <segment state="translated">
         <source>Marching</source>
         <target>Marching</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.forward">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorwärts</source>
-        <target>Vorwärts</target>
+        <target>Forward</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückwärts</source>
-        <target>Rückwärts</target>
+        <target>Reverse</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.walking">
-      <segment state="initial">
+      <segment state="translated">
         <source>Walking</source>
         <target>Walking</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.lateral">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Lateral</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.curtsy">
-      <segment state="initial">
+      <segment state="translated">
         <source>Curtsy</source>
         <target>Curtsy</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.jumping">
-      <segment state="initial">
+      <segment state="translated">
         <source>Jumping</source>
         <target>Jumping</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.chin-up">
-      <segment state="initial">
+      <segment state="translated">
         <source>Chin-up</source>
         <target>Chin-up</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.wide-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Breiter Griff</source>
-        <target>Breiter Griff</target>
+        <target>Wide Grip</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.neutral-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neutraler Griff</source>
-        <target>Neutraler Griff</target>
+        <target>Neutral Grip</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.negative">
-      <segment state="initial">
+      <segment state="translated">
         <source>Negativ</source>
-        <target>Negativ</target>
+        <target>Negative</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.assisted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Assistiert</source>
-        <target>Assistiert</target>
+        <target>Assisted</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.archer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Archer</source>
         <target>Archer</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.inverted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Inverted Row</source>
         <target>Inverted Row</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.australian">
-      <segment state="initial">
+      <segment state="translated">
         <source>Australian Row</source>
         <target>Australian Row</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.dumbbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kurzhantel</source>
-        <target>Kurzhantel</target>
+        <target>Dumbbell</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.barbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel</source>
-        <target>Langhantel</target>
+        <target>Barbell</target>
       </segment>
     </unit>
     <unit id="exercise.push.dips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dips</source>
         <target>Dips</target>
       </segment>
     </unit>
     <unit id="exercise.push.benchdips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdips</source>
-        <target>Bankdips</target>
+        <target>Bench Dips</target>
       </segment>
     </unit>
     <unit id="exercise.push.handstandhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Handstand-Hold</source>
-        <target>Handstand-Hold</target>
+        <target>Handstand Hold</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.parallel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Barren</source>
-        <target>Barren</target>
+        <target>Parallel Bars</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.straight-bar">
-      <segment state="initial">
+      <segment state="translated">
         <source>Stange</source>
-        <target>Stange</target>
+        <target>Straight Bar</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.ring">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ringe</source>
-        <target>Ringe</target>
+        <target>Rings</target>
       </segment>
     </unit>
       <unit id="exerciseTimer.title">
@@ -9613,8 +9609,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="plan.push-pull-6w.summary">
       <segment state="translated">
-        <source>Symmetrischer 6-Wochen-Plan für Liegestütze und Rückenübungen (Rudern, Klimmzug-Negative, Face Pulls). Vermeidet das klassische &quot;nur Push&quot;-Ungleichgewicht und stärkt die hintere Kette gleichwertig. Pull-Tag pro Woche zusätzlich zur Push-Progression.</source>
-        <target>Symmetric 6-week plan for push-ups and pulling work (rows, pull-up negatives, face pulls). Avoids the classic &quot;push only&quot; imbalance and strengthens the posterior chain equally. One dedicated pull day per week on top of the push progression.</target>
+        <source>Symmetrischer 6-Wochen-Plan für Liegestütze und Rückenübungen (Rudern, Klimmzug-Negative, Face Pulls). Vermeidet das klassische "nur Push"-Ungleichgewicht und stärkt die hintere Kette gleichwertig. Pull-Tag pro Woche zusätzlich zur Push-Progression.</source>
+        <target>Symmetric 6-week plan for push-ups and pulling work (rows, pull-up negatives, face pulls). Avoids the classic "push only" imbalance and strengthens the posterior chain equally. One dedicated pull day per week on top of the push progression.</target>
       </segment>
     </unit>
     <unit id="plan.full-body-6w.title">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="de" trgLang="es">
+<?xml version='1.0' encoding='utf-8'?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="de" trgLang="es">
   <file id="ngi18n" original="ng.template">
     <unit id="consent.banner.aria">
       <notes>
@@ -860,8 +860,8 @@
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:45,46</note>
       </notes>
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> bis zum Ziel</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> al destino</target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> bis zum Ziel</source>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> al destino</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.quickAddReps">
@@ -869,8 +869,8 @@
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:59,60</note>
       </notes>
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> Representantes</target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> Reps</source>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> Representantes</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.open">
@@ -914,8 +914,8 @@
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:71</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
-        <target><ph id="0" equiv="REPS" disp="reps"/> Añadir flexiones</target>
+        <source><ph id="0" equiv="REPS" disp="reps" /> Liegestütze hinzufügen</source>
+        <target><ph id="0" equiv="REPS" disp="reps" /> Añadir flexiones</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
@@ -923,8 +923,8 @@
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:75</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="GAP" disp="gap"/> Liegestütze bis zum Tagesziel hinzufügen</source>
-        <target><ph id="0" equiv="GAP" disp="gap"/> Añadir flexiones hasta el objetivo diario</target>
+        <source><ph id="0" equiv="GAP" disp="gap" /> Liegestütze bis zum Tagesziel hinzufügen</source>
+        <target><ph id="0" equiv="GAP" disp="gap" /> Añadir flexiones hasta el objetivo diario</target>
       </segment>
     </unit>
     <unit id="reminder.quickLog.success">
@@ -932,8 +932,8 @@
         <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:70</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="reps" disp="reps"/> Push-ups eingetragen ✓</source>
-        <target><ph id="0" equiv="reps" disp="reps"/> flexiones ingresadas ✓</target>
+        <source><ph id="0" equiv="reps" disp="reps" /> Push-ups eingetragen ✓</source>
+        <target><ph id="0" equiv="reps" disp="reps" /> flexiones ingresadas ✓</target>
       </segment>
     </unit>
     <unit id="snackbar.close">
@@ -994,8 +994,8 @@
         <note category="location">web/src/app/admin/admin-page.component.ts:97,100</note>
       </notes>
       <segment state="translated">
-        <source> Löscht anonyme Benutzer ohne Pushups in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}"/> Tagen. </source>
-        <target> Elimina usuarios anónimos sin flexiones en los últimos días <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}"/>. </target>
+        <source> Löscht anonyme Benutzer ohne Pushups in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}" /> Tagen. </source>
+        <target> Elimina usuarios anónimos sin flexiones en los últimos días <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}" />. </target>
       </segment>
     </unit>
     <unit id="admin.bulk.button">
@@ -1228,8 +1228,8 @@
         <note category="location">web/src/app/admin/admin-page.component.ts:770</note>
       </notes>
       <segment state="translated">
-        <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Abrir detalles para <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier" /></source>
+        <target>Abrir detalles para <ph id="0" equiv="identifier" disp="identifier" /></target>
       </segment>
     </unit>
     <unit id="admin.feedback.delete.title">
@@ -1968,8 +1968,8 @@
         <note category="location">web/src/app/blog/blog-article.component.ts:60,61</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}"/> Min. Lesezeit</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}"/> Mín. tiempo de lectura</target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}" /> Min. Lesezeit</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}" /> Mín. tiempo de lectura</target>
       </segment>
     </unit>
     <unit id="blog.article.updated">
@@ -2222,8 +2222,8 @@
         <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:74,76</note>
       </notes>
       <segment state="translated">
-        <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}"/> Reps </source>
-        <target> Tu puesto: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}"/> Representantes </target>
+        <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}" /> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}" /> Reps </source>
+        <target> Tu puesto: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}" /> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}" /> Representantes </target>
       </segment>
     </unit>
     <unit id="reminder.feature.eyebrow">
@@ -3252,8 +3252,8 @@
         <note category="location">web/src/app/public-profile/public-profile-page.component.ts:129</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze auf Pushup Tracker geschafft 💪 Schau&apos;s dir an:</source>
-        <target><ph id="0" equiv="name" disp="profile.displayName"/> hizo flexiones <ph id="1" equiv="total" disp="profile.total"/> en Pushup Tracker 💪 Compruébalo:</target>
+        <source><ph id="0" equiv="name" disp="profile.displayName" /> hat <ph id="1" equiv="total" disp="profile.total" /> Liegestütze auf Pushup Tracker geschafft 💪 Schau's dir an:</source>
+        <target><ph id="0" equiv="name" disp="profile.displayName" /> hizo flexiones <ph id="1" equiv="total" disp="profile.total" /> en Pushup Tracker 💪 Compruébalo:</target>
       </segment>
     </unit>
     <unit id="publicProfile.share.title">
@@ -3288,8 +3288,8 @@
         <note category="location">web/src/app/public-profile/public-profile-page.component.ts:192</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="profile.displayName"/> – <ph id="1" equiv="total" disp="profile.total"/> Liegestütze · Streak <ph id="2" equiv="streak" disp="profile.currentStreak"/> · Pushup Tracker</source>
-        <target><ph id="0" equiv="name" disp="profile.displayName"/> – <ph id="1" equiv="total" disp="profile.total"/> Flexiones · Racha <ph id="2" equiv="streak" disp="profile.currentStreak"/> · Pushup Tracker</target>
+        <source><ph id="0" equiv="name" disp="profile.displayName" /> – <ph id="1" equiv="total" disp="profile.total" /> Liegestütze · Streak <ph id="2" equiv="streak" disp="profile.currentStreak" /> · Pushup Tracker</source>
+        <target><ph id="0" equiv="name" disp="profile.displayName" /> – <ph id="1" equiv="total" disp="profile.total" /> Flexiones · Racha <ph id="2" equiv="streak" disp="profile.currentStreak" /> · Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="publicProfile.seo.description">
@@ -3297,8 +3297,8 @@
         <note category="location">web/src/app/public-profile/public-profile-page.component.ts:193</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze in <ph id="2" equiv="days" disp="profile.totalDays"/> aktiven Tagen geschafft – aktuelle Streak: <ph id="3" equiv="streak" disp="profile.currentStreak"/> Tage. Tracke selbst kostenlos auf pushup-stats.com.</source>
-        <target><ph id="0" equiv="name" disp="profile.displayName"/> ha completado flexiones <ph id="1" equiv="total" disp="profile.total"/> en días activos <ph id="2" equiv="days" disp="profile.totalDays"/> - racha actual: días <ph id="3" equiv="streak" disp="profile.currentStreak"/>. Realice un seguimiento gratuito en pushup-stats.com.</target>
+        <source><ph id="0" equiv="name" disp="profile.displayName" /> hat <ph id="1" equiv="total" disp="profile.total" /> Liegestütze in <ph id="2" equiv="days" disp="profile.totalDays" /> aktiven Tagen geschafft – aktuelle Streak: <ph id="3" equiv="streak" disp="profile.currentStreak" /> Tage. Tracke selbst kostenlos auf pushup-stats.com.</source>
+        <target><ph id="0" equiv="name" disp="profile.displayName" /> ha completado flexiones <ph id="1" equiv="total" disp="profile.total" /> en días activos <ph id="2" equiv="days" disp="profile.totalDays" /> - racha actual: días <ph id="3" equiv="streak" disp="profile.currentStreak" />. Realice un seguimiento gratuito en pushup-stats.com.</target>
       </segment>
     </unit>
     <unit id="publicProfile.seo.imageAlt">
@@ -3306,8 +3306,8 @@
         <note category="location">web/src/app/public-profile/public-profile-page.component.ts:206</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="profile.displayName"/> auf Pushup Tracker</source>
-        <target><ph id="0" equiv="name" disp="profile.displayName"/> en el rastreador de flexiones</target>
+        <source><ph id="0" equiv="name" disp="profile.displayName" /> auf Pushup Tracker</source>
+        <target><ph id="0" equiv="name" disp="profile.displayName" /> en el rastreador de flexiones</target>
       </segment>
     </unit>
     <unit id="reminders.page.title">
@@ -3495,7 +3495,7 @@
         <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:164,167</note>
       </notes>
       <segment state="translated">
-        <source> Zeigt einen &quot;Eintragen&quot;-Button auf der Push-Benachrichtigung. Wenn die App schon geöffnet ist, wird der Eintrag im Hintergrund gespeichert; ansonsten öffnet sich kurz ein Tab, der den Eintrag automatisch anlegt. </source>
+        <source> Zeigt einen "Eintragen"-Button auf der Push-Benachrichtigung. Wenn die App schon geöffnet ist, wird der Eintrag im Hintergrund gespeichert; ansonsten öffnet sich kurz ein Tab, der den Eintrag automatisch anlegt. </source>
         <target> Muestra un botón "Suscribirse" en la notificación push. Si la aplicación ya está abierta, la entrada se guarda en segundo plano; de lo contrario, se abrirá brevemente una pestaña que creará automáticamente la entrada. </target>
       </segment>
     </unit>
@@ -3657,8 +3657,8 @@
         <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:340,341</note>
       </notes>
       <segment state="translated">
-        <source> Aktiv auf <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}"/> Geräten </source>
-        <target> Activo en dispositivos <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}"/> </target>
+        <source> Aktiv auf <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}" /> Geräten </source>
+        <target> Activo en dispositivos <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}" /> </target>
       </segment>
     </unit>
     <unit id="push.cta.desc">
@@ -3812,8 +3812,8 @@
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:49,50</note>
       </notes>
       <segment state="translated">
-        <source>Streak: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}"/> Tage</source>
-        <target>Racha: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}"/> días</target>
+        <source>Streak: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}" /> Tage</source>
+        <target>Racha: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}" /> días</target>
       </segment>
     </unit>
     <unit id="dashboard.analysisTeaserWeekReps">
@@ -3821,8 +3821,8 @@
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:53,55</note>
       </notes>
       <segment state="translated">
-        <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> Reps</source>
-        <target>Esta semana: Representantes de <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> /<ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/></target>
+        <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}" /> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}" /> Reps</source>
+        <target>Esta semana: Representantes de <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}" /> /<ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}" /></target>
       </segment>
     </unit>
     <unit id="dashboard.analysisTeaserError">
@@ -3884,8 +3884,8 @@
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:117,118</note>
       </notes>
       <segment state="translated">
-        <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Establecer <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
+        <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></source>
+        <target>Establecer <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></target>
       </segment>
     </unit>
     <unit id="repsLabel">
@@ -3929,8 +3929,8 @@
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:158,160</note>
       </notes>
       <segment state="translated">
-        <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
-        <target> Total: Representantes <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> </target>
+        <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}" /> Reps </source>
+        <target> Total: Representantes <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}" /> </target>
       </segment>
     </unit>
     <unit id="typeLabel">
@@ -3998,14 +3998,14 @@
     </unit>
     <unit id="entryDialog.overCapDuration">
       <segment state="translated">
-        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
-        <target>Duración máxima: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}" /></source>
+        <target>Duración máxima: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}" /></target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
-        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
-        <target>Máximo: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}" /></source>
+        <target>Máximo: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}" /></target>
       </segment>
     </unit>
     <unit id="exercise.category.plank">
@@ -4046,8 +4046,8 @@
     </unit>
     <unit id="entryDialog.overCap">
       <segment state="translated">
-        <source> Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> pro Eintrag </source>
-        <target> Máximo: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> por entrada </target>
+        <source> Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}" /> pro Eintrag </source>
+        <target> Máximo: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}" /> por entrada </target>
       </segment>
     </unit>
     <unit id="exerciseSection.lastEntry">
@@ -4379,8 +4379,8 @@
         <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:84</note>
       </notes>
       <segment state="translated">
-        <source>Wochenziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Meta semanal de flexiones <ph id="0" equiv="goal" disp="goal"/> logradas - ¡<ph id="1" equiv="total" disp="total"/> total! 💪 Realice un seguimiento de sus estadísticas de forma gratuita:</target>
+        <source>Wochenziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen geschafft – <ph id="1" equiv="total" disp="total" /> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Meta semanal de flexiones <ph id="0" equiv="goal" disp="goal" /> logradas - ¡<ph id="1" equiv="total" disp="total" /> total! 💪 Realice un seguimiento de sus estadísticas de forma gratuita:</target>
       </segment>
     </unit>
     <unit id="goalReached.monthly.title">
@@ -4415,8 +4415,8 @@
         <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:92</note>
       </notes>
       <segment state="translated">
-        <source>Monatsziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Meta mensual de flexiones <ph id="0" equiv="goal" disp="goal"/> logradas - ¡<ph id="1" equiv="total" disp="total"/> total! 💪 Realice un seguimiento de sus estadísticas de forma gratuita:</target>
+        <source>Monatsziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen geschafft – <ph id="1" equiv="total" disp="total" /> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Meta mensual de flexiones <ph id="0" equiv="goal" disp="goal" /> logradas - ¡<ph id="1" equiv="total" disp="total" /> total! 💪 Realice un seguimiento de sus estadísticas de forma gratuita:</target>
       </segment>
     </unit>
     <unit id="goalReached.plan.title">
@@ -4451,8 +4451,8 @@
         <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:100</note>
       </notes>
       <segment state="translated">
-        <source>Heute mein Trainingsplan-Ziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen erreicht – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
-        <target>¡Hoy alcancé mi objetivo del plan de entrenamiento de <ph id="0" equiv="goal" disp="goal"/> flexiones – <ph id="1" equiv="total" disp="total"/> en total! 💪 Sigue tus estadísticas gratis:</target>
+        <source>Heute mein Trainingsplan-Ziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen erreicht – <ph id="1" equiv="total" disp="total" /> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
+        <target>¡Hoy alcancé mi objetivo del plan de entrenamiento de <ph id="0" equiv="goal" disp="goal" /> flexiones – <ph id="1" equiv="total" disp="total" /> en total! 💪 Sigue tus estadísticas gratis:</target>
       </segment>
     </unit>
     <unit id="goalReached.daily.title">
@@ -4487,8 +4487,8 @@
         <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:100</note>
       </notes>
       <segment state="translated">
-        <source>Heute mein Tagesziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft! 💪 Tracke deine Stats kostenlos:</source>
-        <target>¡Hoy logré mi objetivo diario de flexiones <ph id="0" equiv="goal" disp="goal"/>! 💪 Realice un seguimiento de sus estadísticas de forma gratuita:</target>
+        <source>Heute mein Tagesziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen geschafft! 💪 Tracke deine Stats kostenlos:</source>
+        <target>¡Hoy logré mi objetivo diario de flexiones <ph id="0" equiv="goal" disp="goal" />! 💪 Realice un seguimiento de sus estadísticas de forma gratuita:</target>
       </segment>
     </unit>
     <unit id="goalReached.snapAria">
@@ -4619,8 +4619,8 @@
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:40,42</note>
       </notes>
       <segment state="translated">
-        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> eigene Reps-Buttons fest. Leere Felder werden ignoriert. </source>
-        <target> Configure los botones de repetición personalizados <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/>. Los campos vacíos se ignoran. </target>
+        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> eigene Reps-Buttons fest. Leere Felder werden ignoriert. </source>
+        <target> Configure los botones de repetición personalizados <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" />. Los campos vacíos se ignoran. </target>
       </segment>
     </unit>
     <unit id="quickAddConfig.repsLabel">
@@ -4678,45 +4678,45 @@
       </segment>
     </unit>
     <unit id="intervalsDistribution.noData">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Intervall-Daten vorhanden</source>
-        <target>Keine Intervall-Daten vorhanden</target>
+        <target>No hay datos de intervalo</target>
       </segment>
     </unit>
     <unit id="intervalsDistribution.listLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Verteilung</source>
-        <target>Intervall-Verteilung</target>
+        <target>Distribución de intervalos</target>
       </segment>
     </unit>
     <unit id="entry.interval.label">
-      <segment state="initial">
-        <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
+      <segment state="translated">
+        <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></source>
+        <target>Intervalo  <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></target>
       </segment>
     </unit>
     <unit id="entry.intervals.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervalle</source>
-        <target>Intervalle</target>
+        <target>Intervalos</target>
       </segment>
     </unit>
     <unit id="entry.intervals.remove">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall entfernen</source>
-        <target>Intervall entfernen</target>
+        <target>Eliminar intervalo</target>
       </segment>
     </unit>
     <unit id="entry.intervals.add">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall hinzufügen</source>
-        <target>Intervall hinzufügen</target>
+        <target>Agregar intervalo</target>
       </segment>
     </unit>
     <unit id="entry.intervals.addTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Weiteres Intervall hinzufügen</source>
-        <target>Weiteres Intervall hinzufügen</target>
+        <target>Agregar intervalo adicional</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.reps">
@@ -4899,8 +4899,8 @@
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:5</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/> Einträge</source>
-        <target>Entradas <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/></target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}" /> Einträge</source>
+        <target>Entradas <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}" /></target>
       </segment>
     </unit>
     <unit id="sourceColumnToggle">
@@ -4908,12 +4908,8 @@
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:15,20</note>
       </notes>
       <segment state="translated">
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-        showSourceColumn() ? &apos;visibility&apos; : &apos;visibility_off&apos;
-      }}"/></pc> Quelle </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-        showSourceColumn()? &apos;visibility&apos;: &apos;visibility_off&apos;
-      }}"/></pc> Fuente </target>
+        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{         showSourceColumn() ? 'visibility' : 'visibility_off'       }}" /></pc> Quelle </source>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{         showSourceColumn()? 'visibility': 'visibility_off'       }}" /></pc> Fuente </target>
       </segment>
     </unit>
     <unit id="createNewEntry">
@@ -5080,8 +5076,8 @@
         <note category="location">web/src/app/stats/dashboard.store.ts:436</note>
       </notes>
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Schau dir mein Profil an:</source>
-        <target>Ya hice flexiones <ph id="0" equiv="total" disp="total"/> hoy – Racha: días <ph id="1" equiv="streak" disp="streak"/> 🔥 Mira mi perfil:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak" /> Tage 🔥 Schau dir mein Profil an:</source>
+        <target>Ya hice flexiones <ph id="0" equiv="total" disp="total" /> hoy – Racha: días <ph id="1" equiv="streak" disp="streak" /> 🔥 Mira mi perfil:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.simple">
@@ -5089,8 +5085,8 @@
         <note category="location">web/src/app/stats/dashboard.store.ts:437</note>
       </notes>
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
-        <target>¡<ph id="0" equiv="total" disp="total"/> flexiones hechas hoy! 💪 Mira mi perfil:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
+        <target>¡<ph id="0" equiv="total" disp="total" /> flexiones hechas hoy! 💪 Mira mi perfil:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.streak">
@@ -5098,8 +5094,8 @@
         <note category="location">web/src/app/stats/dashboard.store.ts:441</note>
       </notes>
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
-        <target>Flexiones <ph id="0" equiv="total" disp="total"/> ya hechas hoy – Racha: días <ph id="1" equiv="streak" disp="streak"/> 🔥 Realice un seguimiento de sus estadísticas de forma gratuita:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak" /> Tage 🔥 Tracke deine Stats kostenlos:</source>
+        <target>Flexiones <ph id="0" equiv="total" disp="total" /> ya hechas hoy – Racha: días <ph id="1" equiv="streak" disp="streak" /> 🔥 Realice un seguimiento de sus estadísticas de forma gratuita:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.simple">
@@ -5107,8 +5103,8 @@
         <note category="location">web/src/app/stats/dashboard.store.ts:442</note>
       </notes>
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
-        <target>¡Ya hice flexiones <ph id="0" equiv="total" disp="total"/> hoy! 💪 Realice un seguimiento de sus estadísticas de forma gratuita:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
+        <target>¡Ya hice flexiones <ph id="0" equiv="total" disp="total" /> hoy! 💪 Realice un seguimiento de sus estadísticas de forma gratuita:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.title">
@@ -5254,8 +5250,8 @@
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:194,195</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}"/> Tage</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}"/> días</target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}" /> Tage</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}" /> días</target>
       </segment>
     </unit>
     <unit id="analysis.longestStreak">
@@ -5522,7 +5518,7 @@
     </unit>
     <unit id="settings.leaderboardRequiresPublicProfile">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Solo los perfiles con Perfil público activado aparecen en la tabla de clasificación. Activa «Perfil público» abajo para usar esta opción. </target>
       </segment>
     </unit>
@@ -5891,8 +5887,8 @@
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:23,25</note>
       </notes>
       <segment state="translated">
-        <source> Live: <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;verbunden&apos; : &apos;getrennt&apos; }}"/> </source>
-        <target> En vivo: <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected()? &apos;verbunden&apos;: &apos;getrennt&apos; }}"/> </target>
+        <source> Live: <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? 'verbunden' : 'getrennt' }}" /> </source>
+        <target> En vivo: <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected()? 'verbunden': 'getrennt' }}" /> </target>
       </segment>
     </unit>
     <unit id="allTimeSummaryAria">
@@ -6079,8 +6075,8 @@
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:163,165</note>
       </notes>
       <segment state="translated">
-        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/> </source>
-        <target> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/> </target>
+        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}" /> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || 'Standard' }}" /> </source>
+        <target> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}" /> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || 'Standard' }}" /> </target>
       </segment>
     </unit>
     <unit id="dashboard.noEntryYet">
@@ -6124,8 +6120,8 @@
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
       </notes>
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Representantes</target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /> Reps</source>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /> Representantes</target>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.reached">
@@ -6142,8 +6138,8 @@
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:225,226</note>
       </notes>
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> bis zum Ziel</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> al destino</target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}" /> bis zum Ziel</source>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}" /> al destino</target>
       </segment>
     </unit>
     <unit id="quickAddNew">
@@ -6205,8 +6201,8 @@
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:110</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="label" disp="label"/> in der Historie öffnen</source>
-        <target>Abrir <ph id="0" equiv="label" disp="label"/> en el historial</target>
+        <source><ph id="0" equiv="label" disp="label" /> in der Historie öffnen</source>
+        <target>Abrir <ph id="0" equiv="label" disp="label" /> en el historial</target>
       </segment>
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
@@ -6430,8 +6426,8 @@
     </unit>
     <unit id="trainingPlans.jumped">
       <segment state="translated">
-        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
-        <target>Saltado al día <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex" /> gesprungen.</source>
+        <target>Saltado al día <ph id="0" equiv="INTERPOLATION" disp="dayIndex" />.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.notFound">
@@ -6642,7 +6638,7 @@
       </segment>
     </unit>
 
-    <!-- Pushup-types wiki page -->
+    
     <unit id="seo.wiki.pushupTypes.title">
       <segment state="translated">
         <source>Liegestütztypen erklärt – Pushup Tracker</source>
@@ -6710,7 +6706,7 @@
       </segment>
     </unit>
 
-    <!-- Exercises wiki page -->
+    
     <unit id="seo.wiki.exercises.title">
       <segment state="translated">
         <source>Übungen erklärt – Pushup Tracker</source>
@@ -7781,265 +7777,265 @@
     </unit>
     <unit id="leaderboard.visibilityHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> ¿Cambiar la visibilidad o el nombre? </target>
       </segment>
     </unit>
     <unit id="leaderboard.visibilityHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Abrir configuración</target>
       </segment>
     </unit>
     <unit id="leaderboard.loginHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> ¿Quieres participar y aparecer aquí? </target>
       </segment>
     </unit>
     <unit id="leaderboard.loginHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Iniciar sesión</target>
       </segment>
     </unit>
     <unit id="analysis.empty.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Aún no hay datos para analizar.</target>
       </segment>
     </unit>
     <unit id="analysis.empty.body">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Inicia un plan de entrenamiento o registra tu primera serie y mostraremos tendencias y rachas aquí. </target>
       </segment>
     </unit>
     <unit id="analysis.empty.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Elegir plan de entrenamiento </target>
       </segment>
     </unit>
     <unit id="analysis.tabs.overview">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Resumen</target>
       </segment>
     </unit>
     <unit id="analysis.overview.empty">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Aún no hay entradas en el rango de fechas actual.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.uncategorisedNotice">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Estas entradas no pertenecen a ninguna categoría conocida — agregado abajo.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Comparación por grupo de ejercicios</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
-        <source/>
+        <source />
         <target>No hay datos en el rango de fechas actual.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalReps">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Repeticiones totales</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Hoy</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Racha</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Mejor día</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metricLabel">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Sesiones</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.repsTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Repeticiones</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalSets">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Total de series</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.timeTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Tiempo</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalTime">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Tiempo total</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayTime">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Hoy</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.distanceTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Distancia</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalDistance">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Distancia total</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayDistance">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Hoy</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.distanceTimeTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Distancia y tiempo</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.entries">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Sesiones</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Ver detalles</target>
       </segment>
     </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Aún no hay entradas.</target>
       </segment>
     </unit>
     <unit id="entries.empty.body">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Añade tu primera entrada de entrenamiento — tu historial aparecerá aquí. </target>
       </segment>
     </unit>
     <unit id="entries.empty.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc> Crear entrada </target>
       </segment>
     </unit>
     <unit id="settings.displayNameHint.leaderboardLink">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Ver la clasificación</target>
       </segment>
     </unit>
     <unit id="settings.publicProfile.previewCta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">visibility</pc> Vista previa</target>
       </segment>
     </unit>
     <unit id="settings.goals.planOverrideHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Un plan de entrenamiento activo establece tu objetivo diario automáticamente. Los valores manuales solo se aplican al finalizar el plan. </target>
       </segment>
     </unit>
     <unit id="settings.goals.openActivePlan">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Abrir plan activo</target>
       </segment>
     </unit>
     <unit id="settings.adsConsent.privacyLink">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Política de privacidad</target>
       </segment>
     </unit>
     <unit id="dashboard.noPlanTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Aún no hay un plan de entrenamiento activo</target>
       </segment>
     </unit>
     <unit id="dashboard.noPlanSubtitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Elige un plan para que tu objetivo diario se fije automáticamente. </target>
       </segment>
     </unit>
     <unit id="dashboard.noPlanCta">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Elegir plan </target>
       </segment>
     </unit>
     <unit id="dashboard.goalEditAria">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Abrir el objetivo diario en la configuración</target>
       </segment>
     </unit>
     <unit id="dashboard.lastEntryLinkAria">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Abrir la última entrada en el historial</target>
       </segment>
     </unit>
     <unit id="dashboard.allTimeBadges.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Al análisis</target>
       </segment>
     </unit>
     <unit id="trainingPlans.goalOverrideHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> El objetivo diario lo establece el plan. </target>
       </segment>
     </unit>
     <unit id="trainingPlans.goalOverrideHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Ajustar objetivos manuales</target>
       </segment>
     </unit>
@@ -8074,711 +8070,711 @@
       </segment>
     </unit>
       <unit id="exercise.category.push">
-      <segment state="initial">
+      <segment state="translated">
         <source>Drücken</source>
-        <target>Drücken</target>
+        <target>Empujar</target>
       </segment>
     </unit>
     <unit id="exercise.category.pull">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziehen</source>
-        <target>Ziehen</target>
+        <target>Tirar</target>
       </segment>
     </unit>
     <unit id="exercise.category.squat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kniebeuge</source>
-        <target>Kniebeuge</target>
+        <target>Sentadilla</target>
       </segment>
     </unit>
     <unit id="exercise.category.hinge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftstreckung</source>
-        <target>Hüftstreckung</target>
+        <target>Extensión de cadera</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausfallschritt</source>
-        <target>Ausfallschritt</target>
+        <target>Estocada</target>
       </segment>
     </unit>
     <unit id="exercise.category.carry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tragen</source>
-        <target>Tragen</target>
+        <target>Levantamiento</target>
       </segment>
     </unit>
     <unit id="exercise.category.core">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rumpf</source>
-        <target>Rumpf</target>
+        <target>Core</target>
       </segment>
     </unit>
     <unit id="exercise.category.mobility">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mobilität</source>
-        <target>Mobilität</target>
+        <target>Movilidad</target>
       </segment>
     </unit>
     <unit id="exercise.category.strength">
-      <segment state="initial">
+      <segment state="translated">
         <source>Krafttraining</source>
-        <target>Krafttraining</target>
+        <target>Entrenamiento de fuerza</target>
       </segment>
     </unit>
     <unit id="exercise.core.deadbug.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Bug</source>
         <target>Dead Bug</target>
       </segment>
     </unit>
     <unit id="exercise.core.hollowhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
         <target>Hollow Hold</target>
       </segment>
     </unit>
     <unit id="exercise.squat.wallsit.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wandsitz</source>
-        <target>Wandsitz</target>
+        <target>Wall Sit</target>
       </segment>
     </unit>
     <unit id="exercise.squat.boxjump.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Box Jumps</source>
         <target>Box Jumps</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.singlelegRdl.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeiniges Kreuzheben</source>
-        <target>Einbeiniges Kreuzheben</target>
+        <target>Peso muerto de una pierna</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.goodmorning.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Good Morning</source>
         <target>Good Morning</target>
       </segment>
     </unit>
     <unit id="exercise.lunge.stepup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Step-ups</source>
         <target>Step-ups</target>
       </segment>
     </unit>
     <unit id="exercise.pull.pullups.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Klimmzüge</source>
-        <target>Klimmzüge</target>
+        <target>Dominadas</target>
       </segment>
     </unit>
     <unit id="exercise.pull.rows.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ruderzug</source>
-        <target>Ruderzug</target>
+        <target>Remo</target>
       </segment>
     </unit>
     <unit id="exercise.pull.deadhang.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Hang</source>
         <target>Dead Hang</target>
       </segment>
     </unit>
     <unit id="exercise.pull.facepull.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Face Pull</source>
         <target>Face Pull</target>
       </segment>
     </unit>
     <unit id="exercise.carry.farmer.name">
-      <segment state="initial">
-        <source>Farmer&apos;s Walk</source>
-        <target>Farmer&apos;s Walk</target>
+      <segment state="translated">
+        <source>Farmer's Walk</source>
+        <target>Farmer's Walk</target>
       </segment>
     </unit>
     <unit id="exercise.carry.suitcase.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Suitcase Carry</source>
         <target>Suitcase Carry</target>
       </segment>
     </unit>
     <unit id="exercise.carry.overhead.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Overhead Carry</source>
         <target>Overhead Carry</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.walking.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gehen</source>
-        <target>Gehen</target>
+        <target>Caminar</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.cycling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Radfahren</source>
-        <target>Radfahren</target>
+        <target>Ciclismo</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.rowing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rudern</source>
-        <target>Rudern</target>
+        <target>Remo</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.swimming.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schwimmen</source>
-        <target>Schwimmen</target>
+        <target>Natación</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumprope.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seilspringen</source>
-        <target>Seilspringen</target>
+        <target>Saltar la cuerda</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.burpees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Burpees</source>
         <target>Burpees</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumpingjacks.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hampelmänner</source>
-        <target>Hampelmänner</target>
+        <target>Saltos de tijera</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.highknees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>High Knees</source>
         <target>High Knees</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.stretching.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dehnen</source>
-        <target>Dehnen</target>
+        <target>Estiramientos</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.yoga.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Yoga</source>
         <target>Yoga</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.foamrolling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Faszienrolle</source>
-        <target>Faszienrolle</target>
+        <target>Rodillo de espuma</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dynamisches Aufwärmen</source>
-        <target>Dynamisches Aufwärmen</target>
+        <target>Calentamiento dinámico</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.catcow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Katze-Kuh</source>
-        <target>Katze-Kuh</target>
+        <target>Gato-Vaca</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.hipopener.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftöffner</source>
-        <target>Hüftöffner</target>
+        <target>Apertura de cadera</target>
       </segment>
     </unit>
     <unit id="exercise.strength.benchpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdrücken</source>
-        <target>Bankdrücken</target>
+        <target>Press de banca</target>
       </segment>
     </unit>
     <unit id="exercise.strength.overheadpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schulterdrücken</source>
-        <target>Schulterdrücken</target>
+        <target>Press de hombro</target>
       </segment>
     </unit>
     <unit id="exercise.strength.deadlift.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kreuzheben</source>
-        <target>Kreuzheben</target>
+        <target>Peso muerto</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellsquat.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel-Kniebeuge</source>
-        <target>Langhantel-Kniebeuge</target>
+        <target>Sentadilla con barra</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellrow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantelrudern</source>
-        <target>Langhantelrudern</target>
+        <target>Remo con barra</target>
       </segment>
     </unit>
     <unit id="exercise.strength.kettlebellswing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kettlebell Swing</source>
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
       <unit id="exercise.variant.situps.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
+        <target>Estándar</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source>Decline</source>
         <target>Decline</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Con peso adicional</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
+        <target>Estándar</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reverse Crunches</source>
         <target>Reverse Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.bicycle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bicycle Crunches</source>
         <target>Bicycle Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.oblique">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schräge Crunches</source>
-        <target>Schräge Crunches</target>
+        <target>Crunches oblicuos</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.lying">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegend</source>
-        <target>Liegend</target>
+        <target>Acostado</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-knee">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (Knie)</source>
-        <target>Hängend (Knie)</target>
+        <target>Colgante (rodilla)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-straight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (gestreckt)</source>
-        <target>Hängend (gestreckt)</target>
+        <target>Colgante (estirado)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Peso corporal</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Con peso adicional</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
+        <target>Estándar</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.cross-body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Cross-Body</source>
         <target>Cross-Body</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
+        <target>Estándar</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.forearm">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unterarmstütz</source>
-        <target>Unterarmstütz</target>
+        <target>Plancha de antebrazo</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.side">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Lateral</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Umgekehrt</source>
-        <target>Umgekehrt</target>
+        <target>Invertido</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Peso corporal</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.sumo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sumo</source>
         <target>Sumo</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.goblet">
-      <segment state="initial">
+      <segment state="translated">
         <source>Goblet</source>
         <target>Goblet</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bulgarian-split">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bulgarian Split</source>
         <target>Bulgarian Split</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.pistol">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pistol</source>
         <target>Pistol</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
+        <target>Estándar</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>De una pierna</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.seated">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sitzend</source>
-        <target>Sitzend</target>
+        <target>Sentado</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
+        <target>Estándar</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>De una pierna</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.hip-thrust">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hip Thrust</source>
         <target>Hip Thrust</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.march">
-      <segment state="initial">
+      <segment state="translated">
         <source>Marching</source>
-        <target>Marching</target>
+        <target>Marcha</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.forward">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorwärts</source>
-        <target>Vorwärts</target>
+        <target>Hacia adelante</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückwärts</source>
-        <target>Rückwärts</target>
+        <target>Hacia atrás</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.walking">
-      <segment state="initial">
+      <segment state="translated">
         <source>Walking</source>
-        <target>Walking</target>
+        <target>Caminando</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.lateral">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Lateral</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.curtsy">
-      <segment state="initial">
+      <segment state="translated">
         <source>Curtsy</source>
         <target>Curtsy</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.jumping">
-      <segment state="initial">
+      <segment state="translated">
         <source>Jumping</source>
-        <target>Jumping</target>
+        <target>Con salto</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
+        <target>Estándar</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.chin-up">
-      <segment state="initial">
+      <segment state="translated">
         <source>Chin-up</source>
         <target>Chin-up</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.wide-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Breiter Griff</source>
-        <target>Breiter Griff</target>
+        <target>Agarre ancho</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.neutral-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neutraler Griff</source>
-        <target>Neutraler Griff</target>
+        <target>Agarre neutral</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.negative">
-      <segment state="initial">
+      <segment state="translated">
         <source>Negativ</source>
-        <target>Negativ</target>
+        <target>Negativo</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.assisted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Assistiert</source>
-        <target>Assistiert</target>
+        <target>Asistido</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.archer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Archer</source>
         <target>Archer</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.inverted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Inverted Row</source>
-        <target>Inverted Row</target>
+        <target>Remo invertido</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.australian">
-      <segment state="initial">
+      <segment state="translated">
         <source>Australian Row</source>
-        <target>Australian Row</target>
+        <target>Remo australiano</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.dumbbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kurzhantel</source>
-        <target>Kurzhantel</target>
+        <target>Mancuerna</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.barbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel</source>
-        <target>Langhantel</target>
+        <target>Barra</target>
       </segment>
     </unit>
     <unit id="exercise.push.dips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dips</source>
         <target>Dips</target>
       </segment>
     </unit>
     <unit id="exercise.push.benchdips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdips</source>
-        <target>Bankdips</target>
+        <target>Dips en banco</target>
       </segment>
     </unit>
     <unit id="exercise.push.handstandhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Handstand-Hold</source>
         <target>Handstand-Hold</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.parallel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Barren</source>
-        <target>Barren</target>
+        <target>Barras</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.straight-bar">
-      <segment state="initial">
+      <segment state="translated">
         <source>Stange</source>
-        <target>Stange</target>
+        <target>Barra</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.ring">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ringe</source>
-        <target>Ringe</target>
+        <target>Anillas</target>
       </segment>
     </unit>
       <unit id="exerciseTimer.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübung-Timer</source>
-        <target>Halteübung-Timer</target>
+        <target>Temporizador de retención</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercisePickerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung wählen</source>
-        <target>Übung wählen</target>
+        <target>Seleccionar ejercicio</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraMode">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera: Start/Ende automatisch erkennen </source>
-        <target> Kamera: Start/Ende automatisch erkennen </target>
+        <target> Cámara: detectar inicio/fin automáticamente </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraStarting">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kamera startet …</source>
-        <target>Kamera startet …</target>
+        <target>Iniciando cámara…</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraUnavailable">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera nicht verfügbar </source>
-        <target> Kamera nicht verfügbar </target>
+        <target> Cámara no disponible </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.toggleAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Form-Check anzeigen oder ausblenden</source>
-        <target>Form-Check anzeigen oder ausblenden</target>
+        <target>Mostrar u ocultar verificación de forma</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.angle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Winkel</source>
-        <target>Winkel</target>
+        <target>Ángulo</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.confidence">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sicherheit</source>
-        <target>Sicherheit</target>
+        <target>Seguridad</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.pause">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
+        <target>Pausa</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.start">
-      <segment state="initial">
+      <segment state="translated">
         <source>Start</source>
-        <target>Start</target>
+        <target>Iniciar</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
-        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+        <target> Posiciona la cámara para que se vean el hombro, la cadera y la rodilla. El temporizador se inicia automáticamente cuando estés en posición y se pausa cuando salgas. </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurücksetzen </source>
-        <target> Zurücksetzen </target>
+        <target> Restablecer </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Cancelar </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Übernehmen </source>
-        <target> Übernehmen </target>
+        <target> Aplicar </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.holding">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halten</source>
-        <target>Halten</target>
+        <target>Mantener</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.paused">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
+        <target>Pausa</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.ready">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bereit</source>
-        <target>Bereit</target>
+        <target>Listo</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercise.plank">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank</source>
-        <target>Plank</target>
+        <target>Plancha</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercise.hollowhold">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
         <target>Hollow Hold</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübungs-Timer öffnen</source>
-        <target>Halteübungs-Timer öffnen</target>
+        <target>Abrir temporizador de retención</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank‑Timer</source>
-        <target>Plank‑Timer</target>
+        <target>Temporizador de Plancha</target>
       </segment>
     </unit>
     <unit id="quickAddConfig.hintV2">
       <segment state="translated">
-        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> Schnellaktionen fest. Wähle pro Button die Übung und – wo verfügbar – Auto-Messung über die Kamera. Leere Felder werden ignoriert. </source>
-        <target> Configura hasta <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> acciones rápidas. Elige el ejercicio para cada botón y, donde esté disponible, la medición automática con la cámara. Los campos vacíos se ignoran. </target>
+        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> Schnellaktionen fest. Wähle pro Button die Übung und – wo verfügbar – Auto-Messung über die Kamera. Leere Felder werden ignoriert. </source>
+        <target> Configura hasta <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> acciones rápidas. Elige el ejercicio para cada botón y, donde esté disponible, la medición automática con la cámara. Los campos vacíos se ignoran. </target>
       </segment>
     </unit>
     <unit id="quickAddConfig.exerciseLabel">
@@ -9443,8 +9439,8 @@
     </unit>
     <unit id="plan.push-pull-6w.summary">
       <segment state="translated">
-        <source>Symmetrischer 6-Wochen-Plan für Liegestütze und Rückenübungen (Rudern, Klimmzug-Negative, Face Pulls). Vermeidet das klassische &quot;nur Push&quot;-Ungleichgewicht und stärkt die hintere Kette gleichwertig. Pull-Tag pro Woche zusätzlich zur Push-Progression.</source>
-        <target>Plan simétrico de 6 semanas para flexiones y trabajo de tracción (remos, dominadas negativas, face pulls). Evita el clásico desequilibrio &quot;solo empuje&quot; y fortalece la cadena posterior por igual. Un día dedicado a la tracción por semana, además de la progresión de empuje.</target>
+        <source>Symmetrischer 6-Wochen-Plan für Liegestütze und Rückenübungen (Rudern, Klimmzug-Negative, Face Pulls). Vermeidet das klassische "nur Push"-Ungleichgewicht und stärkt die hintere Kette gleichwertig. Pull-Tag pro Woche zusätzlich zur Push-Progression.</source>
+        <target>Plan simétrico de 6 semanas para flexiones y trabajo de tracción (remos, dominadas negativas, face pulls). Evita el clásico desequilibrio "solo empuje" y fortalece la cadena posterior por igual. Un día dedicado a la tracción por semana, además de la progresión de empuje.</target>
       </segment>
     </unit>
     <unit id="plan.full-body-6w.title">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -870,7 +870,7 @@
       </notes>
       <segment state="translated">
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> Representantes</target>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> repeticiones</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.open">
@@ -2223,7 +2223,7 @@
       </notes>
       <segment state="translated">
         <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}" /> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}" /> Reps </source>
-        <target> Tu puesto: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}" /> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}" /> Representantes </target>
+        <target> Tu puesto: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}" /> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}" /> repeticiones </target>
       </segment>
     </unit>
     <unit id="reminder.feature.eyebrow">
@@ -3298,7 +3298,7 @@
       </notes>
       <segment state="translated">
         <source><ph id="0" equiv="name" disp="profile.displayName" /> hat <ph id="1" equiv="total" disp="profile.total" /> Liegestütze in <ph id="2" equiv="days" disp="profile.totalDays" /> aktiven Tagen geschafft – aktuelle Streak: <ph id="3" equiv="streak" disp="profile.currentStreak" /> Tage. Tracke selbst kostenlos auf pushup-stats.com.</source>
-        <target><ph id="0" equiv="name" disp="profile.displayName" /> ha completado flexiones <ph id="1" equiv="total" disp="profile.total" /> en días activos <ph id="2" equiv="days" disp="profile.totalDays" /> - racha actual: días <ph id="3" equiv="streak" disp="profile.currentStreak" />. Realice un seguimiento gratuito en pushup-stats.com.</target>
+        <target><ph id="0" equiv="name" disp="profile.displayName" /> ha completado <ph id="1" equiv="total" disp="profile.total" /> flexiones en <ph id="2" equiv="days" disp="profile.totalDays" /> días activos — racha actual: <ph id="3" equiv="streak" disp="profile.currentStreak" /> días. Haz tu seguimiento gratis en pushup-stats.com.</target>
       </segment>
     </unit>
     <unit id="publicProfile.seo.imageAlt">
@@ -3496,7 +3496,7 @@
       </notes>
       <segment state="translated">
         <source> Zeigt einen "Eintragen"-Button auf der Push-Benachrichtigung. Wenn die App schon geöffnet ist, wird der Eintrag im Hintergrund gespeichert; ansonsten öffnet sich kurz ein Tab, der den Eintrag automatisch anlegt. </source>
-        <target> Muestra un botón "Suscribirse" en la notificación push. Si la aplicación ya está abierta, la entrada se guarda en segundo plano; de lo contrario, se abrirá brevemente una pestaña que creará automáticamente la entrada. </target>
+        <target> Muestra un botón «Registrar» en la notificación push. Si la aplicación ya está abierta, la entrada se guarda en segundo plano; de lo contrario, se abrirá brevemente una pestaña que creará automáticamente la entrada. </target>
       </segment>
     </unit>
     <unit id="reminder.quickLog.toggle">
@@ -3658,7 +3658,7 @@
       </notes>
       <segment state="translated">
         <source> Aktiv auf <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}" /> Geräten </source>
-        <target> Activo en dispositivos <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}" /> </target>
+        <target> Activo en <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}" /> dispositivos </target>
       </segment>
     </unit>
     <unit id="push.cta.desc">
@@ -3822,7 +3822,7 @@
       </notes>
       <segment state="translated">
         <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}" /> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}" /> Reps</source>
-        <target>Esta semana: Representantes de <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}" /> /<ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}" /></target>
+        <target>Esta semana: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}" /> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}" /> repeticiones</target>
       </segment>
     </unit>
     <unit id="dashboard.analysisTeaserError">
@@ -3930,7 +3930,7 @@
       </notes>
       <segment state="translated">
         <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}" /> Reps </source>
-        <target> Total: Representantes <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}" /> </target>
+        <target> Total: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}" /> repeticiones </target>
       </segment>
     </unit>
     <unit id="typeLabel">
@@ -4900,7 +4900,7 @@
       </notes>
       <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}" /> Einträge</source>
-        <target>Entradas <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}" /></target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}" /> entradas</target>
       </segment>
     </unit>
     <unit id="sourceColumnToggle">
@@ -5077,7 +5077,7 @@
       </notes>
       <segment state="translated">
         <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak" /> Tage 🔥 Schau dir mein Profil an:</source>
-        <target>Ya hice flexiones <ph id="0" equiv="total" disp="total" /> hoy – Racha: días <ph id="1" equiv="streak" disp="streak" /> 🔥 Mira mi perfil:</target>
+        <target>Ya hice <ph id="0" equiv="total" disp="total" /> flexiones hoy – Racha: <ph id="1" equiv="streak" disp="streak" /> días 🔥 Mira mi perfil:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.simple">
@@ -5095,7 +5095,7 @@
       </notes>
       <segment state="translated">
         <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak" /> Tage 🔥 Tracke deine Stats kostenlos:</source>
-        <target>Flexiones <ph id="0" equiv="total" disp="total" /> ya hechas hoy – Racha: días <ph id="1" equiv="streak" disp="streak" /> 🔥 Realice un seguimiento de sus estadísticas de forma gratuita:</target>
+        <target><ph id="0" equiv="total" disp="total" /> flexiones ya hechas hoy – Racha: <ph id="1" equiv="streak" disp="streak" /> días 🔥 Haz seguimiento de tus estadísticas gratis:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.simple">
@@ -5627,7 +5627,7 @@
       </notes>
       <segment state="translated">
         <source>Monatsziel (Reps)</source>
-        <target>Objetivo Mensual (Representantes)</target>
+        <target>Objetivo Mensual (repeticiones)</target>
       </segment>
     </unit>
     <unit id="monthlyGoalPlaceholder">
@@ -6121,7 +6121,7 @@
       </notes>
       <segment state="translated">
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /> Representantes</target>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /> repeticiones</target>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.reached">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -3496,7 +3496,7 @@
       </notes>
       <segment state="translated">
         <source> Zeigt einen "Eintragen"-Button auf der Push-Benachrichtigung. Wenn die App schon geöffnet ist, wird der Eintrag im Hintergrund gespeichert; ansonsten öffnet sich kurz ein Tab, der den Eintrag automatisch anlegt. </source>
-        <target> Affiche un bouton "S'abonner" sur la notification push. Si l'application est déjà ouverte, l'entrée est enregistrée en arrière-plan; sinon, un onglet s'ouvrira brièvement et créera automatiquement l'entrée. </target>
+        <target> Affiche un bouton « Enregistrer » sur la notification push. Si l'application est déjà ouverte, l'entrée est enregistrée en arrière-plan ; sinon, un onglet s'ouvre brièvement et crée automatiquement l'entrée. </target>
       </segment>
     </unit>
     <unit id="reminder.quickLog.toggle">
@@ -4690,7 +4690,7 @@
     <unit id="entry.interval.label">
       <segment state="translated">
         <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></source>
-        <target>Intervalle </target></segment>
+        <target>Intervalle <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></target></segment>
     </unit>
     <unit id="entry.intervals.label">
       <segment state="translated">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="de" trgLang="fr">
+<?xml version='1.0' encoding='utf-8'?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="de" trgLang="fr">
   <file id="ngi18n" original="ng.template">
     <unit id="consent.banner.aria">
       <notes>
@@ -860,8 +860,8 @@
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:45,46</note>
       </notes>
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> bis zum Ziel</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> vers la destination</target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> bis zum Ziel</source>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> vers la destination</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.quickAddReps">
@@ -869,8 +869,8 @@
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:59,60</note>
       </notes>
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> répétitions</target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> Reps</source>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> répétitions</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.open">
@@ -914,8 +914,8 @@
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:71</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
-        <target><ph id="0" equiv="REPS" disp="reps"/> Ajouter des pompes</target>
+        <source><ph id="0" equiv="REPS" disp="reps" /> Liegestütze hinzufügen</source>
+        <target><ph id="0" equiv="REPS" disp="reps" /> Ajouter des pompes</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
@@ -923,8 +923,8 @@
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:75</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="GAP" disp="gap"/> Liegestütze bis zum Tagesziel hinzufügen</source>
-        <target><ph id="0" equiv="GAP" disp="gap"/> Ajouter des pompes jusqu'à l'objectif quotidien</target>
+        <source><ph id="0" equiv="GAP" disp="gap" /> Liegestütze bis zum Tagesziel hinzufügen</source>
+        <target><ph id="0" equiv="GAP" disp="gap" /> Ajouter des pompes jusqu'à l'objectif quotidien</target>
       </segment>
     </unit>
     <unit id="reminder.quickLog.success">
@@ -932,8 +932,8 @@
         <note category="location">libs/reminders/src/lib/push/quick-log-listener.service.ts:70</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="reps" disp="reps"/> Push-ups eingetragen ✓</source>
-        <target>Pompes <ph id="0" equiv="reps" disp="reps"/> saisies ✓</target>
+        <source><ph id="0" equiv="reps" disp="reps" /> Push-ups eingetragen ✓</source>
+        <target>Pompes <ph id="0" equiv="reps" disp="reps" /> saisies ✓</target>
       </segment>
     </unit>
     <unit id="snackbar.close">
@@ -994,8 +994,8 @@
         <note category="location">web/src/app/admin/admin-page.component.ts:97,100</note>
       </notes>
       <segment state="translated">
-        <source> Löscht anonyme Benutzer ohne Pushups in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}"/> Tagen. </source>
-        <target> Supprime les utilisateurs anonymes sans pompes au cours des derniers jours <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}"/>. </target>
+        <source> Löscht anonyme Benutzer ohne Pushups in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}" /> Tagen. </source>
+        <target> Supprime les utilisateurs anonymes sans pompes au cours des derniers jours <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}" />. </target>
       </segment>
     </unit>
     <unit id="admin.bulk.button">
@@ -1228,8 +1228,8 @@
         <note category="location">web/src/app/admin/admin-page.component.ts:770</note>
       </notes>
       <segment state="translated">
-        <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Ouvrir les détails pour <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier" /></source>
+        <target>Ouvrir les détails pour <ph id="0" equiv="identifier" disp="identifier" /></target>
       </segment>
     </unit>
     <unit id="admin.feedback.delete.title">
@@ -1968,8 +1968,8 @@
         <note category="location">web/src/app/blog/blog-article.component.ts:60,61</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}"/> Min. Lesezeit</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}"/> Min. temps de lecture</target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}" /> Min. Lesezeit</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ readingTimeMinutes }}" /> Min. temps de lecture</target>
       </segment>
     </unit>
     <unit id="blog.article.updated">
@@ -2222,8 +2222,8 @@
         <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:74,76</note>
       </notes>
       <segment state="translated">
-        <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}"/> Reps </source>
-        <target> Votre poste: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · Représentants <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}"/> </target>
+        <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}" /> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}" /> Reps </source>
+        <target> Votre poste: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}" /> · Représentants <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}" /> </target>
       </segment>
     </unit>
     <unit id="reminder.feature.eyebrow">
@@ -3252,8 +3252,8 @@
         <note category="location">web/src/app/public-profile/public-profile-page.component.ts:129</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze auf Pushup Tracker geschafft 💪 Schau&apos;s dir an:</source>
-        <target><ph id="0" equiv="name" disp="profile.displayName"/> a fait des pompes <ph id="1" equiv="total" disp="profile.total"/> sur Pushup Tracker 💪 Regardez-le:</target>
+        <source><ph id="0" equiv="name" disp="profile.displayName" /> hat <ph id="1" equiv="total" disp="profile.total" /> Liegestütze auf Pushup Tracker geschafft 💪 Schau's dir an:</source>
+        <target><ph id="0" equiv="name" disp="profile.displayName" /> a fait des pompes <ph id="1" equiv="total" disp="profile.total" /> sur Pushup Tracker 💪 Regardez-le:</target>
       </segment>
     </unit>
     <unit id="publicProfile.share.title">
@@ -3288,8 +3288,8 @@
         <note category="location">web/src/app/public-profile/public-profile-page.component.ts:192</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="profile.displayName"/> – <ph id="1" equiv="total" disp="profile.total"/> Liegestütze · Streak <ph id="2" equiv="streak" disp="profile.currentStreak"/> · Pushup Tracker</source>
-        <target><ph id="0" equiv="name" disp="profile.displayName"/> – Pompes <ph id="1" equiv="total" disp="profile.total"/> · Streak <ph id="2" equiv="streak" disp="profile.currentStreak"/> · Suivi des pompes</target>
+        <source><ph id="0" equiv="name" disp="profile.displayName" /> – <ph id="1" equiv="total" disp="profile.total" /> Liegestütze · Streak <ph id="2" equiv="streak" disp="profile.currentStreak" /> · Pushup Tracker</source>
+        <target><ph id="0" equiv="name" disp="profile.displayName" /> – Pompes <ph id="1" equiv="total" disp="profile.total" /> · Streak <ph id="2" equiv="streak" disp="profile.currentStreak" /> · Suivi des pompes</target>
       </segment>
     </unit>
     <unit id="publicProfile.seo.description">
@@ -3297,8 +3297,8 @@
         <note category="location">web/src/app/public-profile/public-profile-page.component.ts:193</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="profile.displayName"/> hat <ph id="1" equiv="total" disp="profile.total"/> Liegestütze in <ph id="2" equiv="days" disp="profile.totalDays"/> aktiven Tagen geschafft – aktuelle Streak: <ph id="3" equiv="streak" disp="profile.currentStreak"/> Tage. Tracke selbst kostenlos auf pushup-stats.com.</source>
-        <target><ph id="0" equiv="name" disp="profile.displayName"/> a effectué des pompes <ph id="1" equiv="total" disp="profile.total"/> au cours des jours actifs <ph id="2" equiv="days" disp="profile.totalDays"/> - séquence en cours: jours <ph id="3" equiv="streak" disp="profile.currentStreak"/>. Suivez-vous gratuitement sur pushup-stats.com.</target>
+        <source><ph id="0" equiv="name" disp="profile.displayName" /> hat <ph id="1" equiv="total" disp="profile.total" /> Liegestütze in <ph id="2" equiv="days" disp="profile.totalDays" /> aktiven Tagen geschafft – aktuelle Streak: <ph id="3" equiv="streak" disp="profile.currentStreak" /> Tage. Tracke selbst kostenlos auf pushup-stats.com.</source>
+        <target><ph id="0" equiv="name" disp="profile.displayName" /> a effectué des pompes <ph id="1" equiv="total" disp="profile.total" /> au cours des jours actifs <ph id="2" equiv="days" disp="profile.totalDays" /> - séquence en cours: jours <ph id="3" equiv="streak" disp="profile.currentStreak" />. Suivez-vous gratuitement sur pushup-stats.com.</target>
       </segment>
     </unit>
     <unit id="publicProfile.seo.imageAlt">
@@ -3306,8 +3306,8 @@
         <note category="location">web/src/app/public-profile/public-profile-page.component.ts:206</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="name" disp="profile.displayName"/> auf Pushup Tracker</source>
-        <target><ph id="0" equiv="name" disp="profile.displayName"/> sur Pushup Tracker</target>
+        <source><ph id="0" equiv="name" disp="profile.displayName" /> auf Pushup Tracker</source>
+        <target><ph id="0" equiv="name" disp="profile.displayName" /> sur Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="reminders.page.title">
@@ -3495,7 +3495,7 @@
         <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:164,167</note>
       </notes>
       <segment state="translated">
-        <source> Zeigt einen &quot;Eintragen&quot;-Button auf der Push-Benachrichtigung. Wenn die App schon geöffnet ist, wird der Eintrag im Hintergrund gespeichert; ansonsten öffnet sich kurz ein Tab, der den Eintrag automatisch anlegt. </source>
+        <source> Zeigt einen "Eintragen"-Button auf der Push-Benachrichtigung. Wenn die App schon geöffnet ist, wird der Eintrag im Hintergrund gespeichert; ansonsten öffnet sich kurz ein Tab, der den Eintrag automatisch anlegt. </source>
         <target> Affiche un bouton "S'abonner" sur la notification push. Si l'application est déjà ouverte, l'entrée est enregistrée en arrière-plan; sinon, un onglet s'ouvrira brièvement et créera automatiquement l'entrée. </target>
       </segment>
     </unit>
@@ -3657,8 +3657,8 @@
         <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:340,341</note>
       </notes>
       <segment state="translated">
-        <source> Aktiv auf <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}"/> Geräten </source>
-        <target> Actif sur les appareils <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}"/> </target>
+        <source> Aktiv auf <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}" /> Geräten </source>
+        <target> Actif sur les appareils <ph id="0" equiv="INTERPOLATION" disp="{{ pushService.deviceCount() }}" /> </target>
       </segment>
     </unit>
     <unit id="push.cta.desc">
@@ -3812,8 +3812,8 @@
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:49,50</note>
       </notes>
       <segment state="translated">
-        <source>Streak: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}"/> Tage</source>
-        <target>Série: jours <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}"/></target>
+        <source>Streak: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}" /> Tage</source>
+        <target>Série: jours <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}" /></target>
       </segment>
     </unit>
     <unit id="dashboard.analysisTeaserWeekReps">
@@ -3821,8 +3821,8 @@
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:53,55</note>
       </notes>
       <segment state="translated">
-        <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> Reps</source>
-        <target>Cette semaine: représentants <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> /<ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/></target>
+        <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}" /> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}" /> Reps</source>
+        <target>Cette semaine: représentants <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}" /> /<ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}" /></target>
       </segment>
     </unit>
     <unit id="dashboard.analysisTeaserError">
@@ -3884,8 +3884,8 @@
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:117,118</note>
       </notes>
       <segment state="translated">
-        <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Ensemble <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
+        <source>Set <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></source>
+        <target>Ensemble <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></target>
       </segment>
     </unit>
     <unit id="repsLabel">
@@ -3929,8 +3929,8 @@
         <note category="location">web/src/app/stats/components/create-entry-dialog/create-entry-dialog.component.ts:158,160</note>
       </notes>
       <segment state="translated">
-        <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> Reps </source>
-        <target> Total: représentants <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}"/> </target>
+        <source> Gesamt: <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}" /> Reps </source>
+        <target> Total: représentants <ph id="0" equiv="INTERPOLATION" disp="{{ totalReps() }}" /> </target>
       </segment>
     </unit>
     <unit id="typeLabel">
@@ -3998,14 +3998,14 @@
     </unit>
     <unit id="entryDialog.overCapDuration">
       <segment state="translated">
-        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
-        <target>Durée maximale : <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}" /></source>
+        <target>Durée maximale : <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}" /></target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
-        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
-        <target>Maximum : <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}" /></source>
+        <target>Maximum : <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}" /></target>
       </segment>
     </unit>
     <unit id="exercise.category.plank">
@@ -4046,8 +4046,8 @@
     </unit>
     <unit id="entryDialog.overCap">
       <segment state="translated">
-        <source> Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> pro Eintrag </source>
-        <target> Maximum : <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> par entrée </target>
+        <source> Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}" /> pro Eintrag </source>
+        <target> Maximum : <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}" /> par entrée </target>
       </segment>
     </unit>
     <unit id="exerciseSection.lastEntry">
@@ -4379,8 +4379,8 @@
         <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:84</note>
       </notes>
       <segment state="translated">
-        <source>Wochenziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Objectif hebdomadaire de pompes <ph id="0" equiv="goal" disp="goal"/> atteint - Total <ph id="1" equiv="total" disp="total"/>! 💪 Suivez vos statistiques gratuitement:</target>
+        <source>Wochenziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen geschafft – <ph id="1" equiv="total" disp="total" /> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Objectif hebdomadaire de pompes <ph id="0" equiv="goal" disp="goal" /> atteint - Total <ph id="1" equiv="total" disp="total" />! 💪 Suivez vos statistiques gratuitement:</target>
       </segment>
     </unit>
     <unit id="goalReached.monthly.title">
@@ -4415,8 +4415,8 @@
         <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:92</note>
       </notes>
       <segment state="translated">
-        <source>Monatsziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Objectif mensuel de pompes <ph id="0" equiv="goal" disp="goal"/> atteint - Total <ph id="1" equiv="total" disp="total"/>! 💪 Suivez vos statistiques gratuitement:</target>
+        <source>Monatsziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen geschafft – <ph id="1" equiv="total" disp="total" /> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Objectif mensuel de pompes <ph id="0" equiv="goal" disp="goal" /> atteint - Total <ph id="1" equiv="total" disp="total" />! 💪 Suivez vos statistiques gratuitement:</target>
       </segment>
     </unit>
     <unit id="goalReached.plan.title">
@@ -4451,8 +4451,8 @@
         <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:100</note>
       </notes>
       <segment state="translated">
-        <source>Heute mein Trainingsplan-Ziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen erreicht – <ph id="1" equiv="total" disp="total"/> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Atteint aujourd'hui mon objectif du plan d'entraînement de <ph id="0" equiv="goal" disp="goal"/> pompes – <ph id="1" equiv="total" disp="total"/> au total ! 💪 Suivez vos statistiques gratuitement :</target>
+        <source>Heute mein Trainingsplan-Ziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen erreicht – <ph id="1" equiv="total" disp="total" /> insgesamt! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Atteint aujourd'hui mon objectif du plan d'entraînement de <ph id="0" equiv="goal" disp="goal" /> pompes – <ph id="1" equiv="total" disp="total" /> au total ! 💪 Suivez vos statistiques gratuitement :</target>
       </segment>
     </unit>
     <unit id="goalReached.daily.title">
@@ -4487,8 +4487,8 @@
         <note category="location">web/src/app/stats/components/goal-reached-dialog/goal-reached-dialog.component.ts:100</note>
       </notes>
       <segment state="translated">
-        <source>Heute mein Tagesziel von <ph id="0" equiv="goal" disp="goal"/> Liegestützen geschafft! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Aujourd'hui, j'ai atteint mon objectif quotidien de pompes <ph id="0" equiv="goal" disp="goal"/>! 💪 Suivez vos statistiques gratuitement:</target>
+        <source>Heute mein Tagesziel von <ph id="0" equiv="goal" disp="goal" /> Liegestützen geschafft! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Aujourd'hui, j'ai atteint mon objectif quotidien de pompes <ph id="0" equiv="goal" disp="goal" />! 💪 Suivez vos statistiques gratuitement:</target>
       </segment>
     </unit>
     <unit id="goalReached.snapAria">
@@ -4619,8 +4619,8 @@
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:40,42</note>
       </notes>
       <segment state="translated">
-        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> eigene Reps-Buttons fest. Leere Felder werden ignoriert. </source>
-        <target> Configurez les boutons de répétition personnalisés <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/>. Les champs vides sont ignorés. </target>
+        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> eigene Reps-Buttons fest. Leere Felder werden ignoriert. </source>
+        <target> Configurez les boutons de répétition personnalisés <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" />. Les champs vides sont ignorés. </target>
       </segment>
     </unit>
     <unit id="quickAddConfig.repsLabel">
@@ -4678,46 +4678,39 @@
       </segment>
     </unit>
     <unit id="intervalsDistribution.noData">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Intervall-Daten vorhanden</source>
-        <target>Keine Intervall-Daten vorhanden</target>
-      </segment>
+        <target>Aucune donnée d'intervalle disponible</target></segment>
     </unit>
     <unit id="intervalsDistribution.listLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Verteilung</source>
-        <target>Intervall-Verteilung</target>
-      </segment>
+        <target>Distribution des intervalles</target></segment>
     </unit>
     <unit id="entry.interval.label">
-      <segment state="initial">
-        <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
-      </segment>
+      <segment state="translated">
+        <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></source>
+        <target>Intervalle </target></segment>
     </unit>
     <unit id="entry.intervals.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervalle</source>
-        <target>Intervalle</target>
-      </segment>
+        <target>Intervalles</target></segment>
     </unit>
     <unit id="entry.intervals.remove">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall entfernen</source>
-        <target>Intervall entfernen</target>
-      </segment>
+        <target>Supprimer l'intervalle</target></segment>
     </unit>
     <unit id="entry.intervals.add">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall hinzufügen</source>
-        <target>Intervall hinzufügen</target>
-      </segment>
+        <target>Ajouter un intervalle</target></segment>
     </unit>
     <unit id="entry.intervals.addTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Weiteres Intervall hinzufügen</source>
-        <target>Weiteres Intervall hinzufügen</target>
-      </segment>
+        <target>Ajouter un autre intervalle</target></segment>
     </unit>
     <unit id="chart.subtitle.reps">
       <notes>
@@ -4899,8 +4892,8 @@
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:5</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/> Einträge</source>
-        <target>Entrées <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}"/></target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}" /> Einträge</source>
+        <target>Entrées <ph id="0" equiv="INTERPOLATION" disp="{{ entries().length }}" /></target>
       </segment>
     </unit>
     <unit id="sourceColumnToggle">
@@ -4908,12 +4901,8 @@
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:15,20</note>
       </notes>
       <segment state="translated">
-        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-        showSourceColumn() ? &apos;visibility&apos; : &apos;visibility_off&apos;
-      }}"/></pc> Quelle </source>
-        <target>Source <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-        showSourceColumn()? &apos;visibility&apos;: &apos;visibility_off&apos;
-      }}"/></pc> </target>
+        <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{         showSourceColumn() ? 'visibility' : 'visibility_off'       }}" /></pc> Quelle </source>
+        <target>Source <pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{         showSourceColumn()? 'visibility': 'visibility_off'       }}" /></pc> </target>
       </segment>
     </unit>
     <unit id="createNewEntry">
@@ -5080,8 +5069,8 @@
         <note category="location">web/src/app/stats/dashboard.store.ts:436</note>
       </notes>
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Schau dir mein Profil an:</source>
-        <target>Pompes <ph id="0" equiv="total" disp="total"/> déjà faites aujourd'hui – Série: jours <ph id="1" equiv="streak" disp="streak"/> 🔥 Consultez mon profil:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak" /> Tage 🔥 Schau dir mein Profil an:</source>
+        <target>Pompes <ph id="0" equiv="total" disp="total" /> déjà faites aujourd'hui – Série: jours <ph id="1" equiv="streak" disp="streak" /> 🔥 Consultez mon profil:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.profile.simple">
@@ -5089,8 +5078,8 @@
         <note category="location">web/src/app/stats/dashboard.store.ts:437</note>
       </notes>
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
-        <target>Pompes <ph id="0" equiv="total" disp="total"/> réalisées aujourd'hui! 💪 Consultez mon profil:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
+        <target>Pompes <ph id="0" equiv="total" disp="total" /> réalisées aujourd'hui! 💪 Consultez mon profil:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.streak">
@@ -5098,8 +5087,8 @@
         <note category="location">web/src/app/stats/dashboard.store.ts:441</note>
       </notes>
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
-        <target>Pompes <ph id="0" equiv="total" disp="total"/> déjà réalisées aujourd'hui – Série: jours <ph id="1" equiv="streak" disp="streak"/> 🔥 Suivez vos statistiques gratuitement:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak" /> Tage 🔥 Tracke deine Stats kostenlos:</source>
+        <target>Pompes <ph id="0" equiv="total" disp="total" /> déjà réalisées aujourd'hui – Série: jours <ph id="1" equiv="streak" disp="streak" /> 🔥 Suivez vos statistiques gratuitement:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.text.simple">
@@ -5107,8 +5096,8 @@
         <note category="location">web/src/app/stats/dashboard.store.ts:442</note>
       </notes>
       <segment state="translated">
-        <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
-        <target>Des pompes <ph id="0" equiv="total" disp="total"/> déjà faites aujourd'hui! 💪 Suivez vos statistiques gratuitement:</target>
+        <source>Heute schon <ph id="0" equiv="total" disp="total" /> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
+        <target>Des pompes <ph id="0" equiv="total" disp="total" /> déjà faites aujourd'hui! 💪 Suivez vos statistiques gratuitement:</target>
       </segment>
     </unit>
     <unit id="dashboard.share.title">
@@ -5254,8 +5243,8 @@
         <note category="location">web/src/app/stats/shell/analysis-page.component.ts:194,195</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}"/> Tage</source>
-        <target>Jours <ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}"/></target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}" /> Tage</source>
+        <target>Jours <ph id="0" equiv="INTERPOLATION" disp="{{ store.currentStreak() }}" /></target>
       </segment>
     </unit>
     <unit id="analysis.longestStreak">
@@ -5522,7 +5511,7 @@
     </unit>
     <unit id="settings.leaderboardRequiresPublicProfile">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Seuls les profils avec Profil public activé apparaissent dans le classement. Activez « Profil public » ci-dessous pour utiliser cette option. </target>
       </segment>
     </unit>
@@ -5891,8 +5880,8 @@
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:23,25</note>
       </notes>
       <segment state="translated">
-        <source> Live: <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? &apos;verbunden&apos; : &apos;getrennt&apos; }}"/> </source>
-        <target> En direct: <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected()? &apos;verbunden&apos;: &apos;getrennt&apos; }}"/> </target>
+        <source> Live: <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected() ? 'verbunden' : 'getrennt' }}" /> </source>
+        <target> En direct: <ph id="0" equiv="INTERPOLATION" disp="{{ liveConnected()? 'verbunden': 'getrennt' }}" /> </target>
       </segment>
     </unit>
     <unit id="allTimeSummaryAria">
@@ -6079,8 +6068,8 @@
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:163,165</note>
       </notes>
       <segment state="translated">
-        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/> </source>
-        <target> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || &apos;Standard&apos; }}"/> </target>
+        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}" /> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || 'Standard' }}" /> </source>
+        <target> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}" /> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ latest.type || 'Standard' }}" /> </target>
       </segment>
     </unit>
     <unit id="dashboard.noEntryYet">
@@ -6124,8 +6113,8 @@
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
       </notes>
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
-        <target>+ Représentants <ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/></target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /> Reps</source>
+        <target>+ Représentants <ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /></target>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.reached">
@@ -6142,8 +6131,8 @@
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:225,226</note>
       </notes>
       <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> bis zum Ziel</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> vers la destination</target>
+        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}" /> bis zum Ziel</source>
+        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}" /> vers la destination</target>
       </segment>
     </unit>
     <unit id="quickAddNew">
@@ -6205,8 +6194,8 @@
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:110</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="label" disp="label"/> in der Historie öffnen</source>
-        <target>Ouvrir <ph id="0" equiv="label" disp="label"/> dans l'historique</target>
+        <source><ph id="0" equiv="label" disp="label" /> in der Historie öffnen</source>
+        <target>Ouvrir <ph id="0" equiv="label" disp="label" /> dans l'historique</target>
       </segment>
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
@@ -6430,8 +6419,8 @@
     </unit>
     <unit id="trainingPlans.jumped">
       <segment state="translated">
-        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
-        <target>Saut au jour <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/>.</target>
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex" /> gesprungen.</source>
+        <target>Saut au jour <ph id="0" equiv="INTERPOLATION" disp="dayIndex" />.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.notFound">
@@ -6642,7 +6631,7 @@
       </segment>
     </unit>
 
-    <!-- Pushup-types wiki page -->
+    
     <unit id="seo.wiki.pushupTypes.title">
       <segment state="translated">
         <source>Liegestütztypen erklärt – Pushup Tracker</source>
@@ -6710,7 +6699,7 @@
       </segment>
     </unit>
 
-    <!-- Exercises wiki page -->
+    
     <unit id="seo.wiki.exercises.title">
       <segment state="translated">
         <source>Übungen erklärt – Pushup Tracker</source>
@@ -7557,7 +7546,7 @@
       </notes>
       <segment state="translated">
         <source>Fehler beim Speichern</source>
-        <target>Erreur lors de l&apos;enregistrement</target>
+        <target>Erreur lors de l'enregistrement</target>
       </segment>
     </unit>
     <unit id="settings.status.retry">
@@ -7602,7 +7591,7 @@
       </notes>
       <segment state="translated">
         <source> Wie du in der App und der Bestenliste erscheinst. </source>
-        <target> Comment vous apparaissez dans l&apos;application et dans le classement. </target>
+        <target> Comment vous apparaissez dans l'application et dans le classement. </target>
       </segment>
     </unit>
     <unit id="settings.section.privacy.title">
@@ -7781,265 +7770,265 @@
     </unit>
     <unit id="leaderboard.visibilityHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Modifier la visibilité ou le nom d'affichage ? </target>
       </segment>
     </unit>
     <unit id="leaderboard.visibilityHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Ouvrir les paramètres</target>
       </segment>
     </unit>
     <unit id="leaderboard.loginHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Participer et apparaître ? </target>
       </segment>
     </unit>
     <unit id="leaderboard.loginHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Se connecter</target>
       </segment>
     </unit>
     <unit id="analysis.empty.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Pas encore de données à analyser.</target>
       </segment>
     </unit>
     <unit id="analysis.empty.body">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Démarrez un plan d'entraînement ou enregistrez votre première série — nous afficherons ici tendances et séries. </target>
       </segment>
     </unit>
     <unit id="analysis.empty.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Choisir un plan d'entraînement </target>
       </segment>
     </unit>
     <unit id="analysis.tabs.overview">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Aperçu</target>
       </segment>
     </unit>
     <unit id="analysis.overview.empty">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Aucune entrée dans la plage de dates actuelle.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.uncategorisedNotice">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Ces entrées n'appartiennent à aucune catégorie connue — agrégat ci-dessous.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Comparaison par groupe d'exercices</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Aucune donnée dans la plage de dates actuelle.</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalReps">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Total des répétitions</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Aujourd'hui</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Série</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Meilleur jour</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metricLabel">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Séances</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.repsTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Répétitions</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalSets">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Total des séries</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.timeTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Temps</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalTime">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Temps total</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayTime">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Aujourd'hui</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.distanceTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Distance</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalDistance">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Distance totale</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayDistance">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Aujourd'hui</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.distanceTimeTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Distance et temps</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.entries">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Séances</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Voir les détails</target>
       </segment>
     </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Pas encore d'entrées.</target>
       </segment>
     </unit>
     <unit id="entries.empty.body">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Saisissez votre première entrée d'entraînement — votre historique apparaîtra ici. </target>
       </segment>
     </unit>
     <unit id="entries.empty.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc> Créer une entrée </target>
       </segment>
     </unit>
     <unit id="settings.displayNameHint.leaderboardLink">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Voir le classement</target>
       </segment>
     </unit>
     <unit id="settings.publicProfile.previewCta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">visibility</pc> Aperçu</target>
       </segment>
     </unit>
     <unit id="settings.goals.planOverrideHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Un plan d'entraînement actif définit automatiquement votre objectif quotidien. Les valeurs manuelles ne s'appliqueront qu'après la fin du plan. </target>
       </segment>
     </unit>
     <unit id="settings.goals.openActivePlan">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Ouvrir le plan actif</target>
       </segment>
     </unit>
     <unit id="settings.adsConsent.privacyLink">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Politique de confidentialité</target>
       </segment>
     </unit>
     <unit id="dashboard.noPlanTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Pas encore de plan d'entraînement actif</target>
       </segment>
     </unit>
     <unit id="dashboard.noPlanSubtitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Choisissez un plan pour définir automatiquement votre objectif quotidien. </target>
       </segment>
     </unit>
     <unit id="dashboard.noPlanCta">
       <segment state="translated">
-        <source/>
+        <source />
         <target> Choisir un plan </target>
       </segment>
     </unit>
     <unit id="dashboard.goalEditAria">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Ouvrir l'objectif quotidien dans les paramètres</target>
       </segment>
     </unit>
     <unit id="dashboard.lastEntryLinkAria">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Ouvrir la dernière entrée dans l'historique</target>
       </segment>
     </unit>
     <unit id="dashboard.allTimeBadges.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Vers l'analyse</target>
       </segment>
     </unit>
     <unit id="trainingPlans.goalOverrideHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> L'objectif quotidien est défini par le plan. </target>
       </segment>
     </unit>
     <unit id="trainingPlans.goalOverrideHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>Ajuster les objectifs manuels</target>
       </segment>
     </unit>
@@ -8074,711 +8063,594 @@
       </segment>
     </unit>
       <unit id="exercise.category.push">
-      <segment state="initial">
+      <segment state="translated">
         <source>Drücken</source>
-        <target>Drücken</target>
-      </segment>
+        <target>Pousser</target></segment>
     </unit>
     <unit id="exercise.category.pull">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziehen</source>
-        <target>Ziehen</target>
-      </segment>
+        <target>Tirer</target></segment>
     </unit>
     <unit id="exercise.category.squat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kniebeuge</source>
-        <target>Kniebeuge</target>
-      </segment>
+        <target>Squat</target></segment>
     </unit>
     <unit id="exercise.category.hinge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftstreckung</source>
-        <target>Hüftstreckung</target>
-      </segment>
+        <target>Extension de hanche</target></segment>
     </unit>
     <unit id="exercise.category.lunge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausfallschritt</source>
-        <target>Ausfallschritt</target>
-      </segment>
+        <target>Fente</target></segment>
     </unit>
     <unit id="exercise.category.carry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tragen</source>
-        <target>Tragen</target>
-      </segment>
+        <target>Porter</target></segment>
     </unit>
     <unit id="exercise.category.core">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rumpf</source>
-        <target>Rumpf</target>
-      </segment>
+        <target>Tronc</target></segment>
     </unit>
     <unit id="exercise.category.mobility">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mobilität</source>
-        <target>Mobilität</target>
-      </segment>
+        <target>Mobilité</target></segment>
     </unit>
     <unit id="exercise.category.strength">
-      <segment state="initial">
+      <segment state="translated">
         <source>Krafttraining</source>
-        <target>Krafttraining</target>
-      </segment>
+        <target>Entraînement de force</target></segment>
     </unit>
     <unit id="exercise.core.deadbug.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Bug</source>
-        <target>Dead Bug</target>
-      </segment>
+        <target>Dead Bug</target></segment>
     </unit>
     <unit id="exercise.core.hollowhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
-        <target>Hollow Hold</target>
-      </segment>
+        <target>Hollow Hold</target></segment>
     </unit>
     <unit id="exercise.squat.wallsit.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wandsitz</source>
-        <target>Wandsitz</target>
-      </segment>
+        <target>Mur assis</target></segment>
     </unit>
     <unit id="exercise.squat.boxjump.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Box Jumps</source>
-        <target>Box Jumps</target>
-      </segment>
+        <target>Box Jumps</target></segment>
     </unit>
     <unit id="exercise.hinge.singlelegRdl.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeiniges Kreuzheben</source>
-        <target>Einbeiniges Kreuzheben</target>
-      </segment>
+        <target>Soulevé de terre d'une jambe</target></segment>
     </unit>
     <unit id="exercise.hinge.goodmorning.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Good Morning</source>
-        <target>Good Morning</target>
-      </segment>
+        <target>Good Morning</target></segment>
     </unit>
     <unit id="exercise.lunge.stepup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Step-ups</source>
-        <target>Step-ups</target>
-      </segment>
+        <target>Step-ups</target></segment>
     </unit>
     <unit id="exercise.pull.pullups.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Klimmzüge</source>
-        <target>Klimmzüge</target>
-      </segment>
+        <target>Tractions</target></segment>
     </unit>
     <unit id="exercise.pull.rows.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ruderzug</source>
-        <target>Ruderzug</target>
-      </segment>
+        <target>Rameur</target></segment>
     </unit>
     <unit id="exercise.pull.deadhang.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Hang</source>
-        <target>Dead Hang</target>
-      </segment>
+        <target>Dead Hang</target></segment>
     </unit>
     <unit id="exercise.pull.facepull.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Face Pull</source>
-        <target>Face Pull</target>
-      </segment>
+        <target>Face Pull</target></segment>
     </unit>
     <unit id="exercise.carry.farmer.name">
-      <segment state="initial">
-        <source>Farmer&apos;s Walk</source>
-        <target>Farmer&apos;s Walk</target>
-      </segment>
+      <segment state="translated">
+        <source>Farmer's Walk</source>
+        <target>Farmer's Walk</target></segment>
     </unit>
     <unit id="exercise.carry.suitcase.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Suitcase Carry</source>
-        <target>Suitcase Carry</target>
-      </segment>
+        <target>Suitcase Carry</target></segment>
     </unit>
     <unit id="exercise.carry.overhead.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Overhead Carry</source>
-        <target>Overhead Carry</target>
-      </segment>
+        <target>Overhead Carry</target></segment>
     </unit>
     <unit id="exercise.cardio.walking.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gehen</source>
-        <target>Gehen</target>
-      </segment>
+        <target>Marcher</target></segment>
     </unit>
     <unit id="exercise.cardio.cycling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Radfahren</source>
-        <target>Radfahren</target>
-      </segment>
+        <target>Cyclisme</target></segment>
     </unit>
     <unit id="exercise.cardio.rowing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rudern</source>
-        <target>Rudern</target>
-      </segment>
+        <target>Aviron</target></segment>
     </unit>
     <unit id="exercise.cardio.swimming.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schwimmen</source>
-        <target>Schwimmen</target>
-      </segment>
+        <target>Natation</target></segment>
     </unit>
     <unit id="exercise.cardio.jumprope.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seilspringen</source>
-        <target>Seilspringen</target>
-      </segment>
+        <target>Corde à sauter</target></segment>
     </unit>
     <unit id="exercise.cardio.burpees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Burpees</source>
-        <target>Burpees</target>
-      </segment>
+        <target>Burpees</target></segment>
     </unit>
     <unit id="exercise.cardio.jumpingjacks.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hampelmänner</source>
-        <target>Hampelmänner</target>
-      </segment>
+        <target>Jumping jacks</target></segment>
     </unit>
     <unit id="exercise.cardio.highknees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>High Knees</source>
-        <target>High Knees</target>
-      </segment>
+        <target>High Knees</target></segment>
     </unit>
     <unit id="exercise.mobility.stretching.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dehnen</source>
-        <target>Dehnen</target>
-      </segment>
+        <target>Étirements</target></segment>
     </unit>
     <unit id="exercise.mobility.yoga.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Yoga</source>
-        <target>Yoga</target>
-      </segment>
+        <target>Yoga</target></segment>
     </unit>
     <unit id="exercise.mobility.foamrolling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Faszienrolle</source>
-        <target>Faszienrolle</target>
-      </segment>
+        <target>Rouleau de mousse</target></segment>
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dynamisches Aufwärmen</source>
-        <target>Dynamisches Aufwärmen</target>
-      </segment>
+        <target>Échauffement dynamique</target></segment>
     </unit>
     <unit id="exercise.mobility.catcow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Katze-Kuh</source>
-        <target>Katze-Kuh</target>
-      </segment>
+        <target>Chat-Vache</target></segment>
     </unit>
     <unit id="exercise.mobility.hipopener.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftöffner</source>
-        <target>Hüftöffner</target>
-      </segment>
+        <target>Ouverture de hanche</target></segment>
     </unit>
     <unit id="exercise.strength.benchpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdrücken</source>
-        <target>Bankdrücken</target>
-      </segment>
+        <target>Développé couché</target></segment>
     </unit>
     <unit id="exercise.strength.overheadpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schulterdrücken</source>
-        <target>Schulterdrücken</target>
-      </segment>
+        <target>Développé épaules</target></segment>
     </unit>
     <unit id="exercise.strength.deadlift.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kreuzheben</source>
-        <target>Kreuzheben</target>
-      </segment>
+        <target>Soulevé de terre</target></segment>
     </unit>
     <unit id="exercise.strength.barbellsquat.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel-Kniebeuge</source>
-        <target>Langhantel-Kniebeuge</target>
-      </segment>
+        <target>Squat à la barre</target></segment>
     </unit>
     <unit id="exercise.strength.barbellrow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantelrudern</source>
-        <target>Langhantelrudern</target>
-      </segment>
+        <target>Tirage à la barre</target></segment>
     </unit>
     <unit id="exercise.strength.kettlebellswing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kettlebell Swing</source>
-        <target>Kettlebell Swing</target>
-      </segment>
+        <target>Kettlebell Swing</target></segment>
     </unit>
       <unit id="exercise.variant.situps.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>Standard</target></segment>
     </unit>
     <unit id="exercise.variant.situps.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source>Decline</source>
-        <target>Decline</target>
-      </segment>
+        <target>Decline</target></segment>
     </unit>
     <unit id="exercise.variant.situps.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
-      </segment>
+        <target>Avec poids supplémentaire</target></segment>
     </unit>
     <unit id="exercise.variant.crunches.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>Standard</target></segment>
     </unit>
     <unit id="exercise.variant.crunches.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reverse Crunches</source>
-        <target>Reverse Crunches</target>
-      </segment>
+        <target>Reverse Crunches</target></segment>
     </unit>
     <unit id="exercise.variant.crunches.bicycle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bicycle Crunches</source>
-        <target>Bicycle Crunches</target>
-      </segment>
+        <target>Bicycle Crunches</target></segment>
     </unit>
     <unit id="exercise.variant.crunches.oblique">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schräge Crunches</source>
-        <target>Schräge Crunches</target>
-      </segment>
+        <target>Crunches obliques</target></segment>
     </unit>
     <unit id="exercise.variant.legraises.lying">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegend</source>
-        <target>Liegend</target>
-      </segment>
+        <target>Allongé</target></segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-knee">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (Knie)</source>
-        <target>Hängend (Knie)</target>
-      </segment>
+        <target>Suspendu (genoux)</target></segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-straight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (gestreckt)</source>
-        <target>Hängend (gestreckt)</target>
-      </segment>
+        <target>Suspendu (étendu)</target></segment>
     </unit>
     <unit id="exercise.variant.russiantwist.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
-      </segment>
+        <target>Poids du corps</target></segment>
     </unit>
     <unit id="exercise.variant.russiantwist.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
-      </segment>
+        <target>Avec poids supplémentaire</target></segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>Standard</target></segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.cross-body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Cross-Body</source>
-        <target>Cross-Body</target>
-      </segment>
+        <target>Cross-Body</target></segment>
     </unit>
     <unit id="exercise.variant.plank.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>Standard</target></segment>
     </unit>
     <unit id="exercise.variant.plank.forearm">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unterarmstütz</source>
-        <target>Unterarmstütz</target>
-      </segment>
+        <target>Planche avant-bras</target></segment>
     </unit>
     <unit id="exercise.variant.plank.side">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
-      </segment>
+        <target>Latéral</target></segment>
     </unit>
     <unit id="exercise.variant.plank.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Umgekehrt</source>
-        <target>Umgekehrt</target>
-      </segment>
+        <target>Inversé</target></segment>
     </unit>
     <unit id="exercise.variant.squats.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
-      </segment>
+        <target>Poids du corps</target></segment>
     </unit>
     <unit id="exercise.variant.squats.sumo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sumo</source>
-        <target>Sumo</target>
-      </segment>
+        <target>Sumo</target></segment>
     </unit>
     <unit id="exercise.variant.squats.goblet">
-      <segment state="initial">
+      <segment state="translated">
         <source>Goblet</source>
-        <target>Goblet</target>
-      </segment>
+        <target>Goblet</target></segment>
     </unit>
     <unit id="exercise.variant.squats.bulgarian-split">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bulgarian Split</source>
-        <target>Bulgarian Split</target>
-      </segment>
+        <target>Bulgarian Split</target></segment>
     </unit>
     <unit id="exercise.variant.squats.pistol">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pistol</source>
-        <target>Pistol</target>
-      </segment>
+        <target>Pistol</target></segment>
     </unit>
     <unit id="exercise.variant.calfraises.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>Standard</target></segment>
     </unit>
     <unit id="exercise.variant.calfraises.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
-      </segment>
+        <target>Unilatéral</target></segment>
     </unit>
     <unit id="exercise.variant.calfraises.seated">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sitzend</source>
-        <target>Sitzend</target>
-      </segment>
+        <target>Assis</target></segment>
     </unit>
     <unit id="exercise.variant.glutebridge.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>Standard</target></segment>
     </unit>
     <unit id="exercise.variant.glutebridge.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
-      </segment>
+        <target>Unilatéral</target></segment>
     </unit>
     <unit id="exercise.variant.glutebridge.hip-thrust">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hip Thrust</source>
-        <target>Hip Thrust</target>
-      </segment>
+        <target>Hip Thrust</target></segment>
     </unit>
     <unit id="exercise.variant.glutebridge.march">
-      <segment state="initial">
+      <segment state="translated">
         <source>Marching</source>
-        <target>Marching</target>
-      </segment>
+        <target>Marching</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.forward">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorwärts</source>
-        <target>Vorwärts</target>
-      </segment>
+        <target>En avant</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückwärts</source>
-        <target>Rückwärts</target>
-      </segment>
+        <target>En arrière</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.walking">
-      <segment state="initial">
+      <segment state="translated">
         <source>Walking</source>
-        <target>Walking</target>
-      </segment>
+        <target>Marche</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.lateral">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
-      </segment>
+        <target>Latéral</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.curtsy">
-      <segment state="initial">
+      <segment state="translated">
         <source>Curtsy</source>
-        <target>Curtsy</target>
-      </segment>
+        <target>Curtsy</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.jumping">
-      <segment state="initial">
+      <segment state="translated">
         <source>Jumping</source>
-        <target>Jumping</target>
-      </segment>
+        <target>Saut</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>Standard</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.chin-up">
-      <segment state="initial">
+      <segment state="translated">
         <source>Chin-up</source>
-        <target>Chin-up</target>
-      </segment>
+        <target>Chin-up</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.wide-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Breiter Griff</source>
-        <target>Breiter Griff</target>
-      </segment>
+        <target>Prise large</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.neutral-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neutraler Griff</source>
-        <target>Neutraler Griff</target>
-      </segment>
+        <target>Prise neutre</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.negative">
-      <segment state="initial">
+      <segment state="translated">
         <source>Negativ</source>
-        <target>Negativ</target>
-      </segment>
+        <target>Négatif</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.assisted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Assistiert</source>
-        <target>Assistiert</target>
-      </segment>
+        <target>Assisté</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.archer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Archer</source>
-        <target>Archer</target>
-      </segment>
+        <target>Archer</target></segment>
     </unit>
     <unit id="exercise.variant.rows.inverted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Inverted Row</source>
-        <target>Inverted Row</target>
-      </segment>
+        <target>Inverted Row</target></segment>
     </unit>
     <unit id="exercise.variant.rows.australian">
-      <segment state="initial">
+      <segment state="translated">
         <source>Australian Row</source>
-        <target>Australian Row</target>
-      </segment>
+        <target>Australian Row</target></segment>
     </unit>
     <unit id="exercise.variant.rows.dumbbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kurzhantel</source>
-        <target>Kurzhantel</target>
-      </segment>
+        <target>Haltère</target></segment>
     </unit>
     <unit id="exercise.variant.rows.barbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel</source>
-        <target>Langhantel</target>
-      </segment>
+        <target>Barre</target></segment>
     </unit>
     <unit id="exercise.push.dips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dips</source>
-        <target>Dips</target>
-      </segment>
+        <target>Dips</target></segment>
     </unit>
     <unit id="exercise.push.benchdips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdips</source>
-        <target>Bankdips</target>
-      </segment>
+        <target>Dips sur banc</target></segment>
     </unit>
     <unit id="exercise.push.handstandhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Handstand-Hold</source>
-        <target>Handstand-Hold</target>
-      </segment>
+        <target>Handstand Hold</target></segment>
     </unit>
     <unit id="exercise.variant.dips.parallel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Barren</source>
-        <target>Barren</target>
-      </segment>
+        <target>Barres parallèles</target></segment>
     </unit>
     <unit id="exercise.variant.dips.straight-bar">
-      <segment state="initial">
+      <segment state="translated">
         <source>Stange</source>
-        <target>Stange</target>
-      </segment>
+        <target>Barre</target></segment>
     </unit>
     <unit id="exercise.variant.dips.ring">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ringe</source>
-        <target>Ringe</target>
-      </segment>
+        <target>Anneaux</target></segment>
     </unit>
       <unit id="exerciseTimer.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübung-Timer</source>
-        <target>Halteübung-Timer</target>
-      </segment>
+        <target>Chronomètre d'exercice d'endurance</target></segment>
     </unit>
     <unit id="exerciseTimer.exercisePickerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung wählen</source>
-        <target>Übung wählen</target>
-      </segment>
+        <target>Sélectionner l'exercice</target></segment>
     </unit>
     <unit id="exerciseTimer.cameraMode">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera: Start/Ende automatisch erkennen </source>
-        <target> Kamera: Start/Ende automatisch erkennen </target>
-      </segment>
+        <target> Caméra : Reconnaissance automatique du début/fin </target></segment>
     </unit>
     <unit id="exerciseTimer.cameraStarting">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kamera startet …</source>
-        <target>Kamera startet …</target>
-      </segment>
+        <target>La caméra démarre...</target></segment>
     </unit>
     <unit id="exerciseTimer.cameraUnavailable">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera nicht verfügbar </source>
-        <target> Kamera nicht verfügbar </target>
-      </segment>
+        <target> Caméra non disponible </target></segment>
     </unit>
     <unit id="exerciseTimer.formCheck.toggleAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Form-Check anzeigen oder ausblenden</source>
-        <target>Form-Check anzeigen oder ausblenden</target>
-      </segment>
+        <target>Afficher ou masquer la vérification de la forme</target></segment>
     </unit>
     <unit id="exerciseTimer.formCheck.angle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Winkel</source>
-        <target>Winkel</target>
-      </segment>
+        <target>Angle</target></segment>
     </unit>
     <unit id="exerciseTimer.formCheck.confidence">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sicherheit</source>
-        <target>Sicherheit</target>
-      </segment>
+        <target>Sécurité</target></segment>
     </unit>
     <unit id="exerciseTimer.pause">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
-      </segment>
+        <target>Pause</target></segment>
     </unit>
     <unit id="exerciseTimer.start">
-      <segment state="initial">
+      <segment state="translated">
         <source>Start</source>
-        <target>Start</target>
-      </segment>
+        <target>Démarrer</target></segment>
     </unit>
     <unit id="exerciseTimer.cameraHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
-        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
-      </segment>
+        <target> Configurez la caméra pour que les épaules, les hanches et les genoux soient visibles. Le chronomètre démarre automatiquement une fois que vous êtes en position et s'arrête lorsque vous quittez la position. </target></segment>
     </unit>
     <unit id="exerciseTimer.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurücksetzen </source>
-        <target> Zurücksetzen </target>
-      </segment>
+        <target> Réinitialiser </target></segment>
     </unit>
     <unit id="exerciseTimer.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
-      </segment>
+        <target> Annuler </target></segment>
     </unit>
     <unit id="exerciseTimer.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Übernehmen </source>
-        <target> Übernehmen </target>
-      </segment>
+        <target> Accepter </target></segment>
     </unit>
     <unit id="exerciseTimer.phase.holding">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halten</source>
-        <target>Halten</target>
-      </segment>
+        <target>Maintenir</target></segment>
     </unit>
     <unit id="exerciseTimer.phase.paused">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
-      </segment>
+        <target>Pause</target></segment>
     </unit>
     <unit id="exerciseTimer.phase.ready">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bereit</source>
-        <target>Bereit</target>
-      </segment>
+        <target>Prêt</target></segment>
     </unit>
     <unit id="exerciseTimer.exercise.plank">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank</source>
-        <target>Plank</target>
-      </segment>
+        <target>Plank</target></segment>
     </unit>
     <unit id="exerciseTimer.exercise.hollowhold">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
-        <target>Hollow Hold</target>
-      </segment>
+        <target>Hollow Hold</target></segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübungs-Timer öffnen</source>
-        <target>Halteübungs-Timer öffnen</target>
-      </segment>
+        <target>Ouvrir le chronomètre d'exercice d'endurance</target></segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank‑Timer</source>
-        <target>Plank‑Timer</target>
-      </segment>
+        <target>Chronomètre Plank</target></segment>
     </unit>
     <unit id="quickAddConfig.hintV2">
       <segment state="translated">
-        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> Schnellaktionen fest. Wähle pro Button die Übung und – wo verfügbar – Auto-Messung über die Kamera. Leere Felder werden ignoriert. </source>
-        <target> Configurez jusqu'à <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> actions rapides. Choisissez l'exercice pour chaque bouton et — lorsque disponible — le comptage automatique via la caméra. Les champs vides sont ignorés. </target>
+        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> Schnellaktionen fest. Wähle pro Button die Übung und – wo verfügbar – Auto-Messung über die Kamera. Leere Felder werden ignoriert. </source>
+        <target> Configurez jusqu'à <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> actions rapides. Choisissez l'exercice pour chaque bouton et — lorsque disponible — le comptage automatique via la caméra. Les champs vides sont ignorés. </target>
       </segment>
     </unit>
     <unit id="quickAddConfig.exerciseLabel">
@@ -9443,8 +9315,8 @@
     </unit>
     <unit id="plan.push-pull-6w.summary">
       <segment state="translated">
-        <source>Symmetrischer 6-Wochen-Plan für Liegestütze und Rückenübungen (Rudern, Klimmzug-Negative, Face Pulls). Vermeidet das klassische &quot;nur Push&quot;-Ungleichgewicht und stärkt die hintere Kette gleichwertig. Pull-Tag pro Woche zusätzlich zur Push-Progression.</source>
-        <target>Plan symétrique de 6 semaines pour les pompes et le travail de tirage (rangées, tractions négatives, face pulls). Évite le déséquilibre classique &quot;poussée seule&quot; et renforce la chaîne postérieure à parts égales. Une journée de tirage dédiée par semaine en plus de la progression de poussée.</target>
+        <source>Symmetrischer 6-Wochen-Plan für Liegestütze und Rückenübungen (Rudern, Klimmzug-Negative, Face Pulls). Vermeidet das klassische "nur Push"-Ungleichgewicht und stärkt die hintere Kette gleichwertig. Pull-Tag pro Woche zusätzlich zur Push-Progression.</source>
+        <target>Plan symétrique de 6 semaines pour les pompes et le travail de tirage (rangées, tractions négatives, face pulls). Évite le déséquilibre classique "poussée seule" et renforce la chaîne postérieure à parts égales. Une journée de tirage dédiée par semaine en plus de la progression de poussée.</target>
       </segment>
     </unit>
     <unit id="plan.full-body-6w.title">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -8178,7 +8178,7 @@
     <unit id="exercise.pull.rows.name">
       <segment state="translated">
         <source>Ruderzug</source>
-        <target>Remata</target>
+        <target>Rematore</target>
       </segment>
     </unit>
     <unit id="exercise.pull.deadhang.name">
@@ -8292,7 +8292,7 @@
     <unit id="exercise.mobility.hipopener.name">
       <segment state="translated">
         <source>Hüftöffner</source>
-        <target>Apriscchi</target>
+        <target>Apertura delle anche</target>
       </segment>
     </unit>
     <unit id="exercise.strength.benchpress.name">
@@ -8712,7 +8712,7 @@
     <unit id="exerciseTimer.cameraHint">
       <segment state="translated">
         <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
-        <target>Posiziona la fotocamera in modo che siano visibili spalla, fianco e ginocchio. Il timer si avvia automaticamente</target>
+        <target>Posiziona la fotocamera in modo che siano visibili spalla, fianco e ginocchio. Il timer si avvia automaticamente non appena sei in posizione e si mette in pausa quando esci dalla posizione.</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.reset">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -4678,45 +4678,45 @@
       </segment>
     </unit>
     <unit id="intervalsDistribution.noData">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Intervall-Daten vorhanden</source>
-        <target>Keine Intervall-Daten vorhanden</target>
+        <target>Nessun dato di intervallo disponibile</target>
       </segment>
     </unit>
     <unit id="intervalsDistribution.listLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Verteilung</source>
-        <target>Intervall-Verteilung</target>
+        <target>Distribuzione intervalli</target>
       </segment>
     </unit>
     <unit id="entry.interval.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
+        <target>Intervallo <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
       </segment>
     </unit>
     <unit id="entry.intervals.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervalle</source>
-        <target>Intervalle</target>
+        <target>Intervalli</target>
       </segment>
     </unit>
     <unit id="entry.intervals.remove">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall entfernen</source>
-        <target>Intervall entfernen</target>
+        <target>Rimuovi intervallo</target>
       </segment>
     </unit>
     <unit id="entry.intervals.add">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall hinzufügen</source>
-        <target>Intervall hinzufügen</target>
+        <target>Aggiungi intervallo</target>
       </segment>
     </unit>
     <unit id="entry.intervals.addTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Weiteres Intervall hinzufügen</source>
-        <target>Weiteres Intervall hinzufügen</target>
+        <target>Aggiungi un altro intervallo</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.reps">
@@ -8074,705 +8074,705 @@
       </segment>
     </unit>
       <unit id="exercise.category.push">
-      <segment state="initial">
+      <segment state="translated">
         <source>Drücken</source>
-        <target>Drücken</target>
+        <target>Spinta</target>
       </segment>
     </unit>
     <unit id="exercise.category.pull">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziehen</source>
-        <target>Ziehen</target>
+        <target>Trazione</target>
       </segment>
     </unit>
     <unit id="exercise.category.squat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kniebeuge</source>
-        <target>Kniebeuge</target>
+        <target>Squat</target>
       </segment>
     </unit>
     <unit id="exercise.category.hinge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftstreckung</source>
-        <target>Hüftstreckung</target>
+        <target>Cardine</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausfallschritt</source>
-        <target>Ausfallschritt</target>
+        <target>Affondo</target>
       </segment>
     </unit>
     <unit id="exercise.category.carry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tragen</source>
-        <target>Tragen</target>
+        <target>Trasporto</target>
       </segment>
     </unit>
     <unit id="exercise.category.core">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rumpf</source>
-        <target>Rumpf</target>
+        <target>Core</target>
       </segment>
     </unit>
     <unit id="exercise.category.mobility">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mobilität</source>
-        <target>Mobilität</target>
+        <target>Mobilità</target>
       </segment>
     </unit>
     <unit id="exercise.category.strength">
-      <segment state="initial">
+      <segment state="translated">
         <source>Krafttraining</source>
-        <target>Krafttraining</target>
+        <target>Forza</target>
       </segment>
     </unit>
     <unit id="exercise.core.deadbug.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Bug</source>
         <target>Dead Bug</target>
       </segment>
     </unit>
     <unit id="exercise.core.hollowhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
         <target>Hollow Hold</target>
       </segment>
     </unit>
     <unit id="exercise.squat.wallsit.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wandsitz</source>
-        <target>Wandsitz</target>
+        <target>Wall Sit</target>
       </segment>
     </unit>
     <unit id="exercise.squat.boxjump.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Box Jumps</source>
         <target>Box Jumps</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.singlelegRdl.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeiniges Kreuzheben</source>
-        <target>Einbeiniges Kreuzheben</target>
+        <target>Stacco su una gamba</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.goodmorning.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Good Morning</source>
         <target>Good Morning</target>
       </segment>
     </unit>
     <unit id="exercise.lunge.stepup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Step-ups</source>
-        <target>Step-ups</target>
+        <target>Step-up</target>
       </segment>
     </unit>
     <unit id="exercise.pull.pullups.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Klimmzüge</source>
-        <target>Klimmzüge</target>
+        <target>Trazioni</target>
       </segment>
     </unit>
     <unit id="exercise.pull.rows.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ruderzug</source>
-        <target>Ruderzug</target>
+        <target>Remata</target>
       </segment>
     </unit>
     <unit id="exercise.pull.deadhang.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Hang</source>
         <target>Dead Hang</target>
       </segment>
     </unit>
     <unit id="exercise.pull.facepull.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Face Pull</source>
         <target>Face Pull</target>
       </segment>
     </unit>
     <unit id="exercise.carry.farmer.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Farmer&apos;s Walk</source>
-        <target>Farmer&apos;s Walk</target>
+        <target>Farmer's Walk</target>
       </segment>
     </unit>
     <unit id="exercise.carry.suitcase.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Suitcase Carry</source>
         <target>Suitcase Carry</target>
       </segment>
     </unit>
     <unit id="exercise.carry.overhead.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Overhead Carry</source>
         <target>Overhead Carry</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.walking.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gehen</source>
-        <target>Gehen</target>
+        <target>Camminata</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.cycling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Radfahren</source>
-        <target>Radfahren</target>
+        <target>Ciclismo</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.rowing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rudern</source>
-        <target>Rudern</target>
+        <target>Canottaggio</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.swimming.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schwimmen</source>
-        <target>Schwimmen</target>
+        <target>Nuoto</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumprope.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seilspringen</source>
-        <target>Seilspringen</target>
+        <target>Salto con la corda</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.burpees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Burpees</source>
         <target>Burpees</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumpingjacks.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hampelmänner</source>
-        <target>Hampelmänner</target>
+        <target>Jumping jacks</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.highknees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>High Knees</source>
         <target>High Knees</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.stretching.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dehnen</source>
-        <target>Dehnen</target>
+        <target>Stretching</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.yoga.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Yoga</source>
         <target>Yoga</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.foamrolling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Faszienrolle</source>
-        <target>Faszienrolle</target>
+        <target>Foam rolling</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dynamisches Aufwärmen</source>
-        <target>Dynamisches Aufwärmen</target>
+        <target>Riscaldamento dinamico</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.catcow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Katze-Kuh</source>
-        <target>Katze-Kuh</target>
+        <target>Cat-Cow</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.hipopener.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftöffner</source>
-        <target>Hüftöffner</target>
+        <target>Apriscchi</target>
       </segment>
     </unit>
     <unit id="exercise.strength.benchpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdrücken</source>
-        <target>Bankdrücken</target>
+        <target>Panca piana</target>
       </segment>
     </unit>
     <unit id="exercise.strength.overheadpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schulterdrücken</source>
-        <target>Schulterdrücken</target>
+        <target>Spinta in alto</target>
       </segment>
     </unit>
     <unit id="exercise.strength.deadlift.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kreuzheben</source>
-        <target>Kreuzheben</target>
+        <target>Stacco da terra</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellsquat.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel-Kniebeuge</source>
-        <target>Langhantel-Kniebeuge</target>
+        <target>Squat con bilanciere</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellrow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantelrudern</source>
-        <target>Langhantelrudern</target>
+        <target>Remata con bilanciere</target>
       </segment>
     </unit>
     <unit id="exercise.strength.kettlebellswing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kettlebell Swing</source>
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
       <unit id="exercise.variant.situps.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source>Decline</source>
         <target>Decline</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Con carico</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reverse Crunches</source>
         <target>Reverse Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.bicycle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bicycle Crunches</source>
         <target>Bicycle Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.oblique">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schräge Crunches</source>
-        <target>Schräge Crunches</target>
+        <target>Crunches obliqui</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.lying">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegend</source>
-        <target>Liegend</target>
+        <target>Sdraiato</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-knee">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (Knie)</source>
-        <target>Hängend (Knie)</target>
+        <target>Sospeso (ginocchia)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-straight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (gestreckt)</source>
-        <target>Hängend (gestreckt)</target>
+        <target>Sospeso (gambe tese)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Peso corporeo</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Con carico</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.cross-body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Cross-Body</source>
         <target>Cross-Body</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.forearm">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unterarmstütz</source>
-        <target>Unterarmstütz</target>
+        <target>Plank avambracci</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.side">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Laterale</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Umgekehrt</source>
-        <target>Umgekehrt</target>
+        <target>Inverso</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Peso corporeo</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.sumo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sumo</source>
         <target>Sumo</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.goblet">
-      <segment state="initial">
+      <segment state="translated">
         <source>Goblet</source>
         <target>Goblet</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bulgarian-split">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bulgarian Split</source>
         <target>Bulgarian Split</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.pistol">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pistol</source>
         <target>Pistol</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>Su una gamba</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.seated">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sitzend</source>
-        <target>Sitzend</target>
+        <target>Seduto</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>Su una gamba</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.hip-thrust">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hip Thrust</source>
         <target>Hip Thrust</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.march">
-      <segment state="initial">
+      <segment state="translated">
         <source>Marching</source>
         <target>Marching</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.forward">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorwärts</source>
-        <target>Vorwärts</target>
+        <target>Avanti</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückwärts</source>
-        <target>Rückwärts</target>
+        <target>Indietro</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.walking">
-      <segment state="initial">
+      <segment state="translated">
         <source>Walking</source>
         <target>Walking</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.lateral">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Laterale</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.curtsy">
-      <segment state="initial">
+      <segment state="translated">
         <source>Curtsy</source>
         <target>Curtsy</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.jumping">
-      <segment state="initial">
+      <segment state="translated">
         <source>Jumping</source>
         <target>Jumping</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.chin-up">
-      <segment state="initial">
+      <segment state="translated">
         <source>Chin-up</source>
         <target>Chin-up</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.wide-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Breiter Griff</source>
-        <target>Breiter Griff</target>
+        <target>Presa larga</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.neutral-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neutraler Griff</source>
-        <target>Neutraler Griff</target>
+        <target>Presa neutra</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.negative">
-      <segment state="initial">
+      <segment state="translated">
         <source>Negativ</source>
-        <target>Negativ</target>
+        <target>Negativa</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.assisted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Assistiert</source>
-        <target>Assistiert</target>
+        <target>Assistita</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.archer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Archer</source>
         <target>Archer</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.inverted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Inverted Row</source>
         <target>Inverted Row</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.australian">
-      <segment state="initial">
+      <segment state="translated">
         <source>Australian Row</source>
         <target>Australian Row</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.dumbbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kurzhantel</source>
-        <target>Kurzhantel</target>
+        <target>Manubrio</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.barbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel</source>
-        <target>Langhantel</target>
+        <target>Bilanciere</target>
       </segment>
     </unit>
     <unit id="exercise.push.dips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dips</source>
         <target>Dips</target>
       </segment>
     </unit>
     <unit id="exercise.push.benchdips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdips</source>
-        <target>Bankdips</target>
+        <target>Bench Dips</target>
       </segment>
     </unit>
     <unit id="exercise.push.handstandhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Handstand-Hold</source>
-        <target>Handstand-Hold</target>
+        <target>Handstand Hold</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.parallel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Barren</source>
-        <target>Barren</target>
+        <target>Parallele</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.straight-bar">
-      <segment state="initial">
+      <segment state="translated">
         <source>Stange</source>
-        <target>Stange</target>
+        <target>Sbarra</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.ring">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ringe</source>
-        <target>Ringe</target>
+        <target>Anelli</target>
       </segment>
     </unit>
       <unit id="exerciseTimer.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübung-Timer</source>
-        <target>Halteübung-Timer</target>
+        <target>Timer esercizio di resistenza</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercisePickerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung wählen</source>
-        <target>Übung wählen</target>
+        <target>Seleziona esercizio</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraMode">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera: Start/Ende automatisch erkennen </source>
-        <target> Kamera: Start/Ende automatisch erkennen </target>
+        <target>Fotocamera: rileva automaticamente inizio/fine</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraStarting">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kamera startet …</source>
-        <target>Kamera startet …</target>
+        <target>Fotocamera in avvio…</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraUnavailable">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera nicht verfügbar </source>
-        <target> Kamera nicht verfügbar </target>
+        <target>Fotocamera non disponibile</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.toggleAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Form-Check anzeigen oder ausblenden</source>
-        <target>Form-Check anzeigen oder ausblenden</target>
+        <target>Mostra o nascondi controllo forma</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.angle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Winkel</source>
-        <target>Winkel</target>
+        <target>Angolo</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.confidence">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sicherheit</source>
-        <target>Sicherheit</target>
+        <target>Affidabilità</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.pause">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
+        <target>Pausa</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.start">
-      <segment state="initial">
+      <segment state="translated">
         <source>Start</source>
-        <target>Start</target>
+        <target>Avvia</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
-        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+        <target>Posiziona la fotocamera in modo che siano visibili spalla, fianco e ginocchio. Il timer si avvia automaticamente</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurücksetzen </source>
-        <target> Zurücksetzen </target>
+        <target>Reimposta</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target>Annulla</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Übernehmen </source>
-        <target> Übernehmen </target>
+        <target>Salva</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.holding">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halten</source>
-        <target>Halten</target>
+        <target>Mantieni</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.paused">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
+        <target>In pausa</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.ready">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bereit</source>
-        <target>Bereit</target>
+        <target>Pronto</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercise.plank">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank</source>
         <target>Plank</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercise.hollowhold">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
         <target>Hollow Hold</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübungs-Timer öffnen</source>
-        <target>Halteübungs-Timer öffnen</target>
+        <target>Apri timer esercizio di resistenza</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank‑Timer</source>
-        <target>Plank‑Timer</target>
+        <target>Timer Plank</target>
       </segment>
     </unit>
     <unit id="quickAddConfig.hintV2">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -8220,7 +8220,7 @@
     <unit id="exercise.cardio.cycling.name">
       <segment state="translated">
         <source>Radfahren</source>
-        <target>Cyclopedia</target>
+        <target>Cyclismus</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.rowing.name">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -4678,45 +4678,45 @@
       </segment>
     </unit>
     <unit id="intervalsDistribution.noData">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Intervall-Daten vorhanden</source>
-        <target>Keine Intervall-Daten vorhanden</target>
+        <target>Nulla notitia intervalorum</target>
       </segment>
     </unit>
     <unit id="intervalsDistribution.listLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Verteilung</source>
-        <target>Intervall-Verteilung</target>
+        <target>Distributio intervalorum</target>
       </segment>
     </unit>
     <unit id="entry.interval.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
+        <target>Intervallum <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
       </segment>
     </unit>
     <unit id="entry.intervals.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervalle</source>
-        <target>Intervalle</target>
+        <target>Intervalla</target>
       </segment>
     </unit>
     <unit id="entry.intervals.remove">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall entfernen</source>
-        <target>Intervall entfernen</target>
+        <target>Intervallum auferre</target>
       </segment>
     </unit>
     <unit id="entry.intervals.add">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall hinzufügen</source>
-        <target>Intervall hinzufügen</target>
+        <target>Intervallum addere</target>
       </segment>
     </unit>
     <unit id="entry.intervals.addTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Weiteres Intervall hinzufügen</source>
-        <target>Weiteres Intervall hinzufügen</target>
+        <target>Aliud intervallum addere</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.reps">
@@ -8074,705 +8074,705 @@
       </segment>
     </unit>
       <unit id="exercise.category.push">
-      <segment state="initial">
+      <segment state="translated">
         <source>Drücken</source>
-        <target>Drücken</target>
+        <target>Pulsus</target>
       </segment>
     </unit>
     <unit id="exercise.category.pull">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziehen</source>
-        <target>Ziehen</target>
+        <target>Tractus</target>
       </segment>
     </unit>
     <unit id="exercise.category.squat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kniebeuge</source>
-        <target>Kniebeuge</target>
+        <target>Genuflexio</target>
       </segment>
     </unit>
     <unit id="exercise.category.hinge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftstreckung</source>
-        <target>Hüftstreckung</target>
+        <target>Extensio coxae</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausfallschritt</source>
-        <target>Ausfallschritt</target>
+        <target>Passus lunatus</target>
       </segment>
     </unit>
     <unit id="exercise.category.carry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tragen</source>
-        <target>Tragen</target>
+        <target>Gestatio</target>
       </segment>
     </unit>
     <unit id="exercise.category.core">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rumpf</source>
-        <target>Rumpf</target>
+        <target>Truncus</target>
       </segment>
     </unit>
     <unit id="exercise.category.mobility">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mobilität</source>
-        <target>Mobilität</target>
+        <target>Mobilitas</target>
       </segment>
     </unit>
     <unit id="exercise.category.strength">
-      <segment state="initial">
+      <segment state="translated">
         <source>Krafttraining</source>
-        <target>Krafttraining</target>
+        <target>Exercitatio fortitudinis</target>
       </segment>
     </unit>
     <unit id="exercise.core.deadbug.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Bug</source>
         <target>Dead Bug</target>
       </segment>
     </unit>
     <unit id="exercise.core.hollowhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
         <target>Hollow Hold</target>
       </segment>
     </unit>
     <unit id="exercise.squat.wallsit.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wandsitz</source>
-        <target>Wandsitz</target>
+        <target>Sessio parietis</target>
       </segment>
     </unit>
     <unit id="exercise.squat.boxjump.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Box Jumps</source>
         <target>Box Jumps</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.singlelegRdl.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeiniges Kreuzheben</source>
-        <target>Einbeiniges Kreuzheben</target>
+        <target>Sublevatio mortua unius cruris</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.goodmorning.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Good Morning</source>
         <target>Good Morning</target>
       </segment>
     </unit>
     <unit id="exercise.lunge.stepup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Step-ups</source>
         <target>Step-ups</target>
       </segment>
     </unit>
     <unit id="exercise.pull.pullups.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Klimmzüge</source>
-        <target>Klimmzüge</target>
+        <target>Tractiones</target>
       </segment>
     </unit>
     <unit id="exercise.pull.rows.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ruderzug</source>
-        <target>Ruderzug</target>
+        <target>Tractio remigum</target>
       </segment>
     </unit>
     <unit id="exercise.pull.deadhang.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Hang</source>
         <target>Dead Hang</target>
       </segment>
     </unit>
     <unit id="exercise.pull.facepull.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Face Pull</source>
-        <target>Face Pull</target>
+        <target>Tractio faciei</target>
       </segment>
     </unit>
     <unit id="exercise.carry.farmer.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Farmer&apos;s Walk</source>
-        <target>Farmer&apos;s Walk</target>
+        <target>Ambulatio agricolae</target>
       </segment>
     </unit>
     <unit id="exercise.carry.suitcase.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Suitcase Carry</source>
-        <target>Suitcase Carry</target>
+        <target>Gestatio malae</target>
       </segment>
     </unit>
     <unit id="exercise.carry.overhead.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Overhead Carry</source>
-        <target>Overhead Carry</target>
+        <target>Gestatio capitis superioris</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.walking.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gehen</source>
-        <target>Gehen</target>
+        <target>Ambulatio</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.cycling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Radfahren</source>
-        <target>Radfahren</target>
+        <target>Cyclopedia</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.rowing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rudern</source>
-        <target>Rudern</target>
+        <target>Remigatio</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.swimming.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schwimmen</source>
-        <target>Schwimmen</target>
+        <target>Natatio</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumprope.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seilspringen</source>
-        <target>Seilspringen</target>
+        <target>Saltus fune</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.burpees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Burpees</source>
         <target>Burpees</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumpingjacks.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hampelmänner</source>
-        <target>Hampelmänner</target>
+        <target>Saltus laterales</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.highknees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>High Knees</source>
         <target>High Knees</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.stretching.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dehnen</source>
-        <target>Dehnen</target>
+        <target>Extensio</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.yoga.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Yoga</source>
         <target>Yoga</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.foamrolling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Faszienrolle</source>
-        <target>Faszienrolle</target>
+        <target>Rotula fasciae</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dynamisches Aufwärmen</source>
-        <target>Dynamisches Aufwärmen</target>
+        <target>Praeparatio dynamica</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.catcow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Katze-Kuh</source>
-        <target>Katze-Kuh</target>
+        <target>Felis-Bos</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.hipopener.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftöffner</source>
-        <target>Hüftöffner</target>
+        <target>Apertura coxae</target>
       </segment>
     </unit>
     <unit id="exercise.strength.benchpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdrücken</source>
-        <target>Bankdrücken</target>
+        <target>Pulsus supinus</target>
       </segment>
     </unit>
     <unit id="exercise.strength.overheadpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schulterdrücken</source>
-        <target>Schulterdrücken</target>
+        <target>Pulsus umeralis</target>
       </segment>
     </unit>
     <unit id="exercise.strength.deadlift.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kreuzheben</source>
-        <target>Kreuzheben</target>
+        <target>Sublevatio mortua</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellsquat.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel-Kniebeuge</source>
-        <target>Langhantel-Kniebeuge</target>
+        <target>Genuflexio cum vectis</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellrow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantelrudern</source>
-        <target>Langhantelrudern</target>
+        <target>Tractio cum vectis</target>
       </segment>
     </unit>
     <unit id="exercise.strength.kettlebellswing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kettlebell Swing</source>
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
       <unit id="exercise.variant.situps.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source>Decline</source>
         <target>Decline</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Cum pondere addito</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reverse Crunches</source>
         <target>Reverse Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.bicycle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bicycle Crunches</source>
         <target>Bicycle Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.oblique">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schräge Crunches</source>
-        <target>Schräge Crunches</target>
+        <target>Crunches obliqua</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.lying">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegend</source>
-        <target>Liegend</target>
+        <target>Supinus</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-knee">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (Knie)</source>
-        <target>Hängend (Knie)</target>
+        <target>Pendens (genu)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-straight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (gestreckt)</source>
-        <target>Hängend (gestreckt)</target>
+        <target>Pendens (extensum)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Libra corporalis</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Cum pondere addito</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.cross-body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Cross-Body</source>
         <target>Cross-Body</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.forearm">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unterarmstütz</source>
-        <target>Unterarmstütz</target>
+        <target>Fulcrum antebrachii</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.side">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Lateralis</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Umgekehrt</source>
-        <target>Umgekehrt</target>
+        <target>Inversus</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Libra corporalis</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.sumo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sumo</source>
         <target>Sumo</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.goblet">
-      <segment state="initial">
+      <segment state="translated">
         <source>Goblet</source>
         <target>Goblet</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bulgarian-split">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bulgarian Split</source>
         <target>Bulgarian Split</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.pistol">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pistol</source>
         <target>Pistol</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>Unius cruris</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.seated">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sitzend</source>
-        <target>Sitzend</target>
+        <target>Sedens</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>Unius cruris</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.hip-thrust">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hip Thrust</source>
         <target>Hip Thrust</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.march">
-      <segment state="initial">
+      <segment state="translated">
         <source>Marching</source>
         <target>Marching</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.forward">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorwärts</source>
-        <target>Vorwärts</target>
+        <target>Antrorsum</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückwärts</source>
-        <target>Rückwärts</target>
+        <target>Retrorsum</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.walking">
-      <segment state="initial">
+      <segment state="translated">
         <source>Walking</source>
         <target>Walking</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.lateral">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Lateralis</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.curtsy">
-      <segment state="initial">
+      <segment state="translated">
         <source>Curtsy</source>
         <target>Curtsy</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.jumping">
-      <segment state="initial">
+      <segment state="translated">
         <source>Jumping</source>
         <target>Jumping</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.chin-up">
-      <segment state="initial">
+      <segment state="translated">
         <source>Chin-up</source>
         <target>Chin-up</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.wide-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Breiter Griff</source>
-        <target>Breiter Griff</target>
+        <target>Praehensio lata</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.neutral-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neutraler Griff</source>
-        <target>Neutraler Griff</target>
+        <target>Praehensio neutra</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.negative">
-      <segment state="initial">
+      <segment state="translated">
         <source>Negativ</source>
-        <target>Negativ</target>
+        <target>Negativa</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.assisted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Assistiert</source>
-        <target>Assistiert</target>
+        <target>Adiutoria</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.archer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Archer</source>
         <target>Archer</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.inverted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Inverted Row</source>
         <target>Inverted Row</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.australian">
-      <segment state="initial">
+      <segment state="translated">
         <source>Australian Row</source>
         <target>Australian Row</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.dumbbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kurzhantel</source>
-        <target>Kurzhantel</target>
+        <target>Alteres</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.barbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel</source>
-        <target>Langhantel</target>
+        <target>Vectis</target>
       </segment>
     </unit>
     <unit id="exercise.push.dips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dips</source>
         <target>Dips</target>
       </segment>
     </unit>
     <unit id="exercise.push.benchdips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdips</source>
-        <target>Bankdips</target>
+        <target>Dips supini</target>
       </segment>
     </unit>
     <unit id="exercise.push.handstandhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Handstand-Hold</source>
         <target>Handstand-Hold</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.parallel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Barren</source>
         <target>Barren</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.straight-bar">
-      <segment state="initial">
+      <segment state="translated">
         <source>Stange</source>
-        <target>Stange</target>
+        <target>Baculum</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.ring">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ringe</source>
-        <target>Ringe</target>
+        <target>Annuli</target>
       </segment>
     </unit>
       <unit id="exerciseTimer.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübung-Timer</source>
-        <target>Halteübung-Timer</target>
+        <target>Horologium exercitationis</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercisePickerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung wählen</source>
-        <target>Übung wählen</target>
+        <target>Exercitium seligere</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraMode">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera: Start/Ende automatisch erkennen </source>
-        <target> Kamera: Start/Ende automatisch erkennen </target>
+        <target> Camera: initium/finis automatice agnoscere </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraStarting">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kamera startet …</source>
-        <target>Kamera startet …</target>
+        <target>Camera incipit ...</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraUnavailable">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera nicht verfügbar </source>
-        <target> Kamera nicht verfügbar </target>
+        <target> Camera non praesto est </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.toggleAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Form-Check anzeigen oder ausblenden</source>
-        <target>Form-Check anzeigen oder ausblenden</target>
+        <target>Inspectio formae monstrare vel celare</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.angle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Winkel</source>
-        <target>Winkel</target>
+        <target>Angulus</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.confidence">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sicherheit</source>
-        <target>Sicherheit</target>
+        <target>Certitudo</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.pause">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
+        <target>Pausa</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.start">
-      <segment state="initial">
+      <segment state="translated">
         <source>Start</source>
-        <target>Start</target>
+        <target>Incepto</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
-        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+        <target> Instrui camerae ut umerus, coxa et genu videnda sunt. Horologium incepit automatice cum in positione sis, et pausatur cum positionem relinquis. </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurücksetzen </source>
-        <target> Zurücksetzen </target>
+        <target> Reducere </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Renuntiare </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Übernehmen </source>
-        <target> Übernehmen </target>
+        <target> Suscipere </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.holding">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halten</source>
-        <target>Halten</target>
+        <target>Manere</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.paused">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
+        <target>Pausa</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.ready">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bereit</source>
-        <target>Bereit</target>
+        <target>Paratus</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercise.plank">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank</source>
         <target>Plank</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercise.hollowhold">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
         <target>Hollow Hold</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübungs-Timer öffnen</source>
-        <target>Halteübungs-Timer öffnen</target>
+        <target>Horologium exercitationis aperire</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank‑Timer</source>
-        <target>Plank‑Timer</target>
+        <target>Horologium Plank</target>
       </segment>
     </unit>
     <unit id="quickAddConfig.hintV2">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -8154,7 +8154,7 @@
     <unit id="exercise.hinge.singlelegRdl.name">
       <segment state="translated">
         <source>Einbeiniges Kreuzheben</source>
-        <target>Eenbenigig deadlift</target>
+        <target>Eenbenig deadlift</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.goodmorning.name">
@@ -8178,7 +8178,7 @@
     <unit id="exercise.pull.rows.name">
       <segment state="translated">
         <source>Ruderzug</source>
-        <target>Rij</target>
+        <target>Roeien</target>
       </segment>
     </unit>
     <unit id="exercise.pull.deadhang.name">
@@ -8478,7 +8478,7 @@
     <unit id="exercise.variant.calfraises.single-leg">
       <segment state="translated">
         <source>Einbeinig</source>
-        <target>Eenbenigig</target>
+        <target>Eenbenig</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.seated">
@@ -8496,7 +8496,7 @@
     <unit id="exercise.variant.glutebridge.single-leg">
       <segment state="translated">
         <source>Einbeinig</source>
-        <target>Eenbenigig</target>
+        <target>Eenbenig</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.hip-thrust">
@@ -8664,7 +8664,7 @@
     <unit id="exerciseTimer.cameraMode">
       <segment state="translated">
         <source> Kamera: Start/Ende automatisch erkennen </source>
-        <target> Kamera: Start/Ende automatisch erkennen </target>
+        <target> Camera: begin/einde automatisch detecteren </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraStarting">
@@ -8676,7 +8676,7 @@
     <unit id="exerciseTimer.cameraUnavailable">
       <segment state="translated">
         <source> Kamera nicht verfügbar </source>
-        <target> Kamera nicht verfügbar </target>
+        <target> Camera niet beschikbaar </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.toggleAria">
@@ -8712,25 +8712,25 @@
     <unit id="exerciseTimer.cameraHint">
       <segment state="translated">
         <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
-        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+        <target> Plaats de camera zo dat schouder, heup en knie zichtbaar zijn. De timer start automatisch zodra je in positie bent en pauzeert wanneer je de positie verlaat. </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.reset">
       <segment state="translated">
         <source> Zurücksetzen </source>
-        <target> Zurücksetzen </target>
+        <target> Resetten </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cancel">
       <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Annuleren </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.save">
       <segment state="translated">
         <source> Übernehmen </source>
-        <target> Übernehmen </target>
+        <target> Toepassen </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.holding">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -2983,7 +2983,7 @@
       </notes>
       <segment state="translated">
         <source> Auf iPhone &amp; iPad: Teilen-Symbol antippen und „Zum Home-Bildschirm“ wählen. </source>
-        <target> Op iPhone & iPad: tik op het deelpictogram en kies “Voeg toe aan beginscherm”. </target>
+        <target> Op iPhone &amp; iPad: tik op het deelpictogram en kies “Voeg toe aan beginscherm”. </target>
       </segment>
     </unit>
     <unit id="landing.feature.privacy.title">
@@ -4678,45 +4678,45 @@
       </segment>
     </unit>
     <unit id="intervalsDistribution.noData">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Intervall-Daten vorhanden</source>
-        <target>Keine Intervall-Daten vorhanden</target>
+        <target>Geen intervalgegevens beschikbaar</target>
       </segment>
     </unit>
     <unit id="intervalsDistribution.listLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Verteilung</source>
-        <target>Intervall-Verteilung</target>
+        <target>Intervalverdeling</target>
       </segment>
     </unit>
     <unit id="entry.interval.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
+        <target>Interval <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
       </segment>
     </unit>
     <unit id="entry.intervals.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervalle</source>
-        <target>Intervalle</target>
+        <target>Intervallen</target>
       </segment>
     </unit>
     <unit id="entry.intervals.remove">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall entfernen</source>
-        <target>Intervall entfernen</target>
+        <target>Interval verwijderen</target>
       </segment>
     </unit>
     <unit id="entry.intervals.add">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall hinzufügen</source>
-        <target>Intervall hinzufügen</target>
+        <target>Interval toevoegen</target>
       </segment>
     </unit>
     <unit id="entry.intervals.addTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Weiteres Intervall hinzufügen</source>
-        <target>Weiteres Intervall hinzufügen</target>
+        <target>Nog een interval toevoegen</target>
       </segment>
     </unit>
     <unit id="chart.subtitle.reps">
@@ -8074,705 +8074,705 @@
       </segment>
     </unit>
       <unit id="exercise.category.push">
-      <segment state="initial">
+      <segment state="translated">
         <source>Drücken</source>
-        <target>Drücken</target>
+        <target>Duwen</target>
       </segment>
     </unit>
     <unit id="exercise.category.pull">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziehen</source>
-        <target>Ziehen</target>
+        <target>Trekken</target>
       </segment>
     </unit>
     <unit id="exercise.category.squat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kniebeuge</source>
-        <target>Kniebeuge</target>
+        <target>Squat</target>
       </segment>
     </unit>
     <unit id="exercise.category.hinge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftstreckung</source>
-        <target>Hüftstreckung</target>
+        <target>Heupstrekking</target>
       </segment>
     </unit>
     <unit id="exercise.category.lunge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausfallschritt</source>
-        <target>Ausfallschritt</target>
+        <target>Longe</target>
       </segment>
     </unit>
     <unit id="exercise.category.carry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tragen</source>
-        <target>Tragen</target>
+        <target>Dragen</target>
       </segment>
     </unit>
     <unit id="exercise.category.core">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rumpf</source>
-        <target>Rumpf</target>
+        <target>Romp</target>
       </segment>
     </unit>
     <unit id="exercise.category.mobility">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mobilität</source>
-        <target>Mobilität</target>
+        <target>Mobiliteit</target>
       </segment>
     </unit>
     <unit id="exercise.category.strength">
-      <segment state="initial">
+      <segment state="translated">
         <source>Krafttraining</source>
-        <target>Krafttraining</target>
+        <target>Krachttraining</target>
       </segment>
     </unit>
     <unit id="exercise.core.deadbug.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Bug</source>
         <target>Dead Bug</target>
       </segment>
     </unit>
     <unit id="exercise.core.hollowhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
         <target>Hollow Hold</target>
       </segment>
     </unit>
     <unit id="exercise.squat.wallsit.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wandsitz</source>
-        <target>Wandsitz</target>
+        <target>Wall sit</target>
       </segment>
     </unit>
     <unit id="exercise.squat.boxjump.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Box Jumps</source>
         <target>Box Jumps</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.singlelegRdl.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeiniges Kreuzheben</source>
-        <target>Einbeiniges Kreuzheben</target>
+        <target>Eenbenigig deadlift</target>
       </segment>
     </unit>
     <unit id="exercise.hinge.goodmorning.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Good Morning</source>
         <target>Good Morning</target>
       </segment>
     </unit>
     <unit id="exercise.lunge.stepup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Step-ups</source>
         <target>Step-ups</target>
       </segment>
     </unit>
     <unit id="exercise.pull.pullups.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Klimmzüge</source>
-        <target>Klimmzüge</target>
+        <target>Optrekken</target>
       </segment>
     </unit>
     <unit id="exercise.pull.rows.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ruderzug</source>
-        <target>Ruderzug</target>
+        <target>Rij</target>
       </segment>
     </unit>
     <unit id="exercise.pull.deadhang.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Hang</source>
         <target>Dead Hang</target>
       </segment>
     </unit>
     <unit id="exercise.pull.facepull.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Face Pull</source>
         <target>Face Pull</target>
       </segment>
     </unit>
     <unit id="exercise.carry.farmer.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Farmer&apos;s Walk</source>
         <target>Farmer&apos;s Walk</target>
       </segment>
     </unit>
     <unit id="exercise.carry.suitcase.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Suitcase Carry</source>
         <target>Suitcase Carry</target>
       </segment>
     </unit>
     <unit id="exercise.carry.overhead.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Overhead Carry</source>
         <target>Overhead Carry</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.walking.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gehen</source>
-        <target>Gehen</target>
+        <target>Lopen</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.cycling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Radfahren</source>
-        <target>Radfahren</target>
+        <target>Fietsen</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.rowing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rudern</source>
-        <target>Rudern</target>
+        <target>Roeien</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.swimming.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schwimmen</source>
-        <target>Schwimmen</target>
+        <target>Zwemmen</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumprope.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seilspringen</source>
-        <target>Seilspringen</target>
+        <target>Touw springen</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.burpees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Burpees</source>
         <target>Burpees</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.jumpingjacks.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hampelmänner</source>
-        <target>Hampelmänner</target>
+        <target>Jumping jacks</target>
       </segment>
     </unit>
     <unit id="exercise.cardio.highknees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>High Knees</source>
         <target>High Knees</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.stretching.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dehnen</source>
-        <target>Dehnen</target>
+        <target>Stretchen</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.yoga.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Yoga</source>
         <target>Yoga</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.foamrolling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Faszienrolle</source>
-        <target>Faszienrolle</target>
+        <target>Fasciaroller</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dynamisches Aufwärmen</source>
-        <target>Dynamisches Aufwärmen</target>
+        <target>Dynamische opwarming</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.catcow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Katze-Kuh</source>
-        <target>Katze-Kuh</target>
+        <target>Kat-Koe</target>
       </segment>
     </unit>
     <unit id="exercise.mobility.hipopener.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftöffner</source>
-        <target>Hüftöffner</target>
+        <target>Heupopener</target>
       </segment>
     </unit>
     <unit id="exercise.strength.benchpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdrücken</source>
-        <target>Bankdrücken</target>
+        <target>Bankdrukken</target>
       </segment>
     </unit>
     <unit id="exercise.strength.overheadpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schulterdrücken</source>
-        <target>Schulterdrücken</target>
+        <target>Shoulder press</target>
       </segment>
     </unit>
     <unit id="exercise.strength.deadlift.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kreuzheben</source>
-        <target>Kreuzheben</target>
+        <target>Deadlift</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellsquat.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel-Kniebeuge</source>
-        <target>Langhantel-Kniebeuge</target>
+        <target>Barbell squat</target>
       </segment>
     </unit>
     <unit id="exercise.strength.barbellrow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantelrudern</source>
-        <target>Langhantelrudern</target>
+        <target>Barbell row</target>
       </segment>
     </unit>
     <unit id="exercise.strength.kettlebellswing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kettlebell Swing</source>
         <target>Kettlebell Swing</target>
       </segment>
     </unit>
       <unit id="exercise.variant.situps.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source>Decline</source>
         <target>Decline</target>
       </segment>
     </unit>
     <unit id="exercise.variant.situps.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Met extra gewicht</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reverse Crunches</source>
         <target>Reverse Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.bicycle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bicycle Crunches</source>
         <target>Bicycle Crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.crunches.oblique">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schräge Crunches</source>
-        <target>Schräge Crunches</target>
+        <target>Schuin crunches</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.lying">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegend</source>
-        <target>Liegend</target>
+        <target>Liggend</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-knee">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (Knie)</source>
-        <target>Hängend (Knie)</target>
+        <target>Hangend (knie)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-straight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (gestreckt)</source>
-        <target>Hängend (gestreckt)</target>
+        <target>Hangend (uitgestrekt)</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Lichaamsgewicht</target>
       </segment>
     </unit>
     <unit id="exercise.variant.russiantwist.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+        <target>Met extra gewicht</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.cross-body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Cross-Body</source>
         <target>Cross-Body</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.forearm">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unterarmstütz</source>
-        <target>Unterarmstütz</target>
+        <target>Onderarm plank</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.side">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Zijdelings</target>
       </segment>
     </unit>
     <unit id="exercise.variant.plank.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Umgekehrt</source>
-        <target>Umgekehrt</target>
+        <target>Omgekeerd</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+        <target>Lichaamsgewicht</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.sumo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sumo</source>
         <target>Sumo</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.goblet">
-      <segment state="initial">
+      <segment state="translated">
         <source>Goblet</source>
         <target>Goblet</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.bulgarian-split">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bulgarian Split</source>
         <target>Bulgarian Split</target>
       </segment>
     </unit>
     <unit id="exercise.variant.squats.pistol">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pistol</source>
         <target>Pistol</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>Eenbenigig</target>
       </segment>
     </unit>
     <unit id="exercise.variant.calfraises.seated">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sitzend</source>
-        <target>Sitzend</target>
+        <target>Zittend</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
+        <target>Eenbenigig</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.hip-thrust">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hip Thrust</source>
         <target>Hip Thrust</target>
       </segment>
     </unit>
     <unit id="exercise.variant.glutebridge.march">
-      <segment state="initial">
+      <segment state="translated">
         <source>Marching</source>
         <target>Marching</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.forward">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorwärts</source>
-        <target>Vorwärts</target>
+        <target>Voorwaarts</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückwärts</source>
-        <target>Rückwärts</target>
+        <target>Achterwaarts</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.walking">
-      <segment state="initial">
+      <segment state="translated">
         <source>Walking</source>
-        <target>Walking</target>
+        <target>Wandelen</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.lateral">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
+        <target>Zijdelings</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.curtsy">
-      <segment state="initial">
+      <segment state="translated">
         <source>Curtsy</source>
         <target>Curtsy</target>
       </segment>
     </unit>
     <unit id="exercise.variant.lunges.jumping">
-      <segment state="initial">
+      <segment state="translated">
         <source>Jumping</source>
-        <target>Jumping</target>
+        <target>Springen</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
         <target>Standard</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.chin-up">
-      <segment state="initial">
+      <segment state="translated">
         <source>Chin-up</source>
         <target>Chin-up</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.wide-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Breiter Griff</source>
-        <target>Breiter Griff</target>
+        <target>Brede greep</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.neutral-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neutraler Griff</source>
-        <target>Neutraler Griff</target>
+        <target>Neutrale greep</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.negative">
-      <segment state="initial">
+      <segment state="translated">
         <source>Negativ</source>
-        <target>Negativ</target>
+        <target>Negatief</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.assisted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Assistiert</source>
-        <target>Assistiert</target>
+        <target>Ondersteund</target>
       </segment>
     </unit>
     <unit id="exercise.variant.pullups.archer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Archer</source>
         <target>Archer</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.inverted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Inverted Row</source>
         <target>Inverted Row</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.australian">
-      <segment state="initial">
+      <segment state="translated">
         <source>Australian Row</source>
         <target>Australian Row</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.dumbbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kurzhantel</source>
-        <target>Kurzhantel</target>
+        <target>Dumbbell</target>
       </segment>
     </unit>
     <unit id="exercise.variant.rows.barbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel</source>
-        <target>Langhantel</target>
+        <target>Barbell</target>
       </segment>
     </unit>
     <unit id="exercise.push.dips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dips</source>
         <target>Dips</target>
       </segment>
     </unit>
     <unit id="exercise.push.benchdips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdips</source>
         <target>Bankdips</target>
       </segment>
     </unit>
     <unit id="exercise.push.handstandhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Handstand-Hold</source>
-        <target>Handstand-Hold</target>
+        <target>Handstand-hold</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.parallel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Barren</source>
-        <target>Barren</target>
+        <target>Balk</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.straight-bar">
-      <segment state="initial">
+      <segment state="translated">
         <source>Stange</source>
-        <target>Stange</target>
+        <target>Balk</target>
       </segment>
     </unit>
     <unit id="exercise.variant.dips.ring">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ringe</source>
-        <target>Ringe</target>
+        <target>Ringen</target>
       </segment>
     </unit>
       <unit id="exerciseTimer.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübung-Timer</source>
-        <target>Halteübung-Timer</target>
+        <target>Holding-exercise-timer</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercisePickerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung wählen</source>
-        <target>Übung wählen</target>
+        <target>Oefening selecteren</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraMode">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera: Start/Ende automatisch erkennen </source>
         <target> Kamera: Start/Ende automatisch erkennen </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraStarting">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kamera startet …</source>
-        <target>Kamera startet …</target>
+        <target>Camera starten...</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraUnavailable">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera nicht verfügbar </source>
         <target> Kamera nicht verfügbar </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.toggleAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Form-Check anzeigen oder ausblenden</source>
-        <target>Form-Check anzeigen oder ausblenden</target>
+        <target>Formulieringscontrole weergeven of verbergen</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.angle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Winkel</source>
-        <target>Winkel</target>
+        <target>Hoek</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.formCheck.confidence">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sicherheit</source>
-        <target>Sicherheit</target>
+        <target>Veiligheid</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.pause">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
+        <target>Pauze</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.start">
-      <segment state="initial">
+      <segment state="translated">
         <source>Start</source>
         <target>Start</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
         <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurücksetzen </source>
         <target> Zurücksetzen </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
         <target> Abbrechen </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Übernehmen </source>
         <target> Übernehmen </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.holding">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halten</source>
-        <target>Halten</target>
+        <target>Houden</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.paused">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
+        <target>Pauze</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.phase.ready">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bereit</source>
-        <target>Bereit</target>
+        <target>Klaar</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercise.plank">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank</source>
         <target>Plank</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.exercise.hollowhold">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
         <target>Hollow Hold</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübungs-Timer öffnen</source>
-        <target>Halteübungs-Timer öffnen</target>
+        <target>Holding-exercise-timer openen</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank‑Timer</source>
-        <target>Plank‑Timer</target>
+        <target>Plank-timer</target>
       </segment>
     </unit>
     <unit id="quickAddConfig.hintV2">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -459,46 +459,26 @@ Aktiv:         </target>
         <target>Ingen seriedata tilgjengelig</target>
       </segment>
     </unit>
-    <unit id="intervalsDistribution.noData">
-      <segment state="initial">
-        <source>Keine Intervall-Daten vorhanden</source>
-        <target>Keine Intervall-Daten vorhanden</target>
+    <unit id="intervalsDistribution.noData"> <segment state="translated"> <source>Keine Intervall-Daten vorhanden</source> <target>Ingen intervalldata tilgjengelig</target>
       </segment>
     </unit>
-    <unit id="intervalsDistribution.listLabel">
-      <segment state="initial">
-        <source>Intervall-Verteilung</source>
-        <target>Intervall-Verteilung</target>
+    <unit id="intervalsDistribution.listLabel"> <segment state="translated"> <source>Intervall-Verteilung</source> <target>Intervallfordeling</target>
       </segment>
     </unit>
     <unit id="entry.interval.label">
-      <segment state="initial">
-        <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
+      <segment state="translated"> <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source> <target>Intervall </target>
       </segment>
     </unit>
-    <unit id="entry.intervals.label">
-      <segment state="initial">
-        <source>Intervalle</source>
-        <target>Intervalle</target>
+    <unit id="entry.intervals.label"> <segment state="translated"> <source>Intervalle</source> <target>Intervaller</target>
       </segment>
     </unit>
-    <unit id="entry.intervals.remove">
-      <segment state="initial">
-        <source>Intervall entfernen</source>
-        <target>Intervall entfernen</target>
+    <unit id="entry.intervals.remove"> <segment state="translated"> <source>Intervall entfernen</source> <target>Fjern intervall</target>
       </segment>
     </unit>
-    <unit id="entry.intervals.add">
-      <segment state="initial">
-        <source>Intervall hinzufügen</source>
-        <target>Intervall hinzufügen</target>
+    <unit id="entry.intervals.add"> <segment state="translated"> <source>Intervall hinzufügen</source> <target>Legg til intervall</target>
       </segment>
     </unit>
-    <unit id="entry.intervals.addTooltip">
-      <segment state="initial">
-        <source>Weiteres Intervall hinzufügen</source>
-        <target>Weiteres Intervall hinzufügen</target>
+    <unit id="entry.intervals.addTooltip"> <segment state="translated"> <source>Weiteres Intervall hinzufügen</source> <target>Legg til et til intervall</target>
       </segment>
     </unit>
     <unit id="pie.top5">
@@ -7333,706 +7313,362 @@ Deine Position: # ·  Reps        </source>
         <target>Spill av animasjon for dagsmål på nytt</target>
       </segment>
     </unit>
-      <unit id="exercise.category.push">
-      <segment state="initial">
-        <source>Drücken</source>
-        <target>Drücken</target>
+      <unit id="exercise.category.push"> <segment state="translated"> <source>Drücken</source> <target>Press</target>
       </segment>
     </unit>
-    <unit id="exercise.category.pull">
-      <segment state="initial">
-        <source>Ziehen</source>
-        <target>Ziehen</target>
+    <unit id="exercise.category.pull"> <segment state="translated"> <source>Ziehen</source> <target>Trekk</target>
       </segment>
     </unit>
-    <unit id="exercise.category.squat">
-      <segment state="initial">
-        <source>Kniebeuge</source>
-        <target>Kniebeuge</target>
+    <unit id="exercise.category.squat"> <segment state="translated"> <source>Kniebeuge</source> <target>Knebøy</target>
       </segment>
     </unit>
-    <unit id="exercise.category.hinge">
-      <segment state="initial">
-        <source>Hüftstreckung</source>
-        <target>Hüftstreckung</target>
+    <unit id="exercise.category.hinge"> <segment state="translated"> <source>Hüftstreckung</source> <target>Hoftelengde</target>
       </segment>
     </unit>
-    <unit id="exercise.category.lunge">
-      <segment state="initial">
-        <source>Ausfallschritt</source>
-        <target>Ausfallschritt</target>
+    <unit id="exercise.category.lunge"> <segment state="translated"> <source>Ausfallschritt</source> <target>Utfall</target>
       </segment>
     </unit>
-    <unit id="exercise.category.carry">
-      <segment state="initial">
-        <source>Tragen</source>
-        <target>Tragen</target>
+    <unit id="exercise.category.carry"> <segment state="translated"> <source>Tragen</source> <target>Bæring</target>
       </segment>
     </unit>
-    <unit id="exercise.category.core">
-      <segment state="initial">
-        <source>Rumpf</source>
-        <target>Rumpf</target>
+    <unit id="exercise.category.core"> <segment state="translated"> <source>Rumpf</source> <target>Kjerne</target>
       </segment>
     </unit>
-    <unit id="exercise.category.mobility">
-      <segment state="initial">
-        <source>Mobilität</source>
-        <target>Mobilität</target>
+    <unit id="exercise.category.mobility"> <segment state="translated"> <source>Mobilität</source> <target>Mobilitet</target>
       </segment>
     </unit>
-    <unit id="exercise.category.strength">
-      <segment state="initial">
-        <source>Krafttraining</source>
-        <target>Krafttraining</target>
+    <unit id="exercise.category.strength"> <segment state="translated"> <source>Krafttraining</source> <target>Styrke</target>
       </segment>
     </unit>
-    <unit id="exercise.core.deadbug.name">
-      <segment state="initial">
-        <source>Dead Bug</source>
-        <target>Dead Bug</target>
+    <unit id="exercise.core.deadbug.name"> <segment state="translated"> <source>Dead Bug</source> <target>Dead Bug</target>
       </segment>
     </unit>
-    <unit id="exercise.core.hollowhold.name">
-      <segment state="initial">
-        <source>Hollow Hold</source>
-        <target>Hollow Hold</target>
+    <unit id="exercise.core.hollowhold.name"> <segment state="translated"> <source>Hollow Hold</source> <target>Hollow Hold</target>
       </segment>
     </unit>
-    <unit id="exercise.squat.wallsit.name">
-      <segment state="initial">
-        <source>Wandsitz</source>
-        <target>Wandsitz</target>
+    <unit id="exercise.squat.wallsit.name"> <segment state="translated"> <source>Wandsitz</source> <target>Veggstøtte</target>
       </segment>
     </unit>
-    <unit id="exercise.squat.boxjump.name">
-      <segment state="initial">
-        <source>Box Jumps</source>
-        <target>Box Jumps</target>
+    <unit id="exercise.squat.boxjump.name"> <segment state="translated"> <source>Box Jumps</source> <target>Box Jumps</target>
       </segment>
     </unit>
-    <unit id="exercise.hinge.singlelegRdl.name">
-      <segment state="initial">
-        <source>Einbeiniges Kreuzheben</source>
-        <target>Einbeiniges Kreuzheben</target>
+    <unit id="exercise.hinge.singlelegRdl.name"> <segment state="translated"> <source>Einbeiniges Kreuzheben</source> <target>Einbenet markløft</target>
       </segment>
     </unit>
-    <unit id="exercise.hinge.goodmorning.name">
-      <segment state="initial">
-        <source>Good Morning</source>
-        <target>Good Morning</target>
+    <unit id="exercise.hinge.goodmorning.name"> <segment state="translated"> <source>Good Morning</source> <target>Good Morning</target>
       </segment>
     </unit>
-    <unit id="exercise.lunge.stepup.name">
-      <segment state="initial">
-        <source>Step-ups</source>
-        <target>Step-ups</target>
+    <unit id="exercise.lunge.stepup.name"> <segment state="translated"> <source>Step-ups</source> <target>Step-ups</target>
       </segment>
     </unit>
-    <unit id="exercise.pull.pullups.name">
-      <segment state="initial">
-        <source>Klimmzüge</source>
-        <target>Klimmzüge</target>
+    <unit id="exercise.pull.pullups.name"> <segment state="translated"> <source>Klimmzüge</source> <target>Kroppshevninger</target>
       </segment>
     </unit>
-    <unit id="exercise.pull.rows.name">
-      <segment state="initial">
-        <source>Ruderzug</source>
-        <target>Ruderzug</target>
+    <unit id="exercise.pull.rows.name"> <segment state="translated"> <source>Ruderzug</source> <target>Roing</target>
       </segment>
     </unit>
-    <unit id="exercise.pull.deadhang.name">
-      <segment state="initial">
-        <source>Dead Hang</source>
-        <target>Dead Hang</target>
+    <unit id="exercise.pull.deadhang.name"> <segment state="translated"> <source>Dead Hang</source> <target>Dead Hang</target>
       </segment>
     </unit>
-    <unit id="exercise.pull.facepull.name">
-      <segment state="initial">
-        <source>Face Pull</source>
-        <target>Face Pull</target>
+    <unit id="exercise.pull.facepull.name"> <segment state="translated"> <source>Face Pull</source> <target>Face Pull</target>
       </segment>
     </unit>
     <unit id="exercise.carry.farmer.name">
-      <segment state="initial">
-        <source>Farmer&apos;s Walk</source>
-        <target>Farmer&apos;s Walk</target>
+      <segment state="translated"> <source>Farmer&apos;s Walk</source> <target>Farmer&apos;s Walk</target>
       </segment>
     </unit>
-    <unit id="exercise.carry.suitcase.name">
-      <segment state="initial">
-        <source>Suitcase Carry</source>
-        <target>Suitcase Carry</target>
+    <unit id="exercise.carry.suitcase.name"> <segment state="translated"> <source>Suitcase Carry</source> <target>Suitcase Carry</target>
       </segment>
     </unit>
-    <unit id="exercise.carry.overhead.name">
-      <segment state="initial">
-        <source>Overhead Carry</source>
-        <target>Overhead Carry</target>
+    <unit id="exercise.carry.overhead.name"> <segment state="translated"> <source>Overhead Carry</source> <target>Overhead Carry</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.walking.name">
-      <segment state="initial">
-        <source>Gehen</source>
-        <target>Gehen</target>
+    <unit id="exercise.cardio.walking.name"> <segment state="translated"> <source>Gehen</source> <target>Gåing</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.cycling.name">
-      <segment state="initial">
-        <source>Radfahren</source>
-        <target>Radfahren</target>
+    <unit id="exercise.cardio.cycling.name"> <segment state="translated"> <source>Radfahren</source> <target>Sykling</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.rowing.name">
-      <segment state="initial">
-        <source>Rudern</source>
-        <target>Rudern</target>
+    <unit id="exercise.cardio.rowing.name"> <segment state="translated"> <source>Rudern</source> <target>Roing</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.swimming.name">
-      <segment state="initial">
-        <source>Schwimmen</source>
-        <target>Schwimmen</target>
+    <unit id="exercise.cardio.swimming.name"> <segment state="translated"> <source>Schwimmen</source> <target>Svømming</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.jumprope.name">
-      <segment state="initial">
-        <source>Seilspringen</source>
-        <target>Seilspringen</target>
+    <unit id="exercise.cardio.jumprope.name"> <segment state="translated"> <source>Seilspringen</source> <target>Tauhopping</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.burpees.name">
-      <segment state="initial">
-        <source>Burpees</source>
-        <target>Burpees</target>
+    <unit id="exercise.cardio.burpees.name"> <segment state="translated"> <source>Burpees</source> <target>Burpees</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.jumpingjacks.name">
-      <segment state="initial">
-        <source>Hampelmänner</source>
-        <target>Hampelmänner</target>
+    <unit id="exercise.cardio.jumpingjacks.name"> <segment state="translated"> <source>Hampelmänner</source> <target>Hoppestrekk</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.highknees.name">
-      <segment state="initial">
-        <source>High Knees</source>
-        <target>High Knees</target>
+    <unit id="exercise.cardio.highknees.name"> <segment state="translated"> <source>High Knees</source> <target>High Knees</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.stretching.name">
-      <segment state="initial">
-        <source>Dehnen</source>
-        <target>Dehnen</target>
+    <unit id="exercise.mobility.stretching.name"> <segment state="translated"> <source>Dehnen</source> <target>Tøyninger</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.yoga.name">
-      <segment state="initial">
-        <source>Yoga</source>
-        <target>Yoga</target>
+    <unit id="exercise.mobility.yoga.name"> <segment state="translated"> <source>Yoga</source> <target>Yoga</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.foamrolling.name">
-      <segment state="initial">
-        <source>Faszienrolle</source>
-        <target>Faszienrolle</target>
+    <unit id="exercise.mobility.foamrolling.name"> <segment state="translated"> <source>Faszienrolle</source> <target>Faszieroller</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.dynamicwarmup.name">
-      <segment state="initial">
-        <source>Dynamisches Aufwärmen</source>
-        <target>Dynamisches Aufwärmen</target>
+    <unit id="exercise.mobility.dynamicwarmup.name"> <segment state="translated"> <source>Dynamisches Aufwärmen</source> <target>Dynamisk oppvarming</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.catcow.name">
-      <segment state="initial">
-        <source>Katze-Kuh</source>
-        <target>Katze-Kuh</target>
+    <unit id="exercise.mobility.catcow.name"> <segment state="translated"> <source>Katze-Kuh</source> <target>Katt-Ku</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.hipopener.name">
-      <segment state="initial">
-        <source>Hüftöffner</source>
-        <target>Hüftöffner</target>
+    <unit id="exercise.mobility.hipopener.name"> <segment state="translated"> <source>Hüftöffner</source> <target>Hofteåpner</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.benchpress.name">
-      <segment state="initial">
-        <source>Bankdrücken</source>
-        <target>Bankdrücken</target>
+    <unit id="exercise.strength.benchpress.name"> <segment state="translated"> <source>Bankdrücken</source> <target>Benkepress</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.overheadpress.name">
-      <segment state="initial">
-        <source>Schulterdrücken</source>
-        <target>Schulterdrücken</target>
+    <unit id="exercise.strength.overheadpress.name"> <segment state="translated"> <source>Schulterdrücken</source> <target>Skulderpres</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.deadlift.name">
-      <segment state="initial">
-        <source>Kreuzheben</source>
-        <target>Kreuzheben</target>
+    <unit id="exercise.strength.deadlift.name"> <segment state="translated"> <source>Kreuzheben</source> <target>Markløft</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.barbellsquat.name">
-      <segment state="initial">
-        <source>Langhantel-Kniebeuge</source>
-        <target>Langhantel-Kniebeuge</target>
+    <unit id="exercise.strength.barbellsquat.name"> <segment state="translated"> <source>Langhantel-Kniebeuge</source> <target>Stangknebøy</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.barbellrow.name">
-      <segment state="initial">
-        <source>Langhantelrudern</source>
-        <target>Langhantelrudern</target>
+    <unit id="exercise.strength.barbellrow.name"> <segment state="translated"> <source>Langhantelrudern</source> <target>Stangroing</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.kettlebellswing.name">
-      <segment state="initial">
-        <source>Kettlebell Swing</source>
-        <target>Kettlebell Swing</target>
+    <unit id="exercise.strength.kettlebellswing.name"> <segment state="translated"> <source>Kettlebell Swing</source> <target>Kettlebell Swing</target>
       </segment>
     </unit>
-      <unit id="exercise.variant.situps.standard">
-      <segment state="initial">
-        <source>Standard</source>
-        <target>Standard</target>
+      <unit id="exercise.variant.situps.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.situps.decline">
-      <segment state="initial">
-        <source>Decline</source>
-        <target>Decline</target>
+    <unit id="exercise.variant.situps.decline"> <segment state="translated"> <source>Decline</source> <target>Decline</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.situps.weighted">
-      <segment state="initial">
-        <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+    <unit id="exercise.variant.situps.weighted"> <segment state="translated"> <source>Mit Zusatzgewicht</source> <target>Med ekstra vekt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.crunches.standard">
-      <segment state="initial">
-        <source>Standard</source>
-        <target>Standard</target>
+    <unit id="exercise.variant.crunches.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.crunches.reverse">
-      <segment state="initial">
-        <source>Reverse Crunches</source>
-        <target>Reverse Crunches</target>
+    <unit id="exercise.variant.crunches.reverse"> <segment state="translated"> <source>Reverse Crunches</source> <target>Reverse Crunches</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.crunches.bicycle">
-      <segment state="initial">
-        <source>Bicycle Crunches</source>
-        <target>Bicycle Crunches</target>
+    <unit id="exercise.variant.crunches.bicycle"> <segment state="translated"> <source>Bicycle Crunches</source> <target>Bicycle Crunches</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.crunches.oblique">
-      <segment state="initial">
-        <source>Schräge Crunches</source>
-        <target>Schräge Crunches</target>
+    <unit id="exercise.variant.crunches.oblique"> <segment state="translated"> <source>Schräge Crunches</source> <target>Skrå Crunches</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.legraises.lying">
-      <segment state="initial">
-        <source>Liegend</source>
-        <target>Liegend</target>
+    <unit id="exercise.variant.legraises.lying"> <segment state="translated"> <source>Liegend</source> <target>Liggende</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.legraises.hanging-knee">
-      <segment state="initial">
-        <source>Hängend (Knie)</source>
-        <target>Hängend (Knie)</target>
+    <unit id="exercise.variant.legraises.hanging-knee"> <segment state="translated"> <source>Hängend (Knie)</source> <target>Hengende (knær)</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.legraises.hanging-straight">
-      <segment state="initial">
-        <source>Hängend (gestreckt)</source>
-        <target>Hängend (gestreckt)</target>
+    <unit id="exercise.variant.legraises.hanging-straight"> <segment state="translated"> <source>Hängend (gestreckt)</source> <target>Hengende (strekt)</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.russiantwist.bodyweight">
-      <segment state="initial">
-        <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+    <unit id="exercise.variant.russiantwist.bodyweight"> <segment state="translated"> <source>Eigengewicht</source> <target>Kroppsvekt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.russiantwist.weighted">
-      <segment state="initial">
-        <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
+    <unit id="exercise.variant.russiantwist.weighted"> <segment state="translated"> <source>Mit Zusatzgewicht</source> <target>Med ekstra vekt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.mountainclimbers.standard">
-      <segment state="initial">
-        <source>Standard</source>
-        <target>Standard</target>
+    <unit id="exercise.variant.mountainclimbers.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.mountainclimbers.cross-body">
-      <segment state="initial">
-        <source>Cross-Body</source>
-        <target>Cross-Body</target>
+    <unit id="exercise.variant.mountainclimbers.cross-body"> <segment state="translated"> <source>Cross-Body</source> <target>Cross-Body</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.plank.standard">
-      <segment state="initial">
-        <source>Standard</source>
-        <target>Standard</target>
+    <unit id="exercise.variant.plank.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.plank.forearm">
-      <segment state="initial">
-        <source>Unterarmstütz</source>
-        <target>Unterarmstütz</target>
+    <unit id="exercise.variant.plank.forearm"> <segment state="translated"> <source>Unterarmstütz</source> <target>Underarmsplanken</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.plank.side">
-      <segment state="initial">
-        <source>Seitlich</source>
-        <target>Seitlich</target>
+    <unit id="exercise.variant.plank.side"> <segment state="translated"> <source>Seitlich</source> <target>Sideveis</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.plank.reverse">
-      <segment state="initial">
-        <source>Umgekehrt</source>
-        <target>Umgekehrt</target>
+    <unit id="exercise.variant.plank.reverse"> <segment state="translated"> <source>Umgekehrt</source> <target>Omvendt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.squats.bodyweight">
-      <segment state="initial">
-        <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
+    <unit id="exercise.variant.squats.bodyweight"> <segment state="translated"> <source>Eigengewicht</source> <target>Kroppsvekt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.squats.sumo">
-      <segment state="initial">
-        <source>Sumo</source>
-        <target>Sumo</target>
+    <unit id="exercise.variant.squats.sumo"> <segment state="translated"> <source>Sumo</source> <target>Sumo</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.squats.goblet">
-      <segment state="initial">
-        <source>Goblet</source>
-        <target>Goblet</target>
+    <unit id="exercise.variant.squats.goblet"> <segment state="translated"> <source>Goblet</source> <target>Goblet</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.squats.bulgarian-split">
-      <segment state="initial">
-        <source>Bulgarian Split</source>
-        <target>Bulgarian Split</target>
+    <unit id="exercise.variant.squats.bulgarian-split"> <segment state="translated"> <source>Bulgarian Split</source> <target>Bulgarian Split</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.squats.pistol">
-      <segment state="initial">
-        <source>Pistol</source>
-        <target>Pistol</target>
+    <unit id="exercise.variant.squats.pistol"> <segment state="translated"> <source>Pistol</source> <target>Pistol</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.calfraises.standard">
-      <segment state="initial">
-        <source>Standard</source>
-        <target>Standard</target>
+    <unit id="exercise.variant.calfraises.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.calfraises.single-leg">
-      <segment state="initial">
-        <source>Einbeinig</source>
-        <target>Einbeinig</target>
+    <unit id="exercise.variant.calfraises.single-leg"> <segment state="translated"> <source>Einbeinig</source> <target>Énbenet</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.calfraises.seated">
-      <segment state="initial">
-        <source>Sitzend</source>
-        <target>Sitzend</target>
+    <unit id="exercise.variant.calfraises.seated"> <segment state="translated"> <source>Sitzend</source> <target>Sittende</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.glutebridge.standard">
-      <segment state="initial">
-        <source>Standard</source>
-        <target>Standard</target>
+    <unit id="exercise.variant.glutebridge.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.glutebridge.single-leg">
-      <segment state="initial">
-        <source>Einbeinig</source>
-        <target>Einbeinig</target>
+    <unit id="exercise.variant.glutebridge.single-leg"> <segment state="translated"> <source>Einbeinig</source> <target>Énbenet</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.glutebridge.hip-thrust">
-      <segment state="initial">
-        <source>Hip Thrust</source>
-        <target>Hip Thrust</target>
+    <unit id="exercise.variant.glutebridge.hip-thrust"> <segment state="translated"> <source>Hip Thrust</source> <target>Hip Thrust</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.glutebridge.march">
-      <segment state="initial">
-        <source>Marching</source>
-        <target>Marching</target>
+    <unit id="exercise.variant.glutebridge.march"> <segment state="translated"> <source>Marching</source> <target>Marsjering</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.forward">
-      <segment state="initial">
-        <source>Vorwärts</source>
-        <target>Vorwärts</target>
+    <unit id="exercise.variant.lunges.forward"> <segment state="translated"> <source>Vorwärts</source> <target>Fremover</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.reverse">
-      <segment state="initial">
-        <source>Rückwärts</source>
-        <target>Rückwärts</target>
+    <unit id="exercise.variant.lunges.reverse"> <segment state="translated"> <source>Rückwärts</source> <target>Bakover</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.walking">
-      <segment state="initial">
-        <source>Walking</source>
-        <target>Walking</target>
+    <unit id="exercise.variant.lunges.walking"> <segment state="translated"> <source>Walking</source> <target>Gåing</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.lateral">
-      <segment state="initial">
-        <source>Seitlich</source>
-        <target>Seitlich</target>
+    <unit id="exercise.variant.lunges.lateral"> <segment state="translated"> <source>Seitlich</source> <target>Sideveis</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.curtsy">
-      <segment state="initial">
-        <source>Curtsy</source>
-        <target>Curtsy</target>
+    <unit id="exercise.variant.lunges.curtsy"> <segment state="translated"> <source>Curtsy</source> <target>Curtsy</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.jumping">
-      <segment state="initial">
-        <source>Jumping</source>
-        <target>Jumping</target>
+    <unit id="exercise.variant.lunges.jumping"> <segment state="translated"> <source>Jumping</source> <target>Hopping</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.standard">
-      <segment state="initial">
-        <source>Standard</source>
-        <target>Standard</target>
+    <unit id="exercise.variant.pullups.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.chin-up">
-      <segment state="initial">
-        <source>Chin-up</source>
-        <target>Chin-up</target>
+    <unit id="exercise.variant.pullups.chin-up"> <segment state="translated"> <source>Chin-up</source> <target>Chin-up</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.wide-grip">
-      <segment state="initial">
-        <source>Breiter Griff</source>
-        <target>Breiter Griff</target>
+    <unit id="exercise.variant.pullups.wide-grip"> <segment state="translated"> <source>Breiter Griff</source> <target>Bredt grep</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.neutral-grip">
-      <segment state="initial">
-        <source>Neutraler Griff</source>
-        <target>Neutraler Griff</target>
+    <unit id="exercise.variant.pullups.neutral-grip"> <segment state="translated"> <source>Neutraler Griff</source> <target>Nøytralt grep</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.negative">
-      <segment state="initial">
-        <source>Negativ</source>
-        <target>Negativ</target>
+    <unit id="exercise.variant.pullups.negative"> <segment state="translated"> <source>Negativ</source> <target>Negativ</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.assisted">
-      <segment state="initial">
-        <source>Assistiert</source>
-        <target>Assistiert</target>
+    <unit id="exercise.variant.pullups.assisted"> <segment state="translated"> <source>Assistiert</source> <target>Assistert</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.archer">
-      <segment state="initial">
-        <source>Archer</source>
-        <target>Archer</target>
+    <unit id="exercise.variant.pullups.archer"> <segment state="translated"> <source>Archer</source> <target>Archer</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.rows.inverted">
-      <segment state="initial">
-        <source>Inverted Row</source>
-        <target>Inverted Row</target>
+    <unit id="exercise.variant.rows.inverted"> <segment state="translated"> <source>Inverted Row</source> <target>Inverted Row</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.rows.australian">
-      <segment state="initial">
-        <source>Australian Row</source>
-        <target>Australian Row</target>
+    <unit id="exercise.variant.rows.australian"> <segment state="translated"> <source>Australian Row</source> <target>Australian Row</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.rows.dumbbell">
-      <segment state="initial">
-        <source>Kurzhantel</source>
-        <target>Kurzhantel</target>
+    <unit id="exercise.variant.rows.dumbbell"> <segment state="translated"> <source>Kurzhantel</source> <target>Håndvekt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.rows.barbell">
-      <segment state="initial">
-        <source>Langhantel</source>
-        <target>Langhantel</target>
+    <unit id="exercise.variant.rows.barbell"> <segment state="translated"> <source>Langhantel</source> <target>Stang</target>
       </segment>
     </unit>
-    <unit id="exercise.push.dips.name">
-      <segment state="initial">
-        <source>Dips</source>
-        <target>Dips</target>
+    <unit id="exercise.push.dips.name"> <segment state="translated"> <source>Dips</source> <target>Dips</target>
       </segment>
     </unit>
-    <unit id="exercise.push.benchdips.name">
-      <segment state="initial">
-        <source>Bankdips</source>
-        <target>Bankdips</target>
+    <unit id="exercise.push.benchdips.name"> <segment state="translated"> <source>Bankdips</source> <target>Benk-dips</target>
       </segment>
     </unit>
-    <unit id="exercise.push.handstandhold.name">
-      <segment state="initial">
-        <source>Handstand-Hold</source>
-        <target>Handstand-Hold</target>
+    <unit id="exercise.push.handstandhold.name"> <segment state="translated"> <source>Handstand-Hold</source> <target>Handstand-hold</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.dips.parallel">
-      <segment state="initial">
-        <source>Barren</source>
-        <target>Barren</target>
+    <unit id="exercise.variant.dips.parallel"> <segment state="translated"> <source>Barren</source> <target>Barrer</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.dips.straight-bar">
-      <segment state="initial">
-        <source>Stange</source>
-        <target>Stange</target>
+    <unit id="exercise.variant.dips.straight-bar"> <segment state="translated"> <source>Stange</source> <target>Stang</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.dips.ring">
-      <segment state="initial">
-        <source>Ringe</source>
-        <target>Ringe</target>
+    <unit id="exercise.variant.dips.ring"> <segment state="translated"> <source>Ringe</source> <target>Ringer</target>
       </segment>
     </unit>
-      <unit id="exerciseTimer.title">
-      <segment state="initial">
-        <source>Halteübung-Timer</source>
-        <target>Halteübung-Timer</target>
+      <unit id="exerciseTimer.title"> <segment state="translated"> <source>Halteübung-Timer</source> <target>Hold-øvelses-timer</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.exercisePickerAria">
-      <segment state="initial">
-        <source>Übung wählen</source>
-        <target>Übung wählen</target>
+    <unit id="exerciseTimer.exercisePickerAria"> <segment state="translated"> <source>Übung wählen</source> <target>Velg øvelse</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraMode">
-      <segment state="initial">
-        <source> Kamera: Start/Ende automatisch erkennen </source>
-        <target> Kamera: Start/Ende automatisch erkennen </target>
+      <segment state="translated"> <source> Kamera: Start/Ende automatisch erkennen </source> <target> Kamera: Automatisk start/stopp deteksjon </target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.cameraStarting">
-      <segment state="initial">
-        <source>Kamera startet …</source>
-        <target>Kamera startet …</target>
+    <unit id="exerciseTimer.cameraStarting"> <segment state="translated"> <source>Kamera startet …</source> <target>Kamera starter...</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraUnavailable">
-      <segment state="initial">
-        <source> Kamera nicht verfügbar </source>
-        <target> Kamera nicht verfügbar </target>
+      <segment state="translated"> <source> Kamera nicht verfügbar </source> <target> Kamera ikke tilgjengelig </target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.formCheck.toggleAria">
-      <segment state="initial">
-        <source>Form-Check anzeigen oder ausblenden</source>
-        <target>Form-Check anzeigen oder ausblenden</target>
+    <unit id="exerciseTimer.formCheck.toggleAria"> <segment state="translated"> <source>Form-Check anzeigen oder ausblenden</source> <target>Vis eller skjul formkontroll</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.formCheck.angle">
-      <segment state="initial">
-        <source>Winkel</source>
-        <target>Winkel</target>
+    <unit id="exerciseTimer.formCheck.angle"> <segment state="translated"> <source>Winkel</source> <target>Vinkel</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.formCheck.confidence">
-      <segment state="initial">
-        <source>Sicherheit</source>
-        <target>Sicherheit</target>
+    <unit id="exerciseTimer.formCheck.confidence"> <segment state="translated"> <source>Sicherheit</source> <target>Sikkerhet</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.pause">
-      <segment state="initial">
-        <source>Pause</source>
-        <target>Pause</target>
+    <unit id="exerciseTimer.pause"> <segment state="translated"> <source>Pause</source> <target>Pause</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.start">
-      <segment state="initial">
-        <source>Start</source>
-        <target>Start</target>
+    <unit id="exerciseTimer.start"> <segment state="translated"> <source>Start</source> <target>Start</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraHint">
-      <segment state="initial">
-        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
-        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
+      <segment state="translated"> <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source> <target> Still kameraet slik at skulder, hofte og knie er synlige. Timeren starter automatisk når du er i posisjon, og pauser når du forlater posisjonen. </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.reset">
-      <segment state="initial">
-        <source> Zurücksetzen </source>
-        <target> Zurücksetzen </target>
+      <segment state="translated"> <source> Zurücksetzen </source> <target> Tilbakestill </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cancel">
-      <segment state="initial">
-        <source> Abbrechen </source>
-        <target> Abbrechen </target>
+      <segment state="translated"> <source> Abbrechen </source> <target> Avbryt </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.save">
-      <segment state="initial">
-        <source> Übernehmen </source>
-        <target> Übernehmen </target>
+      <segment state="translated"> <source> Übernehmen </source> <target> Bruk </target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.phase.holding">
-      <segment state="initial">
-        <source>Halten</source>
-        <target>Halten</target>
+    <unit id="exerciseTimer.phase.holding"> <segment state="translated"> <source>Halten</source> <target>Hold</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.phase.paused">
-      <segment state="initial">
-        <source>Pause</source>
-        <target>Pause</target>
+    <unit id="exerciseTimer.phase.paused"> <segment state="translated"> <source>Pause</source> <target>Pause</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.phase.ready">
-      <segment state="initial">
-        <source>Bereit</source>
-        <target>Bereit</target>
+    <unit id="exerciseTimer.phase.ready"> <segment state="translated"> <source>Bereit</source> <target>Klar</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.exercise.plank">
-      <segment state="initial">
-        <source>Plank</source>
-        <target>Plank</target>
+    <unit id="exerciseTimer.exercise.plank"> <segment state="translated"> <source>Plank</source> <target>Plank</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.exercise.hollowhold">
-      <segment state="initial">
-        <source>Hollow Hold</source>
-        <target>Hollow Hold</target>
+    <unit id="exerciseTimer.exercise.hollowhold"> <segment state="translated"> <source>Hollow Hold</source> <target>Hollow Hold</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.exerciseTimerAria">
-      <segment state="initial">
-        <source>Halteübungs-Timer öffnen</source>
-        <target>Halteübungs-Timer öffnen</target>
+    <unit id="quickAdd.fab.exerciseTimerAria"> <segment state="translated"> <source>Halteübungs-Timer öffnen</source> <target>Åpne hold-øvelses-timer</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.exerciseTimer">
-      <segment state="initial">
-        <source>Plank‑Timer</source>
-        <target>Plank‑Timer</target>
+    <unit id="quickAdd.fab.exerciseTimer"> <segment state="translated"> <source>Plank‑Timer</source> <target>Plank-timer</target>
       </segment>
     </unit>
     <unit id="quickAddConfig.hintV2">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -459,26 +459,46 @@ Aktiv:         </target>
         <target>Ingen seriedata tilgjengelig</target>
       </segment>
     </unit>
-    <unit id="intervalsDistribution.noData"> <segment state="translated"> <source>Keine Intervall-Daten vorhanden</source> <target>Ingen intervalldata tilgjengelig</target>
+    <unit id="intervalsDistribution.noData">
+      <segment state="translated">
+        <source>Keine Intervall-Daten vorhanden</source>
+        <target>Ingen intervalldata tilgjengelig</target>
       </segment>
     </unit>
-    <unit id="intervalsDistribution.listLabel"> <segment state="translated"> <source>Intervall-Verteilung</source> <target>Intervallfordeling</target>
+    <unit id="intervalsDistribution.listLabel">
+      <segment state="translated">
+        <source>Intervall-Verteilung</source>
+        <target>Intervallfordeling</target>
       </segment>
     </unit>
     <unit id="entry.interval.label">
-      <segment state="translated"> <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source> <target>Intervall </target>
+      <segment state="translated">
+        <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
+        <target>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
       </segment>
     </unit>
-    <unit id="entry.intervals.label"> <segment state="translated"> <source>Intervalle</source> <target>Intervaller</target>
+    <unit id="entry.intervals.label">
+      <segment state="translated">
+        <source>Intervalle</source>
+        <target>Intervaller</target>
       </segment>
     </unit>
-    <unit id="entry.intervals.remove"> <segment state="translated"> <source>Intervall entfernen</source> <target>Fjern intervall</target>
+    <unit id="entry.intervals.remove">
+      <segment state="translated">
+        <source>Intervall entfernen</source>
+        <target>Fjern intervall</target>
       </segment>
     </unit>
-    <unit id="entry.intervals.add"> <segment state="translated"> <source>Intervall hinzufügen</source> <target>Legg til intervall</target>
+    <unit id="entry.intervals.add">
+      <segment state="translated">
+        <source>Intervall hinzufügen</source>
+        <target>Legg til intervall</target>
       </segment>
     </unit>
-    <unit id="entry.intervals.addTooltip"> <segment state="translated"> <source>Weiteres Intervall hinzufügen</source> <target>Legg til et til intervall</target>
+    <unit id="entry.intervals.addTooltip">
+      <segment state="translated">
+        <source>Weiteres Intervall hinzufügen</source>
+        <target>Legg til et til intervall</target>
       </segment>
     </unit>
     <unit id="pie.top5">
@@ -7313,362 +7333,706 @@ Deine Position: # ·  Reps        </source>
         <target>Spill av animasjon for dagsmål på nytt</target>
       </segment>
     </unit>
-      <unit id="exercise.category.push"> <segment state="translated"> <source>Drücken</source> <target>Press</target>
+      <unit id="exercise.category.push">
+        <segment state="translated">
+          <source>Drücken</source>
+          <target>Press</target>
       </segment>
     </unit>
-    <unit id="exercise.category.pull"> <segment state="translated"> <source>Ziehen</source> <target>Trekk</target>
+    <unit id="exercise.category.pull">
+      <segment state="translated">
+        <source>Ziehen</source>
+        <target>Trekk</target>
       </segment>
     </unit>
-    <unit id="exercise.category.squat"> <segment state="translated"> <source>Kniebeuge</source> <target>Knebøy</target>
+    <unit id="exercise.category.squat">
+      <segment state="translated">
+        <source>Kniebeuge</source>
+        <target>Knebøy</target>
       </segment>
     </unit>
-    <unit id="exercise.category.hinge"> <segment state="translated"> <source>Hüftstreckung</source> <target>Hoftelengde</target>
+    <unit id="exercise.category.hinge">
+      <segment state="translated">
+        <source>Hüftstreckung</source>
+        <target>Hoftelengde</target>
       </segment>
     </unit>
-    <unit id="exercise.category.lunge"> <segment state="translated"> <source>Ausfallschritt</source> <target>Utfall</target>
+    <unit id="exercise.category.lunge">
+      <segment state="translated">
+        <source>Ausfallschritt</source>
+        <target>Utfall</target>
       </segment>
     </unit>
-    <unit id="exercise.category.carry"> <segment state="translated"> <source>Tragen</source> <target>Bæring</target>
+    <unit id="exercise.category.carry">
+      <segment state="translated">
+        <source>Tragen</source>
+        <target>Bæring</target>
       </segment>
     </unit>
-    <unit id="exercise.category.core"> <segment state="translated"> <source>Rumpf</source> <target>Kjerne</target>
+    <unit id="exercise.category.core">
+      <segment state="translated">
+        <source>Rumpf</source>
+        <target>Kjerne</target>
       </segment>
     </unit>
-    <unit id="exercise.category.mobility"> <segment state="translated"> <source>Mobilität</source> <target>Mobilitet</target>
+    <unit id="exercise.category.mobility">
+      <segment state="translated">
+        <source>Mobilität</source>
+        <target>Mobilitet</target>
       </segment>
     </unit>
-    <unit id="exercise.category.strength"> <segment state="translated"> <source>Krafttraining</source> <target>Styrke</target>
+    <unit id="exercise.category.strength">
+      <segment state="translated">
+        <source>Krafttraining</source>
+        <target>Styrke</target>
       </segment>
     </unit>
-    <unit id="exercise.core.deadbug.name"> <segment state="translated"> <source>Dead Bug</source> <target>Dead Bug</target>
+    <unit id="exercise.core.deadbug.name">
+      <segment state="translated">
+        <source>Dead Bug</source>
+        <target>Dead Bug</target>
       </segment>
     </unit>
-    <unit id="exercise.core.hollowhold.name"> <segment state="translated"> <source>Hollow Hold</source> <target>Hollow Hold</target>
+    <unit id="exercise.core.hollowhold.name">
+      <segment state="translated">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
       </segment>
     </unit>
-    <unit id="exercise.squat.wallsit.name"> <segment state="translated"> <source>Wandsitz</source> <target>Veggstøtte</target>
+    <unit id="exercise.squat.wallsit.name">
+      <segment state="translated">
+        <source>Wandsitz</source>
+        <target>Veggstøtte</target>
       </segment>
     </unit>
-    <unit id="exercise.squat.boxjump.name"> <segment state="translated"> <source>Box Jumps</source> <target>Box Jumps</target>
+    <unit id="exercise.squat.boxjump.name">
+      <segment state="translated">
+        <source>Box Jumps</source>
+        <target>Box Jumps</target>
       </segment>
     </unit>
-    <unit id="exercise.hinge.singlelegRdl.name"> <segment state="translated"> <source>Einbeiniges Kreuzheben</source> <target>Einbenet markløft</target>
+    <unit id="exercise.hinge.singlelegRdl.name">
+      <segment state="translated">
+        <source>Einbeiniges Kreuzheben</source>
+        <target>Einbenet markløft</target>
       </segment>
     </unit>
-    <unit id="exercise.hinge.goodmorning.name"> <segment state="translated"> <source>Good Morning</source> <target>Good Morning</target>
+    <unit id="exercise.hinge.goodmorning.name">
+      <segment state="translated">
+        <source>Good Morning</source>
+        <target>Good Morning</target>
       </segment>
     </unit>
-    <unit id="exercise.lunge.stepup.name"> <segment state="translated"> <source>Step-ups</source> <target>Step-ups</target>
+    <unit id="exercise.lunge.stepup.name">
+      <segment state="translated">
+        <source>Step-ups</source>
+        <target>Step-ups</target>
       </segment>
     </unit>
-    <unit id="exercise.pull.pullups.name"> <segment state="translated"> <source>Klimmzüge</source> <target>Kroppshevninger</target>
+    <unit id="exercise.pull.pullups.name">
+      <segment state="translated">
+        <source>Klimmzüge</source>
+        <target>Kroppshevinger</target>
       </segment>
     </unit>
-    <unit id="exercise.pull.rows.name"> <segment state="translated"> <source>Ruderzug</source> <target>Roing</target>
+    <unit id="exercise.pull.rows.name">
+      <segment state="translated">
+        <source>Ruderzug</source>
+        <target>Roing</target>
       </segment>
     </unit>
-    <unit id="exercise.pull.deadhang.name"> <segment state="translated"> <source>Dead Hang</source> <target>Dead Hang</target>
+    <unit id="exercise.pull.deadhang.name">
+      <segment state="translated">
+        <source>Dead Hang</source>
+        <target>Dead Hang</target>
       </segment>
     </unit>
-    <unit id="exercise.pull.facepull.name"> <segment state="translated"> <source>Face Pull</source> <target>Face Pull</target>
+    <unit id="exercise.pull.facepull.name">
+      <segment state="translated">
+        <source>Face Pull</source>
+        <target>Face Pull</target>
       </segment>
     </unit>
     <unit id="exercise.carry.farmer.name">
-      <segment state="translated"> <source>Farmer&apos;s Walk</source> <target>Farmer&apos;s Walk</target>
+      <segment state="translated">
+        <source>Farmer&apos;s Walk</source>
+        <target>Farmer&apos;s Walk</target>
       </segment>
     </unit>
-    <unit id="exercise.carry.suitcase.name"> <segment state="translated"> <source>Suitcase Carry</source> <target>Suitcase Carry</target>
+    <unit id="exercise.carry.suitcase.name">
+      <segment state="translated">
+        <source>Suitcase Carry</source>
+        <target>Suitcase Carry</target>
       </segment>
     </unit>
-    <unit id="exercise.carry.overhead.name"> <segment state="translated"> <source>Overhead Carry</source> <target>Overhead Carry</target>
+    <unit id="exercise.carry.overhead.name">
+      <segment state="translated">
+        <source>Overhead Carry</source>
+        <target>Overhead Carry</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.walking.name"> <segment state="translated"> <source>Gehen</source> <target>Gåing</target>
+    <unit id="exercise.cardio.walking.name">
+      <segment state="translated">
+        <source>Gehen</source>
+        <target>Gåing</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.cycling.name"> <segment state="translated"> <source>Radfahren</source> <target>Sykling</target>
+    <unit id="exercise.cardio.cycling.name">
+      <segment state="translated">
+        <source>Radfahren</source>
+        <target>Sykling</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.rowing.name"> <segment state="translated"> <source>Rudern</source> <target>Roing</target>
+    <unit id="exercise.cardio.rowing.name">
+      <segment state="translated">
+        <source>Rudern</source>
+        <target>Roing</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.swimming.name"> <segment state="translated"> <source>Schwimmen</source> <target>Svømming</target>
+    <unit id="exercise.cardio.swimming.name">
+      <segment state="translated">
+        <source>Schwimmen</source>
+        <target>Svømming</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.jumprope.name"> <segment state="translated"> <source>Seilspringen</source> <target>Tauhopping</target>
+    <unit id="exercise.cardio.jumprope.name">
+      <segment state="translated">
+        <source>Seilspringen</source>
+        <target>Tauhopping</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.burpees.name"> <segment state="translated"> <source>Burpees</source> <target>Burpees</target>
+    <unit id="exercise.cardio.burpees.name">
+      <segment state="translated">
+        <source>Burpees</source>
+        <target>Burpees</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.jumpingjacks.name"> <segment state="translated"> <source>Hampelmänner</source> <target>Hoppestrekk</target>
+    <unit id="exercise.cardio.jumpingjacks.name">
+      <segment state="translated">
+        <source>Hampelmänner</source>
+        <target>Hoppestrekk</target>
       </segment>
     </unit>
-    <unit id="exercise.cardio.highknees.name"> <segment state="translated"> <source>High Knees</source> <target>High Knees</target>
+    <unit id="exercise.cardio.highknees.name">
+      <segment state="translated">
+        <source>High Knees</source>
+        <target>High Knees</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.stretching.name"> <segment state="translated"> <source>Dehnen</source> <target>Tøyninger</target>
+    <unit id="exercise.mobility.stretching.name">
+      <segment state="translated">
+        <source>Dehnen</source>
+        <target>Tøyninger</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.yoga.name"> <segment state="translated"> <source>Yoga</source> <target>Yoga</target>
+    <unit id="exercise.mobility.yoga.name">
+      <segment state="translated">
+        <source>Yoga</source>
+        <target>Yoga</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.foamrolling.name"> <segment state="translated"> <source>Faszienrolle</source> <target>Faszieroller</target>
+    <unit id="exercise.mobility.foamrolling.name">
+      <segment state="translated">
+        <source>Faszienrolle</source>
+        <target>Faszieroller</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.dynamicwarmup.name"> <segment state="translated"> <source>Dynamisches Aufwärmen</source> <target>Dynamisk oppvarming</target>
+    <unit id="exercise.mobility.dynamicwarmup.name">
+      <segment state="translated">
+        <source>Dynamisches Aufwärmen</source>
+        <target>Dynamisk oppvarming</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.catcow.name"> <segment state="translated"> <source>Katze-Kuh</source> <target>Katt-Ku</target>
+    <unit id="exercise.mobility.catcow.name">
+      <segment state="translated">
+        <source>Katze-Kuh</source>
+        <target>Katt-Ku</target>
       </segment>
     </unit>
-    <unit id="exercise.mobility.hipopener.name"> <segment state="translated"> <source>Hüftöffner</source> <target>Hofteåpner</target>
+    <unit id="exercise.mobility.hipopener.name">
+      <segment state="translated">
+        <source>Hüftöffner</source>
+        <target>Hofteåpner</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.benchpress.name"> <segment state="translated"> <source>Bankdrücken</source> <target>Benkepress</target>
+    <unit id="exercise.strength.benchpress.name">
+      <segment state="translated">
+        <source>Bankdrücken</source>
+        <target>Benkepress</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.overheadpress.name"> <segment state="translated"> <source>Schulterdrücken</source> <target>Skulderpres</target>
+    <unit id="exercise.strength.overheadpress.name">
+      <segment state="translated">
+        <source>Schulterdrücken</source>
+        <target>Skulderpress</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.deadlift.name"> <segment state="translated"> <source>Kreuzheben</source> <target>Markløft</target>
+    <unit id="exercise.strength.deadlift.name">
+      <segment state="translated">
+        <source>Kreuzheben</source>
+        <target>Markløft</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.barbellsquat.name"> <segment state="translated"> <source>Langhantel-Kniebeuge</source> <target>Stangknebøy</target>
+    <unit id="exercise.strength.barbellsquat.name">
+      <segment state="translated">
+        <source>Langhantel-Kniebeuge</source>
+        <target>Stangknebøy</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.barbellrow.name"> <segment state="translated"> <source>Langhantelrudern</source> <target>Stangroing</target>
+    <unit id="exercise.strength.barbellrow.name">
+      <segment state="translated">
+        <source>Langhantelrudern</source>
+        <target>Stangroing</target>
       </segment>
     </unit>
-    <unit id="exercise.strength.kettlebellswing.name"> <segment state="translated"> <source>Kettlebell Swing</source> <target>Kettlebell Swing</target>
+    <unit id="exercise.strength.kettlebellswing.name">
+      <segment state="translated">
+        <source>Kettlebell Swing</source>
+        <target>Kettlebell Swing</target>
       </segment>
     </unit>
-      <unit id="exercise.variant.situps.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
+      <unit id="exercise.variant.situps.standard">
+        <segment state="translated">
+          <source>Standard</source>
+          <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.situps.decline"> <segment state="translated"> <source>Decline</source> <target>Decline</target>
+    <unit id="exercise.variant.situps.decline">
+      <segment state="translated">
+        <source>Decline</source>
+        <target>Decline</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.situps.weighted"> <segment state="translated"> <source>Mit Zusatzgewicht</source> <target>Med ekstra vekt</target>
+    <unit id="exercise.variant.situps.weighted">
+      <segment state="translated">
+        <source>Mit Zusatzgewicht</source>
+        <target>Med ekstra vekt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.crunches.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
+    <unit id="exercise.variant.crunches.standard">
+      <segment state="translated">
+        <source>Standard</source>
+        <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.crunches.reverse"> <segment state="translated"> <source>Reverse Crunches</source> <target>Reverse Crunches</target>
+    <unit id="exercise.variant.crunches.reverse">
+      <segment state="translated">
+        <source>Reverse Crunches</source>
+        <target>Reverse Crunches</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.crunches.bicycle"> <segment state="translated"> <source>Bicycle Crunches</source> <target>Bicycle Crunches</target>
+    <unit id="exercise.variant.crunches.bicycle">
+      <segment state="translated">
+        <source>Bicycle Crunches</source>
+        <target>Bicycle Crunches</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.crunches.oblique"> <segment state="translated"> <source>Schräge Crunches</source> <target>Skrå Crunches</target>
+    <unit id="exercise.variant.crunches.oblique">
+      <segment state="translated">
+        <source>Schräge Crunches</source>
+        <target>Skrå Crunches</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.legraises.lying"> <segment state="translated"> <source>Liegend</source> <target>Liggende</target>
+    <unit id="exercise.variant.legraises.lying">
+      <segment state="translated">
+        <source>Liegend</source>
+        <target>Liggende</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.legraises.hanging-knee"> <segment state="translated"> <source>Hängend (Knie)</source> <target>Hengende (knær)</target>
+    <unit id="exercise.variant.legraises.hanging-knee">
+      <segment state="translated">
+        <source>Hängend (Knie)</source>
+        <target>Hengende (knær)</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.legraises.hanging-straight"> <segment state="translated"> <source>Hängend (gestreckt)</source> <target>Hengende (strekt)</target>
+    <unit id="exercise.variant.legraises.hanging-straight">
+      <segment state="translated">
+        <source>Hängend (gestreckt)</source>
+        <target>Hengende (strekt)</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.russiantwist.bodyweight"> <segment state="translated"> <source>Eigengewicht</source> <target>Kroppsvekt</target>
+    <unit id="exercise.variant.russiantwist.bodyweight">
+      <segment state="translated">
+        <source>Eigengewicht</source>
+        <target>Kroppsvekt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.russiantwist.weighted"> <segment state="translated"> <source>Mit Zusatzgewicht</source> <target>Med ekstra vekt</target>
+    <unit id="exercise.variant.russiantwist.weighted">
+      <segment state="translated">
+        <source>Mit Zusatzgewicht</source>
+        <target>Med ekstra vekt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.mountainclimbers.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
+    <unit id="exercise.variant.mountainclimbers.standard">
+      <segment state="translated">
+        <source>Standard</source>
+        <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.mountainclimbers.cross-body"> <segment state="translated"> <source>Cross-Body</source> <target>Cross-Body</target>
+    <unit id="exercise.variant.mountainclimbers.cross-body">
+      <segment state="translated">
+        <source>Cross-Body</source>
+        <target>Cross-Body</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.plank.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
+    <unit id="exercise.variant.plank.standard">
+      <segment state="translated">
+        <source>Standard</source>
+        <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.plank.forearm"> <segment state="translated"> <source>Unterarmstütz</source> <target>Underarmsplanken</target>
+    <unit id="exercise.variant.plank.forearm">
+      <segment state="translated">
+        <source>Unterarmstütz</source>
+        <target>Underarmsplanken</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.plank.side"> <segment state="translated"> <source>Seitlich</source> <target>Sideveis</target>
+    <unit id="exercise.variant.plank.side">
+      <segment state="translated">
+        <source>Seitlich</source>
+        <target>Sideveis</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.plank.reverse"> <segment state="translated"> <source>Umgekehrt</source> <target>Omvendt</target>
+    <unit id="exercise.variant.plank.reverse">
+      <segment state="translated">
+        <source>Umgekehrt</source>
+        <target>Omvendt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.squats.bodyweight"> <segment state="translated"> <source>Eigengewicht</source> <target>Kroppsvekt</target>
+    <unit id="exercise.variant.squats.bodyweight">
+      <segment state="translated">
+        <source>Eigengewicht</source>
+        <target>Kroppsvekt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.squats.sumo"> <segment state="translated"> <source>Sumo</source> <target>Sumo</target>
+    <unit id="exercise.variant.squats.sumo">
+      <segment state="translated">
+        <source>Sumo</source>
+        <target>Sumo</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.squats.goblet"> <segment state="translated"> <source>Goblet</source> <target>Goblet</target>
+    <unit id="exercise.variant.squats.goblet">
+      <segment state="translated">
+        <source>Goblet</source>
+        <target>Goblet</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.squats.bulgarian-split"> <segment state="translated"> <source>Bulgarian Split</source> <target>Bulgarian Split</target>
+    <unit id="exercise.variant.squats.bulgarian-split">
+      <segment state="translated">
+        <source>Bulgarian Split</source>
+        <target>Bulgarian Split</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.squats.pistol"> <segment state="translated"> <source>Pistol</source> <target>Pistol</target>
+    <unit id="exercise.variant.squats.pistol">
+      <segment state="translated">
+        <source>Pistol</source>
+        <target>Pistol</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.calfraises.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
+    <unit id="exercise.variant.calfraises.standard">
+      <segment state="translated">
+        <source>Standard</source>
+        <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.calfraises.single-leg"> <segment state="translated"> <source>Einbeinig</source> <target>Énbenet</target>
+    <unit id="exercise.variant.calfraises.single-leg">
+      <segment state="translated">
+        <source>Einbeinig</source>
+        <target>Énbenet</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.calfraises.seated"> <segment state="translated"> <source>Sitzend</source> <target>Sittende</target>
+    <unit id="exercise.variant.calfraises.seated">
+      <segment state="translated">
+        <source>Sitzend</source>
+        <target>Sittende</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.glutebridge.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
+    <unit id="exercise.variant.glutebridge.standard">
+      <segment state="translated">
+        <source>Standard</source>
+        <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.glutebridge.single-leg"> <segment state="translated"> <source>Einbeinig</source> <target>Énbenet</target>
+    <unit id="exercise.variant.glutebridge.single-leg">
+      <segment state="translated">
+        <source>Einbeinig</source>
+        <target>Énbenet</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.glutebridge.hip-thrust"> <segment state="translated"> <source>Hip Thrust</source> <target>Hip Thrust</target>
+    <unit id="exercise.variant.glutebridge.hip-thrust">
+      <segment state="translated">
+        <source>Hip Thrust</source>
+        <target>Hip Thrust</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.glutebridge.march"> <segment state="translated"> <source>Marching</source> <target>Marsjering</target>
+    <unit id="exercise.variant.glutebridge.march">
+      <segment state="translated">
+        <source>Marching</source>
+        <target>Marsjering</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.forward"> <segment state="translated"> <source>Vorwärts</source> <target>Fremover</target>
+    <unit id="exercise.variant.lunges.forward">
+      <segment state="translated">
+        <source>Vorwärts</source>
+        <target>Fremover</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.reverse"> <segment state="translated"> <source>Rückwärts</source> <target>Bakover</target>
+    <unit id="exercise.variant.lunges.reverse">
+      <segment state="translated">
+        <source>Rückwärts</source>
+        <target>Bakover</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.walking"> <segment state="translated"> <source>Walking</source> <target>Gåing</target>
+    <unit id="exercise.variant.lunges.walking">
+      <segment state="translated">
+        <source>Walking</source>
+        <target>Gåing</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.lateral"> <segment state="translated"> <source>Seitlich</source> <target>Sideveis</target>
+    <unit id="exercise.variant.lunges.lateral">
+      <segment state="translated">
+        <source>Seitlich</source>
+        <target>Sideveis</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.curtsy"> <segment state="translated"> <source>Curtsy</source> <target>Curtsy</target>
+    <unit id="exercise.variant.lunges.curtsy">
+      <segment state="translated">
+        <source>Curtsy</source>
+        <target>Curtsy</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.lunges.jumping"> <segment state="translated"> <source>Jumping</source> <target>Hopping</target>
+    <unit id="exercise.variant.lunges.jumping">
+      <segment state="translated">
+        <source>Jumping</source>
+        <target>Hopping</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.standard"> <segment state="translated"> <source>Standard</source> <target>Standard</target>
+    <unit id="exercise.variant.pullups.standard">
+      <segment state="translated">
+        <source>Standard</source>
+        <target>Standard</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.chin-up"> <segment state="translated"> <source>Chin-up</source> <target>Chin-up</target>
+    <unit id="exercise.variant.pullups.chin-up">
+      <segment state="translated">
+        <source>Chin-up</source>
+        <target>Chin-up</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.wide-grip"> <segment state="translated"> <source>Breiter Griff</source> <target>Bredt grep</target>
+    <unit id="exercise.variant.pullups.wide-grip">
+      <segment state="translated">
+        <source>Breiter Griff</source>
+        <target>Bredt grep</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.neutral-grip"> <segment state="translated"> <source>Neutraler Griff</source> <target>Nøytralt grep</target>
+    <unit id="exercise.variant.pullups.neutral-grip">
+      <segment state="translated">
+        <source>Neutraler Griff</source>
+        <target>Nøytralt grep</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.negative"> <segment state="translated"> <source>Negativ</source> <target>Negativ</target>
+    <unit id="exercise.variant.pullups.negative">
+      <segment state="translated">
+        <source>Negativ</source>
+        <target>Negativ</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.assisted"> <segment state="translated"> <source>Assistiert</source> <target>Assistert</target>
+    <unit id="exercise.variant.pullups.assisted">
+      <segment state="translated">
+        <source>Assistiert</source>
+        <target>Assistert</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.pullups.archer"> <segment state="translated"> <source>Archer</source> <target>Archer</target>
+    <unit id="exercise.variant.pullups.archer">
+      <segment state="translated">
+        <source>Archer</source>
+        <target>Archer</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.rows.inverted"> <segment state="translated"> <source>Inverted Row</source> <target>Inverted Row</target>
+    <unit id="exercise.variant.rows.inverted">
+      <segment state="translated">
+        <source>Inverted Row</source>
+        <target>Inverted Row</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.rows.australian"> <segment state="translated"> <source>Australian Row</source> <target>Australian Row</target>
+    <unit id="exercise.variant.rows.australian">
+      <segment state="translated">
+        <source>Australian Row</source>
+        <target>Australian Row</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.rows.dumbbell"> <segment state="translated"> <source>Kurzhantel</source> <target>Håndvekt</target>
+    <unit id="exercise.variant.rows.dumbbell">
+      <segment state="translated">
+        <source>Kurzhantel</source>
+        <target>Håndvekt</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.rows.barbell"> <segment state="translated"> <source>Langhantel</source> <target>Stang</target>
+    <unit id="exercise.variant.rows.barbell">
+      <segment state="translated">
+        <source>Langhantel</source>
+        <target>Stang</target>
       </segment>
     </unit>
-    <unit id="exercise.push.dips.name"> <segment state="translated"> <source>Dips</source> <target>Dips</target>
+    <unit id="exercise.push.dips.name">
+      <segment state="translated">
+        <source>Dips</source>
+        <target>Dips</target>
       </segment>
     </unit>
-    <unit id="exercise.push.benchdips.name"> <segment state="translated"> <source>Bankdips</source> <target>Benk-dips</target>
+    <unit id="exercise.push.benchdips.name">
+      <segment state="translated">
+        <source>Bankdips</source>
+        <target>Benk-dips</target>
       </segment>
     </unit>
-    <unit id="exercise.push.handstandhold.name"> <segment state="translated"> <source>Handstand-Hold</source> <target>Handstand-hold</target>
+    <unit id="exercise.push.handstandhold.name">
+      <segment state="translated">
+        <source>Handstand-Hold</source>
+        <target>Handstand-hold</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.dips.parallel"> <segment state="translated"> <source>Barren</source> <target>Barrer</target>
+    <unit id="exercise.variant.dips.parallel">
+      <segment state="translated">
+        <source>Barren</source>
+        <target>Barrer</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.dips.straight-bar"> <segment state="translated"> <source>Stange</source> <target>Stang</target>
+    <unit id="exercise.variant.dips.straight-bar">
+      <segment state="translated">
+        <source>Stange</source>
+        <target>Stang</target>
       </segment>
     </unit>
-    <unit id="exercise.variant.dips.ring"> <segment state="translated"> <source>Ringe</source> <target>Ringer</target>
+    <unit id="exercise.variant.dips.ring">
+      <segment state="translated">
+        <source>Ringe</source>
+        <target>Ringer</target>
       </segment>
     </unit>
-      <unit id="exerciseTimer.title"> <segment state="translated"> <source>Halteübung-Timer</source> <target>Hold-øvelses-timer</target>
+      <unit id="exerciseTimer.title">
+        <segment state="translated">
+          <source>Halteübung-Timer</source>
+          <target>Hold-øvelses-timer</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.exercisePickerAria"> <segment state="translated"> <source>Übung wählen</source> <target>Velg øvelse</target>
+    <unit id="exerciseTimer.exercisePickerAria">
+      <segment state="translated">
+        <source>Übung wählen</source>
+        <target>Velg øvelse</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraMode">
-      <segment state="translated"> <source> Kamera: Start/Ende automatisch erkennen </source> <target> Kamera: Automatisk start/stopp deteksjon </target>
+      <segment state="translated">
+        <source> Kamera: Start/Ende automatisch erkennen </source>
+        <target> Kamera: Automatisk start/stopp deteksjon </target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.cameraStarting"> <segment state="translated"> <source>Kamera startet …</source> <target>Kamera starter...</target>
+    <unit id="exerciseTimer.cameraStarting">
+      <segment state="translated">
+        <source>Kamera startet …</source>
+        <target>Kamera starter...</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraUnavailable">
-      <segment state="translated"> <source> Kamera nicht verfügbar </source> <target> Kamera ikke tilgjengelig </target>
+      <segment state="translated">
+        <source> Kamera nicht verfügbar </source>
+        <target> Kamera ikke tilgjengelig </target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.formCheck.toggleAria"> <segment state="translated"> <source>Form-Check anzeigen oder ausblenden</source> <target>Vis eller skjul formkontroll</target>
+    <unit id="exerciseTimer.formCheck.toggleAria">
+      <segment state="translated">
+        <source>Form-Check anzeigen oder ausblenden</source>
+        <target>Vis eller skjul formkontroll</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.formCheck.angle"> <segment state="translated"> <source>Winkel</source> <target>Vinkel</target>
+    <unit id="exerciseTimer.formCheck.angle">
+      <segment state="translated">
+        <source>Winkel</source>
+        <target>Vinkel</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.formCheck.confidence"> <segment state="translated"> <source>Sicherheit</source> <target>Sikkerhet</target>
+    <unit id="exerciseTimer.formCheck.confidence">
+      <segment state="translated">
+        <source>Sicherheit</source>
+        <target>Sikkerhet</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.pause"> <segment state="translated"> <source>Pause</source> <target>Pause</target>
+    <unit id="exerciseTimer.pause">
+      <segment state="translated">
+        <source>Pause</source>
+        <target>Pause</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.start"> <segment state="translated"> <source>Start</source> <target>Start</target>
+    <unit id="exerciseTimer.start">
+      <segment state="translated">
+        <source>Start</source>
+        <target>Start</target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cameraHint">
-      <segment state="translated"> <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source> <target> Still kameraet slik at skulder, hofte og knie er synlige. Timeren starter automatisk når du er i posisjon, og pauser når du forlater posisjonen. </target>
+      <segment state="translated">
+        <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
+        <target> Still kameraet slik at skulder, hofte og kne er synlige. Timeren starter automatisk når du er i posisjon, og pauser når du forlater posisjonen. </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.reset">
-      <segment state="translated"> <source> Zurücksetzen </source> <target> Tilbakestill </target>
+      <segment state="translated">
+        <source> Zurücksetzen </source>
+        <target> Tilbakestill </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.cancel">
-      <segment state="translated"> <source> Abbrechen </source> <target> Avbryt </target>
+      <segment state="translated">
+        <source> Abbrechen </source>
+        <target> Avbryt </target>
       </segment>
     </unit>
     <unit id="exerciseTimer.save">
-      <segment state="translated"> <source> Übernehmen </source> <target> Bruk </target>
+      <segment state="translated">
+        <source> Übernehmen </source>
+        <target> Bruk </target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.phase.holding"> <segment state="translated"> <source>Halten</source> <target>Hold</target>
+    <unit id="exerciseTimer.phase.holding">
+      <segment state="translated">
+        <source>Halten</source>
+        <target>Hold</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.phase.paused"> <segment state="translated"> <source>Pause</source> <target>Pause</target>
+    <unit id="exerciseTimer.phase.paused">
+      <segment state="translated">
+        <source>Pause</source>
+        <target>Pause</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.phase.ready"> <segment state="translated"> <source>Bereit</source> <target>Klar</target>
+    <unit id="exerciseTimer.phase.ready">
+      <segment state="translated">
+        <source>Bereit</source>
+        <target>Klar</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.exercise.plank"> <segment state="translated"> <source>Plank</source> <target>Plank</target>
+    <unit id="exerciseTimer.exercise.plank">
+      <segment state="translated">
+        <source>Plank</source>
+        <target>Plank</target>
       </segment>
     </unit>
-    <unit id="exerciseTimer.exercise.hollowhold"> <segment state="translated"> <source>Hollow Hold</source> <target>Hollow Hold</target>
+    <unit id="exerciseTimer.exercise.hollowhold">
+      <segment state="translated">
+        <source>Hollow Hold</source>
+        <target>Hollow Hold</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.exerciseTimerAria"> <segment state="translated"> <source>Halteübungs-Timer öffnen</source> <target>Åpne hold-øvelses-timer</target>
+    <unit id="quickAdd.fab.exerciseTimerAria">
+      <segment state="translated">
+        <source>Halteübungs-Timer öffnen</source>
+        <target>Åpne hold-øvelses-timer</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.exerciseTimer"> <segment state="translated"> <source>Plank‑Timer</source> <target>Plank-timer</target>
+    <unit id="quickAdd.fab.exerciseTimer">
+      <segment state="translated">
+        <source>Plank‑Timer</source>
+        <target>Plank-timer</target>
       </segment>
     </unit>
     <unit id="quickAddConfig.hintV2">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -4735,7 +4735,7 @@
     <unit id="exercise.abs.legraises.name">
       <segment state="translated">
         <source>Beinheben</source>
-        <target>Beinheben</target>
+        <target>抬腿</target>
       </segment>
     </unit>
     <unit id="exercise.abs.russiantwist.name">
@@ -7737,7 +7737,7 @@
     <unit id="exercise.core.hollowhold.name">
       <segment state="translated">
         <source>Hollow Hold</source>
-        <target>空心式hold</target></segment>
+        <target>空心支撑</target></segment>
     </unit>
     <unit id="exercise.squat.wallsit.name">
       <segment state="translated">
@@ -7777,7 +7777,7 @@
     <unit id="exercise.pull.deadhang.name">
       <segment state="translated">
         <source>Dead Hang</source>
-        <target>悬垂hold</target></segment>
+        <target>悬垂保持</target></segment>
     </unit>
     <unit id="exercise.pull.facepull.name">
       <segment state="translated">
@@ -7852,7 +7852,7 @@
     <unit id="exercise.mobility.foamrolling.name">
       <segment state="translated">
         <source>Faszienrolle</source>
-        <target>筋膜枪</target></segment>
+        <target>泡沫轴</target></segment>
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
       <segment state="translated">
@@ -8147,7 +8147,7 @@
     <unit id="exercise.push.handstandhold.name">
       <segment state="translated">
         <source>Handstand-Hold</source>
-        <target>倒立hold</target></segment>
+        <target>倒立保持</target></segment>
     </unit>
     <unit id="exercise.variant.dips.parallel">
       <segment state="translated">
@@ -8192,7 +8192,7 @@
     <unit id="exerciseTimer.formCheck.toggleAria">
       <segment state="translated">
         <source>Form-Check anzeigen oder ausblenden</source>
-        <target>显示或隐藏表单检查</target></segment>
+        <target>显示或隐藏动作检查</target></segment>
     </unit>
     <unit id="exerciseTimer.formCheck.angle">
       <segment state="translated">
@@ -8257,7 +8257,7 @@
     <unit id="exerciseTimer.exercise.hollowhold">
       <segment state="translated">
         <source>Hollow Hold</source>
-        <target>空心式hold</target></segment>
+        <target>空心支撑</target></segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimerAria">
       <segment state="translated">
@@ -8650,7 +8650,7 @@
     <unit id="plan.core-4w.day.3.desc">
       <segment state="translated">
         <source>Beinheben 3×10 · Russian Twist 3×15 · Plank 3×30 s · LS 2×12</source>
-        <target>Beinheben 3×10 · 俄罗斯转体 3×15 · 平板支撑 3×30 s · 俯卧撑 2×12</target>
+        <target>抬腿 3×10 · 俄罗斯转体 3×15 · 平板支撑 3×30 s · 俯卧撑 2×12</target>
       </segment>
     </unit>
     <unit id="plan.core-4w.day.5.desc">
@@ -8674,7 +8674,7 @@
     <unit id="plan.core-4w.day.9.desc">
       <segment state="translated">
         <source>Beinheben 3×12 · Russian Twist 3×18 · Plank 3×40 s · LS 2×12</source>
-        <target>Beinheben 3×12 · 俄罗斯转体 3×18 · 平板支撑 3×40 s · 俯卧撑 2×12</target>
+        <target>抬腿 3×12 · 俄罗斯转体 3×18 · 平板支撑 3×40 s · 俯卧撑 2×12</target>
       </segment>
     </unit>
     <unit id="plan.core-4w.day.11.desc">
@@ -8722,7 +8722,7 @@
     <unit id="plan.core-4w.day.20.desc">
       <segment state="translated">
         <source>Core-Zirkel 3 Runden — 50 s Plank · 12 Beinheben · 20 Russian Twists · 10 LS</source>
-        <target>核心循环 3 轮 — 50 s 平板支撑 · 12 Beinheben · 20 俄罗斯转体 · 10 俯卧撑</target>
+        <target>核心循环 3 轮 — 50 s 平板支撑 · 12 抬腿 · 20 俄罗斯转体 · 10 俯卧撑</target>
       </segment>
     </unit>
     <unit id="plan.core-4w.day.22.desc">
@@ -8734,7 +8734,7 @@
     <unit id="plan.core-4w.day.23.desc">
       <segment state="translated">
         <source>Core-Zirkel 3 Runden — 1 min Plank · 30 Russian Twists · 12 Beinheben · 12 LS</source>
-        <target>核心循环 3 轮 — 1 min 平板支撑 · 30 俄罗斯转体 · 12 Beinheben · 12 俯卧撑</target>
+        <target>核心循环 3 轮 — 1 min 平板支撑 · 30 俄罗斯转体 · 12 抬腿 · 12 俯卧撑</target>
       </segment>
     </unit>
     <unit id="plan.core-4w.day.25.desc">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="de" trgLang="zh">
   <file id="ngi18n" original="ng.template">
     <unit id="consent.banner.aria">
@@ -4626,14 +4626,14 @@
     </unit>
     <unit id="entryDialog.overCapDuration">
       <segment state="translated">
-        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></source>
-        <target>最长时长：<ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}"/></target>
+        <source>Maximum-Dauer: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}" /></source>
+        <target>最长时长：<ph id="0" equiv="INTERPOLATION" disp="{{ formattedDurationMax() }}" /></target>
       </segment>
     </unit>
     <unit id="entryDialog.overCapTime">
       <segment state="translated">
-        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></source>
-        <target>最大: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}"/></target>
+        <source>Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}" /></source>
+        <target>最大: <ph id="0" equiv="INTERPOLATION" disp="{{ formattedMax() }}" /></target>
       </segment>
     </unit>
     <unit id="exercise.category.plank">
@@ -4674,8 +4674,8 @@
     </unit>
     <unit id="entryDialog.overCap">
       <segment state="translated">
-        <source> Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> pro Eintrag </source>
-        <target> 每条记录最多 <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}"/> </target>
+        <source> Maximum: <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}" /> pro Eintrag </source>
+        <target> 每条记录最多 <ph id="0" equiv="INTERPOLATION" disp="{{ data.definition.max }}" /> </target>
       </segment>
     </unit>
     <unit id="exerciseSection.lastEntry">
@@ -5258,46 +5258,39 @@
       <target> 没有可用的组次数数据 </target></segment>
     </unit>
     <unit id="intervalsDistribution.noData">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Intervall-Daten vorhanden</source>
-        <target>Keine Intervall-Daten vorhanden</target>
-      </segment>
+        <target>无区间数据</target></segment>
     </unit>
     <unit id="intervalsDistribution.listLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Verteilung</source>
-        <target>Intervall-Verteilung</target>
-      </segment>
+        <target>区间分布</target></segment>
     </unit>
     <unit id="entry.interval.label">
-      <segment state="initial">
-        <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></source>
-        <target>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}"/></target>
-      </segment>
+      <segment state="translated">
+        <source>Intervall <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></source>
+        <target>区间 <ph id="0" equiv="INTERPOLATION" disp="{{ $index + 1 }}" /></target></segment>
     </unit>
     <unit id="entry.intervals.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervalle</source>
-        <target>Intervalle</target>
-      </segment>
+        <target>区间</target></segment>
     </unit>
     <unit id="entry.intervals.remove">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall entfernen</source>
-        <target>Intervall entfernen</target>
-      </segment>
+        <target>移除区间</target></segment>
     </unit>
     <unit id="entry.intervals.add">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall hinzufügen</source>
-        <target>Intervall hinzufügen</target>
-      </segment>
+        <target>添加区间</target></segment>
     </unit>
     <unit id="entry.intervals.addTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Weiteres Intervall hinzufügen</source>
-        <target>Weiteres Intervall hinzufügen</target>
-      </segment>
+        <target>添加另一个区间</target></segment>
     </unit>
     <unit id="chart.subtitle.reps">
       <notes>
@@ -6114,7 +6107,7 @@
     </unit>
     <unit id="settings.leaderboardRequiresPublicProfile">
       <segment state="translated">
-        <source/>
+        <source />
         <target> 只有启用了「公开档案」的用户才会出现在排行榜上。请在下方启用「公开档案」以使用此选项。 </target>
       </segment>
     </unit>
@@ -6758,8 +6751,8 @@
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:110</note>
       </notes>
       <segment state="translated">
-        <source><ph id="0" equiv="label" disp="label"/> in der Historie öffnen</source>
-        <target>在历史记录中打开<ph id="0" equiv="label" disp="label"/></target>
+        <source><ph id="0" equiv="label" disp="label" /> in der Historie öffnen</source>
+        <target>在历史记录中打开<ph id="0" equiv="label" disp="label" /></target>
       </segment>
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
@@ -6962,8 +6955,8 @@
     </unit>
     <unit id="trainingPlans.jumped">
       <segment state="translated">
-        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
-        <target>已跳转到第 <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> 天。</target>
+        <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex" /> gesprungen.</source>
+        <target>已跳转到第 <ph id="0" equiv="INTERPOLATION" disp="dayIndex" /> 天。</target>
       </segment>
     </unit>
     <unit id="trainingPlans.notFound">
@@ -7212,7 +7205,7 @@
       <target>高级</target></segment>
     </unit>
 
-    <!-- Exercises wiki page -->
+    
     <unit id="seo.wiki.exercises.title">
       <segment state="translated">
         <source>Übungen erklärt – Pushup Tracker</source>
@@ -7399,265 +7392,265 @@
     </unit>
     <unit id="leaderboard.visibilityHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> 想修改可见性或显示名称？ </target>
       </segment>
     </unit>
     <unit id="leaderboard.visibilityHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>打开设置</target>
       </segment>
     </unit>
     <unit id="leaderboard.loginHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> 想参与并出现在这里？ </target>
       </segment>
     </unit>
     <unit id="leaderboard.loginHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>登录</target>
       </segment>
     </unit>
     <unit id="analysis.empty.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>还没有可分析的数据。</target>
       </segment>
     </unit>
     <unit id="analysis.empty.body">
       <segment state="translated">
-        <source/>
+        <source />
         <target> 启动训练计划或记录第一组——我们会在这里显示趋势和连续记录。 </target>
       </segment>
     </unit>
     <unit id="analysis.empty.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> 选择训练计划 </target>
       </segment>
     </unit>
     <unit id="analysis.tabs.overview">
       <segment state="translated">
-        <source/>
+        <source />
         <target>概览</target>
       </segment>
     </unit>
     <unit id="analysis.overview.empty">
       <segment state="translated">
-        <source/>
+        <source />
         <target>当前日期范围内尚无条目。</target>
       </segment>
     </unit>
     <unit id="analysis.overview.uncategorisedNotice">
       <segment state="translated">
-        <source/>
+        <source />
         <target>这些条目不属于任何已知类别 — 下方为汇总。</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>按训练组对比</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.empty">
       <segment state="translated">
-        <source/>
+        <source />
         <target>当前日期范围内暂无数据。</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalReps">
       <segment state="translated">
-        <source/>
+        <source />
         <target>总次数</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayReps">
       <segment state="translated">
-        <source/>
+        <source />
         <target>今天</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.streak">
       <segment state="translated">
-        <source/>
+        <source />
         <target>连续天数</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.bestDay">
       <segment state="translated">
-        <source/>
+        <source />
         <target>最佳日</target>
       </segment>
     </unit>
     <unit id="analysis.overview.comparison.metricLabel">
       <segment state="translated">
-        <source/>
+        <source />
         <target>训练次数</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.repsTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>次数</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalSets">
       <segment state="translated">
-        <source/>
+        <source />
         <target>总组数</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.timeTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>时间</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalTime">
       <segment state="translated">
-        <source/>
+        <source />
         <target>总时间</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayTime">
       <segment state="translated">
-        <source/>
+        <source />
         <target>今天</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.distanceTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>距离</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.totalDistance">
       <segment state="translated">
-        <source/>
+        <source />
         <target>总距离</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.todayDistance">
       <segment state="translated">
-        <source/>
+        <source />
         <target>今天</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.facet.distanceTimeTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>距离与时间</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.entries">
       <segment state="translated">
-        <source/>
+        <source />
         <target>训练次数</target>
       </segment>
     </unit>
     <unit id="analysis.overview.cards.viewDetails">
       <segment state="translated">
-        <source/>
+        <source />
         <target>查看详情</target>
       </segment>
     </unit>
     <unit id="entries.empty.title">
       <segment state="translated">
-        <source/>
+        <source />
         <target>还没有记录。</target>
       </segment>
     </unit>
     <unit id="entries.empty.body">
       <segment state="translated">
-        <source/>
+        <source />
         <target> 添加你的第一条训练记录——历史记录就会显示在这里。 </target>
       </segment>
     </unit>
     <unit id="entries.empty.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc> 创建记录 </target>
       </segment>
     </unit>
     <unit id="settings.displayNameHint.leaderboardLink">
       <segment state="translated">
-        <source/>
+        <source />
         <target>查看排行榜</target>
       </segment>
     </unit>
     <unit id="settings.publicProfile.previewCta">
       <segment state="translated">
-        <source/>
+        <source />
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">visibility</pc> 预览</target>
       </segment>
     </unit>
     <unit id="settings.goals.planOverrideHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> 活动的训练计划会自动设定每日目标。手动值仅在计划结束后生效。 </target>
       </segment>
     </unit>
     <unit id="settings.goals.openActivePlan">
       <segment state="translated">
-        <source/>
+        <source />
         <target>打开活动计划</target>
       </segment>
     </unit>
     <unit id="settings.adsConsent.privacyLink">
       <segment state="translated">
-        <source/>
+        <source />
         <target>隐私声明</target>
       </segment>
     </unit>
     <unit id="dashboard.noPlanTitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target>尚无活动训练计划</target>
       </segment>
     </unit>
     <unit id="dashboard.noPlanSubtitle">
       <segment state="translated">
-        <source/>
+        <source />
         <target> 选择一个计划，让每日目标自动设定。 </target>
       </segment>
     </unit>
     <unit id="dashboard.noPlanCta">
       <segment state="translated">
-        <source/>
+        <source />
         <target> 选择计划 </target>
       </segment>
     </unit>
     <unit id="dashboard.goalEditAria">
       <segment state="translated">
-        <source/>
+        <source />
         <target>在设置中打开每日目标</target>
       </segment>
     </unit>
     <unit id="dashboard.lastEntryLinkAria">
       <segment state="translated">
-        <source/>
+        <source />
         <target>在历史记录中打开最后一条记录</target>
       </segment>
     </unit>
     <unit id="dashboard.allTimeBadges.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>查看分析</target>
       </segment>
     </unit>
     <unit id="trainingPlans.goalOverrideHint">
       <segment state="translated">
-        <source/>
+        <source />
         <target> 每日目标由计划设定。 </target>
       </segment>
     </unit>
     <unit id="trainingPlans.goalOverrideHint.cta">
       <segment state="translated">
-        <source/>
+        <source />
         <target>调整手动目标</target>
       </segment>
     </unit>
@@ -7692,711 +7685,594 @@
       </segment>
     </unit>
       <unit id="exercise.category.push">
-      <segment state="initial">
+      <segment state="translated">
         <source>Drücken</source>
-        <target>Drücken</target>
-      </segment>
+        <target>推</target></segment>
     </unit>
     <unit id="exercise.category.pull">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziehen</source>
-        <target>Ziehen</target>
-      </segment>
+        <target>拉</target></segment>
     </unit>
     <unit id="exercise.category.squat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kniebeuge</source>
-        <target>Kniebeuge</target>
-      </segment>
+        <target>深蹲</target></segment>
     </unit>
     <unit id="exercise.category.hinge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftstreckung</source>
-        <target>Hüftstreckung</target>
-      </segment>
+        <target>髋部伸展</target></segment>
     </unit>
     <unit id="exercise.category.lunge">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausfallschritt</source>
-        <target>Ausfallschritt</target>
-      </segment>
+        <target>弓步</target></segment>
     </unit>
     <unit id="exercise.category.carry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tragen</source>
-        <target>Tragen</target>
-      </segment>
+        <target>负重行走</target></segment>
     </unit>
     <unit id="exercise.category.core">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rumpf</source>
-        <target>Rumpf</target>
-      </segment>
+        <target>核心</target></segment>
     </unit>
     <unit id="exercise.category.mobility">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mobilität</source>
-        <target>Mobilität</target>
-      </segment>
+        <target>活动能力</target></segment>
     </unit>
     <unit id="exercise.category.strength">
-      <segment state="initial">
+      <segment state="translated">
         <source>Krafttraining</source>
-        <target>Krafttraining</target>
-      </segment>
+        <target>力量训练</target></segment>
     </unit>
     <unit id="exercise.core.deadbug.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Bug</source>
-        <target>Dead Bug</target>
-      </segment>
+        <target>死虫式</target></segment>
     </unit>
     <unit id="exercise.core.hollowhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
-        <target>Hollow Hold</target>
-      </segment>
+        <target>空心式hold</target></segment>
     </unit>
     <unit id="exercise.squat.wallsit.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wandsitz</source>
-        <target>Wandsitz</target>
-      </segment>
+        <target>靠墙深蹲</target></segment>
     </unit>
     <unit id="exercise.squat.boxjump.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Box Jumps</source>
-        <target>Box Jumps</target>
-      </segment>
+        <target>跳箱</target></segment>
     </unit>
     <unit id="exercise.hinge.singlelegRdl.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeiniges Kreuzheben</source>
-        <target>Einbeiniges Kreuzheben</target>
-      </segment>
+        <target>单腿硬拉</target></segment>
     </unit>
     <unit id="exercise.hinge.goodmorning.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Good Morning</source>
-        <target>Good Morning</target>
-      </segment>
+        <target>早安式</target></segment>
     </unit>
     <unit id="exercise.lunge.stepup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Step-ups</source>
-        <target>Step-ups</target>
-      </segment>
+        <target>台阶式</target></segment>
     </unit>
     <unit id="exercise.pull.pullups.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Klimmzüge</source>
-        <target>Klimmzüge</target>
-      </segment>
+        <target>引体向上</target></segment>
     </unit>
     <unit id="exercise.pull.rows.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ruderzug</source>
-        <target>Ruderzug</target>
-      </segment>
+        <target>划船</target></segment>
     </unit>
     <unit id="exercise.pull.deadhang.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dead Hang</source>
-        <target>Dead Hang</target>
-      </segment>
+        <target>悬垂hold</target></segment>
     </unit>
     <unit id="exercise.pull.facepull.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Face Pull</source>
-        <target>Face Pull</target>
-      </segment>
+        <target>面部拉力</target></segment>
     </unit>
     <unit id="exercise.carry.farmer.name">
-      <segment state="initial">
-        <source>Farmer&apos;s Walk</source>
-        <target>Farmer&apos;s Walk</target>
-      </segment>
+      <segment state="translated">
+        <source>Farmer's Walk</source>
+        <target>农夫行走</target></segment>
     </unit>
     <unit id="exercise.carry.suitcase.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Suitcase Carry</source>
-        <target>Suitcase Carry</target>
-      </segment>
+        <target>手提箱负重行走</target></segment>
     </unit>
     <unit id="exercise.carry.overhead.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Overhead Carry</source>
-        <target>Overhead Carry</target>
-      </segment>
+        <target>头顶负重行走</target></segment>
     </unit>
     <unit id="exercise.cardio.walking.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gehen</source>
-        <target>Gehen</target>
-      </segment>
+        <target>步行</target></segment>
     </unit>
     <unit id="exercise.cardio.cycling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Radfahren</source>
-        <target>Radfahren</target>
-      </segment>
+        <target>骑自行车</target></segment>
     </unit>
     <unit id="exercise.cardio.rowing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rudern</source>
-        <target>Rudern</target>
-      </segment>
+        <target>划船</target></segment>
     </unit>
     <unit id="exercise.cardio.swimming.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schwimmen</source>
-        <target>Schwimmen</target>
-      </segment>
+        <target>游泳</target></segment>
     </unit>
     <unit id="exercise.cardio.jumprope.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seilspringen</source>
-        <target>Seilspringen</target>
-      </segment>
+        <target>跳绳</target></segment>
     </unit>
     <unit id="exercise.cardio.burpees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Burpees</source>
-        <target>Burpees</target>
-      </segment>
+        <target>波比跳</target></segment>
     </unit>
     <unit id="exercise.cardio.jumpingjacks.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hampelmänner</source>
-        <target>Hampelmänner</target>
-      </segment>
+        <target>开合跳</target></segment>
     </unit>
     <unit id="exercise.cardio.highknees.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>High Knees</source>
-        <target>High Knees</target>
-      </segment>
+        <target>高抬腿</target></segment>
     </unit>
     <unit id="exercise.mobility.stretching.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dehnen</source>
-        <target>Dehnen</target>
-      </segment>
+        <target>拉伸</target></segment>
     </unit>
     <unit id="exercise.mobility.yoga.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Yoga</source>
-        <target>Yoga</target>
-      </segment>
+        <target>瑜伽</target></segment>
     </unit>
     <unit id="exercise.mobility.foamrolling.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Faszienrolle</source>
-        <target>Faszienrolle</target>
-      </segment>
+        <target>筋膜枪</target></segment>
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dynamisches Aufwärmen</source>
-        <target>Dynamisches Aufwärmen</target>
-      </segment>
+        <target>动态热身</target></segment>
     </unit>
     <unit id="exercise.mobility.catcow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Katze-Kuh</source>
-        <target>Katze-Kuh</target>
-      </segment>
+        <target>猫牛式</target></segment>
     </unit>
     <unit id="exercise.mobility.hipopener.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hüftöffner</source>
-        <target>Hüftöffner</target>
-      </segment>
+        <target>开髋</target></segment>
     </unit>
     <unit id="exercise.strength.benchpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdrücken</source>
-        <target>Bankdrücken</target>
-      </segment>
+        <target>卧推</target></segment>
     </unit>
     <unit id="exercise.strength.overheadpress.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schulterdrücken</source>
-        <target>Schulterdrücken</target>
-      </segment>
+        <target>肩推</target></segment>
     </unit>
     <unit id="exercise.strength.deadlift.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kreuzheben</source>
-        <target>Kreuzheben</target>
-      </segment>
+        <target>硬拉</target></segment>
     </unit>
     <unit id="exercise.strength.barbellsquat.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel-Kniebeuge</source>
-        <target>Langhantel-Kniebeuge</target>
-      </segment>
+        <target>杠铃深蹲</target></segment>
     </unit>
     <unit id="exercise.strength.barbellrow.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantelrudern</source>
-        <target>Langhantelrudern</target>
-      </segment>
+        <target>杠铃划船</target></segment>
     </unit>
     <unit id="exercise.strength.kettlebellswing.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kettlebell Swing</source>
-        <target>Kettlebell Swing</target>
-      </segment>
+        <target>壶铃摇摆</target></segment>
     </unit>
       <unit id="exercise.variant.situps.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>标准</target></segment>
     </unit>
     <unit id="exercise.variant.situps.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source>Decline</source>
-        <target>Decline</target>
-      </segment>
+        <target>下斜</target></segment>
     </unit>
     <unit id="exercise.variant.situps.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
-      </segment>
+        <target>带负重</target></segment>
     </unit>
     <unit id="exercise.variant.crunches.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>标准</target></segment>
     </unit>
     <unit id="exercise.variant.crunches.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reverse Crunches</source>
-        <target>Reverse Crunches</target>
-      </segment>
+        <target>反向卷腹</target></segment>
     </unit>
     <unit id="exercise.variant.crunches.bicycle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bicycle Crunches</source>
-        <target>Bicycle Crunches</target>
-      </segment>
+        <target>自行车卷腹</target></segment>
     </unit>
     <unit id="exercise.variant.crunches.oblique">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schräge Crunches</source>
-        <target>Schräge Crunches</target>
-      </segment>
+        <target>斜向卷腹</target></segment>
     </unit>
     <unit id="exercise.variant.legraises.lying">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegend</source>
-        <target>Liegend</target>
-      </segment>
+        <target>平躺</target></segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-knee">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (Knie)</source>
-        <target>Hängend (Knie)</target>
-      </segment>
+        <target>悬垂（膝盖）</target></segment>
     </unit>
     <unit id="exercise.variant.legraises.hanging-straight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hängend (gestreckt)</source>
-        <target>Hängend (gestreckt)</target>
-      </segment>
+        <target>悬垂（伸直）</target></segment>
     </unit>
     <unit id="exercise.variant.russiantwist.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
-      </segment>
+        <target>自重</target></segment>
     </unit>
     <unit id="exercise.variant.russiantwist.weighted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mit Zusatzgewicht</source>
-        <target>Mit Zusatzgewicht</target>
-      </segment>
+        <target>带负重</target></segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>标准</target></segment>
     </unit>
     <unit id="exercise.variant.mountainclimbers.cross-body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Cross-Body</source>
-        <target>Cross-Body</target>
-      </segment>
+        <target>交叉身体</target></segment>
     </unit>
     <unit id="exercise.variant.plank.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>标准</target></segment>
     </unit>
     <unit id="exercise.variant.plank.forearm">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unterarmstütz</source>
-        <target>Unterarmstütz</target>
-      </segment>
+        <target>前臂平板支撑</target></segment>
     </unit>
     <unit id="exercise.variant.plank.side">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
-      </segment>
+        <target>侧卧</target></segment>
     </unit>
     <unit id="exercise.variant.plank.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Umgekehrt</source>
-        <target>Umgekehrt</target>
-      </segment>
+        <target>反向</target></segment>
     </unit>
     <unit id="exercise.variant.squats.bodyweight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eigengewicht</source>
-        <target>Eigengewicht</target>
-      </segment>
+        <target>自重</target></segment>
     </unit>
     <unit id="exercise.variant.squats.sumo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sumo</source>
-        <target>Sumo</target>
-      </segment>
+        <target>相扑式</target></segment>
     </unit>
     <unit id="exercise.variant.squats.goblet">
-      <segment state="initial">
+      <segment state="translated">
         <source>Goblet</source>
-        <target>Goblet</target>
-      </segment>
+        <target>哥布林式</target></segment>
     </unit>
     <unit id="exercise.variant.squats.bulgarian-split">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bulgarian Split</source>
-        <target>Bulgarian Split</target>
-      </segment>
+        <target>保加利亚分腿蹲</target></segment>
     </unit>
     <unit id="exercise.variant.squats.pistol">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pistol</source>
-        <target>Pistol</target>
-      </segment>
+        <target>手枪蹲</target></segment>
     </unit>
     <unit id="exercise.variant.calfraises.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>标准</target></segment>
     </unit>
     <unit id="exercise.variant.calfraises.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
-      </segment>
+        <target>单腿</target></segment>
     </unit>
     <unit id="exercise.variant.calfraises.seated">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sitzend</source>
-        <target>Sitzend</target>
-      </segment>
+        <target>坐姿</target></segment>
     </unit>
     <unit id="exercise.variant.glutebridge.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>标准</target></segment>
     </unit>
     <unit id="exercise.variant.glutebridge.single-leg">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einbeinig</source>
-        <target>Einbeinig</target>
-      </segment>
+        <target>单腿</target></segment>
     </unit>
     <unit id="exercise.variant.glutebridge.hip-thrust">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hip Thrust</source>
-        <target>Hip Thrust</target>
-      </segment>
+        <target>臀推</target></segment>
     </unit>
     <unit id="exercise.variant.glutebridge.march">
-      <segment state="initial">
+      <segment state="translated">
         <source>Marching</source>
-        <target>Marching</target>
-      </segment>
+        <target>行军式</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.forward">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorwärts</source>
-        <target>Vorwärts</target>
-      </segment>
+        <target>向前</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.reverse">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückwärts</source>
-        <target>Rückwärts</target>
-      </segment>
+        <target>向后</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.walking">
-      <segment state="initial">
+      <segment state="translated">
         <source>Walking</source>
-        <target>Walking</target>
-      </segment>
+        <target>行走</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.lateral">
-      <segment state="initial">
+      <segment state="translated">
         <source>Seitlich</source>
-        <target>Seitlich</target>
-      </segment>
+        <target>侧卧</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.curtsy">
-      <segment state="initial">
+      <segment state="translated">
         <source>Curtsy</source>
-        <target>Curtsy</target>
-      </segment>
+        <target>屈膝式</target></segment>
     </unit>
     <unit id="exercise.variant.lunges.jumping">
-      <segment state="initial">
+      <segment state="translated">
         <source>Jumping</source>
-        <target>Jumping</target>
-      </segment>
+        <target>跳跃</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.standard">
-      <segment state="initial">
+      <segment state="translated">
         <source>Standard</source>
-        <target>Standard</target>
-      </segment>
+        <target>标准</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.chin-up">
-      <segment state="initial">
+      <segment state="translated">
         <source>Chin-up</source>
-        <target>Chin-up</target>
-      </segment>
+        <target>正握引体向上</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.wide-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Breiter Griff</source>
-        <target>Breiter Griff</target>
-      </segment>
+        <target>宽握</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.neutral-grip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neutraler Griff</source>
-        <target>Neutraler Griff</target>
-      </segment>
+        <target>中立握</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.negative">
-      <segment state="initial">
+      <segment state="translated">
         <source>Negativ</source>
-        <target>Negativ</target>
-      </segment>
+        <target>负向</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.assisted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Assistiert</source>
-        <target>Assistiert</target>
-      </segment>
+        <target>辅助</target></segment>
     </unit>
     <unit id="exercise.variant.pullups.archer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Archer</source>
-        <target>Archer</target>
-      </segment>
+        <target>弓箭式</target></segment>
     </unit>
     <unit id="exercise.variant.rows.inverted">
-      <segment state="initial">
+      <segment state="translated">
         <source>Inverted Row</source>
-        <target>Inverted Row</target>
-      </segment>
+        <target>反向划船</target></segment>
     </unit>
     <unit id="exercise.variant.rows.australian">
-      <segment state="initial">
+      <segment state="translated">
         <source>Australian Row</source>
-        <target>Australian Row</target>
-      </segment>
+        <target>澳大利亚划船</target></segment>
     </unit>
     <unit id="exercise.variant.rows.dumbbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kurzhantel</source>
-        <target>Kurzhantel</target>
-      </segment>
+        <target>哑铃</target></segment>
     </unit>
     <unit id="exercise.variant.rows.barbell">
-      <segment state="initial">
+      <segment state="translated">
         <source>Langhantel</source>
-        <target>Langhantel</target>
-      </segment>
+        <target>杠铃</target></segment>
     </unit>
     <unit id="exercise.push.dips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dips</source>
-        <target>Dips</target>
-      </segment>
+        <target>屈臂撑</target></segment>
     </unit>
     <unit id="exercise.push.benchdips.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bankdips</source>
-        <target>Bankdips</target>
-      </segment>
+        <target>长凳屈臂撑</target></segment>
     </unit>
     <unit id="exercise.push.handstandhold.name">
-      <segment state="initial">
+      <segment state="translated">
         <source>Handstand-Hold</source>
-        <target>Handstand-Hold</target>
-      </segment>
+        <target>倒立hold</target></segment>
     </unit>
     <unit id="exercise.variant.dips.parallel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Barren</source>
-        <target>Barren</target>
-      </segment>
+        <target>双杠</target></segment>
     </unit>
     <unit id="exercise.variant.dips.straight-bar">
-      <segment state="initial">
+      <segment state="translated">
         <source>Stange</source>
-        <target>Stange</target>
-      </segment>
+        <target>单杠</target></segment>
     </unit>
     <unit id="exercise.variant.dips.ring">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ringe</source>
-        <target>Ringe</target>
-      </segment>
+        <target>吊环</target></segment>
     </unit>
       <unit id="exerciseTimer.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübung-Timer</source>
-        <target>Halteübung-Timer</target>
-      </segment>
+        <target>静力练习计时器</target></segment>
     </unit>
     <unit id="exerciseTimer.exercisePickerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung wählen</source>
-        <target>Übung wählen</target>
-      </segment>
+        <target>选择练习</target></segment>
     </unit>
     <unit id="exerciseTimer.cameraMode">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera: Start/Ende automatisch erkennen </source>
-        <target> Kamera: Start/Ende automatisch erkennen </target>
-      </segment>
+        <target> 相机：自动识别开始/结束 </target></segment>
     </unit>
     <unit id="exerciseTimer.cameraStarting">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kamera startet …</source>
-        <target>Kamera startet …</target>
-      </segment>
+        <target>相机启动中…</target></segment>
     </unit>
     <unit id="exerciseTimer.cameraUnavailable">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kamera nicht verfügbar </source>
-        <target> Kamera nicht verfügbar </target>
-      </segment>
+        <target> 相机不可用 </target></segment>
     </unit>
     <unit id="exerciseTimer.formCheck.toggleAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Form-Check anzeigen oder ausblenden</source>
-        <target>Form-Check anzeigen oder ausblenden</target>
-      </segment>
+        <target>显示或隐藏表单检查</target></segment>
     </unit>
     <unit id="exerciseTimer.formCheck.angle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Winkel</source>
-        <target>Winkel</target>
-      </segment>
+        <target>角度</target></segment>
     </unit>
     <unit id="exerciseTimer.formCheck.confidence">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sicherheit</source>
-        <target>Sicherheit</target>
-      </segment>
+        <target>置信度</target></segment>
     </unit>
     <unit id="exerciseTimer.pause">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
-      </segment>
+        <target>暂停</target></segment>
     </unit>
     <unit id="exerciseTimer.start">
-      <segment state="initial">
+      <segment state="translated">
         <source>Start</source>
-        <target>Start</target>
-      </segment>
+        <target>开始</target></segment>
     </unit>
     <unit id="exerciseTimer.cameraHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </source>
-        <target> Stelle die Kamera so auf, dass Schulter, Hüfte und Knie sichtbar sind. Der Timer startet automatisch, sobald du in Position bist, und pausiert, wenn du die Position verlässt. </target>
-      </segment>
+        <target> 将摄像头对准肩膀、臀部和膝盖。当你就位时计时器会自动开始，当你离开位置时会暂停。 </target></segment>
     </unit>
     <unit id="exerciseTimer.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurücksetzen </source>
-        <target> Zurücksetzen </target>
-      </segment>
+        <target> 重置 </target></segment>
     </unit>
     <unit id="exerciseTimer.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
-      </segment>
+        <target> 取消 </target></segment>
     </unit>
     <unit id="exerciseTimer.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Übernehmen </source>
-        <target> Übernehmen </target>
-      </segment>
+        <target> 保存 </target></segment>
     </unit>
     <unit id="exerciseTimer.phase.holding">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halten</source>
-        <target>Halten</target>
-      </segment>
+        <target>保持</target></segment>
     </unit>
     <unit id="exerciseTimer.phase.paused">
-      <segment state="initial">
+      <segment state="translated">
         <source>Pause</source>
-        <target>Pause</target>
-      </segment>
+        <target>暂停</target></segment>
     </unit>
     <unit id="exerciseTimer.phase.ready">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bereit</source>
-        <target>Bereit</target>
-      </segment>
+        <target>就绪</target></segment>
     </unit>
     <unit id="exerciseTimer.exercise.plank">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank</source>
-        <target>Plank</target>
-      </segment>
+        <target>平板支撑</target></segment>
     </unit>
     <unit id="exerciseTimer.exercise.hollowhold">
-      <segment state="initial">
+      <segment state="translated">
         <source>Hollow Hold</source>
-        <target>Hollow Hold</target>
-      </segment>
+        <target>空心式hold</target></segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimerAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Halteübungs-Timer öffnen</source>
-        <target>Halteübungs-Timer öffnen</target>
-      </segment>
+        <target>打开静力练习计时器</target></segment>
     </unit>
     <unit id="quickAdd.fab.exerciseTimer">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plank‑Timer</source>
-        <target>Plank‑Timer</target>
-      </segment>
+        <target>平板支撑计时器</target></segment>
     </unit>
     <unit id="quickAddConfig.hintV2">
       <segment state="translated">
-        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> Schnellaktionen fest. Wähle pro Button die Übung und – wo verfügbar – Auto-Messung über die Kamera. Leere Felder werden ignoriert. </source>
-        <target> 最多可设置 <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}"/> 个快速操作。为每个按钮选择训练项目，并在支持时启用通过相机进行自动计数。空白项将被忽略。 </target>
+        <source> Lege bis zu <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> Schnellaktionen fest. Wähle pro Button die Übung und – wo verfügbar – Auto-Messung über die Kamera. Leere Felder werden ignoriert. </source>
+        <target> 最多可设置 <ph id="0" equiv="INTERPOLATION" disp="{{ maxRows }}" /> 个快速操作。为每个按钮选择训练项目，并在支持时启用通过相机进行自动计数。空白项将被忽略。 </target>
       </segment>
     </unit>
     <unit id="quickAddConfig.exerciseLabel">
@@ -9061,7 +8937,7 @@
     </unit>
     <unit id="plan.push-pull-6w.summary">
       <segment state="translated">
-        <source>Symmetrischer 6-Wochen-Plan für Liegestütze und Rückenübungen (Rudern, Klimmzug-Negative, Face Pulls). Vermeidet das klassische &quot;nur Push&quot;-Ungleichgewicht und stärkt die hintere Kette gleichwertig. Pull-Tag pro Woche zusätzlich zur Push-Progression.</source>
+        <source>Symmetrischer 6-Wochen-Plan für Liegestütze und Rückenübungen (Rudern, Klimmzug-Negative, Face Pulls). Vermeidet das klassische "nur Push"-Ungleichgewicht und stärkt die hintere Kette gleichwertig. Pull-Tag pro Woche zusätzlich zur Push-Progression.</source>
         <target>6周对称推拉训练计划：俯卧撑配合拉力训练（划船、引体向上离心、面拉）。避免经典的"只推不拉"失衡，均衡强化后链。每周一天专门的拉日，作为推力进阶之外的补充。</target>
       </segment>
     </unit>


### PR DESCRIPTION
Translate 96 entries in en, and 124 entries each in el, es, fr, it, la,
nl, no, zh covering exercise categories (push, pull, squat, hinge, core,
mobility, strength), exercise names (pull-ups, deadlift, planks, etc.),
exercise variants, and interval/timer UI strings.

https://claude.ai/code/session_0163nEYLq3VM5E4CWwpuXZXG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated translations across multiple languages (Greek, Spanish, French, Italian, Latin, Dutch, Norwegian, Chinese, and English).
  * Added translations for exercise categories, exercise names, and exercise timer UI.
  * Improved translations for intervals distribution UI and entry editor labels.
  * Enhanced consistency in formatting and punctuation across all language translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->