### PR TITLE
feat(stats): thread custom-exercise resolver into analysis category filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,12 @@ Angular 21 / Nx monorepo for tracking pushup statistics with Firebase backend.
 - **Never commit secrets or user-identifiable data** (API keys, service account JSON, database UIDs, user email addresses) to the repository. Pass them as CLI arguments, environment variables, or Firebase Secrets instead.
 - **Pre-commit reformats files:** Husky + lint-staged run `eslint --fix` + `prettier --write` on every commit. Your staged files may differ from what you wrote. Re-read the file before further edits after a commit.
 
+## Pull Requests
+
+- **Issue work → feature branch + PR.** When implementing a tracked issue (e.g. `claude/implement-NNN-*` branches), open a PR proactively once the change is pushed and CI-ready, without waiting for an explicit ask. Link the issue with `Closes #ID`.
+- **Ad-hoc trunk changes still go straight to `main`.** Only open a PR when there is an issue, when the change is risky/large, or when the user requests one.
+- **After opening the PR, subscribe to its activity** via `subscribe_pr_activity` so review comments and CI failures are addressed in the same session without prompting.
+
 ## Development Flow (Project Board)
 
 - Create/triage issue → add to **PUS Roadmap** project → Status = **Todo**.

--- a/libs/data-access-state/src/lib/live/live-data.store.ts
+++ b/libs/data-access-state/src/lib/live/live-data.store.ts
@@ -32,11 +32,11 @@ type LiveDataState = {
    */
   exerciseEntries: ExerciseEntry[];
   /**
-   * User-defined exercise definitions — exposed as an empty signal
-   * until the storage layer (Firestore collection + rules + UI) lands.
-   * Consumers like the analysis page already thread this through
-   * `unifiedEntryCategoryId` so that a custom exercise's category
-   * resolves the moment definitions start flowing in. See issue #319.
+   * User-defined exercise definitions. Currently always empty: the
+   * Firestore collection is not yet provisioned (rules forbid client
+   * writes), so the signal is plumbing for the eventual storage layer.
+   * The shape is fixed now so category-resolution chains can rely on
+   * `id`/`categoryId` without a follow-up type change.
    */
   exerciseDefinitions: ExerciseDefinition[];
   connected: boolean;

--- a/libs/data-access-state/src/lib/live/live-data.store.ts
+++ b/libs/data-access-state/src/lib/live/live-data.store.ts
@@ -10,7 +10,11 @@ import {
   query,
   where,
 } from '@angular/fire/firestore';
-import { ExerciseEntry, PushupRecord } from '@pu-stats/models';
+import {
+  ExerciseDefinition,
+  ExerciseEntry,
+  PushupRecord,
+} from '@pu-stats/models';
 import {
   patchState,
   signalStore,
@@ -27,6 +31,14 @@ type LiveDataState = {
    * every existing consumer; new code reads `exerciseEntries`.
    */
   exerciseEntries: ExerciseEntry[];
+  /**
+   * User-defined exercise definitions — exposed as an empty signal
+   * until the storage layer (Firestore collection + rules + UI) lands.
+   * Consumers like the analysis page already thread this through
+   * `unifiedEntryCategoryId` so that a custom exercise's category
+   * resolves the moment definitions start flowing in. See issue #319.
+   */
+  exerciseDefinitions: ExerciseDefinition[];
   connected: boolean;
   updateTick: number;
 };
@@ -36,6 +48,7 @@ export const LiveDataStore = signalStore(
   withState<LiveDataState>({
     entries: [],
     exerciseEntries: [],
+    exerciseDefinitions: [],
     connected: false,
     updateTick: 0,
   }),
@@ -64,6 +77,7 @@ export const LiveDataStore = signalStore(
             connected: false,
             entries: [],
             exerciseEntries: [],
+            exerciseDefinitions: [],
             updateTick: 0,
           });
           return;

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -18,7 +18,9 @@ import {
   displayPushupType,
   exerciseEntryToUnified,
   type ExerciseCategoryId,
+  type ExerciseDefinition,
   EXERCISE_CATEGORIES,
+  findExerciseDefinition,
   inferRangeMode,
   type MeasurementType,
   PushupRecord,
@@ -682,17 +684,33 @@ export const AnalysisStore = signalStore(
       });
     });
 
-    // Entries whose exerciseId is absent from the standard catalog
-    // (e.g. a removed-and-never-replaced custom user exercise) drop
-    // out of every per-category tab — `unifiedEntryCategoryId` returns
-    // null and no tab matches. That's intentional: the overview tab
-    // still surfaces their volume, and resurrecting them under an
-    // "Andere" bucket would mask the catalog-mismatch in normal use.
+    // Resolver chain for `unifiedEntryCategoryId`: the standard catalog
+    // first, then the user's custom definitions from `LiveDataStore`.
+    // Custom definitions are keyed by id so a sparse list is fine for
+    // typical user-defined counts (well under a hundred per user).
+    //
+    // Entries whose `exerciseId` is absent from both layers still drop
+    // out of every per-category tab — the resolver returns `null` and
+    // no tab matches. That's intentional: the overview tab continues
+    // to surface their volume, and resurrecting them under an "Andere"
+    // bucket would mask catalog/definition drift.
+    const resolveDefinition = computed<
+      (id: string) => ExerciseDefinition | null
+    >(() => {
+      const userDefs = store._live.exerciseDefinitions();
+      if (!userDefs.length) return findExerciseDefinition;
+      const byId = new Map<string, ExerciseDefinition>(
+        userDefs.map((d) => [d.id, d])
+      );
+      return (id: string) => findExerciseDefinition(id) ?? byId.get(id) ?? null;
+    });
+
     const viewFilteredRows = computed<UnifiedEntry[]>(() => {
       const view = store.activeView();
       if (view === 'overview') return unifiedRows();
+      const resolver = resolveDefinition();
       return unifiedRows().filter(
-        (row) => unifiedEntryCategoryId(row) === view
+        (row) => unifiedEntryCategoryId(row, resolver) === view
       );
     });
 
@@ -915,9 +933,10 @@ export const AnalysisStore = signalStore(
     const categorySummaries = computed<CategorySummary[]>(() => {
       const todayKey = store.lastDayKey();
       const rows = unifiedRows();
+      const resolver = resolveDefinition();
       const byCategory = new Map<ExerciseCategoryId, UnifiedEntry[]>();
       for (const row of rows) {
-        const cat = unifiedEntryCategoryId(row);
+        const cat = unifiedEntryCategoryId(row, resolver);
         if (!cat) continue;
         const bucket = byCategory.get(cat);
         if (bucket) bucket.push(row);
@@ -1000,7 +1019,10 @@ export const AnalysisStore = signalStore(
     const applyViewFilter = (rows: UnifiedEntry[]): UnifiedEntry[] => {
       const view = store.activeView();
       if (view === 'overview') return rows;
-      return rows.filter((row) => unifiedEntryCategoryId(row) === view);
+      const resolver = resolveDefinition();
+      return rows.filter(
+        (row) => unifiedEntryCategoryId(row, resolver) === view
+      );
     };
 
     const weekTrendRows = computed<UnifiedEntry[]>(() =>

--- a/web/src/app/stats/shell/analysis-group-view.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-group-view.component.spec.ts
@@ -82,6 +82,7 @@ describe('AnalysisGroupViewComponent', () => {
     connected: signal(true),
     entries: signal([] as never[]),
     exerciseEntries: liveExerciseEntries,
+    exerciseDefinitions: signal([]),
     updateTick: signal(0),
   };
 

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -23,7 +23,11 @@ import {
   PLATFORM_ID,
   signal,
 } from '@angular/core';
-import { ExerciseEntry, RangeModes } from '@pu-stats/models';
+import {
+  ExerciseDefinition,
+  ExerciseEntry,
+  RangeModes,
+} from '@pu-stats/models';
 
 @Component({
   selector: 'app-filter-bar',
@@ -88,10 +92,15 @@ describe('AnalysisPageComponent', () => {
   // Mutable mirror of the LiveDataStore so tests can seed exercise
   // entries that the analysis store reads via `unifiedRows`.
   const liveExerciseEntries = signal<ExerciseEntry[]>([]);
+  // Mutable mirror of user-defined exercise definitions, threaded into
+  // `AnalysisStore.resolveDefinition` so custom-exercise rows can be
+  // bucketed into the right category tab without a catalog entry.
+  const liveExerciseDefinitions = signal<ExerciseDefinition[]>([]);
   const liveMock = {
     connected: signal(true),
     entries: signal([] as never[]),
     exerciseEntries: liveExerciseEntries,
+    exerciseDefinitions: liveExerciseDefinitions,
     updateTick: signal(0),
   };
 
@@ -175,6 +184,7 @@ describe('AnalysisPageComponent', () => {
     vitest.setSystemTime(new Date(2026, 1, 15, 12));
 
     liveExerciseEntries.set([]);
+    liveExerciseDefinitions.set([]);
     await TestBed.configureTestingModule({
       imports: [AnalysisPageComponent],
       providers: [
@@ -906,6 +916,103 @@ describe('AnalysisPageComponent', () => {
       expect(
         entries.some((e) => Array.isArray(e.sets) && e.sets.length > 1)
       ).toBe(true);
+    describe('custom-exercise resolver', () => {
+      // `carry` has no catalog exercises in the current restructure, so
+      // it doubles as a clean target for a user-defined definition.
+      const customDef: ExerciseDefinition = {
+        id: 'custom.kettlebell',
+        categoryId: 'carry',
+        ownerId: 'u1',
+        measurement: 'reps',
+        min: 1,
+        max: 500,
+        unit: 'reps',
+        customName: 'Kettlebell Carries',
+      };
+
+      beforeEach(() => {
+        liveExerciseEntries.update((entries) => [
+          ...entries,
+          {
+            _id: 'ex-custom',
+            userId: 'u1',
+            exerciseId: 'custom.kettlebell',
+            timestamp: '2026-02-14T08:00:00.000Z',
+            reps: 50,
+            source: 'web',
+          } as ExerciseEntry,
+        ]);
+      });
+
+      it('drops custom-exercise rows from per-category tabs without a resolver', () => {
+        const { store } = fixture.componentInstance;
+        store.setActiveView('carry');
+        expect(
+          store
+            .viewFilteredRows()
+            .some(
+              (r) =>
+                r.kind === 'exercise' && r.exerciseId === 'custom.kettlebell'
+            )
+        ).toBe(false);
+      });
+
+      it('routes custom-exercise rows into the user-defined category when the definition is exposed', () => {
+        liveExerciseDefinitions.set([customDef]);
+        const { store } = fixture.componentInstance;
+        store.setActiveView('carry');
+        expect(
+          store
+            .viewFilteredRows()
+            .some(
+              (r) =>
+                r.kind === 'exercise' && r.exerciseId === 'custom.kettlebell'
+            )
+        ).toBe(true);
+      });
+
+      it('feeds custom-exercise reps into categorySummaries via the resolver', () => {
+        liveExerciseDefinitions.set([customDef]);
+        const { store } = fixture.componentInstance;
+        const carry = store
+          .categorySummaries()
+          .find((s) => s.categoryId === 'carry');
+        expect(carry?.entries).toBe(1);
+        expect(carry?.volume).toMatchObject({
+          kind: 'reps',
+          totalReps: 50,
+        });
+      });
+
+      it('extends the per-category week trend to include custom-exercise reps', () => {
+        liveExerciseDefinitions.set([customDef]);
+        const { store } = fixture.componentInstance;
+        store.setActiveView('carry');
+        const week = store.weekTrend().find((w) => w.label === '2026-W07');
+        expect(week?.total).toBe(50);
+      });
+
+      it('lets the catalog win on id collision with a user-defined definition', () => {
+        // The standard catalog maps `legs.squats` to `squat`. A
+        // user-defined definition reusing the id with a different
+        // category must not steal the row.
+        liveExerciseDefinitions.set([
+          {
+            ...customDef,
+            id: 'legs.squats',
+            categoryId: 'carry',
+          },
+        ]);
+        const { store } = fixture.componentInstance;
+        store.setActiveView('carry');
+        expect(
+          store
+            .viewFilteredRows()
+            .some(
+              (r) => r.kind === 'exercise' && r.exerciseId === 'legs.squats'
+            )
+        ).toBe(false);
+      });
     });
 
     it('typeBreakdownDisplay localises kind-mode ids when activeView scopes to a non-pushup category', () => {
@@ -1091,6 +1198,7 @@ describe('AnalysisPageComponent empty-state CTA gating', () => {
             connected: signal(true),
             entries: signal([]),
             exerciseEntries: signal([]),
+            exerciseDefinitions: signal([]),
             updateTick: signal(0),
           },
         },

--- a/web/src/app/stats/shell/analysis-page.component.spec.ts
+++ b/web/src/app/stats/shell/analysis-page.component.spec.ts
@@ -92,9 +92,10 @@ describe('AnalysisPageComponent', () => {
   // Mutable mirror of the LiveDataStore so tests can seed exercise
   // entries that the analysis store reads via `unifiedRows`.
   const liveExerciseEntries = signal<ExerciseEntry[]>([]);
-  // Mutable mirror of user-defined exercise definitions, threaded into
-  // `AnalysisStore.resolveDefinition` so custom-exercise rows can be
-  // bucketed into the right category tab without a catalog entry.
+  // Mutable mirror of user-defined exercise definitions. The analysis
+  // store passes these to `unifiedEntryCategoryId` when bucketing rows
+  // into per-category tabs, so seeding them here lets a test exercise
+  // the custom-id branch that the standard catalog cannot reach.
   const liveExerciseDefinitions = signal<ExerciseDefinition[]>([]);
   const liveMock = {
     connected: signal(true),
@@ -916,18 +917,21 @@ describe('AnalysisPageComponent', () => {
       expect(
         entries.some((e) => Array.isArray(e.sets) && e.sets.length > 1)
       ).toBe(true);
+    });
+
     describe('custom-exercise resolver', () => {
-      // `carry` has no catalog exercises in the current restructure, so
-      // it doubles as a clean target for a user-defined definition.
+      // `mobility` is in the picker but the parent `beforeEach` seeds
+      // no mobility rows, so it isolates the contribution of the
+      // custom definition from the catalog rows already in scope.
       const customDef: ExerciseDefinition = {
-        id: 'custom.kettlebell',
-        categoryId: 'carry',
+        id: 'custom.foam-roll',
+        categoryId: 'mobility',
         ownerId: 'u1',
         measurement: 'reps',
         min: 1,
         max: 500,
         unit: 'reps',
-        customName: 'Kettlebell Carries',
+        customName: 'Foam Rolling',
       };
 
       beforeEach(() => {
@@ -936,7 +940,7 @@ describe('AnalysisPageComponent', () => {
           {
             _id: 'ex-custom',
             userId: 'u1',
-            exerciseId: 'custom.kettlebell',
+            exerciseId: 'custom.foam-roll',
             timestamp: '2026-02-14T08:00:00.000Z',
             reps: 50,
             source: 'web',
@@ -946,13 +950,13 @@ describe('AnalysisPageComponent', () => {
 
       it('drops custom-exercise rows from per-category tabs without a resolver', () => {
         const { store } = fixture.componentInstance;
-        store.setActiveView('carry');
+        store.setActiveView('mobility');
         expect(
           store
             .viewFilteredRows()
             .some(
               (r) =>
-                r.kind === 'exercise' && r.exerciseId === 'custom.kettlebell'
+                r.kind === 'exercise' && r.exerciseId === 'custom.foam-roll'
             )
         ).toBe(false);
       });
@@ -960,13 +964,13 @@ describe('AnalysisPageComponent', () => {
       it('routes custom-exercise rows into the user-defined category when the definition is exposed', () => {
         liveExerciseDefinitions.set([customDef]);
         const { store } = fixture.componentInstance;
-        store.setActiveView('carry');
+        store.setActiveView('mobility');
         expect(
           store
             .viewFilteredRows()
             .some(
               (r) =>
-                r.kind === 'exercise' && r.exerciseId === 'custom.kettlebell'
+                r.kind === 'exercise' && r.exerciseId === 'custom.foam-roll'
             )
         ).toBe(true);
       });
@@ -974,11 +978,11 @@ describe('AnalysisPageComponent', () => {
       it('feeds custom-exercise reps into categorySummaries via the resolver', () => {
         liveExerciseDefinitions.set([customDef]);
         const { store } = fixture.componentInstance;
-        const carry = store
+        const mobility = store
           .categorySummaries()
-          .find((s) => s.categoryId === 'carry');
-        expect(carry?.entries).toBe(1);
-        expect(carry?.volume).toMatchObject({
+          .find((s) => s.categoryId === 'mobility');
+        expect(mobility?.entries).toBe(1);
+        expect(mobility?.volume).toMatchObject({
           kind: 'reps',
           totalReps: 50,
         });
@@ -987,7 +991,7 @@ describe('AnalysisPageComponent', () => {
       it('extends the per-category week trend to include custom-exercise reps', () => {
         liveExerciseDefinitions.set([customDef]);
         const { store } = fixture.componentInstance;
-        store.setActiveView('carry');
+        store.setActiveView('mobility');
         const week = store.weekTrend().find((w) => w.label === '2026-W07');
         expect(week?.total).toBe(50);
       });
@@ -1000,11 +1004,11 @@ describe('AnalysisPageComponent', () => {
           {
             ...customDef,
             id: 'legs.squats',
-            categoryId: 'carry',
+            categoryId: 'mobility',
           },
         ]);
         const { store } = fixture.componentInstance;
-        store.setActiveView('carry');
+        store.setActiveView('mobility');
         expect(
           store
             .viewFilteredRows()


### PR DESCRIPTION
## Summary

- `LiveDataStore` now exposes `exerciseDefinitions: ExerciseDefinition[]` (defaults to `[]`; no Firestore listener yet — current rules forbid client-created definitions, so this is plumbing for when storage lands).
- `AnalysisStore` adds a `resolveDefinition` computed that chains `findExerciseDefinition` (catalog) → user `exerciseDefinitions` map → `null`. Catalog wins on id collision.
- Resolver is threaded into every `unifiedEntryCategoryId(row, resolver)` call site: `viewFilteredRows`, `categorySummaries`, and `applyViewFilter` (which powers the per-category week/month trend filters).

## Why

Without the resolver, user-defined exercise rows whose `exerciseId` is absent from the standard catalog drop out of every per-category tab — `unifiedEntryCategoryId` returns `null` and no tab matches. They remain visible in `overview` but never reach `viewFilteredRows`, `categorySummaries`, or the trend filter. The resolver lets these rows route into the user-defined category once their definitions become available on `LiveDataStore`.

## Test plan

- [x] `pnpm nx test stats-data-access` — 95 passed
- [x] `pnpm nx test stats-models` — passed
- [x] `pnpm nx test web` — passed, including 5 new tests in the `custom-exercise resolver` block:
  - Baseline: custom-exercise rows still drop from per-category tabs when no definition is exposed
  - Routing: custom row appears in its user-defined category alongside catalog rows
  - `categorySummaries` aggregates custom-exercise reps into the right category
  - Per-category week trend includes custom-exercise reps
  - Catalog wins on id collision with a user-defined definition
- [x] `pnpm nx lint web,stats-data-access,stats-models` — 0 errors
- [x] `pnpm nx build web --configuration=development` — prerendered 2380 routes

Closes #319

https://claude.ai/code/session_01GwfhReeamKh2YuJjnNjMbt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwfhReeamKh2YuJjnNjMbt)_