### PR TITLE
feat: quick-win batch — eslint sw-push boundary, displayName validation, pushup error snackbar

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ Enforced via `@nx/enforce-module-boundaries` in `eslint.config.mjs`:
 - `scope:cloud-functions` -> `scope:models` only
 - `scope:push` -> `scope:models`, `scope:data-access` (no auth, no reminders!)
 - `scope:reminders` -> `scope:models`, `scope:data-access`, `scope:data-access-state`, `scope:motivation`, `scope:push` (no auth!)
+- `scope:sw-push` -> nothing (standalone service-worker bundle; bundling anything else would bloat the SW)
 - `scope:app` -> everything
 
 ## Nx Project Names

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -84,6 +84,11 @@ export default [
               sourceTag: 'scope:ads',
               onlyDependOnLibsWithTags: ['scope:models'],
             },
+            // sw-push is a standalone service-worker bundle — must stay isolated
+            {
+              sourceTag: 'scope:sw-push',
+              onlyDependOnLibsWithTags: [],
+            },
             // testing can depend on anything (test utilities)
             {
               sourceTag: 'scope:testing',

--- a/libs/auth/src/lib/ui/register/register-ui.store.spec.ts
+++ b/libs/auth/src/lib/ui/register/register-ui.store.spec.ts
@@ -130,6 +130,46 @@ describe('RegisterUiStore', () => {
     expect(store.registerSuccess()).toBe(false);
   });
 
+  describe('displayName validation', () => {
+    it('Given a too-short displayName Then violation is "too-short" and submission is blocked', async () => {
+      const store = await setup();
+      store.setDisplayName('A');
+      store.setDailyGoal(10);
+      store.setConsentAccepted(true);
+
+      expect(store.displayNameViolation()).toBe('too-short');
+      expect(store.isProfileStepValid()).toBe(false);
+      expect(store.canSubmit(false, false, 'Secret#123', 'Secret#123')).toBe(
+        false
+      );
+    });
+
+    it('Given an over-long displayName Then violation is "too-long"', async () => {
+      const store = await setup();
+      store.setDisplayName('A'.repeat(31));
+
+      expect(store.displayNameViolation()).toBe('too-long');
+      expect(store.isProfileStepValid()).toBe(false);
+    });
+
+    it('Given an emoji in the displayName Then violation is "invalid-characters"', async () => {
+      const store = await setup();
+      store.setDisplayName('Wolf🚀');
+
+      expect(store.displayNameViolation()).toBe('invalid-characters');
+      expect(store.isProfileStepValid()).toBe(false);
+    });
+
+    it('Given a valid displayName Then violation is null and isProfileStepValid is true', async () => {
+      const store = await setup();
+      store.setDisplayName('Alex');
+      store.setDailyGoal(10);
+
+      expect(store.displayNameViolation()).toBeNull();
+      expect(store.isProfileStepValid()).toBe(true);
+    });
+  });
+
   describe('training plan preselection', () => {
     it('Given a known plan id When setSelectedPlanId Then exposes the plan and a return URL with autoStart', async () => {
       const store = await setup();

--- a/libs/auth/src/lib/ui/register/register-ui.store.ts
+++ b/libs/auth/src/lib/ui/register/register-ui.store.ts
@@ -8,7 +8,12 @@ import {
   withProps,
   withState,
 } from '@ngrx/signals';
-import { findPlanById, TrainingPlan } from '@pu-stats/models';
+import {
+  DisplayNameViolation,
+  findPlanById,
+  TrainingPlan,
+  validateDisplayName,
+} from '@pu-stats/models';
 import { AuthStore } from '../../core/state/auth.store';
 import { RegisterOnboardingStore } from '../../core/state/register-onboarding.store';
 import { hasStrongPasswordPolicy } from '../password-policy';
@@ -60,6 +65,9 @@ export const RegisterUiStore = signalStore(
       const id = store.selectedPlanId();
       return id ? findPlanById(id) : null;
     }),
+    displayNameViolation: computed<DisplayNameViolation | null>(() =>
+      validateDisplayName(store.displayName())
+    ),
   })),
   withMethods(({ authStore, onboardingStore, auth, ...store }) => ({
     toggleHidePassword: () =>
@@ -103,7 +111,8 @@ export const RegisterUiStore = signalStore(
       hasStrongPasswordPolicy(password) &&
       password === repeatPassword,
     isProfileStepValid: () =>
-      store.displayName().trim().length >= 2 && store.dailyGoal() >= 1,
+      validateDisplayName(store.displayName()) === null &&
+      store.dailyGoal() >= 1,
     canSubmit: (
       emailInvalid: boolean,
       passwordInvalid: boolean,
@@ -111,7 +120,7 @@ export const RegisterUiStore = signalStore(
       repeatPassword: string
     ) =>
       store.consentAccepted() &&
-      store.displayName().trim().length >= 2 &&
+      validateDisplayName(store.displayName()) === null &&
       store.dailyGoal() >= 1 &&
       (store.isGoogleRegistration() ||
         (!emailInvalid &&

--- a/libs/auth/src/lib/ui/register/register.component.html
+++ b/libs/auth/src/lib/ui/register/register.component.html
@@ -228,7 +228,7 @@
           </mat-step>
 
           <mat-step
-            [completed]="registerUiStore.displayName().trim().length >= 2"
+            [completed]="registerUiStore.displayNameViolation() === null"
           >
             <ng-template matStepLabel i18n="@@auth.onboarding.google.username"
               >Benutzername</ng-template
@@ -243,6 +243,38 @@
                   registerUiStore.setDisplayName($any($event.target).value)
                 "
             /></mat-form-field>
+            @switch (registerUiStore.displayNameViolation()) {
+              @case ('too-short') {
+                <p
+                  class="field-error"
+                  role="alert"
+                  data-testid="register-displayname-error"
+                  i18n="@@displayName.violation.tooShort"
+                >
+                  Mindestens 2 Zeichen.
+                </p>
+              }
+              @case ('too-long') {
+                <p
+                  class="field-error"
+                  role="alert"
+                  data-testid="register-displayname-error"
+                  i18n="@@displayName.violation.tooLong"
+                >
+                  Höchstens 30 Zeichen.
+                </p>
+              }
+              @case ('invalid-characters') {
+                <p
+                  class="field-error"
+                  role="alert"
+                  data-testid="register-displayname-error"
+                  i18n="@@displayName.violation.invalidCharacters"
+                >
+                  Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt.
+                </p>
+              }
+            }
             <div class="form-actions">
               <button
                 mat-stroked-button
@@ -256,7 +288,7 @@
                 color="primary"
                 matStepperNext
                 type="button"
-                [disabled]="registerUiStore.displayName().trim().length < 2"
+                [disabled]="registerUiStore.displayNameViolation() !== null"
                 i18n="@@auth.next"
               >
                 Weiter

--- a/libs/auth/src/lib/ui/register/register.component.scss
+++ b/libs/auth/src/lib/ui/register/register.component.scss
@@ -68,6 +68,12 @@ mat-checkbox {
   margin-bottom: 16px;
 }
 
+.field-error {
+  margin: -16px 0 16px;
+  color: #f44336;
+  font-size: 0.85rem;
+}
+
 .plan-banner {
   display: flex;
   gap: 12px;

--- a/libs/data-access/src/lib/api/pushup-firestore.service.spec.ts
+++ b/libs/data-access/src/lib/api/pushup-firestore.service.spec.ts
@@ -19,6 +19,7 @@ import * as firestoreFns from '@angular/fire/firestore';
 import {
   PushupFirestoreService,
   PushupValidationError,
+  pushupValidationMessage,
 } from './pushup-firestore.service';
 
 describe('PushupFirestoreService', () => {
@@ -489,6 +490,33 @@ describe('PushupFirestoreService', () => {
 
       expect(deleteDocSpy).toHaveBeenCalledWith(rowRef);
       expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe('pushupValidationMessage', () => {
+    it('Given out-of-range Then surfaces the 1..500 cap message', () => {
+      expect(
+        pushupValidationMessage(
+          new PushupValidationError('reps', 'out-of-range')
+        )
+      ).toMatch(/zwischen 1 und 500/);
+    });
+
+    it('Given not-integer Then surfaces the integer hint', () => {
+      expect(
+        pushupValidationMessage(
+          new PushupValidationError('reps', 'not-integer')
+        )
+      ).toMatch(/ganze Zahl/);
+    });
+
+    it('Given an unrelated error Then falls back to the generic message', () => {
+      expect(pushupValidationMessage(new Error('boom'))).toMatch(
+        /konnte nicht gespeichert/
+      );
+      expect(pushupValidationMessage(undefined)).toMatch(
+        /konnte nicht gespeichert/
+      );
     });
   });
 });

--- a/libs/data-access/src/lib/api/pushup-firestore.service.spec.ts
+++ b/libs/data-access/src/lib/api/pushup-firestore.service.spec.ts
@@ -499,7 +499,7 @@ describe('PushupFirestoreService', () => {
         pushupValidationMessage(
           new PushupValidationError('reps', 'out-of-range')
         )
-      ).toMatch(/zwischen 1 und 500/);
+      ).toMatch(/zwischen 1.*und 500.*liegen/);
     });
 
     it('Given not-integer Then surfaces the integer hint', () => {

--- a/libs/data-access/src/lib/api/pushup-firestore.service.ts
+++ b/libs/data-access/src/lib/api/pushup-firestore.service.ts
@@ -45,7 +45,7 @@ export class PushupValidationError extends Error {
 export function pushupValidationMessage(err: unknown): string {
   if (err instanceof PushupValidationError && err.field === 'reps') {
     if (err.violation === 'out-of-range') {
-      return $localize`:@@pushup.validation.reps.outOfRange:Reps müssen zwischen 1 und 500 liegen.`;
+      return $localize`:@@pushup.validation.reps.outOfRange:Reps müssen zwischen ${PUSHUP_REPS_MIN}:min: und ${PUSHUP_REPS_MAX}:max: liegen.`;
     }
     if (err.violation === 'not-integer') {
       return $localize`:@@pushup.validation.reps.notInteger:Reps muss eine ganze Zahl sein.`;

--- a/libs/data-access/src/lib/api/pushup-firestore.service.ts
+++ b/libs/data-access/src/lib/api/pushup-firestore.service.ts
@@ -36,6 +36,25 @@ export class PushupValidationError extends Error {
 }
 
 /**
+ * Map a failed `createPushup`/`updatePushup` rejection to a human-readable,
+ * localized snack-bar message. Surfacing the specific cap/violation reason
+ * is more actionable than the generic "konnte nicht gespeichert werden" —
+ * users hitting the 500-rep cap get a clear hint instead of a silent retry
+ * loop.
+ */
+export function pushupValidationMessage(err: unknown): string {
+  if (err instanceof PushupValidationError && err.field === 'reps') {
+    if (err.violation === 'out-of-range') {
+      return $localize`:@@pushup.validation.reps.outOfRange:Reps müssen zwischen 1 und 500 liegen.`;
+    }
+    if (err.violation === 'not-integer') {
+      return $localize`:@@pushup.validation.reps.notInteger:Reps muss eine ganze Zahl sein.`;
+    }
+  }
+  return $localize`:@@pushup.validation.generic:Eintrag konnte nicht gespeichert werden.`;
+}
+
+/**
  * Returns an Observable that errors with `PushupValidationError` if the
  * reps fail validation, otherwise null. Wrapping the throw in a cold
  * Observable lets RxJS subscribers see the error via their `error`

--- a/libs/push/src/lib/quick-log-listener.service.spec.ts
+++ b/libs/push/src/lib/quick-log-listener.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { StatsApiService } from '@pu-stats/data-access';
+import { PushupValidationError, StatsApiService } from '@pu-stats/data-access';
 import { of, throwError } from 'rxjs';
 import { QuickLogListenerService } from './quick-log-listener.service';
 
@@ -137,5 +137,31 @@ describe('QuickLogListenerService', () => {
     const service = TestBed.inject(QuickLogListenerService);
     await service.logEntry(10);
     expect(snackOpen).toHaveBeenCalled();
+  });
+
+  it('Given a PushupValidationError When logEntry fails Then snack-bar shows the localized cap message', async () => {
+    createPushup.mockReturnValue(
+      throwError(() => new PushupValidationError('reps', 'out-of-range'))
+    );
+    const service = TestBed.inject(QuickLogListenerService);
+
+    await service.logEntry(10);
+
+    expect(snackOpen).toHaveBeenCalled();
+    const message = snackOpen.mock.calls[0][0];
+    expect(message).toMatch(/zwischen 1 und 500/);
+  });
+
+  it('Given a non-integer PushupValidationError When logEntry fails Then snack-bar surfaces the integer hint', async () => {
+    createPushup.mockReturnValue(
+      throwError(() => new PushupValidationError('reps', 'not-integer'))
+    );
+    const service = TestBed.inject(QuickLogListenerService);
+
+    await service.logEntry(10);
+
+    expect(snackOpen).toHaveBeenCalled();
+    const message = snackOpen.mock.calls[0][0];
+    expect(message).toMatch(/ganze Zahl/);
   });
 });

--- a/libs/push/src/lib/quick-log-listener.service.spec.ts
+++ b/libs/push/src/lib/quick-log-listener.service.spec.ts
@@ -149,7 +149,7 @@ describe('QuickLogListenerService', () => {
 
     expect(snackOpen).toHaveBeenCalled();
     const message = snackOpen.mock.calls[0][0];
-    expect(message).toMatch(/zwischen 1 und 500/);
+    expect(message).toMatch(/zwischen 1.*und 500.*liegen/);
   });
 
   it('Given a non-integer PushupValidationError When logEntry fails Then snack-bar surfaces the integer hint', async () => {

--- a/libs/push/src/lib/quick-log-listener.service.ts
+++ b/libs/push/src/lib/quick-log-listener.service.ts
@@ -1,7 +1,10 @@
 import { isPlatformBrowser } from '@angular/common';
 import { inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { StatsApiService } from '@pu-stats/data-access';
+import {
+  pushupValidationMessage,
+  StatsApiService,
+} from '@pu-stats/data-access';
 import {
   appendLocalOffset,
   QUICK_LOG_REPS_MAX,
@@ -67,9 +70,9 @@ export class QuickLogListenerService {
         $localize`:@@snackbar.close:Schließen`,
         { duration: 3000 }
       );
-    } catch {
+    } catch (err) {
       this.snackBar.open(
-        $localize`:@@reminder.quickLog.error:Eintrag konnte nicht gespeichert werden.`,
+        pushupValidationMessage(err),
         $localize`:@@snackbar.close:Schließen`,
         { duration: 5000 }
       );

--- a/web/src/app/core/quick-add-orchestration.service.spec.ts
+++ b/web/src/app/core/quick-add-orchestration.service.spec.ts
@@ -129,7 +129,7 @@ describe('QuickAddOrchestrationService.fillToGoal', () => {
     service.fillToGoal();
 
     const message = snackBarMock.open.mock.calls[0][0] as string;
-    expect(message).toMatch(/zwischen 1 und 500/);
+    expect(message).toMatch(/zwischen 1.*und 500.*liegen/);
   });
 
   it('Given a previous fillToGoal() is still in flight, When called again, Then createPushup is called only once', () => {

--- a/web/src/app/core/quick-add-orchestration.service.spec.ts
+++ b/web/src/app/core/quick-add-orchestration.service.spec.ts
@@ -7,6 +7,7 @@ import { of, Subject, throwError } from 'rxjs';
 import { UserContextService } from '@pu-auth/auth';
 import {
   ExerciseFirestoreService,
+  PushupValidationError,
   StatsApiService,
 } from '@pu-stats/data-access';
 import { QuickAddBridgeService } from '@pu-stats/quick-add';
@@ -117,6 +118,18 @@ describe('QuickAddOrchestrationService.fillToGoal', () => {
     const message = snackBarMock.open.mock.calls[0][0] as string;
     expect(message).toContain('konnte nicht');
     expect(reloadAfterMutation).not.toHaveBeenCalled();
+  });
+
+  it('Given PushupValidationError out-of-range When fillToGoal() is called Then snackbar surfaces the 1..500 cap', () => {
+    const service = setup();
+    statsApiMock.createPushup.mockReturnValue(
+      throwError(() => new PushupValidationError('reps', 'out-of-range'))
+    );
+
+    service.fillToGoal();
+
+    const message = snackBarMock.open.mock.calls[0][0] as string;
+    expect(message).toMatch(/zwischen 1 und 500/);
   });
 
   it('Given a previous fillToGoal() is still in flight, When called again, Then createPushup is called only once', () => {

--- a/web/src/app/core/quick-add-orchestration.service.ts
+++ b/web/src/app/core/quick-add-orchestration.service.ts
@@ -5,6 +5,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { UserContextService } from '@pu-auth/auth';
 import {
   ExerciseFirestoreService,
+  pushupValidationMessage,
   StatsApiService,
 } from '@pu-stats/data-access';
 import {
@@ -120,16 +121,7 @@ export class QuickAddOrchestrationService {
           );
           this.appData.reloadAfterMutation();
         },
-        error: () =>
-          this.snackBar.open(
-            $localize`:@@quickAdd.error.create:Eintrag konnte nicht gespeichert werden.`,
-            '',
-            {
-              duration: 4000,
-              horizontalPosition: 'center',
-              verticalPosition: 'bottom',
-            }
-          ),
+        error: (err) => this.openErrorSnackbar(err),
       });
   }
 
@@ -159,16 +151,8 @@ export class QuickAddOrchestrationService {
           this.appData.reloadAfterMutation();
           this._fillToGoalInFlight.set(false);
         },
-        error: () => {
-          this.snackBar.open(
-            $localize`:@@quickAdd.error.create:Eintrag konnte nicht gespeichert werden.`,
-            '',
-            {
-              duration: 4000,
-              horizontalPosition: 'center',
-              verticalPosition: 'bottom',
-            }
-          );
+        error: (err) => {
+          this.openErrorSnackbar(err);
           this._fillToGoalInFlight.set(false);
         },
       });
@@ -364,21 +348,17 @@ export class QuickAddOrchestrationService {
         }
       );
       this.appData.reloadAfterMutation();
-    } catch {
-      this.openErrorSnackbar();
+    } catch (err) {
+      this.openErrorSnackbar(err);
     }
   }
 
-  private openErrorSnackbar(): void {
-    this.snackBar.open(
-      $localize`:@@quickAdd.error.create:Eintrag konnte nicht gespeichert werden.`,
-      '',
-      {
-        duration: 4000,
-        horizontalPosition: 'center',
-        verticalPosition: 'bottom',
-      }
-    );
+  private openErrorSnackbar(err?: unknown): void {
+    this.snackBar.open(pushupValidationMessage(err), '', {
+      duration: 4000,
+      horizontalPosition: 'center',
+      verticalPosition: 'bottom',
+    });
   }
 }
 

--- a/web/src/app/stats/shell/settings-page.component.spec.ts
+++ b/web/src/app/stats/shell/settings-page.component.spec.ts
@@ -250,4 +250,66 @@ describe('SettingsPageComponent — auto-save', () => {
     expect(saveSpy).not.toHaveBeenCalled();
     expect(component.saveStatus()).toBe('idle');
   });
+
+  describe('displayName validation', () => {
+    it('Given an invalid displayName, When the debounce elapses, Then no save fires and the error message is rendered', async () => {
+      setup({ userId: 'u1', dailyGoal: 10, displayName: 'Alex' });
+      vitest.useFakeTimers({ shouldAdvanceTime: true });
+      await flushMicrotasks();
+
+      component.displayNameDraft.set('Wolf🚀');
+      fixture.detectChanges();
+
+      expect(component.displayNameViolation()).toBe('invalid-characters');
+      expect(component.saveStatus()).toBe('pending');
+
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+      await flushMicrotasks();
+
+      expect(saveSpy).not.toHaveBeenCalled();
+
+      const error = fixture.nativeElement.querySelector(
+        '[data-testid="settings-displayname-error"]'
+      ) as HTMLElement | null;
+      expect(error).not.toBeNull();
+    });
+
+    it('Given a too-short displayName Then save is blocked', async () => {
+      setup({ userId: 'u1', dailyGoal: 10, displayName: 'Alex' });
+      vitest.useFakeTimers({ shouldAdvanceTime: true });
+      await flushMicrotasks();
+
+      component.displayNameDraft.set('A');
+      fixture.detectChanges();
+
+      expect(component.displayNameViolation()).toBe('too-short');
+
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+      await flushMicrotasks();
+
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+
+    it('Given an invalid displayName edited to a valid one Then save fires', async () => {
+      setup({ userId: 'u1', dailyGoal: 10, displayName: 'Alex' });
+      vitest.useFakeTimers({ shouldAdvanceTime: true });
+      await flushMicrotasks();
+
+      component.displayNameDraft.set('Wolf🚀');
+      fixture.detectChanges();
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+      await flushMicrotasks();
+      expect(saveSpy).not.toHaveBeenCalled();
+
+      component.displayNameDraft.set('Wolf');
+      fixture.detectChanges();
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+      await flushMicrotasks();
+
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+      expect(saveSpy.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ displayName: 'Wolf' })
+      );
+    });
+  });
 });

--- a/web/src/app/stats/shell/settings-page.component.ts
+++ b/web/src/app/stats/shell/settings-page.component.ts
@@ -26,7 +26,12 @@ import { AuthStore, UserContextService } from '@pu-auth/auth';
 import { Router } from '@angular/router';
 import { Analytics, logEvent } from '@angular/fire/analytics';
 import { PushSubscriptionService } from '@pu-push/push';
-import { DEFAULT_SNAP_QUALITY, SnapQuality } from '@pu-stats/models';
+import {
+  DEFAULT_SNAP_QUALITY,
+  DisplayNameViolation,
+  SnapQuality,
+  validateDisplayName,
+} from '@pu-stats/models';
 import { UserConfigStore } from '../../core/user-config.store';
 import { ShareService } from '../../core/share.service';
 import { buildProfileShareUrl } from '../../core/profile-share-url';
@@ -168,6 +173,38 @@ interface ResolvedConfig {
               >Kann in der Bestenliste angezeigt werden.</mat-hint
             >
           </mat-form-field>
+          @switch (displayNameViolation()) {
+            @case ('too-short') {
+              <p
+                class="field-error"
+                role="alert"
+                data-testid="settings-displayname-error"
+                i18n="@@displayName.violation.tooShort"
+              >
+                Mindestens 2 Zeichen.
+              </p>
+            }
+            @case ('too-long') {
+              <p
+                class="field-error"
+                role="alert"
+                data-testid="settings-displayname-error"
+                i18n="@@displayName.violation.tooLong"
+              >
+                Höchstens 30 Zeichen.
+              </p>
+            }
+            @case ('invalid-characters') {
+              <p
+                class="field-error"
+                role="alert"
+                data-testid="settings-displayname-error"
+                i18n="@@displayName.violation.invalidCharacters"
+              >
+                Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt.
+              </p>
+            }
+          }
           <p class="muted profile-hint-row">
             <a
               routerLink="/leaderboard"
@@ -640,6 +677,11 @@ interface ResolvedConfig {
     .error {
       color: #ffd8d8;
     }
+    .field-error {
+      margin: -8px 0 4px;
+      color: #ff8b8b;
+      font-size: 0.85rem;
+    }
     .guest-banner {
       display: flex;
       align-items: center;
@@ -713,6 +755,9 @@ export class SettingsPageComponent implements OnDestroy {
   );
 
   readonly displayNameDraft = signal('');
+  readonly displayNameViolation = computed<DisplayNameViolation | null>(() =>
+    validateDisplayName(this.displayNameDraft())
+  );
   readonly dailyGoalDraft = signal<number>(10);
   readonly weeklyGoalDraft = signal<number>(50);
   readonly monthlyGoalDraft = signal<number>(200);
@@ -820,11 +865,25 @@ export class SettingsPageComponent implements OnDestroy {
     effect(() => {
       const draft = this.draftSnapshot();
       const baseline = this.lastPersisted();
+      const violation = this.displayNameViolation();
       untracked(() => {
         if (baseline === null) return;
         if (this.snapshotsEqual(draft, baseline)) {
           this.cancelAutoSaveTimer();
           if (this.saveStatus() === 'pending') this.saveStatus.set('idle');
+          return;
+        }
+        // Block save only when the user actively edited displayName to an
+        // invalid value. If displayName came from storage already invalid
+        // (legacy/migrated data), the user editing OTHER fields should still
+        // succeed — Firestore's rule will reject if the persisted name is
+        // actually rejected. Surface the violation in the inline error and
+        // keep the pill in "pending" so it's obvious the round trip hasn't
+        // happened yet.
+        const displayNameDirty = draft.displayName !== baseline.displayName;
+        if (violation !== null && displayNameDirty) {
+          this.cancelAutoSaveTimer();
+          this.saveStatus.set('pending');
           return;
         }
         this.scheduleAutoSave();

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9593,8 +9593,8 @@
     </unit>
     <unit id="pushup.validation.reps.outOfRange">
       <segment state="translated">
-        <source>Reps müssen zwischen 1 und 500 liegen.</source>
-        <target>Οι επαναλήψεις πρέπει να είναι μεταξύ 1 και 500.</target>
+        <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
+        <target>Οι επαναλήψεις πρέπει να είναι μεταξύ <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> και <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/>.</target>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.notInteger">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9573,5 +9573,41 @@
         <target>Δύο εβδομάδες ενεργητικής αποκατάστασης: καθημερινές συνεδρίες κινητικότητας, γιόγκα και διατάσεων με ελαφρύ όγκο κάμψεων. Ιδανικό ως αποφόρτιση μεταξύ δύο απαιτητικών προγραμμάτων ή για επιστροφή μετά από διάλειμμα.</target>
       </segment>
     </unit>
+    <unit id="displayName.violation.tooShort">
+      <segment state="translated">
+        <source> Mindestens 2 Zeichen. </source>
+        <target> Τουλάχιστον 2 χαρακτήρες. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.tooLong">
+      <segment state="translated">
+        <source> Höchstens 30 Zeichen. </source>
+        <target> Το πολύ 30 χαρακτήρες. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.invalidCharacters">
+      <segment state="translated">
+        <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
+        <target> Επιτρέπονται μόνο γράμματα, ψηφία, κενά και _ . - </target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.outOfRange">
+      <segment state="translated">
+        <source>Reps müssen zwischen 1 und 500 liegen.</source>
+        <target>Οι επαναλήψεις πρέπει να είναι μεταξύ 1 και 500.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.notInteger">
+      <segment state="translated">
+        <source>Reps muss eine ganze Zahl sein.</source>
+        <target>Οι επαναλήψεις πρέπει να είναι ακέραιος αριθμός.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.generic">
+      <segment state="translated">
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+        <target>Δεν ήταν δυνατή η αποθήκευση της καταχώρησης.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1589,19 +1589,55 @@ Active:         </target>
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:75</note>
 
-        
+
             </notes>
       <segment state="translated">
         <source>Wolf</source>
         <target>Wolf</target>
 
-        
-        
+
+
             </segment>
 
-      
-      
+
+
         </unit>
+    <unit id="displayName.violation.tooShort">
+      <segment state="translated">
+        <source> Mindestens 2 Zeichen. </source>
+        <target> At least 2 characters. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.tooLong">
+      <segment state="translated">
+        <source> Höchstens 30 Zeichen. </source>
+        <target> At most 30 characters. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.invalidCharacters">
+      <segment state="translated">
+        <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
+        <target> Only letters, digits, spaces, plus _ . - are allowed. </target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.outOfRange">
+      <segment state="translated">
+        <source>Reps müssen zwischen 1 und 500 liegen.</source>
+        <target>Reps must be between 1 and 500.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.notInteger">
+      <segment state="translated">
+        <source>Reps muss eine ganze Zahl sein.</source>
+        <target>Reps must be a whole number.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.generic">
+      <segment state="translated">
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+        <target>Could not save the entry.</target>
+      </segment>
+    </unit>
     <unit id="editAria">
       <notes>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.html:108,109</note>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -1622,8 +1622,8 @@ Active:         </target>
     </unit>
     <unit id="pushup.validation.reps.outOfRange">
       <segment state="translated">
-        <source>Reps müssen zwischen 1 und 500 liegen.</source>
-        <target>Reps must be between 1 and 500.</target>
+        <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
+        <target>Reps must be between <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> and <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/>.</target>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.notInteger">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9569,5 +9569,41 @@
         <target>Dos semanas de recuperación activa: sesiones diarias de movilidad, yoga y estiramientos con un volumen ligero de flexiones. Ideal como descarga entre dos planes exigentes o para retomar el entrenamiento tras una pausa.</target>
       </segment>
     </unit>
+    <unit id="displayName.violation.tooShort">
+      <segment state="translated">
+        <source> Mindestens 2 Zeichen. </source>
+        <target> Al menos 2 caracteres. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.tooLong">
+      <segment state="translated">
+        <source> Höchstens 30 Zeichen. </source>
+        <target> Como máximo 30 caracteres. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.invalidCharacters">
+      <segment state="translated">
+        <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
+        <target> Solo se permiten letras, dígitos, espacios y _ . - </target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.outOfRange">
+      <segment state="translated">
+        <source>Reps müssen zwischen 1 und 500 liegen.</source>
+        <target>Las repeticiones deben estar entre 1 y 500.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.notInteger">
+      <segment state="translated">
+        <source>Reps muss eine ganze Zahl sein.</source>
+        <target>Las repeticiones deben ser un número entero.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.generic">
+      <segment state="translated">
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+        <target>No se pudo guardar la entrada.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9584,13 +9584,13 @@
     <unit id="displayName.violation.invalidCharacters">
       <segment state="translated">
         <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
-        <target> Solo se permiten letras, dígitos, espacios y _ . - </target>
+        <target> Solo se permiten letras, dígitos, espacios y los caracteres _ . - </target>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.outOfRange">
       <segment state="translated">
-        <source>Reps müssen zwischen 1 und 500 liegen.</source>
-        <target>Las repeticiones deben estar entre 1 y 500.</target>
+        <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
+        <target>Las repeticiones deben estar entre <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> y <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/>.</target>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.notInteger">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9445,5 +9445,41 @@
         <target>Deux semaines de récupération active : séances quotidiennes de mobilité, yoga et étirements avec un volume léger de pompes. Idéal comme décharge entre deux plans intenses ou pour reprendre après une pause d'entraînement.</target>
       </segment>
     </unit>
+    <unit id="displayName.violation.tooShort">
+      <segment state="translated">
+        <source> Mindestens 2 Zeichen. </source>
+        <target> Au moins 2 caractères. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.tooLong">
+      <segment state="translated">
+        <source> Höchstens 30 Zeichen. </source>
+        <target> Au maximum 30 caractères. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.invalidCharacters">
+      <segment state="translated">
+        <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
+        <target> Seuls les lettres, chiffres, espaces et _ . - sont autorisés. </target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.outOfRange">
+      <segment state="translated">
+        <source>Reps müssen zwischen 1 und 500 liegen.</source>
+        <target>Les répétitions doivent être entre 1 et 500.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.notInteger">
+      <segment state="translated">
+        <source>Reps muss eine ganze Zahl sein.</source>
+        <target>Les répétitions doivent être un nombre entier.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.generic">
+      <segment state="translated">
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+        <target>Impossible d&apos;enregistrer l&apos;entrée.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9460,13 +9460,13 @@
     <unit id="displayName.violation.invalidCharacters">
       <segment state="translated">
         <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
-        <target> Seuls les lettres, chiffres, espaces et _ . - sont autorisés. </target>
+        <target> Seules les lettres, les chiffres, les espaces et _ . - sont autorisés. </target>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.outOfRange">
       <segment state="translated">
-        <source>Reps müssen zwischen 1 und 500 liegen.</source>
-        <target>Les répétitions doivent être entre 1 et 500.</target>
+        <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
+        <target>Les répétitions doivent être entre <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> et <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/>.</target>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.notInteger">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9593,8 +9593,8 @@
     </unit>
     <unit id="pushup.validation.reps.outOfRange">
       <segment state="translated">
-        <source>Reps müssen zwischen 1 und 500 liegen.</source>
-        <target>Le ripetizioni devono essere tra 1 e 500.</target>
+        <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
+        <target>Le ripetizioni devono essere tra <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> e <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/>.</target>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.notInteger">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9573,5 +9573,41 @@
         <target>Due settimane di recupero attivo: sessioni quotidiane di mobilità, yoga e stretching con un volume leggero di piegamenti. Ideale come scarico tra due piani intensi o per riprendere dopo una pausa.</target>
       </segment>
     </unit>
+    <unit id="displayName.violation.tooShort">
+      <segment state="translated">
+        <source> Mindestens 2 Zeichen. </source>
+        <target> Almeno 2 caratteri. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.tooLong">
+      <segment state="translated">
+        <source> Höchstens 30 Zeichen. </source>
+        <target> Al massimo 30 caratteri. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.invalidCharacters">
+      <segment state="translated">
+        <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
+        <target> Solo lettere, cifre, spazi e _ . - sono ammessi. </target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.outOfRange">
+      <segment state="translated">
+        <source>Reps müssen zwischen 1 und 500 liegen.</source>
+        <target>Le ripetizioni devono essere tra 1 e 500.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.notInteger">
+      <segment state="translated">
+        <source>Reps muss eine ganze Zahl sein.</source>
+        <target>Le ripetizioni devono essere un numero intero.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.generic">
+      <segment state="translated">
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+        <target>Impossibile salvare la voce.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9593,8 +9593,8 @@
     </unit>
     <unit id="pushup.validation.reps.outOfRange">
       <segment state="translated">
-        <source>Reps müssen zwischen 1 und 500 liegen.</source>
-        <target>Numerus iterationum inter unum et quingentos esse debet.</target>
+        <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
+        <target>Numerus iterationum inter <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> et <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> esse debet.</target>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.notInteger">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9573,5 +9573,41 @@
         <target>Duae hebdomades recuperationis activae: cotidianae sessiones mobilitatis, yoga et extensionum cum levi volumine pectorum. Optimum ut recuperatio inter duo consilia gravia aut ad reditum post intermissionem.</target>
       </segment>
     </unit>
+    <unit id="displayName.violation.tooShort">
+      <segment state="translated">
+        <source> Mindestens 2 Zeichen. </source>
+        <target> Saltem duo characteres. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.tooLong">
+      <segment state="translated">
+        <source> Höchstens 30 Zeichen. </source>
+        <target> Maxime triginta characteres. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.invalidCharacters">
+      <segment state="translated">
+        <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
+        <target> Solum litterae, numeri, spatia, et _ . - permittuntur. </target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.outOfRange">
+      <segment state="translated">
+        <source>Reps müssen zwischen 1 und 500 liegen.</source>
+        <target>Numerus iterationum inter unum et quingentos esse debet.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.notInteger">
+      <segment state="translated">
+        <source>Reps muss eine ganze Zahl sein.</source>
+        <target>Numerus iterationum integer esse debet.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.generic">
+      <segment state="translated">
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+        <target>Viscus salvus esse non potuit.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9573,5 +9573,41 @@
         <target>Twee weken actieve recuperatie: dagelijkse mobiliteits-, yoga- en stretching-sessies met een licht push-up-volume. Ideaal als deload tussen twee zware plannen of om weer in te stappen na een pauze.</target>
       </segment>
     </unit>
+    <unit id="displayName.violation.tooShort">
+      <segment state="translated">
+        <source> Mindestens 2 Zeichen. </source>
+        <target> Minstens 2 tekens. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.tooLong">
+      <segment state="translated">
+        <source> Höchstens 30 Zeichen. </source>
+        <target> Maximaal 30 tekens. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.invalidCharacters">
+      <segment state="translated">
+        <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
+        <target> Alleen letters, cijfers, spaties en _ . - zijn toegestaan. </target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.outOfRange">
+      <segment state="translated">
+        <source>Reps müssen zwischen 1 und 500 liegen.</source>
+        <target>Herhalingen moeten tussen 1 en 500 liggen.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.notInteger">
+      <segment state="translated">
+        <source>Reps muss eine ganze Zahl sein.</source>
+        <target>Herhalingen moeten een geheel getal zijn.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.generic">
+      <segment state="translated">
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+        <target>De invoer kon niet worden opgeslagen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9593,8 +9593,8 @@
     </unit>
     <unit id="pushup.validation.reps.outOfRange">
       <segment state="translated">
-        <source>Reps müssen zwischen 1 und 500 liegen.</source>
-        <target>Herhalingen moeten tussen 1 en 500 liggen.</target>
+        <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
+        <target>Herhalingen moeten tussen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> en <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liggen.</target>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.notInteger">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -8833,5 +8833,41 @@ Deine Position: # ·  Reps        </source>
         <target>To uker aktiv restitusjon: daglige mobilitets-, yoga- og stretching-økter med lett push-up-volum. Ideell som deload mellom to harde planer eller for å komme i gang igjen etter en pause.</target>
       </segment>
     </unit>
+    <unit id="displayName.violation.tooShort">
+      <segment state="translated">
+        <source> Mindestens 2 Zeichen. </source>
+        <target> Minst 2 tegn. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.tooLong">
+      <segment state="translated">
+        <source> Höchstens 30 Zeichen. </source>
+        <target> Maks 30 tegn. </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.invalidCharacters">
+      <segment state="translated">
+        <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
+        <target> Bare bokstaver, sifre, mellomrom og _ . - er tillatt. </target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.outOfRange">
+      <segment state="translated">
+        <source>Reps müssen zwischen 1 und 500 liegen.</source>
+        <target>Antall reps må være mellom 1 og 500.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.notInteger">
+      <segment state="translated">
+        <source>Reps muss eine ganze Zahl sein.</source>
+        <target>Antall reps må være et heltall.</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.generic">
+      <segment state="translated">
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+        <target>Kunne ikke lagre oppføringen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -8853,8 +8853,8 @@ Deine Position: # ·  Reps        </source>
     </unit>
     <unit id="pushup.validation.reps.outOfRange">
       <segment state="translated">
-        <source>Reps müssen zwischen 1 und 500 liegen.</source>
-        <target>Antall reps må være mellom 1 og 500.</target>
+        <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
+        <target>Antall reps må være mellom <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> og <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/>.</target>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.notInteger">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -641,7 +641,7 @@
         <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:48</note>
       </notes>
       <segment>
-        <source>Reps müssen zwischen 1 und 500 liegen.</source>
+        <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.notInteger">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -192,8 +192,8 @@
     <unit id="auth.onboarding.google.goal">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:19,21</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:269,271</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:273,275</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:301,303</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:305,307</note>
       </notes>
       <segment>
         <source>Tagesziel</source>
@@ -202,8 +202,8 @@
     <unit id="auth.onboarding.google.consent.checkbox">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:36,39</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:308,310</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:319,321</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:340,342</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:351,353</note>
       </notes>
       <segment>
         <source>Einwilligung erteilen</source>
@@ -223,8 +223,8 @@
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:81,82</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:153,154</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:224,225</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:262,263</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:299,300</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:294,295</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:331,332</note>
       </notes>
       <segment>
         <source> Weiter </source>
@@ -233,11 +233,11 @@
     <unit id="cancel">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:67,69</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:353,354</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:385,386</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:148,149</note>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:639,640</note>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,520</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:556,557</note>
       </notes>
       <segment>
         <source> Abbrechen </source>
@@ -472,9 +472,9 @@
       <notes>
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:145,146</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:208,209</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:253,254</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:290,291</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:328,329</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:285,286</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:322,323</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:360,361</note>
       </notes>
       <segment>
         <source> Zurück</source>
@@ -496,9 +496,36 @@
         <source>Passwort wiederholen</source>
       </segment>
     </unit>
+    <unit id="displayName.violation.tooShort">
+      <notes>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:254,256</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:184,186</note>
+      </notes>
+      <segment>
+        <source> Mindestens 2 Zeichen. </source>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.tooLong">
+      <notes>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:264,266</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:194,196</note>
+      </notes>
+      <segment>
+        <source> Höchstens 30 Zeichen. </source>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.invalidCharacters">
+      <notes>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:274,276</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:204,207</note>
+      </notes>
+      <segment>
+        <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
+      </segment>
+    </unit>
     <unit id="auth.onboarding.google.consent.text">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:311,314</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:343,346</note>
       </notes>
       <segment>
         <source> Ich willige in die Datenverarbeitung zum Erheben technisch notwendiger Daten, statistischer Auswertungen und zum Ausspielen gezielter Werbung ein. </source>
@@ -506,7 +533,7 @@
     </unit>
     <unit id="auth.register.submit">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:345,346</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:377,378</note>
       </notes>
       <segment>
         <source> Registrieren </source>
@@ -609,9 +636,33 @@
         <source>Anmelde-Menü</source>
       </segment>
     </unit>
+    <unit id="pushup.validation.reps.outOfRange">
+      <notes>
+        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:48</note>
+      </notes>
+      <segment>
+        <source>Reps müssen zwischen 1 und 500 liegen.</source>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.notInteger">
+      <notes>
+        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:51</note>
+      </notes>
+      <segment>
+        <source>Reps muss eine ganze Zahl sein.</source>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.generic">
+      <notes>
+        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:54</note>
+      </notes>
+      <segment>
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+      </segment>
+    </unit>
     <unit id="reminder.quickLog.success">
       <notes>
-        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:66</note>
+        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:69</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="reps" disp="reps"/> Push-ups eingetragen ✓</source>
@@ -619,8 +670,8 @@
     </unit>
     <unit id="snackbar.close">
       <notes>
-        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:67</note>
-        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:73</note>
+        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:70</note>
+        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:76</note>
         <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:484</note>
         <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:512</note>
         <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:528</note>
@@ -631,14 +682,6 @@
       </notes>
       <segment>
         <source>Schließen</source>
-      </segment>
-    </unit>
-    <unit id="reminder.quickLog.error">
-      <notes>
-        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:72</note>
-      </notes>
-      <segment>
-        <source>Eintrag konnte nicht gespeichert werden.</source>
       </segment>
     </unit>
     <unit id="quickAdd.fab.feedbackAria">
@@ -4033,26 +4076,16 @@
     </unit>
     <unit id="quickAdd.success.create">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:113</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:358</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:114</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:342</note>
       </notes>
       <segment>
         <source>Eintrag gespeichert.</source>
       </segment>
     </unit>
-    <unit id="quickAdd.error.create">
-      <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:125</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:164</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:374</note>
-      </notes>
-      <segment>
-        <source>Eintrag konnte nicht gespeichert werden.</source>
-      </segment>
-    </unit>
     <unit id="quickAdd.success.goalReached">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:151</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:143</note>
       </notes>
       <segment>
         <source>Tagesziel erreicht 🎉</source>
@@ -5556,7 +5589,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:44,45</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:45,46</note>
       </notes>
       <segment>
         <source>Analyse öffnen</source>
@@ -5564,7 +5597,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:49,51</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:50,52</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -5572,7 +5605,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserStreak">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:53,54</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:54,55</note>
       </notes>
       <segment>
         <source>Streak: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}"/> Tage</source>
@@ -5580,7 +5613,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserWeekReps">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:57,59</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:58,60</note>
       </notes>
       <segment>
         <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> Reps</source>
@@ -5588,7 +5621,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserError">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:65,67</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:66,68</note>
       </notes>
       <segment>
         <source> Daten konnten nicht geladen werden. </source>
@@ -5596,7 +5629,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:83,84</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:84,85</note>
       </notes>
       <segment>
         <source>Zur Analyse navigieren</source>
@@ -5604,7 +5637,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserCta">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:87,89</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:88,90</note>
       </notes>
       <segment>
         <source>Zur Analyse</source>
@@ -5612,7 +5645,7 @@
     </unit>
     <unit id="chart.kindLabel.all">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:141</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:142</note>
       </notes>
       <segment>
         <source>Alle Übungen</source>
@@ -5620,11 +5653,11 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:147</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:379</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:222</note>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1288</note>
-        <note category="location">web/src/app/stats/dashboard.store.ts:82</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:79</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:197</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:289</note>
@@ -6971,7 +7004,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:543</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:540</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Schau dir mein Profil an:</source>
@@ -6979,7 +7012,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:544</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:541</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
@@ -6987,7 +7020,7 @@
     </unit>
     <unit id="dashboard.share.text.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:548</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:545</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
@@ -6995,7 +7028,7 @@
     </unit>
     <unit id="dashboard.share.text.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:549</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:546</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
@@ -7003,7 +7036,7 @@
     </unit>
     <unit id="dashboard.share.title">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:553</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:550</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -8199,7 +8232,7 @@
     </unit>
     <unit id="settingsHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:82,83</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:87,88</note>
       </notes>
       <segment>
         <source>Einstellungen</source>
@@ -8207,7 +8240,7 @@
     </unit>
     <unit id="settingsHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:84,87</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:89,92</note>
       </notes>
       <segment>
         <source> Profil, Ziele und Sichtbarkeit nach deinem Geschmack. </source>
@@ -8215,7 +8248,7 @@
     </unit>
     <unit id="settings.status.saving">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:100,102</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:105,107</note>
       </notes>
       <segment>
         <source>Speichert…</source>
@@ -8223,7 +8256,7 @@
     </unit>
     <unit id="settings.status.saved">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:104,106</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:109,111</note>
       </notes>
       <segment>
         <source>Gespeichert</source>
@@ -8231,7 +8264,7 @@
     </unit>
     <unit id="settings.status.error">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:108,110</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:113,115</note>
       </notes>
       <segment>
         <source>Fehler beim Speichern</source>
@@ -8239,7 +8272,7 @@
     </unit>
     <unit id="settings.status.retry">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:115,116</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:120,121</note>
       </notes>
       <segment>
         <source> Erneut versuchen </source>
@@ -8247,7 +8280,7 @@
     </unit>
     <unit id="settings.status.pending">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:121,124</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:126,129</note>
       </notes>
       <segment>
         <source>Ungespeicherte Änderungen…</source>
@@ -8255,7 +8288,7 @@
     </unit>
     <unit id="settings.status.synced">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:127,130</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:132,135</note>
       </notes>
       <segment>
         <source>Alle Änderungen gespeichert</source>
@@ -8263,7 +8296,7 @@
     </unit>
     <unit id="guest.banner.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:138,141</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:143,146</note>
       </notes>
       <segment>
         <source>Du nutzt die App als Gast. Erstelle ein Konto um alle Funktionen zu nutzen.</source>
@@ -8271,7 +8304,7 @@
     </unit>
     <unit id="guest.banner.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:142,145</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:147,150</note>
       </notes>
       <segment>
         <source>Konto erstellen</source>
@@ -8279,7 +8312,7 @@
     </unit>
     <unit id="settings.section.profile.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:151,153</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:156,158</note>
       </notes>
       <segment>
         <source>Profil</source>
@@ -8287,7 +8320,7 @@
     </unit>
     <unit id="settings.section.profile.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:154,156</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:159,161</note>
       </notes>
       <segment>
         <source> Wie du in der App und der Bestenliste erscheinst. </source>
@@ -8295,7 +8328,7 @@
     </unit>
     <unit id="displayNameLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:159,160</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:164,165</note>
       </notes>
       <segment>
         <source>Anzeigename</source>
@@ -8303,7 +8336,7 @@
     </unit>
     <unit id="displayNamePlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:165</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:170</note>
       </notes>
       <segment>
         <source>Wolf</source>
@@ -8311,7 +8344,7 @@
     </unit>
     <unit id="settings.displayNameHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:168,170</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:173,175</note>
       </notes>
       <segment>
         <source>Kann in der Bestenliste angezeigt werden.</source>
@@ -8319,7 +8352,7 @@
     </unit>
     <unit id="settings.displayNameHint.leaderboardLink">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:176,179</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:213,216</note>
       </notes>
       <segment>
         <source>Zur Bestenliste</source>
@@ -8327,7 +8360,7 @@
     </unit>
     <unit id="settings.section.privacy.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:186,188</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:223,225</note>
       </notes>
       <segment>
         <source>Sichtbarkeit</source>
@@ -8335,7 +8368,7 @@
     </unit>
     <unit id="settings.section.privacy.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:189,191</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:226,228</note>
       </notes>
       <segment>
         <source> Steuere, wer dein Profil sehen kann. </source>
@@ -8343,7 +8376,7 @@
     </unit>
     <unit id="settings.leaderboardOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:201,202</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:238,239</note>
       </notes>
       <segment>
         <source> In Bestenliste anzeigen </source>
@@ -8351,7 +8384,7 @@
     </unit>
     <unit id="settings.leaderboardOptOutHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:205,207</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:242,244</note>
       </notes>
       <segment>
         <source> Wenn deaktiviert, wird dein Profil in der Bestenliste nicht angezeigt. </source>
@@ -8359,7 +8392,7 @@
     </unit>
     <unit id="settings.leaderboardRequiresPublicProfile">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:214,217</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:251,254</note>
       </notes>
       <segment>
         <source> Nur Profile mit aktiviertem Öffentlichen Profil erscheinen in der Bestenliste. Aktiviere unten „Öffentliches Profil“, um diese Option zu nutzen. </source>
@@ -8367,7 +8400,7 @@
     </unit>
     <unit id="settings.publicProfile.toggle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:228,229</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:265,266</note>
       </notes>
       <segment>
         <source> Öffentliches Profil aktivieren </source>
@@ -8375,7 +8408,7 @@
     </unit>
     <unit id="settings.publicProfile.hint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:231,234</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:268,271</note>
       </notes>
       <segment>
         <source> Erlaubt jedem mit dem Link den Zugriff auf deine Reps, Streak und Bestleistungen. Dein Anzeigename ist sichtbar; E-Mail, Ziele und Erinnerungen bleiben privat. </source>
@@ -8383,7 +8416,7 @@
     </unit>
     <unit id="settings.publicProfile.previewCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:253,255</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:290,292</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">visibility</pc> Vorschau </source>
@@ -8391,7 +8424,7 @@
     </unit>
     <unit id="settings.publicProfile.shareCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:262,264</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:299,301</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">share</pc> Profil teilen </source>
@@ -8399,7 +8432,7 @@
     </unit>
     <unit id="settings.section.goals.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:275,277</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:312,314</note>
       </notes>
       <segment>
         <source>Ziele</source>
@@ -8407,7 +8440,7 @@
     </unit>
     <unit id="settings.section.goals.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:278,280</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:315,317</note>
       </notes>
       <segment>
         <source> Tägliche, wöchentliche und monatliche Ziele. </source>
@@ -8415,7 +8448,7 @@
     </unit>
     <unit id="settings.goals.planOverrideHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:289,291</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:326,328</note>
       </notes>
       <segment>
         <source> Ein aktiver Trainingsplan setzt dein Tagesziel automatisch. Manuelle Werte gelten erst nach Planende. </source>
@@ -8423,7 +8456,7 @@
     </unit>
     <unit id="settings.goals.openActivePlan">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:296,299</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:333,336</note>
       </notes>
       <segment>
         <source>Aktiven Plan öffnen</source>
@@ -8431,7 +8464,7 @@
     </unit>
     <unit id="dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:302,303</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:339,340</note>
       </notes>
       <segment>
         <source>Tagesziel (Reps)</source>
@@ -8439,7 +8472,7 @@
     </unit>
     <unit id="dailyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:312</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:349</note>
       </notes>
       <segment>
         <source>10</source>
@@ -8447,7 +8480,7 @@
     </unit>
     <unit id="settings.goalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:315,317</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:352,354</note>
       </notes>
       <segment>
         <source>Wird prominent in der Toolbar angezeigt.</source>
@@ -8455,7 +8488,7 @@
     </unit>
     <unit id="weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:320,321</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:357,358</note>
       </notes>
       <segment>
         <source>Wochenziel (Reps)</source>
@@ -8463,7 +8496,7 @@
     </unit>
     <unit id="weeklyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:330</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:367</note>
       </notes>
       <segment>
         <source>50</source>
@@ -8471,7 +8504,7 @@
     </unit>
     <unit id="settings.weeklyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:333,335</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:370,372</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Woche (Mo–So).</source>
@@ -8479,7 +8512,7 @@
     </unit>
     <unit id="monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:338,339</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:375,376</note>
       </notes>
       <segment>
         <source>Monatsziel (Reps)</source>
@@ -8487,7 +8520,7 @@
     </unit>
     <unit id="monthlyGoalPlaceholder">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:348</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:385</note>
       </notes>
       <segment>
         <source>200</source>
@@ -8495,7 +8528,7 @@
     </unit>
     <unit id="settings.monthlyGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:351,353</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:388,390</note>
       </notes>
       <segment>
         <source>Gesamtziel pro Monat.</source>
@@ -8503,7 +8536,7 @@
     </unit>
     <unit id="settings.section.display.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:362,364</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:399,401</note>
       </notes>
       <segment>
         <source>Anzeige</source>
@@ -8511,7 +8544,7 @@
     </unit>
     <unit id="settings.section.display.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:365,367</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:402,404</note>
       </notes>
       <segment>
         <source> Animationen und Darstellung. </source>
@@ -8519,7 +8552,7 @@
     </unit>
     <unit id="settings.snapQualityLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:374,376</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:411,413</note>
       </notes>
       <segment>
         <source>Snap-Animation Qualität</source>
@@ -8527,7 +8560,7 @@
     </unit>
     <unit id="settings.snapQuality.low">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:384,386</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:421,423</note>
       </notes>
       <segment>
         <source>Niedrig</source>
@@ -8535,7 +8568,7 @@
     </unit>
     <unit id="settings.snapQuality.middle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:389,391</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:426,428</note>
       </notes>
       <segment>
         <source>Mittel</source>
@@ -8543,7 +8576,7 @@
     </unit>
     <unit id="settings.snapQuality.high">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:392,394</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:429,431</note>
       </notes>
       <segment>
         <source>Hoch</source>
@@ -8551,7 +8584,7 @@
     </unit>
     <unit id="settings.snapQualityHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:396,398</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:433,435</note>
       </notes>
       <segment>
         <source> Steuert die Partikelanzahl der „Ziel erreicht“-Animation (40k / 120k / 200k). </source>
@@ -8559,7 +8592,7 @@
     </unit>
     <unit id="settings.section.ads.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:407,409</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:444,446</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -8567,7 +8600,7 @@
     </unit>
     <unit id="settings.section.ads.subtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:410,412</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:447,449</note>
       </notes>
       <segment>
         <source> Personalisierung der Werbe-Slots. </source>
@@ -8575,7 +8608,7 @@
     </unit>
     <unit id="settings.adsConsentOptIn">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:419,420</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:456,457</note>
       </notes>
       <segment>
         <source> Personalisierte Werbung aktivieren </source>
@@ -8583,7 +8616,7 @@
     </unit>
     <unit id="settings.adsConsentHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:423,426</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:460,463</note>
       </notes>
       <segment>
         <source>Steuert, ob Werbe-Slots im Dashboard geladen werden dürfen.</source>
@@ -8591,7 +8624,7 @@
     </unit>
     <unit id="settings.adsConsent.privacyLink">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:429,432</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:466,469</note>
       </notes>
       <segment>
         <source>Datenschutzerklärung</source>
@@ -8599,7 +8632,7 @@
     </unit>
     <unit id="settings.remindersLinkTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:439,441</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:476,478</note>
       </notes>
       <segment>
         <source>Erinnerungen</source>
@@ -8607,7 +8640,7 @@
     </unit>
     <unit id="settings.remindersLinkDesc">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:442,443</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:479,480</note>
       </notes>
       <segment>
         <source> Liegestütz-Erinnerungen und Push-Benachrichtigungen konfigurieren. </source>
@@ -8615,7 +8648,7 @@
     </unit>
     <unit id="settings.remindersLinkCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:451,453</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:488,490</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">notifications</pc> Erinnerungen verwalten </source>
@@ -8623,7 +8656,7 @@
     </unit>
     <unit id="settings.dangerZoneTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:461,463</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:498,500</note>
       </notes>
       <segment>
         <source>Danger Zone</source>
@@ -8631,7 +8664,7 @@
     </unit>
     <unit id="settings.dangerZoneBody">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:464,466</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:501,503</note>
       </notes>
       <segment>
         <source> Konto löschen entfernt dein Konto. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -8639,7 +8672,7 @@
     </unit>
     <unit id="settings.deleteAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:477,479</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:514,516</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Konto löschen </source>
@@ -8647,7 +8680,7 @@
     </unit>
     <unit id="settings.deletingAccount">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:482,485</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:519,522</note>
       </notes>
       <segment>
         <source>Konto wird gelöscht…</source>
@@ -8655,7 +8688,7 @@
     </unit>
     <unit id="settings.deleteDialogTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:490,492</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:527,529</note>
       </notes>
       <segment>
         <source> Account wirklich löschen? </source>
@@ -8663,7 +8696,7 @@
     </unit>
     <unit id="settings.deleteDialogWarning">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:494,496</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:531,533</note>
       </notes>
       <segment>
         <source> Achtung: Diese Aktion ist nicht rückgängig. </source>
@@ -8671,7 +8704,7 @@
     </unit>
     <unit id="settings.deleteDialogInfo">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:497,500</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:534,537</note>
       </notes>
       <segment>
         <source> Dein Konto wird gelöscht. Trainingsdaten bleiben für statistische Auswertung anonymisiert erhalten. </source>
@@ -8679,7 +8712,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:502,505</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:539,542</note>
       </notes>
       <segment>
         <source>Bestätigungswort eingeben</source>
@@ -8687,7 +8720,7 @@
     </unit>
     <unit id="settings.deleteDialogPhraseHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:511,513</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:548,550</note>
       </notes>
       <segment>
         <source>Bitte exakt „löscchen“ eingeben.</source>
@@ -8695,7 +8728,7 @@
     </unit>
     <unit id="settings.deleteConfirmFinal">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:526,528</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:563,565</note>
       </notes>
       <segment>
         <source> Final löschen </source>
@@ -8703,7 +8736,7 @@
     </unit>
     <unit id="settings.publicProfile.share.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:847</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:906</note>
       </notes>
       <segment>
         <source>Mein Pushup Tracker Profil</source>
@@ -8711,7 +8744,7 @@
     </unit>
     <unit id="settings.publicProfile.share.text">
       <notes>
-        <note category="location">web/src/app/stats/shell/settings-page.component.ts:848</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:907</note>
       </notes>
       <segment>
         <source>Schau dir mein Pushup-Profil an:</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9087,8 +9087,8 @@
     </unit>
     <unit id="pushup.validation.reps.outOfRange">
       <segment state="translated">
-        <source>Reps müssen zwischen 1 und 500 liegen.</source>
-        <target>次数必须在 1 到 500 之间。</target>
+        <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
+        <target>次数必须在 <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> 到 <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> 之间。</target>
       </segment>
     </unit>
     <unit id="pushup.validation.reps.notInteger">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9067,5 +9067,41 @@
         <target>2周主动恢复：每日活动度、瑜伽和拉伸训练，配合轻量俯卧撑。理想用于两个高强度计划之间的减载，或训练间歇后的回归。</target>
       </segment>
     </unit>
+    <unit id="displayName.violation.tooShort">
+      <segment state="translated">
+        <source> Mindestens 2 Zeichen. </source>
+        <target> 至少 2 个字符。 </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.tooLong">
+      <segment state="translated">
+        <source> Höchstens 30 Zeichen. </source>
+        <target> 最多 30 个字符。 </target>
+      </segment>
+    </unit>
+    <unit id="displayName.violation.invalidCharacters">
+      <segment state="translated">
+        <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
+        <target> 只允许字母、数字、空格以及 _ . - 。 </target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.outOfRange">
+      <segment state="translated">
+        <source>Reps müssen zwischen 1 und 500 liegen.</source>
+        <target>次数必须在 1 到 500 之间。</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.reps.notInteger">
+      <segment state="translated">
+        <source>Reps muss eine ganze Zahl sein.</source>
+        <target>次数必须是整数。</target>
+      </segment>
+    </unit>
+    <unit id="pushup.validation.generic">
+      <segment state="translated">
+        <source>Eintrag konnte nicht gespeichert werden.</source>
+        <target>无法保存条目。</target>
+      </segment>
+    </unit>
 </file>
 </xliff>


### PR DESCRIPTION
Batches three small open issues into one PR.

## Closes #378 — `scope:sw-push` module boundary

Adds the missing `depConstraints` entry in `eslint.config.mjs` so the standalone service-worker bundle is locked to zero workspace lib deps. Today the lib happens to import nothing, but the constraint is defense in depth — bringing in `@pu-stats/data-access` from this bundle would silently bloat the SW. Architecture doc updated to match.

## Closes #282 — Inline displayName validation

Wires `validateDisplayName` from `@pu-stats/models` into:

- **`RegisterUiStore`** — new `displayNameViolation` computed; `isProfileStepValid` and `canSubmit` now use the full validator instead of the bare `length >= 2` check.
- **`register.component.html`** — surfaces a localized error paragraph under the displayName field (mat-error needs a FormControl which this field doesn't use, so a `<p class="field-error">` styled as error is used instead).
- **`settings-page.component.ts`** — auto-save is blocked when the displayName draft is **dirty AND** invalid; other field edits still flush (so legacy storage with an empty displayName doesn't lock the entire form). Inline error rendered.

Adds DE/EN/ES/FR/IT/NL/NO/EL/ZH/LA translations for the three violation messages.

## Closes #286 — Friendly snackbar for `PushupValidationError`

Extracts `pushupValidationMessage(err: unknown): string` next to `PushupValidationError` in `@pu-stats/data-access`, mapping `reps` + `out-of-range` / `not-integer` to localized hints. Generic fallback for anything else.

Routes both error paths through it:

- **`QuickLogListenerService.logEntry`** — quick-add from notification action.
- **`QuickAddOrchestrationService`** — `add()`, `fillToGoal()`, and the entry-dialog `persistConfirmed()` flow.

Users hitting the 500-rep cap (e.g. a stale notification payload) now see "Reps müssen zwischen 1 und 500 liegen." instead of the previous generic "Eintrag konnte nicht gespeichert werden.". Translations added for all 9 non-source locales.

## Test plan

- [x] `pnpm nx run-many --target=lint --projects=auth,stats-data-access,pus-push,web,sw-push` — green
- [x] `pnpm nx run-many --target=test --projects=auth,stats-data-access,pus-push,web` — green
- [x] `pnpm nx run web:build -c production` — green (i18n source + 9 translations resolve)
- [x] New unit tests:
  - `RegisterUiStore` — 4 cases covering tooShort / tooLong / invalidCharacters / valid
  - `SettingsPageComponent` — invalid blocks save, too-short blocks save, edit-to-valid flushes
  - `pushupValidationMessage` — outOfRange / notInteger / generic fallback
  - `QuickLogListenerService` — surfaces cap message + integer hint
  - `QuickAddOrchestrationService.fillToGoal` — surfaces cap message



---
_Generated by [Claude Code](https://claude.ai/code/session_01MPa7J5twtJf8WLz3mRkv21)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added detailed validation messages for display names (minimum length, maximum length, allowed characters)
  * Enhanced pushup entry validation with specific error messages (valid range: 1–500 reps, must be whole numbers)
  * Improved error feedback across registration and settings pages with inline validation hints

* **Documentation**
  * Updated architecture guidelines for service-worker module boundaries

* **Chores**
  * Added multi-language translation support (10+ locales) for validation messages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->