### PR TITLE
fix(quick-add): show configured exercise icon + name in SpeedDial, add toggle tooltips

### DIFF
--- a/libs/quick-add/src/lib/quick-add-fab.component.html
+++ b/libs/quick-add/src/lib/quick-add-fab.component.html
@@ -70,18 +70,16 @@
               >
             }
           </button>
-        } @else {
+        } @else if (item.suggestion) {
           <button
             mat-fab
             extended
             class="quick-fab"
-            [attr.aria-label]="repAriaLabel(item.value)"
-            (click)="onQuickAdd(item.value)"
+            [attr.aria-label]="item.ariaLabel"
+            (click)="onQuickAdd(item.suggestion)"
           >
             <mat-icon>{{ item.icon }}</mat-icon>
-            <span i18n="@@quickAdd.fab.quickAddReps"
-              >+{{ item.value }} Reps</span
-            >
+            <span>{{ item.label }}</span>
           </button>
         }
       }

--- a/libs/quick-add/src/lib/quick-add-fab.component.spec.ts
+++ b/libs/quick-add/src/lib/quick-add-fab.component.spec.ts
@@ -1,11 +1,25 @@
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { PointerEventsCheckLevel } from '@testing-library/user-event';
-import { QuickAddFabComponent } from './quick-add-fab.component';
+import {
+  QuickAddFabComponent,
+  type QuickAddSuggestion,
+} from './quick-add-fab.component';
+
+function pushupSuggestion(reps: number): QuickAddSuggestion {
+  return {
+    key: `pushup:${reps}`,
+    reps,
+    icon: 'bolt',
+    label: `+${reps} Reps`,
+    ariaLabel: `${reps} Liegestütze hinzufügen`,
+    exerciseId: 'pushup',
+  };
+}
 
 describe('QuickAddFabComponent — goal dial item', () => {
   async function renderFab(inputs: {
-    suggestions?: number[];
+    suggestions?: QuickAddSuggestion[];
     remainingToGoal?: number;
     goalReached?: boolean;
     fillToGoalInFlight?: boolean;
@@ -27,7 +41,8 @@ describe('QuickAddFabComponent — goal dial item', () => {
 
     const view = await render(QuickAddFabComponent, {
       inputs: {
-        suggestions: inputs.suggestions ?? [5, 10, 15],
+        suggestions:
+          inputs.suggestions ?? [5, 10, 15].map((r) => pushupSuggestion(r)),
         remainingToGoal: inputs.remainingToGoal ?? 0,
         goalReached: inputs.goalReached ?? false,
         fillToGoalInFlight: inputs.fillToGoalInFlight ?? false,
@@ -117,13 +132,54 @@ describe('QuickAddFabComponent — goal dial item', () => {
 
   it('Given suggestions, Then the three quick-rep items still render', async () => {
     await renderFab({
-      suggestions: [5, 10, 15],
+      suggestions: [5, 10, 15].map((r) => pushupSuggestion(r)),
       remainingToGoal: 42,
     });
 
     expect(screen.getByText('+5 Reps')).toBeTruthy();
     expect(screen.getByText('+10 Reps')).toBeTruthy();
     expect(screen.getByText('+15 Reps')).toBeTruthy();
+  });
+
+  it('Given a non-pushup suggestion, Then its localised label and icon render', async () => {
+    const situps: QuickAddSuggestion = {
+      key: 'abs.situps:10',
+      reps: 10,
+      icon: 'self_improvement',
+      label: '+10 Sit-ups',
+      ariaLabel: '10 Sit-ups hinzufügen',
+      exerciseId: 'abs.situps',
+    };
+    await renderFab({ suggestions: [situps] });
+
+    expect(screen.getByText('+10 Sit-ups')).toBeTruthy();
+    const button = screen.getByRole('button', {
+      name: /10 Sit-ups hinzufügen/i,
+    });
+    expect(button).toBeTruthy();
+    expect(button.querySelector('mat-icon')?.textContent).toContain(
+      'self_improvement'
+    );
+  });
+
+  it('When a quick item is clicked, Then the full suggestion is emitted', async () => {
+    const situps: QuickAddSuggestion = {
+      key: 'abs.situps:10',
+      reps: 10,
+      icon: 'self_improvement',
+      label: '+10 Sit-ups',
+      ariaLabel: '10 Sit-ups hinzufügen',
+      exerciseId: 'abs.situps',
+    };
+    const { user, quickAdd } = await renderFab({ suggestions: [situps] });
+
+    const button = screen.getByRole('button', {
+      name: /10 Sit-ups hinzufügen/i,
+    });
+    await user.click(button);
+
+    expect(quickAdd).toHaveBeenCalledTimes(1);
+    expect(quickAdd).toHaveBeenCalledWith(situps);
   });
 
   it('When the main FAB opens the dial, Then opened is emitted once', async () => {

--- a/libs/quick-add/src/lib/quick-add-fab.component.ts
+++ b/libs/quick-add/src/lib/quick-add-fab.component.ts
@@ -3,6 +3,22 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { patchState, signalState } from '@ngrx/signals';
 
+/**
+ * Pre-resolved quick-add the speed dial should render. Producers
+ * (e.g. `AppDataFacade.quickAddSuggestions`) localise the label and
+ * resolve the exercise's icon so the FAB stays presentation-only.
+ * `exerciseId` is opaque to the FAB — it round-trips back through the
+ * `quickAdd` output so the dispatcher can pick the right write target.
+ */
+export interface QuickAddSuggestion {
+  readonly key: string;
+  readonly reps: number;
+  readonly icon: string;
+  readonly label: string;
+  readonly ariaLabel: string;
+  readonly exerciseId: string;
+}
+
 interface DialItem {
   readonly value: number;
   readonly type:
@@ -13,9 +29,10 @@ interface DialItem {
     | 'auto-count'
     | 'exercise-timer';
   readonly icon: string;
+  readonly label?: string;
+  readonly ariaLabel?: string;
+  readonly suggestion?: QuickAddSuggestion;
 }
-
-const QUICK_ICONS = ['bolt', 'flash_on', 'whatshot'] as const;
 
 @Component({
   selector: 'lib-quick-add-fab',
@@ -25,13 +42,13 @@ const QUICK_ICONS = ['bolt', 'flash_on', 'whatshot'] as const;
   styleUrl: './quick-add-fab.component.scss',
 })
 export class QuickAddFabComponent {
-  readonly suggestions = input<number[]>([1, 5, 10]);
+  readonly suggestions = input<QuickAddSuggestion[]>([]);
   readonly remainingToGoal = input<number>(0);
   readonly goalReached = input<boolean>(false);
   readonly fillToGoalInFlight = input<boolean>(false);
   readonly autoCountEnabled = input<boolean>(false);
 
-  readonly quickAdd = output<number>();
+  readonly quickAdd = output<QuickAddSuggestion>();
   readonly openDialog = output<void>();
   readonly openFeedback = output<void>();
   readonly fillToGoal = output<void>();
@@ -46,10 +63,13 @@ export class QuickAddFabComponent {
     const quickItems: DialItem[] = this.suggestions()
       .slice(0, 3)
       .map(
-        (s, i): DialItem => ({
-          value: s,
+        (s): DialItem => ({
+          value: s.reps,
           type: 'quick',
-          icon: QUICK_ICONS[i] ?? 'bolt',
+          icon: s.icon,
+          label: s.label,
+          ariaLabel: s.ariaLabel,
+          suggestion: s,
         })
       );
 
@@ -80,10 +100,6 @@ export class QuickAddFabComponent {
   protected readonly goalReachedLabel = $localize`:@@quickAdd.fab.goalReached:Ziel erreicht ✓`;
   protected readonly goalReachedAria = $localize`:@@quickAdd.fab.goalReachedAria:Tagesziel bereits erreicht`;
 
-  protected repAriaLabel(reps: number): string {
-    return $localize`:@@quickAdd.fab.repAria:${reps}:REPS: Liegestütze hinzufügen`;
-  }
-
   protected fillToGoalAria(gap: number): string {
     return $localize`:@@quickAdd.fab.fillToGoalAria:${gap}:GAP: Liegestütze bis zum Tagesziel hinzufügen`;
   }
@@ -98,9 +114,9 @@ export class QuickAddFabComponent {
     if (nextOpen) this.opened.emit();
   }
 
-  protected onQuickAdd(reps: number): void {
+  protected onQuickAdd(suggestion: QuickAddSuggestion): void {
     patchState(this.fabState, { open: false });
-    this.quickAdd.emit(reps);
+    this.quickAdd.emit(suggestion);
   }
 
   protected onOpenDialog(): void {

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -42,7 +42,10 @@ import {
   QuickLogListenerService,
 } from '@pu-push/push';
 import { CookieConsentBannerComponent } from '@pu-stats/ads';
-import { QuickAddFabComponent } from '@pu-stats/quick-add';
+import {
+  QuickAddFabComponent,
+  type QuickAddSuggestion,
+} from '@pu-stats/quick-add';
 import { ThemeToggleComponent } from './core/theme';
 import { ReminderOrchestrationService } from './core/reminder-orchestration.service';
 import { AppDataFacade } from './core/app-data.facade';
@@ -341,8 +344,8 @@ export class App {
     }
   }
 
-  handleQuickAdd(reps: number): void {
-    this.quickAdd.add(reps);
+  handleQuickAdd(suggestion: QuickAddSuggestion): void {
+    this.quickAdd.addSuggestion(suggestion);
   }
 
   handleOpenDialog(): void {

--- a/web/src/app/core/app-data.facade.spec.ts
+++ b/web/src/app/core/app-data.facade.spec.ts
@@ -161,14 +161,21 @@ describe('AppDataFacade', () => {
   });
 
   describe('quickAddSuggestions', () => {
-    it('Given no configured quickAdds, Then adaptive suggestions are used', async () => {
+    function reps(facade: AppDataFacade): number[] {
+      return facade.quickAddSuggestions().map((s) => s.reps);
+    }
+
+    it('Given no configured quickAdds, Then adaptive suggestions are used (as pushup suggestions)', async () => {
       userConfigApiMock.getConfig.mockReturnValue(
         of({ userId: 'u1', dailyGoal: 100 })
       );
       const facade = setup();
       await flushResources();
 
-      expect(facade.quickAddSuggestions()).toEqual([1, 5, 10]);
+      expect(reps(facade)).toEqual([1, 5, 10]);
+      expect(
+        facade.quickAddSuggestions().every((s) => s.exerciseId === 'pushup')
+      ).toBe(true);
     });
 
     it('Given configured quickAdds, Then only entries with inSpeedDial=true are returned', async () => {
@@ -188,7 +195,35 @@ describe('AppDataFacade', () => {
       const facade = setup();
       await flushResources();
 
-      expect(facade.quickAddSuggestions()).toEqual([15, 50]);
+      expect(reps(facade)).toEqual([15, 50]);
+    });
+
+    it('Given a configured exercise quick-add, Then the suggestion carries the catalog icon and a localised label', async () => {
+      userConfigApiMock.getConfig.mockReturnValue(
+        of({
+          userId: 'u1',
+          dailyGoal: 100,
+          ui: {
+            quickAdds: [
+              {
+                reps: 10,
+                inSpeedDial: true,
+                exerciseId: 'abs.situps',
+                mode: 'reps',
+              },
+            ],
+          },
+        })
+      );
+      const facade = setup();
+      await flushResources();
+
+      const [s] = facade.quickAddSuggestions();
+      expect(s.exerciseId).toBe('abs.situps');
+      expect(s.reps).toBe(10);
+      expect(s.icon).toBe('self_improvement');
+      expect(s.label).toContain('Sit-ups');
+      expect(s.label).toContain('10');
     });
 
     it('Given configured quickAdds with none in SpeedDial, Then returns empty array (no adaptive fallback)', async () => {
@@ -234,7 +269,7 @@ describe('AppDataFacade', () => {
       const facade = setup();
       await flushResources();
 
-      expect(facade.quickAddSuggestions()).toEqual([15, 30]);
+      expect(reps(facade)).toEqual([15, 30]);
     });
 
     it('Given a SpeedDial entry with reps<=0 (legacy/corrupt), Then it is filtered out defensively', async () => {
@@ -254,7 +289,7 @@ describe('AppDataFacade', () => {
       const facade = setup();
       await flushResources();
 
-      expect(facade.quickAddSuggestions()).toEqual([20]);
+      expect(reps(facade)).toEqual([20]);
     });
   });
 
@@ -365,7 +400,9 @@ describe('AppDataFacade', () => {
       const facade = TestBed.inject(AppDataFacade);
       await flushResources();
 
-      expect(facade.quickAddSuggestions()).toEqual([0, 0, 0]);
+      expect(facade.quickAddSuggestions().map((s) => s.reps)).toEqual([
+        0, 0, 0,
+      ]);
 
       // When live data arrives
       liveEntries.set([
@@ -379,7 +416,9 @@ describe('AppDataFacade', () => {
       ]);
 
       // Then suggestions recompute
-      expect(facade.quickAddSuggestions()).toEqual([1, 2, 3]);
+      expect(facade.quickAddSuggestions().map((s) => s.reps)).toEqual([
+        1, 2, 3,
+      ]);
     });
   });
 

--- a/web/src/app/core/app-data.facade.ts
+++ b/web/src/app/core/app-data.facade.ts
@@ -10,10 +10,53 @@ import { firstValueFrom } from 'rxjs';
 import { UserContextService } from '@pu-auth/auth';
 import { StatsApiService } from '@pu-stats/data-access';
 import { LiveDataStore } from '@pu-stats/data-access-state';
-import { toBerlinIsoDate } from '@pu-stats/models';
-import { AdaptiveQuickAddService } from '@pu-stats/quick-add';
+import {
+  findExerciseDefinition,
+  PUSHUP_QUICK_ADD_EXERCISE_ID,
+  type QuickAddConfig,
+  toBerlinIsoDate,
+} from '@pu-stats/models';
+import {
+  AdaptiveQuickAddService,
+  type QuickAddSuggestion,
+} from '@pu-stats/quick-add';
 import { TrainingPlanStore } from '../training-plans/training-plan.store';
 import { UserConfigStore } from './user-config.store';
+import { exerciseDisplayName } from '../stats/i18n/exercise-display-names';
+
+const FALLBACK_QUICK_ICONS = ['bolt', 'flash_on', 'whatshot'] as const;
+
+function pushupSuggestion(reps: number, slot: number): QuickAddSuggestion {
+  return {
+    key: `slot:${slot}`,
+    reps,
+    icon: FALLBACK_QUICK_ICONS[slot] ?? 'bolt',
+    label: $localize`:@@quickAdd.fab.pushupRepsLabel:+${reps}:REPS: Reps`,
+    ariaLabel: $localize`:@@quickAdd.fab.repAria:${reps}:REPS: Liegestütze hinzufügen`,
+    exerciseId: PUSHUP_QUICK_ADD_EXERCISE_ID,
+  };
+}
+
+function configuredSuggestion(
+  cfg: QuickAddConfig,
+  slot: number
+): QuickAddSuggestion {
+  const exerciseId = cfg.exerciseId ?? PUSHUP_QUICK_ADD_EXERCISE_ID;
+  if (exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID) {
+    return pushupSuggestion(cfg.reps, slot);
+  }
+  const def = findExerciseDefinition(exerciseId);
+  const exerciseLabel = exerciseDisplayName(exerciseId);
+  const icon = def?.icon ?? 'fitness_center';
+  return {
+    key: `slot:${slot}`,
+    reps: cfg.reps,
+    icon,
+    label: `+${cfg.reps} ${exerciseLabel}`,
+    ariaLabel: $localize`:@@quickAdd.fab.exerciseRepAria:${cfg.reps}:REPS: ${exerciseLabel}:EXERCISE: hinzufügen`,
+    exerciseId,
+  };
+}
 
 /**
  * Facade that consolidates app-level data resources.
@@ -58,7 +101,7 @@ export class AppDataFacade {
     return this.recentEntriesResource.value() ?? [];
   });
 
-  readonly quickAddSuggestions = computed(() => {
+  readonly quickAddSuggestions = computed<QuickAddSuggestion[]>(() => {
     const configured = this.userConfig.quickAdds();
     if (configured.length > 0) {
       // SpeedDial FAB only knows fixed-reps `quickAdd(n)` so we must
@@ -68,10 +111,12 @@ export class AppDataFacade {
       // alongside `mode: 'auto-count'`.
       return configured
         .filter((q) => q.inSpeedDial && q.mode !== 'auto-count' && q.reps > 0)
-        .map((q) => q.reps)
-        .slice(0, 3);
+        .slice(0, 3)
+        .map((cfg, i) => configuredSuggestion(cfg, i));
     }
-    return this.adaptiveQuickAdd.compute(this.recentEntries());
+    return this.adaptiveQuickAdd
+      .compute(this.recentEntries())
+      .map((reps, i) => pushupSuggestion(reps, i));
   });
 
   /**

--- a/web/src/app/core/quick-add-orchestration.service.spec.ts
+++ b/web/src/app/core/quick-add-orchestration.service.spec.ts
@@ -9,7 +9,10 @@ import {
   ExerciseFirestoreService,
   StatsApiService,
 } from '@pu-stats/data-access';
-import { QuickAddBridgeService } from '@pu-stats/quick-add';
+import {
+  QuickAddBridgeService,
+  type QuickAddSuggestion,
+} from '@pu-stats/quick-add';
 import { QuickAddOrchestrationService } from './quick-add-orchestration.service';
 import { AppDataFacade } from './app-data.facade';
 
@@ -145,6 +148,96 @@ describe('QuickAddOrchestrationService.fillToGoal', () => {
 
     const payload = statsApiMock.createPushup.mock.calls[0][0];
     expect(payload.reps).toBe(42);
+  });
+});
+
+describe('QuickAddOrchestrationService.addSuggestion', () => {
+  const reloadAfterMutation = vitest.fn();
+  const statsApiMock = { createPushup: vitest.fn() };
+  const exerciseApiMock = { createEntry: vitest.fn() };
+  const snackBarMock = { open: vitest.fn() };
+  const routerMock = { url: '/app', navigate: vitest.fn() };
+  const bridgeMock = { requestOpenDialog: vitest.fn() };
+  const appDataMock: Partial<AppDataFacade> = {
+    remainingToGoal: signal(0).asReadonly(),
+    reloadAfterMutation,
+  };
+
+  function setup(opts: { userId?: string } = {}): QuickAddOrchestrationService {
+    vitest.clearAllMocks();
+    statsApiMock.createPushup.mockReturnValue(of({ _id: '1' }));
+    exerciseApiMock.createEntry.mockReturnValue(of({ _id: 'e1' }));
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: baseProviders({
+        statsApiMock,
+        exerciseApiMock,
+        snackBarMock,
+        routerMock,
+        bridgeMock,
+        appDataMock,
+        userId: opts.userId,
+      }),
+    });
+    return TestBed.inject(QuickAddOrchestrationService);
+  }
+
+  const pushupSuggestion: QuickAddSuggestion = {
+    key: 'slot:0',
+    reps: 10,
+    icon: 'bolt',
+    label: '+10 Reps',
+    ariaLabel: '10 Liegestütze hinzufügen',
+    exerciseId: 'pushup',
+  };
+  const situpsSuggestion: QuickAddSuggestion = {
+    key: 'slot:1',
+    reps: 12,
+    icon: 'self_improvement',
+    label: '+12 Sit-ups',
+    ariaLabel: '12 Sit-ups hinzufügen',
+    exerciseId: 'abs.situps',
+  };
+
+  it('Given a pushup suggestion, Then createPushup is called with the suggestion reps and quick-add source', () => {
+    const service = setup();
+
+    service.addSuggestion(pushupSuggestion);
+
+    expect(statsApiMock.createPushup).toHaveBeenCalledTimes(1);
+    const payload = statsApiMock.createPushup.mock.calls[0][0];
+    expect(payload.reps).toBe(10);
+    expect(payload.source).toBe('quick-add');
+    expect(exerciseApiMock.createEntry).not.toHaveBeenCalled();
+  });
+
+  it('Given a non-pushup suggestion, Then exerciseApi.createEntry is called with that exerciseId', async () => {
+    const service = setup();
+
+    service.addSuggestion(situpsSuggestion);
+    await vitest.waitFor(() =>
+      expect(exerciseApiMock.createEntry).toHaveBeenCalledTimes(1)
+    );
+
+    const [userId, payload] = exerciseApiMock.createEntry.mock.calls[0];
+    expect(userId).toBe('u1');
+    expect(payload.exerciseId).toBe('abs.situps');
+    expect(payload.reps).toBe(12);
+    expect(payload.source).toBe('quick-add');
+    expect(statsApiMock.createPushup).not.toHaveBeenCalled();
+  });
+
+  it('Given a non-pushup suggestion without a logged-in user, Then an error snackbar opens and nothing is created', async () => {
+    const service = setup({ userId: '' });
+
+    service.addSuggestion(situpsSuggestion);
+    await vitest.waitFor(() =>
+      expect(snackBarMock.open).toHaveBeenCalledTimes(1)
+    );
+
+    expect(exerciseApiMock.createEntry).not.toHaveBeenCalled();
+    expect(snackBarMock.open.mock.calls[0][0]).toContain('konnte nicht');
   });
 });
 

--- a/web/src/app/core/quick-add-orchestration.service.ts
+++ b/web/src/app/core/quick-add-orchestration.service.ts
@@ -12,7 +12,10 @@ import {
   nowLocalIsoTimestamp,
   PUSHUP_QUICK_ADD_EXERCISE_ID,
 } from '@pu-stats/models';
-import { QuickAddBridgeService } from '@pu-stats/quick-add';
+import {
+  QuickAddBridgeService,
+  type QuickAddSuggestion,
+} from '@pu-stats/quick-add';
 import { firstValueFrom } from 'rxjs';
 
 import { AppDataFacade } from './app-data.facade';
@@ -99,6 +102,53 @@ export class QuickAddOrchestrationService {
 
   private readonly _fillToGoalInFlight = signal(false);
   readonly fillToGoalInFlight = this._fillToGoalInFlight.asReadonly();
+
+  /**
+   * SpeedDial entry point — dispatches by `exerciseId`. Pushup rows flow
+   * through the legacy `pushups` collection; every other catalog id is
+   * written to `exerciseEntries` via `ExerciseFirestoreService`, mirroring
+   * the dashboard's `addQuickEntryFromConfig` so both surfaces stay in
+   * sync.
+   */
+  addSuggestion(suggestion: QuickAddSuggestion): void {
+    if (suggestion.exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID) {
+      this.add(suggestion.reps);
+      return;
+    }
+    void this.addExerciseQuickEntry(suggestion);
+  }
+
+  private async addExerciseQuickEntry(
+    suggestion: QuickAddSuggestion
+  ): Promise<void> {
+    const userId = this.userContext.userIdSafe();
+    if (!userId || !this.exerciseApi) {
+      this.openErrorSnackbar();
+      return;
+    }
+    try {
+      await firstValueFrom(
+        this.exerciseApi.createEntry(userId, {
+          exerciseId: suggestion.exerciseId,
+          timestamp: nowLocalIsoTimestamp(),
+          reps: suggestion.reps,
+          source: 'quick-add',
+        })
+      );
+      this.snackBar.open(
+        $localize`:@@quickAdd.success.create:Eintrag gespeichert.`,
+        '',
+        {
+          duration: 2000,
+          horizontalPosition: 'center',
+          verticalPosition: 'bottom',
+        }
+      );
+      this.appData.reloadAfterMutation();
+    } catch {
+      this.openErrorSnackbar();
+    }
+  }
 
   add(reps: number): void {
     this.statsApi

--- a/web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts
+++ b/web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts
@@ -119,6 +119,8 @@ interface ExerciseOption {
               [checked]="row.mode === 'auto-count'"
               (change)="setAutoCount($index, $event.checked)"
               [attr.data-testid]="'quick-add-autocount-' + $index"
+              [matTooltip]="autoCountTooltip"
+              matTooltipPosition="above"
               i18n="@@quickAddConfig.autoCount"
               >Auto-Messung</mat-checkbox
             >
@@ -129,6 +131,8 @@ interface ExerciseOption {
               [checked]="row.inSpeedDial"
               (change)="setInSpeedDial($index, $event.checked)"
               [attr.data-testid]="'quick-add-speeddial-' + $index"
+              [matTooltip]="inSpeedDialTooltip"
+              matTooltipPosition="above"
               i18n="@@quickAddConfig.inSpeedDial"
               >Im SpeedDial</mat-checkbox
             >
@@ -210,6 +214,8 @@ export class QuickAddConfigDialogComponent {
   // Clears the whole slot (exercise, mode, reps) — not just the reps field —
   // since the picker landed. Keeps the assistive-tech announcement honest.
   protected readonly clearRowAria = $localize`:@@quickAddConfig.clearRowAria:Schnellaktion löschen`;
+  protected readonly autoCountTooltip = $localize`:@@quickAddConfig.autoCount.tooltip:Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.`;
+  protected readonly inSpeedDialTooltip = $localize`:@@quickAddConfig.inSpeedDial.tooltip:Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.`;
   protected readonly saving = signal(false);
 
   protected readonly exerciseOptions: ReadonlyArray<ExerciseOption> =

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -4641,6 +4641,42 @@
         <target>Στο Speed Dial</target>
       </segment>
     </unit>
+    <unit id="quickAddConfig.autoCount.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
+        <target>Χρησιμοποιεί την κάμερα για να μετρά αυτόματα τις επαναλήψεις. Διαθέσιμο μόνο για τις υποστηριζόμενες ασκήσεις.</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.inSpeedDial.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
+        <target>Εμφανίζει αυτήν τη γρήγορη ενέργεια στο επιπλέον κουμπί (SpeedDial) για γρήγορη καταχώρηση.</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseRepAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
+        <target>Προσθήκη <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.pushupRepsLabel">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
+        <target>+<ph id="0" equiv="REPS" disp="reps"/> Επ.</target>
+      </segment>
+    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -3063,6 +3063,42 @@ Deine Position: # ·  Reps        </source>
         <target>In SpeedDial</target>
       </segment>
     </unit>
+    <unit id="quickAddConfig.autoCount.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
+        <target>Uses the camera to count reps automatically. Available only for supported exercises.</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.inSpeedDial.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
+        <target>Shows this quick action in the floating plus button (SpeedDial) for fast logging.</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseRepAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
+        <target>Add <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.pushupRepsLabel">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
+        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
+      </segment>
+    </unit>
     <unit id="quickAddConfig.hintV2">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -4641,6 +4641,42 @@
         <target>En el Marcado Rápido</target>
       </segment>
     </unit>
+    <unit id="quickAddConfig.autoCount.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
+        <target>Usa la cámara para contar repeticiones automáticamente. Disponible solo para ejercicios compatibles.</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.inSpeedDial.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
+        <target>Muestra esta acción rápida en el botón flotante más (SpeedDial) para un registro rápido.</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseRepAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
+        <target>Añadir <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.pushupRepsLabel">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
+        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
+      </segment>
+    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -4641,6 +4641,42 @@
         <target>Dans le SpeedDial</target>
       </segment>
     </unit>
+    <unit id="quickAddConfig.autoCount.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
+        <target>Utilise la caméra pour compter automatiquement les répétitions. Disponible uniquement pour les exercices pris en charge.</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.inSpeedDial.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
+        <target>Affiche cette action rapide dans le bouton flottant plus (SpeedDial) pour une saisie rapide.</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseRepAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
+        <target>Ajouter <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.pushupRepsLabel">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
+        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
+      </segment>
+    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -4641,6 +4641,42 @@
         <target>In Composizione veloce</target>
       </segment>
     </unit>
+    <unit id="quickAddConfig.autoCount.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
+        <target>Usa la fotocamera per contare automaticamente le ripetizioni. Disponibile solo per gli esercizi supportati.</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.inSpeedDial.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
+        <target>Mostra questa azione rapida nel pulsante più fluttuante (SpeedDial) per una registrazione veloce.</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseRepAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
+        <target>Aggiungi <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.pushupRepsLabel">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
+        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
+      </segment>
+    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -4641,6 +4641,42 @@
         <target>in SpeedDial</target>
       </segment>
     </unit>
+    <unit id="quickAddConfig.autoCount.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
+        <target>Camera utitur ad repetitiones automatice numerandas. Solum pro exercitiis sustentatis disponibile.</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.inSpeedDial.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
+        <target>Hanc actionem celerem in pulsabulo plus volante (SpeedDial) ad celerem registrationem ostendit.</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseRepAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
+        <target><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> addere</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.pushupRepsLabel">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
+        <target>+<ph id="0" equiv="REPS" disp="reps"/> Rep.</target>
+      </segment>
+    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -4641,6 +4641,42 @@
         <target>In Snelkiezen</target>
       </segment>
     </unit>
+    <unit id="quickAddConfig.autoCount.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
+        <target>Gebruikt de camera om herhalingen automatisch te tellen. Alleen beschikbaar voor ondersteunde oefeningen.</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.inSpeedDial.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
+        <target>Toont deze snelactie in de zwevende plusknop (SpeedDial) voor snelle invoer.</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseRepAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
+        <target><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> toevoegen</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.pushupRepsLabel">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
+        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
+      </segment>
+    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -2538,6 +2538,42 @@ Deine Position: # ·  Reps        </source>
         <target>I hurtigmeny</target>
       </segment>
     </unit>
+    <unit id="quickAddConfig.autoCount.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
+        <target>Bruker kameraet til å telle repetisjoner automatisk. Bare tilgjengelig for støttede øvelser.</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.inSpeedDial.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
+        <target>Viser denne hurtighandlingen i den flytende pluss-knappen (SpeedDial) for rask registrering.</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseRepAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
+        <target>Legg til <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.pushupRepsLabel">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
+        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
+      </segment>
+    </unit>
     <unit id="quickAddConfig.clearAria">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -6219,6 +6219,38 @@
         <source>Im SpeedDial</source>
       </segment>
     </unit>
+    <unit id="quickAddConfig.autoCount.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment>
+        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.inSpeedDial.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment>
+        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseRepAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.pushupRepsLabel">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts</note>
+      </notes>
+      <segment>
+        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
+      </segment>
+    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:157,158</note>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -5225,6 +5225,42 @@
         <source>Im SpeedDial</source>
       <target>在快速操作中</target></segment>
     </unit>
+    <unit id="quickAddConfig.autoCount.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
+        <target>使用相机自动计数重复次数。仅适用于支持的练习。</target>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.inSpeedDial.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
+        <target>在浮动加号按钮（SpeedDial）中显示此快捷操作以便快速记录。</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseRepAria">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
+      </notes>
+      <segment state="translated">
+        <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
+        <target>添加 <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.pushupRepsLabel">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts</note>
+      </notes>
+      <segment state="translated">
+        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
+        <target>+<ph id="0" equiv="REPS" disp="reps"/> 次</target>
+      </segment>
+    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>


### PR DESCRIPTION
The SpeedDial FAB previously rendered every configured quick-add as a
generic "+N Reps" button with rotating bolt icons, and the click
dispatched a pushup write regardless of the row's exerciseId — so a
configured "10 Sit-ups" button surfaced as "+10 Reps" and logged a
pushup. The FAB now takes a pre-resolved `QuickAddSuggestion` (icon,
localised label, exerciseId) from `AppDataFacade` and the orchestrator
dispatches non-pushup rows to `ExerciseFirestoreService.createEntry`,
mirroring the dashboard's `addQuickEntryFromConfig`.

Also add matTooltip explanations to the "Auto-Messung" and "Im
SpeedDial" checkboxes in the config dialog, with translations across all
10 supported locales.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick-add floating action button now supports multiple exercise types beyond pushups, with proper labels and accessibility features.
  * Added helpful tooltips to quick-add configuration options.

* **Documentation**
  * Enhanced localization support across all languages with new strings for quick-add configuration UI and accessibility labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->