### PR TITLE
feat(leaderboard): Hitliste auf alle Katalog-Übungen erweitern

### DIFF
--- a/data-store/firestore.indexes.json
+++ b/data-store/firestore.indexes.json
@@ -15,6 +15,14 @@
         { "fieldPath": "userId", "order": "ASCENDING" },
         { "fieldPath": "timestamp", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "exerciseEntries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "exerciseId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/libs/data-access-state/src/lib/leaderboard/leaderboard.store.spec.ts
+++ b/libs/data-access-state/src/lib/leaderboard/leaderboard.store.spec.ts
@@ -15,10 +15,14 @@ jest.mock('@angular/fire/firestore', () => ({
 }));
 jest.mock('@angular/fire/auth', () => ({ Auth: jest.fn() }));
 
-import { PLATFORM_ID } from '@angular/core';
+import { PLATFORM_ID, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
-import { LeaderboardData, LeaderboardService } from '@pu-stats/data-access';
+import {
+  LEADERBOARD_PUSHUP_ID,
+  LeaderboardData,
+  LeaderboardService,
+} from '@pu-stats/data-access';
 import { LeaderboardStore } from './leaderboard.store';
 
 const emptyLeaderboard: LeaderboardData = {
@@ -28,7 +32,7 @@ const emptyLeaderboard: LeaderboardData = {
 };
 
 function makeApiMock(): {
-  load: jest.Mock<Promise<LeaderboardData>, []>;
+  load: jest.Mock<Promise<LeaderboardData>, [string?]>;
   observeSnapshot: jest.Mock<Subject<unknown>, []>;
   snapshot$: Subject<unknown>;
 } {
@@ -64,12 +68,18 @@ describe('LeaderboardStore — live snapshot reload', () => {
       await Promise.resolve();
       await Promise.resolve();
 
-      // Then — the API was hit at least once per emission. With the in-flight
-      // queueing in `load()` the second emission may collapse with the first
-      // but is never dropped: the final fetch always reflects the latest doc.
+      // Then — the API was hit at least once per emission, always
+      // targeted at the pushup leaderboard (the only one the Cloud
+      // Function ranker writes a snapshot for). With the in-flight
+      // queueing in `load()` the second emission may collapse with the
+      // first but is never dropped: the final fetch always reflects
+      // the latest doc.
       expect(api.load).toHaveBeenCalled();
+      expect(api.load).toHaveBeenCalledWith(LEADERBOARD_PUSHUP_ID);
       expect(store.loading()).toBe(false);
-      expect(store.data()).toEqual(emptyLeaderboard);
+      expect(store.data()).toEqual({
+        [LEADERBOARD_PUSHUP_ID]: emptyLeaderboard,
+      });
     });
 
     it('Then it unsubscribes from observeSnapshot when the injector is destroyed', () => {
@@ -143,7 +153,7 @@ describe('LeaderboardStore — live snapshot reload', () => {
 
       // Then — both loads ran and the store reflects the LATER snapshot.
       expect(api.load).toHaveBeenCalledTimes(2);
-      expect(store.data()).toEqual(dataB);
+      expect(store.data()).toEqual({ [LEADERBOARD_PUSHUP_ID]: dataB });
       expect(store.loading()).toBe(false);
     });
   });
@@ -165,5 +175,99 @@ describe('LeaderboardStore — live snapshot reload', () => {
       // Then
       expect(api.observeSnapshot).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('LeaderboardStore — per-exercise caching', () => {
+  function setup(api: ReturnType<typeof makeApiMock>): {
+    store: ReturnType<typeof TestBed.inject<typeof LeaderboardStore>>;
+  } {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: LeaderboardService, useValue: api },
+      ],
+    });
+    const store = TestBed.inject(LeaderboardStore);
+    return { store };
+  }
+
+  it('Loads a different exercise into its own cache slot without evicting the pushup bucket', async () => {
+    // Given — `_api.load(id)` returns a distinct dataset per exerciseId.
+    const api = makeApiMock();
+    const pushupData: LeaderboardData = {
+      ...emptyLeaderboard,
+      daily: { top: [{ alias: 'P', reps: 10, rank: 1 }], current: null },
+    };
+    const squatData: LeaderboardData = {
+      ...emptyLeaderboard,
+      daily: { top: [{ alias: 'S', reps: 20, rank: 1 }], current: null },
+    };
+    api.load.mockImplementation((id?: string) =>
+      Promise.resolve(id === 'legs.squats' ? squatData : pushupData)
+    );
+
+    const { store } = setup(api);
+
+    // When — load pushup, then load squats.
+    await store.load(LEADERBOARD_PUSHUP_ID);
+    await store.load('legs.squats');
+
+    // Then — both buckets coexist in the cache, keyed by exerciseId.
+    expect(store.data()).toEqual({
+      [LEADERBOARD_PUSHUP_ID]: pushupData,
+      'legs.squats': squatData,
+    });
+
+    // And — entriesForPeriod resolves from the right bucket per selection.
+    const exerciseSig = signal<string>(LEADERBOARD_PUSHUP_ID);
+    const periodSig = signal<'daily' | 'last7' | 'last30'>('daily');
+    const entries = store.entriesForPeriod(exerciseSig, periodSig);
+    expect(entries()).toEqual(pushupData.daily.top);
+
+    exerciseSig.set('legs.squats');
+    expect(entries()).toEqual(squatData.daily.top);
+  });
+
+  it('Skips the API when the requested exercise is already cached (no force flag)', async () => {
+    // Given
+    const api = makeApiMock();
+    const { store } = setup(api);
+
+    // When — same exerciseId loaded twice in a row.
+    await store.load('plank.standard');
+    await store.load('plank.standard');
+
+    // Then — only one fetch. Caching is the whole point of per-exercise
+    // entries; refetching on every tab switch would be wasteful.
+    expect(api.load).toHaveBeenCalledTimes(1);
+    expect(api.load).toHaveBeenCalledWith('plank.standard');
+  });
+
+  it('Respects `force: true` even when the exercise is already cached', async () => {
+    // Given
+    const api = makeApiMock();
+    const { store } = setup(api);
+
+    // When
+    await store.load('pull.pullups');
+    await store.load('pull.pullups', { force: true });
+
+    // Then — force reloads bypass the cache check, mirroring the
+    // snapshot-driven invalidation for pushup.
+    expect(api.load).toHaveBeenCalledTimes(2);
+  });
+
+  it('Defaults to the pushup sentinel when called without an exerciseId', async () => {
+    // Given
+    const api = makeApiMock();
+    const { store } = setup(api);
+
+    // When
+    await store.load();
+
+    // Then
+    expect(api.load).toHaveBeenCalledWith(LEADERBOARD_PUSHUP_ID);
+    expect(store.data()[LEADERBOARD_PUSHUP_ID]).toEqual(emptyLeaderboard);
   });
 });

--- a/libs/data-access-state/src/lib/leaderboard/leaderboard.store.ts
+++ b/libs/data-access-state/src/lib/leaderboard/leaderboard.store.ts
@@ -10,6 +10,7 @@ import {
   withState,
 } from '@ngrx/signals';
 import {
+  LEADERBOARD_PUSHUP_ID,
   LeaderboardData,
   LeaderboardEntry,
   LeaderboardPeriod,
@@ -17,18 +18,31 @@ import {
 } from '@pu-stats/data-access';
 
 type LeaderboardState = {
-  data: LeaderboardData | null;
+  /**
+   * Per-exercise cache of ranked buckets. Keys are exerciseIds
+   * (`LEADERBOARD_PUSHUP_ID` for the legacy pushup leaderboard, every
+   * other catalog id for `exerciseEntries`-backed rankings).
+   * Switching between exercises is cheap once their entry is populated;
+   * the live-snapshot reload only invalidates the pushup entry because
+   * that's the only one the Cloud Function ranker writes.
+   */
+  data: Record<string, LeaderboardData>;
   loading: boolean;
   error: string | null;
 };
 
 const initialState: LeaderboardState = {
-  data: null,
+  data: {},
   loading: false,
   error: null,
 };
 
 const EMPTY_ENTRIES: LeaderboardEntry[] = [];
+const EMPTY_DATA: LeaderboardData = {
+  daily: { top: [], current: null },
+  last7: { top: [], current: null },
+  last30: { top: [], current: null },
+};
 
 export const LeaderboardStore = signalStore(
   { providedIn: 'root' },
@@ -39,81 +53,92 @@ export const LeaderboardStore = signalStore(
     _destroyRef: inject(DestroyRef),
   })),
   withComputed((store) => ({
-    loaded: computed(() => store.data() !== null),
+    loaded: computed(() => Object.keys(store.data()).length > 0),
   })),
   withMethods(({ _api, ...store }) => {
-    // Tracks whether a `load()` is currently awaiting `_api.load()`. The
-    // `loading` signal flips synchronously inside the same tick, but using a
-    // dedicated closure flag makes the "did another caller try to force a
-    // reload while we were busy?" check explicit and decoupled from the
-    // public state.
-    let inFlight = false;
-    let reloadPending = false;
+    // Tracks loads currently awaiting `_api.load(exerciseId)`, keyed by
+    // exerciseId. The `loading` signal reflects "any load in flight" —
+    // simpler than a per-exerciseId loading map and matches the
+    // visible UI state (one global spinner per page).
+    const inFlight = new Set<string>();
+    // Exercises that should be re-fetched as soon as their current load
+    // finishes — e.g. a snapshot live-reload fired while a slow load
+    // was already running. Dropping these would silently lose updates.
+    const reloadPending = new Set<string>();
 
-    async function performLoad(): Promise<void> {
-      inFlight = true;
+    async function performLoad(exerciseId: string): Promise<void> {
+      inFlight.add(exerciseId);
       patchState(store, { loading: true, error: null });
       try {
         if (!_api) {
           patchState(store, {
-            data: {
-              daily: { top: [], current: null },
-              last7: { top: [], current: null },
-              last30: { top: [], current: null },
-            },
-            loading: false,
+            data: { ...store.data(), [exerciseId]: EMPTY_DATA },
+            loading: inFlight.size > 1,
           });
           return;
         }
-        const data = await _api.load();
-        patchState(store, { data, loading: false });
+        const data = await _api.load(exerciseId);
+        patchState(store, {
+          data: { ...store.data(), [exerciseId]: data },
+          loading: inFlight.size > 1,
+        });
       } catch (err) {
         patchState(store, {
           error: err instanceof Error ? err.message : String(err),
-          loading: false,
+          loading: inFlight.size > 1,
         });
       } finally {
-        inFlight = false;
+        inFlight.delete(exerciseId);
       }
     }
 
     return {
-      async load(options?: { force?: boolean }): Promise<void> {
-        // A previous load is mid-flight. If the caller insists on freshness
-        // (snapshot live-reload, manual user refresh), remember that we owe
-        // them another run after the current one finishes — otherwise live
-        // updates that arrive during a slow load would be silently dropped.
-        if (inFlight) {
-          if (options?.force) reloadPending = true;
+      /**
+       * Ensures the per-exercise leaderboard is loaded. No-op when the
+       * exerciseId already has cached data unless `force: true`. The
+       * live-snapshot subscription uses `force` to invalidate stale
+       * caches; UI navigation between exercises typically doesn't.
+       */
+      async load(
+        exerciseId: string = LEADERBOARD_PUSHUP_ID,
+        options?: { force?: boolean }
+      ): Promise<void> {
+        // A previous load for this exerciseId is mid-flight. If the
+        // caller insists on freshness, queue a follow-up — otherwise
+        // collapsing into the in-flight call is fine.
+        if (inFlight.has(exerciseId)) {
+          if (options?.force) reloadPending.add(exerciseId);
           return;
         }
-        if (store.loaded() && !options?.force) return;
+        if (store.data()[exerciseId] && !options?.force) return;
 
-        await performLoad();
+        await performLoad(exerciseId);
 
-        if (reloadPending) {
-          reloadPending = false;
-          await performLoad();
+        if (reloadPending.has(exerciseId)) {
+          reloadPending.delete(exerciseId);
+          await performLoad(exerciseId);
         }
       },
 
       entriesForPeriod(
+        exerciseId: () => string,
         period: () => LeaderboardPeriod
       ): () => LeaderboardEntry[] {
         return computed(() => {
-          const data = store.data();
-          if (!data) return EMPTY_ENTRIES;
-          return data[period()].top;
+          const bucket = store.data()[exerciseId()];
+          if (!bucket) return EMPTY_ENTRIES;
+          return bucket[period()].top;
         });
       },
 
       currentUserForPeriod(
+        exerciseId: () => string,
         period: () => LeaderboardPeriod
       ): () => LeaderboardEntry | null {
         return computed(() => {
-          const data = store.data();
-          if (!data) return null;
-          return data[period()].current;
+          const bucket = store.data()[exerciseId()];
+          if (!bucket) return null;
+          return bucket[period()].current;
         });
       },
     };
@@ -125,6 +150,10 @@ export const LeaderboardStore = signalStore(
       // (typically minutes), so re-running `load({ force: true })` is cheap
       // and avoids a stale leaderboard between manual refreshes.
       //
+      // The Cloud Function only writes the pushup snapshot — per-exercise
+      // leaderboards run client-side and don't need an invalidation
+      // signal, so only the pushup entry is force-refreshed here.
+      //
       // We subscribe directly (not via `effect`) so the listener attaches
       // synchronously at construction — tests can assert behaviour without
       // having to flush effects, and the cleanup is hooked into `DestroyRef`
@@ -132,7 +161,7 @@ export const LeaderboardStore = signalStore(
       if (!store._isBrowser || !store._api) return;
       const sub = store._api.observeSnapshot().subscribe({
         next: () => {
-          void store.load({ force: true });
+          void store.load(LEADERBOARD_PUSHUP_ID, { force: true });
         },
         error: () => {
           /* swallow — leaderboard is non-critical, fall back to one-shot load */

--- a/libs/data-access/src/lib/api/leaderboard.service.spec.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.spec.ts
@@ -2,14 +2,21 @@
 // into the Jest environment. See docs/gotchas/testing.md → "Jest ↔ Firebase".
 jest.mock('@angular/fire/firestore', () => ({
   Firestore: jest.fn(),
-  collection: jest.fn(() => ({})),
+  collection: jest.fn((_db: unknown, name: string) => ({ __collection: name })),
   doc: jest.fn(() => ({})),
   docData: jest.fn(),
   getDoc: jest.fn(),
   getDocs: jest.fn(),
   orderBy: jest.fn(),
-  query: jest.fn(() => ({})),
-  where: jest.fn(),
+  query: jest.fn(
+    (ref: { __collection?: string } | unknown, ...constraints: unknown[]) => ({
+      __ref: ref,
+      __constraints: constraints,
+    })
+  ),
+  where: jest.fn((field: string, op: string, value: unknown) => ({
+    __where: { field, op, value },
+  })),
 }));
 jest.mock('@angular/fire/auth', () => ({ Auth: jest.fn() }));
 
@@ -17,11 +24,15 @@ import { TestBed } from '@angular/core/testing';
 import { Auth } from '@angular/fire/auth';
 import * as firestoreFns from '@angular/fire/firestore';
 import { Firestore } from '@angular/fire/firestore';
-import { LeaderboardService } from './leaderboard.service';
+import {
+  LEADERBOARD_PUSHUP_ID,
+  LeaderboardService,
+} from './leaderboard.service';
 
 const getDoc = firestoreFns.getDoc as unknown as jest.Mock;
 const getDocs = firestoreFns.getDocs as unknown as jest.Mock;
 const where = firestoreFns.where as unknown as jest.Mock;
+const collection = firestoreFns.collection as unknown as jest.Mock;
 
 function makeSnapshot(periods: Record<string, unknown> | null): {
   exists: () => boolean;
@@ -164,6 +175,190 @@ describe('LeaderboardService — load() merging', () => {
       );
       expect(lowerBoundCall).toBeDefined();
       expect(lowerBoundCall?.[2]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe('Given an exerciseId other than the legacy pushup sentinel', () => {
+    it('Reads from the exerciseEntries collection filtered by exerciseId, and skips the snapshot', async () => {
+      // When
+      await service.load('legs.squats');
+
+      // Then — `getDoc` (snapshot reader) must NOT fire for non-pushup
+      // exerciseIds; the snapshot at `leaderboards/current` doesn't carry
+      // per-exercise rankings.
+      expect(getDoc).not.toHaveBeenCalled();
+
+      // And — the collection that was queried is `exerciseEntries`.
+      const collArg = collection.mock.results
+        .map((r) => r.value as { __collection?: string })
+        .find((v) => v.__collection === 'exerciseEntries');
+      expect(collArg).toBeDefined();
+
+      // And — there's a `where('exerciseId', '==', 'legs.squats')` clause.
+      const exerciseFilter = where.mock.calls.find(
+        ([field, op, value]) =>
+          field === 'exerciseId' && op === '==' && value === 'legs.squats'
+      );
+      expect(exerciseFilter).toBeDefined();
+    });
+
+    it('Aggregates by the measurement-specific value field — reps for `reps` exercises', async () => {
+      // Given — three docs from the exerciseEntries collection for two users.
+      const isoToday = new Date().toISOString();
+      getDocs.mockResolvedValueOnce({
+        docs: [
+          {
+            data: () => ({
+              userId: 'alice',
+              exerciseId: 'legs.squats',
+              reps: 20,
+              timestamp: isoToday,
+            }),
+          },
+          {
+            data: () => ({
+              userId: 'alice',
+              exerciseId: 'legs.squats',
+              reps: 30,
+              timestamp: isoToday,
+            }),
+          },
+          {
+            data: () => ({
+              userId: 'bob',
+              exerciseId: 'legs.squats',
+              reps: 40,
+              timestamp: isoToday,
+            }),
+          },
+        ],
+      });
+
+      // When
+      const result = await service.load('legs.squats');
+
+      // Then — Alice's two entries are summed (50), Bob's one (40); Alice is
+      // ranked first. Aliases come from the privacy-preserving `toAlias`
+      // helper (uppercase first/last letter) — no snapshot to upgrade them.
+      expect(result.daily.top).toEqual([
+        expect.objectContaining({ alias: 'A...E', reps: 50, rank: 1 }),
+        expect.objectContaining({ alias: 'B...B', reps: 40, rank: 2 }),
+      ]);
+    });
+
+    it('Reads `durationSec` for time-measured exercises like plank', async () => {
+      // Given
+      const isoToday = new Date().toISOString();
+      getDocs.mockResolvedValueOnce({
+        docs: [
+          {
+            data: () => ({
+              userId: 'alice',
+              exerciseId: 'plank.standard',
+              durationSec: 90,
+              timestamp: isoToday,
+            }),
+          },
+          {
+            data: () => ({
+              userId: 'bob',
+              exerciseId: 'plank.standard',
+              durationSec: 120,
+              timestamp: isoToday,
+            }),
+          },
+        ],
+      });
+
+      // When
+      const result = await service.load('plank.standard');
+
+      // Then — Bob (120 s) outranks Alice (90 s). The `reps` field on the
+      // entry semantically carries seconds for time-measured exercises —
+      // wire-format compat with the pushup snapshot doc shape.
+      expect(result.daily.top).toEqual([
+        expect.objectContaining({ alias: 'B...B', reps: 120, rank: 1 }),
+        expect.objectContaining({ alias: 'A...E', reps: 90, rank: 2 }),
+      ]);
+    });
+
+    it('Reads `distanceM` for distance-time exercises like running', async () => {
+      // Given
+      const isoToday = new Date().toISOString();
+      getDocs.mockResolvedValueOnce({
+        docs: [
+          {
+            data: () => ({
+              userId: 'alice',
+              exerciseId: 'cardio.running',
+              distanceM: 5000,
+              durationSec: 1800,
+              timestamp: isoToday,
+            }),
+          },
+          {
+            data: () => ({
+              userId: 'alice',
+              exerciseId: 'cardio.running',
+              distanceM: 3000,
+              durationSec: 1100,
+              timestamp: isoToday,
+            }),
+          },
+        ],
+      });
+
+      // When
+      const result = await service.load('cardio.running');
+
+      // Then — Alice's two runs (5000 + 3000) sum to 8000 m. Distance is
+      // the primary value for `distance-time`; the duration companion is
+      // ignored for the leaderboard ranking (it'd be a different metric).
+      expect(result.daily.top).toEqual([
+        expect.objectContaining({ alias: 'A...E', reps: 8000, rank: 1 }),
+      ]);
+    });
+
+    it('Returns empty buckets when the exerciseId is not in the catalog', async () => {
+      // When
+      const result = await service.load('does.not.exist');
+
+      // Then — no Firestore query, just three empty buckets so the store
+      // can settle into a non-loading state.
+      expect(getDocs).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        daily: { top: [], current: null },
+        last7: { top: [], current: null },
+        last30: { top: [], current: null },
+      });
+    });
+  });
+
+  describe('Given the explicit pushup sentinel', () => {
+    it('Behaves identically to the default (no-arg) call', async () => {
+      // Given — same snapshot for both paths.
+      getDoc
+        .mockResolvedValueOnce(
+          makeSnapshot({
+            daily: [{ alias: 'S...R', reps: 7 }],
+            last7: [],
+            last30: [],
+          })
+        )
+        .mockResolvedValueOnce(
+          makeSnapshot({
+            daily: [{ alias: 'S...R', reps: 7 }],
+            last7: [],
+            last30: [],
+          })
+        );
+
+      // When
+      const defaulted = await service.load();
+      const explicit = await service.load(LEADERBOARD_PUSHUP_ID);
+
+      // Then — both routes return the same daily top.
+      expect(defaulted.daily.top).toEqual(explicit.daily.top);
     });
   });
 });

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -61,12 +61,21 @@ const TOP_N = 10;
 const TZ = 'Europe/Berlin';
 const PUSHUPS_COLLECTION = 'pushups';
 const EXERCISE_ENTRIES_COLLECTION = 'exerciseEntries';
-const EMPTY_BUCKET: LeaderboardBucket = { top: [], current: null };
-const EMPTY_DATA: LeaderboardData = {
-  daily: EMPTY_BUCKET,
-  last7: EMPTY_BUCKET,
-  last30: EMPTY_BUCKET,
-};
+
+/**
+ * Factory for an empty leaderboard payload. A factory (not a shared
+ * frozen constant) keeps each call independent: a caller that ever
+ * mutates `.top` (e.g. accidentally splicing in a new entry) only
+ * touches its own snapshot instead of the singleton that every other
+ * bucket would also point at.
+ */
+function emptyLeaderboardData(): LeaderboardData {
+  return {
+    daily: { top: [], current: null },
+    last7: { top: [], current: null },
+    last30: { top: [], current: null },
+  };
+}
 
 type AggregationRow = {
   userId: string;
@@ -146,8 +155,8 @@ export class LeaderboardService {
     // Unknown exercise → empty leaderboard. The store treats this as a
     // successful load so the UI shows the empty list rather than
     // wedging on a perpetual loading state.
-    if (!def) return EMPTY_DATA;
-    if (!supportsLeaderboard(def.measurement)) return EMPTY_DATA;
+    if (!def) return emptyLeaderboardData();
+    if (!supportsLeaderboard(def.measurement)) return emptyLeaderboardData();
 
     const currentUserId = this.auth?.currentUser?.uid ?? null;
     const start = this.last30StartDateKey();

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -11,12 +11,24 @@ import {
   query,
   where,
 } from '@angular/fire/firestore';
+import {
+  findExerciseDefinition,
+  measurementValueField,
+  type MeasurementType,
+} from '@pu-stats/models';
 import { EMPTY, Observable } from 'rxjs';
 
 export type LeaderboardPeriod = 'daily' | 'last7' | 'last30';
 
 export type LeaderboardEntry = {
   alias: string;
+  /**
+   * Primary measurement aggregate over the period. Field is named `reps`
+   * because the precomputed Firestore snapshot writes it under that
+   * key — semantically it carries the aggregated value of whatever
+   * measurement field the selected exercise uses (`reps`, `durationSec`,
+   * `distanceM`).
+   */
   reps: number;
   rank: number;
   isCurrent?: boolean;
@@ -37,12 +49,28 @@ export type LeaderboardBucket = {
 
 export type LeaderboardData = Record<LeaderboardPeriod, LeaderboardBucket>;
 
+/**
+ * Sentinel exerciseId for the legacy `pushups` collection. The Cloud
+ * Function ranker writes the precomputed snapshot at
+ * `leaderboards/current` only for this leaderboard; every other
+ * exerciseId runs the client-side aggregation against `exerciseEntries`.
+ */
+export const LEADERBOARD_PUSHUP_ID = 'pushup';
+
 const TOP_N = 10;
 const TZ = 'Europe/Berlin';
+const PUSHUPS_COLLECTION = 'pushups';
+const EXERCISE_ENTRIES_COLLECTION = 'exerciseEntries';
+const EMPTY_BUCKET: LeaderboardBucket = { top: [], current: null };
+const EMPTY_DATA: LeaderboardData = {
+  daily: EMPTY_BUCKET,
+  last7: EMPTY_BUCKET,
+  last30: EMPTY_BUCKET,
+};
 
-type PushupRow = {
+type AggregationRow = {
   userId: string;
-  reps: number;
+  value: number;
   timestamp: string;
 };
 
@@ -58,20 +86,34 @@ export class LeaderboardService {
    *
    * Used by `LeaderboardStore` to reload aggregates whenever the Cloud
    * Function rewrites the snapshot, giving the leaderboard live updates
-   * without a manual refresh. The store only cares about *change*
-   * notifications, not payload shape — so we forward whatever `docData`
-   * emits (the doc data, or `undefined` when the doc does not exist), and
-   * fall back to `EMPTY` (no emissions) when Firestore is unavailable.
+   * without a manual refresh. The snapshot only covers the legacy
+   * pushup leaderboard — per-exercise rankings are computed client-side
+   * from `exerciseEntries` and don't need a snapshot subscription.
    */
   observeSnapshot(): Observable<unknown> {
     if (!this.firestore) return EMPTY;
     return docData(doc(this.firestore, 'leaderboards', 'current'));
   }
 
-  async load(): Promise<LeaderboardData> {
+  /**
+   * Loads ranked buckets (daily / last7 / last30) for the requested
+   * exercise. The default — and the `LEADERBOARD_PUSHUP_ID` sentinel —
+   * routes through the legacy `pushups` collection and merges in the
+   * precomputed snapshot at `leaderboards/current`. Every other
+   * exerciseId queries `exerciseEntries` and aggregates client-side;
+   * the snapshot doesn't carry per-exercise rankings yet.
+   */
+  async load(
+    exerciseId: string = LEADERBOARD_PUSHUP_ID
+  ): Promise<LeaderboardData> {
+    if (exerciseId === LEADERBOARD_PUSHUP_ID) return this.loadPushup();
+    return this.loadExercise(exerciseId);
+  }
+
+  private async loadPushup(): Promise<LeaderboardData> {
     const currentUserId = this.auth?.currentUser?.uid ?? null;
     const start = this.last30StartDateKey();
-    const rows = await this.fetchRows(start);
+    const rows = await this.fetchPushupRows(start);
 
     const fallback: LeaderboardData = {
       daily: this.aggregate(rows, 'daily', currentUserId),
@@ -88,6 +130,37 @@ export class LeaderboardService {
       daily: this.mergeBucket(cached.daily, fallback.daily),
       last7: this.mergeBucket(cached.last7, fallback.last7),
       last30: this.mergeBucket(cached.last30, fallback.last30),
+    };
+  }
+
+  /**
+   * Per-exercise leaderboard. The Cloud Function ranker doesn't write
+   * per-exercise snapshots yet, so rows here always come from the
+   * client-side aggregation against `exerciseEntries` — and aliases stay
+   * obfuscated via {@link toAlias} regardless of the user's
+   * publicProfile opt-in. Once the ranker grows per-exercise snapshots
+   * the merge path can mirror {@link loadPushup}.
+   */
+  private async loadExercise(exerciseId: string): Promise<LeaderboardData> {
+    const def = findExerciseDefinition(exerciseId);
+    // Unknown exercise → empty leaderboard. The store treats this as a
+    // successful load so the UI shows the empty list rather than
+    // wedging on a perpetual loading state.
+    if (!def) return EMPTY_DATA;
+    if (!supportsLeaderboard(def.measurement)) return EMPTY_DATA;
+
+    const currentUserId = this.auth?.currentUser?.uid ?? null;
+    const start = this.last30StartDateKey();
+    const rows = await this.fetchExerciseRows(
+      exerciseId,
+      def.measurement,
+      start
+    );
+
+    return {
+      daily: this.aggregate(rows, 'daily', currentUserId),
+      last7: this.aggregate(rows, 'last7', currentUserId),
+      last30: this.aggregate(rows, 'last30', currentUserId),
     };
   }
 
@@ -160,11 +233,11 @@ export class LeaderboardService {
     return result;
   }
 
-  private async fetchRows(startKey: string): Promise<PushupRow[]> {
+  private async fetchPushupRows(startKey: string): Promise<AggregationRow[]> {
     if (!this.firestore) return [];
 
     try {
-      const ref = collection(this.firestore, 'pushups');
+      const ref = collection(this.firestore, PUSHUPS_COLLECTION);
       const q = query(
         ref,
         where('timestamp', '>=', startKey),
@@ -173,15 +246,73 @@ export class LeaderboardService {
       const snap = await getDocs(q);
 
       return snap.docs
-        .map((d) => d.data() as Partial<PushupRow>)
+        .map(
+          (d) =>
+            d.data() as Partial<{
+              userId: string;
+              reps: number;
+              timestamp: string;
+            }>
+        )
         .filter(
-          (d): d is PushupRow =>
+          (d): d is { userId: string; reps: number; timestamp: string } =>
             !!d.userId && !!d.timestamp && Number.isFinite(d.reps)
         )
         .map((d) => ({
           userId: d.userId,
           timestamp: d.timestamp,
-          reps: Number(d.reps),
+          value: Number(d.reps),
+        }));
+    } catch {
+      return [];
+    }
+  }
+
+  private async fetchExerciseRows(
+    exerciseId: string,
+    measurement: MeasurementType,
+    startKey: string
+  ): Promise<AggregationRow[]> {
+    if (!this.firestore) return [];
+
+    // Measurement type drives which field carries the primary value
+    // (`reps` for rep counts, `durationSec` for time, `distanceM` for
+    // distance + distance-time). The catalog `min`/`max` already bound
+    // that field, so summing it across rows is safe and unit-stable.
+    const valueField = measurementValueField(measurement);
+
+    try {
+      const ref = collection(this.firestore, EXERCISE_ENTRIES_COLLECTION);
+      const q = query(
+        ref,
+        where('exerciseId', '==', exerciseId),
+        where('timestamp', '>=', startKey),
+        orderBy('timestamp', 'desc')
+      );
+      const snap = await getDocs(q);
+
+      return snap.docs
+        .map((d) => d.data() as Record<string, unknown>)
+        .filter(
+          (
+            d
+          ): d is { userId: string; timestamp: string } & Record<
+            string,
+            number
+          > => {
+            const value = d[valueField];
+            return (
+              typeof d['userId'] === 'string' &&
+              typeof d['timestamp'] === 'string' &&
+              typeof value === 'number' &&
+              Number.isFinite(value)
+            );
+          }
+        )
+        .map((d) => ({
+          userId: d['userId'],
+          timestamp: d['timestamp'],
+          value: Number(d[valueField]),
         }));
     } catch {
       return [];
@@ -189,7 +320,7 @@ export class LeaderboardService {
   }
 
   private aggregate(
-    rows: PushupRow[],
+    rows: AggregationRow[],
     period: LeaderboardPeriod,
     currentUserId: string | null
   ): LeaderboardBucket {
@@ -207,14 +338,14 @@ export class LeaderboardService {
     for (const row of rows) {
       const key = this.berlinDateKey(new Date(row.timestamp));
       if (key < windowStart || key > today) continue;
-      totals.set(row.userId, (totals.get(row.userId) ?? 0) + row.reps);
+      totals.set(row.userId, (totals.get(row.userId) ?? 0) + row.value);
     }
 
     const ranked = [...totals.entries()]
-      .map(([userId, reps]) => ({
+      .map(([userId, value]) => ({
         userId,
         alias: this.toAlias(userId),
-        reps,
+        reps: value,
       }))
       .sort((a, b) => b.reps - a.reps)
       .map((entry, index) => ({
@@ -267,4 +398,15 @@ export class LeaderboardService {
     const anchor = Date.UTC(y, m - 1, d, 10, 0, 0);
     return this.berlinDateKey(new Date(anchor + deltaDays * 86_400_000));
   }
+}
+
+/**
+ * Returns `true` for measurement types we can aggregate into a meaningful
+ * per-period sum: rep counts, hold durations, and distances. `weight`
+ * is excluded because a sum of raw reps across mixed loads isn't a
+ * useful leaderboard metric — the right aggregation is `Σ(weightKg × reps)`,
+ * which requires a dedicated path the catalog doesn't yet ship.
+ */
+function supportsLeaderboard(measurement: MeasurementType): boolean {
+  return measurement !== 'weight';
 }

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -314,7 +314,19 @@ export class LeaderboardService {
           timestamp: d['timestamp'],
           value: Number(d[valueField]),
         }));
-    } catch {
+    } catch (err) {
+      // Surface the underlying Firestore error to the dev console.
+      // The composite index for (`exerciseId` ASC, `timestamp` DESC) on
+      // `exerciseEntries` MUST be deployed alongside this code (see
+      // `data-store/firestore.indexes.json`); without it the query
+      // fails with `failed-precondition` and the empty fallback would
+      // silently mask the misconfiguration. Keep the empty return so a
+      // transient network blip doesn't lock the UI on a loading state.
+
+      console.warn(
+        `[LeaderboardService] exerciseEntries query failed for ${exerciseId}:`,
+        err
+      );
       return [];
     }
   }

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.html
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.html
@@ -77,7 +77,12 @@
         </mat-menu>
       </div>
 
-      <div class="period-switch" role="group" aria-label="Leaderboard Zeitraum">
+      <div
+        class="period-switch"
+        role="group"
+        aria-label="Leaderboard Zeitraum"
+        i18n-aria-label="@@leaderboard.period.ariaLabel"
+      >
         <button
           mat-stroked-button
           type="button"

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.html
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.html
@@ -7,10 +7,14 @@
   </app-page-header>
   <mat-card>
     <mat-card-content>
+      <!-- role="group" instead of "tablist": children are toggle buttons
+           + a menu trigger, not real tabs with `role="tab"` + tabpanel
+           linkage. Tablist semantics confuse screen-reader navigation
+           when there's no tab/panel relationship behind it. -->
       <div
         class="exercise-switch"
-        role="tablist"
-        aria-label="Leaderboard Übung"
+        role="group"
+        aria-label="Bestenlisten-Übung auswählen"
         i18n-aria-label="@@leaderboard.exercise.ariaLabel"
       >
         @for (chip of popularExercises(); track chip.id) {
@@ -73,11 +77,7 @@
         </mat-menu>
       </div>
 
-      <div
-        class="period-switch"
-        role="tablist"
-        aria-label="Leaderboard Zeitraum"
-      >
+      <div class="period-switch" role="group" aria-label="Leaderboard Zeitraum">
         <button
           mat-stroked-button
           type="button"
@@ -127,12 +127,7 @@
             } @else {
               <span class="alias">{{ entry.alias }}</span>
             }
-            <strong>
-              {{ formatValue(entry.reps) }}
-              @if (unitLabel(); as label) {
-                <span class="unit">{{ label }}</span>
-              }
-            </strong>
+            <strong>{{ formatValue(entry.reps) }}</strong>
           </li>
         }
       </ol>
@@ -144,26 +139,23 @@
             [routerLink]="['/u', me.uid]"
             data-testid="leaderboard-own-rank-link"
           >
-            <span>
-              <ng-container i18n="@@leaderboard.ownPosition.prefix"
-                >Deine Position:</ng-container
-              >
-              #{{ me.rank }} · {{ formatValue(me.reps) }}
-              @if (unitLabel(); as label) {
-                <span>{{ label }}</span>
-              }
+            <!-- Single i18n message with two ICU-style placeholders so
+                 translators can re-order rank vs. value freely. The
+                 value placeholder already carries its own unit suffix
+                 (`"30 Reps"`, `"1:30"`, `"5.00 km"`) — see
+                 `formatValue` for the unit-resolution logic. -->
+            <span i18n="@@landing.leaderboard.ownPosition">
+              Deine Position: #{{ me.rank }} · {{ formatValue(me.reps) }}
             </span>
             <mat-icon aria-hidden="true">chevron_right</mat-icon>
           </a>
         } @else {
-          <p class="own-rank" data-testid="leaderboard-own-rank">
-            <ng-container i18n="@@leaderboard.ownPosition.prefix"
-              >Deine Position:</ng-container
-            >
-            #{{ me.rank }} · {{ formatValue(me.reps) }}
-            @if (unitLabel(); as label) {
-              <span>{{ label }}</span>
-            }
+          <p
+            class="own-rank"
+            data-testid="leaderboard-own-rank"
+            i18n="@@landing.leaderboard.ownPosition"
+          >
+            Deine Position: #{{ me.rank }} · {{ formatValue(me.reps) }}
           </p>
         }
       }

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.html
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.html
@@ -8,6 +8,72 @@
   <mat-card>
     <mat-card-content>
       <div
+        class="exercise-switch"
+        role="tablist"
+        aria-label="Leaderboard Übung"
+        i18n-aria-label="@@leaderboard.exercise.ariaLabel"
+      >
+        @for (chip of popularExercises(); track chip.id) {
+          <button
+            mat-stroked-button
+            type="button"
+            class="exercise-chip"
+            [class.active]="isActiveExercise(chip.id)"
+            [attr.aria-pressed]="isActiveExercise(chip.id)"
+            [attr.data-testid]="'leaderboard-exercise-chip-' + chip.id"
+            (click)="selectExercise(chip.id)"
+          >
+            <mat-icon aria-hidden="true">{{ chip.icon }}</mat-icon>
+            <span>{{ chip.label }}</span>
+          </button>
+        }
+        <button
+          mat-stroked-button
+          type="button"
+          class="exercise-chip exercise-more"
+          [class.active]="isOverflowSelection()"
+          [matMenuTriggerFor]="exerciseMenu"
+          data-testid="leaderboard-exercise-more"
+        >
+          <mat-icon aria-hidden="true">expand_more</mat-icon>
+          @if (isOverflowSelection()) {
+            <span>{{ selectedLabel() }}</span>
+          } @else {
+            <span i18n="@@leaderboard.exercise.more">Mehr</span>
+          }
+        </button>
+        <mat-menu #exerciseMenu="matMenu" class="exercise-menu">
+          @for (section of categorySections(); track section.category.id) {
+            <div
+              class="exercise-menu-header"
+              mat-menu-item
+              disabled
+              [attr.data-testid]="
+                'leaderboard-exercise-menu-header-' + section.category.id
+              "
+            >
+              <mat-icon aria-hidden="true">{{
+                section.category.icon
+              }}</mat-icon>
+              <span>{{ categoryDisplayName(section.category.id) }}</span>
+            </div>
+            @for (def of section.exercises; track def.id) {
+              <button
+                mat-menu-item
+                type="button"
+                class="exercise-menu-item"
+                [class.active]="isActiveExercise(def.id)"
+                [attr.data-testid]="'leaderboard-exercise-menu-item-' + def.id"
+                (click)="selectExercise(def.id)"
+              >
+                {{ def.label }}
+              </button>
+            }
+          }
+        </mat-menu>
+      </div>
+
+      <div
         class="period-switch"
         role="tablist"
         aria-label="Leaderboard Zeitraum"
@@ -41,7 +107,7 @@
         </button>
       </div>
 
-      <ol>
+      <ol data-testid="leaderboard-list">
         @for (entry of leaderboardSlots(); track entry.rank) {
           <li>
             <span class="rank">#{{ entry.rank }}</span>
@@ -61,10 +127,12 @@
             } @else {
               <span class="alias">{{ entry.alias }}</span>
             }
-            <strong
-              >{{ entry.reps }}
-              <span i18n="@@landing.leaderboard.reps">Reps</span></strong
-            >
+            <strong>
+              {{ formatValue(entry.reps) }}
+              @if (unitLabel(); as label) {
+                <span class="unit">{{ label }}</span>
+              }
+            </strong>
           </li>
         }
       </ol>
@@ -76,14 +144,26 @@
             [routerLink]="['/u', me.uid]"
             data-testid="leaderboard-own-rank-link"
           >
-            <span i18n="@@landing.leaderboard.ownPosition">
-              Deine Position: #{{ me.rank }} · {{ me.reps }} Reps
+            <span>
+              <ng-container i18n="@@leaderboard.ownPosition.prefix"
+                >Deine Position:</ng-container
+              >
+              #{{ me.rank }} · {{ formatValue(me.reps) }}
+              @if (unitLabel(); as label) {
+                <span>{{ label }}</span>
+              }
             </span>
             <mat-icon aria-hidden="true">chevron_right</mat-icon>
           </a>
         } @else {
-          <p class="own-rank" i18n="@@landing.leaderboard.ownPosition">
-            Deine Position: #{{ me.rank }} · {{ me.reps }} Reps
+          <p class="own-rank" data-testid="leaderboard-own-rank">
+            <ng-container i18n="@@leaderboard.ownPosition.prefix"
+              >Deine Position:</ng-container
+            >
+            #{{ me.rank }} · {{ formatValue(me.reps) }}
+            @if (unitLabel(); as label) {
+              <span>{{ label }}</span>
+            }
           </p>
         }
       }

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.scss
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.scss
@@ -10,6 +10,41 @@
   gap: 16px;
 }
 
+.exercise-switch {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid rgba(123, 159, 255, 0.18);
+
+  .exercise-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9rem;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+      opacity: 0.85;
+    }
+  }
+
+  .active {
+    border-color: #8fb4ff;
+    background: rgba(83, 130, 220, 0.22);
+  }
+
+  .exercise-more.active {
+    // Distinguish an overflow-menu selection from a chip selection:
+    // a faint outline accent so users still spot which chip is "live"
+    // when the actual entry sits behind the menu.
+    border-style: dashed;
+  }
+}
+
 .period-switch {
   display: flex;
   gap: 8px;
@@ -20,6 +55,12 @@
     border-color: #8fb4ff;
     background: rgba(83, 130, 220, 0.22);
   }
+}
+
+.unit {
+  margin-left: 4px;
+  font-weight: 500;
+  opacity: 0.75;
 }
 
 ol {
@@ -148,9 +189,14 @@ li {
     color: #047857;
   }
 
-  .period-switch .active {
+  .period-switch .active,
+  .exercise-switch .active {
     border-color: #2563eb;
     background: rgba(59, 130, 246, 0.15);
+  }
+
+  .exercise-switch {
+    border-bottom-color: rgba(37, 99, 235, 0.22);
   }
 
   // Dark-theme link colours (`#cfe0ff` etc.) are unreadable against the

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.scss
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.scss
@@ -57,12 +57,6 @@
   }
 }
 
-.unit {
-  margin-left: 4px;
-  font-weight: 500;
-  opacity: 0.75;
-}
-
 ol {
   margin: 0;
   padding-left: 20px;

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.spec.ts
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { signal } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import { AuthStore, UserContextService } from '@pu-auth/auth';
 import { makeAuthStoreMock } from '@pu-stats/testing';
 import {
+  LEADERBOARD_PUSHUP_ID,
   type LeaderboardEntry,
   type LeaderboardPeriod,
 } from '@pu-stats/data-access';
@@ -23,26 +24,42 @@ import { LeaderboardPageComponent } from './leaderboard-page.component';
  */
 describe('LeaderboardPageComponent', () => {
   let fixture: ComponentFixture<LeaderboardPageComponent>;
-  const entriesByPeriod: Record<LeaderboardPeriod, LeaderboardEntry[]> = {
-    daily: [],
-    last7: [],
-    last30: [],
-  };
+  const entriesByExerciseAndPeriod: Record<
+    string,
+    Record<LeaderboardPeriod, LeaderboardEntry[]>
+  > = {};
+  const loadMock = vitest.fn();
+
+  function setEntries(exerciseId: string, entries: LeaderboardEntry[]): void {
+    entriesByExerciseAndPeriod[exerciseId] = {
+      daily: entries,
+      last7: entries,
+      last30: entries,
+    };
+  }
 
   const storeMock = {
     entriesForPeriod: (
+      exerciseId: () => string,
       period: () => LeaderboardPeriod
     ): (() => LeaderboardEntry[]) =>
-      signal<LeaderboardEntry[]>(entriesByPeriod[period()]).asReadonly(),
+      // Compute reactively from the exerciseId/period selectors so
+      // switching exercise via `selectExercise()` re-binds the list
+      // without rebuilding the component.
+      computed(
+        () => entriesByExerciseAndPeriod[exerciseId()]?.[period()] ?? []
+      ),
     currentUserForPeriod: (): (() => LeaderboardEntry | null) =>
       signal<LeaderboardEntry | null>(null).asReadonly(),
-    load: vitest.fn(),
+    load: loadMock,
   };
 
-  async function setup(entries: LeaderboardEntry[]): Promise<void> {
-    entriesByPeriod.daily = entries;
-    entriesByPeriod.last7 = entries;
-    entriesByPeriod.last30 = entries;
+  async function setup(
+    entries: LeaderboardEntry[],
+    options?: { exerciseId?: string }
+  ): Promise<void> {
+    const exerciseId = options?.exerciseId ?? LEADERBOARD_PUSHUP_ID;
+    setEntries(exerciseId, entries);
 
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
@@ -66,6 +83,13 @@ describe('LeaderboardPageComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
   }
+
+  beforeEach(() => {
+    loadMock.mockClear();
+    for (const key of Object.keys(entriesByExerciseAndPeriod)) {
+      delete entriesByExerciseAndPeriod[key];
+    }
+  });
 
   describe('Given an entry with uid (both opt-ins on)', () => {
     it('Then the alias is rendered as a router link to /u/<uid>', async () => {
@@ -124,6 +148,133 @@ describe('LeaderboardPageComponent', () => {
       expect(
         root.querySelector('[data-testid="leaderboard-link-3"]')
       ).toBeNull();
+    });
+  });
+
+  describe('Given the initial render', () => {
+    it('Loads the pushup leaderboard by default', async () => {
+      await setup([]);
+      expect(loadMock).toHaveBeenCalledWith(LEADERBOARD_PUSHUP_ID);
+    });
+
+    it('Renders one popular-exercise chip per curated entry plus the pushup default', async () => {
+      await setup([]);
+      const root = fixture.nativeElement as HTMLElement;
+      // Pushup chip is always rendered first.
+      const pushupChip = root.querySelector(
+        `[data-testid="leaderboard-exercise-chip-${LEADERBOARD_PUSHUP_ID}"]`
+      );
+      expect(pushupChip).not.toBeNull();
+      // The popular row also surfaces high-traffic exercises.
+      expect(
+        root.querySelector(
+          '[data-testid="leaderboard-exercise-chip-legs.squats"]'
+        )
+      ).not.toBeNull();
+      expect(
+        root.querySelector(
+          '[data-testid="leaderboard-exercise-chip-pull.pullups"]'
+        )
+      ).not.toBeNull();
+      expect(
+        root.querySelector(
+          '[data-testid="leaderboard-exercise-chip-cardio.running"]'
+        )
+      ).not.toBeNull();
+    });
+  });
+
+  describe('Given a click on a non-default exercise chip', () => {
+    it('Triggers a load for that exerciseId and re-binds the list to its bucket', async () => {
+      // Given — pushup leaderboard is empty, squat leaderboard has rows.
+      await setup([], { exerciseId: LEADERBOARD_PUSHUP_ID });
+      setEntries('legs.squats', [
+        { rank: 1, alias: 'Sue', reps: 50, uid: 'sue1' },
+      ]);
+
+      // When — the user clicks the Kniebeugen chip.
+      const root = fixture.nativeElement as HTMLElement;
+      const squatChip = root.querySelector(
+        '[data-testid="leaderboard-exercise-chip-legs.squats"]'
+      ) as HTMLButtonElement | null;
+      expect(squatChip).not.toBeNull();
+      squatChip?.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      // Then — the store is asked to load the squat bucket.
+      expect(loadMock).toHaveBeenCalledWith('legs.squats');
+
+      // And — the list re-binds to the squat bucket. Sue's row is now
+      // visible at rank 1.
+      const link = root.querySelector(
+        '[data-testid="leaderboard-link-1"]'
+      ) as HTMLAnchorElement | null;
+      expect(link?.textContent?.trim()).toBe('Sue');
+    });
+  });
+
+  describe('Given a time-measured exercise like plank', () => {
+    it('Formats the aggregated value as m:ss and omits the "Reps" suffix', async () => {
+      // Given — 90 s plank aggregated to rank 1.
+      await setup([{ rank: 1, alias: 'Tom', reps: 90, uid: 'tom1' }], {
+        exerciseId: 'plank.standard',
+      });
+
+      // When — select via the component contract; mat-menu items render
+      // in a cdk-overlay portal outside the component nativeElement,
+      // so clicking through the DOM would couple the test to Material's
+      // overlay-open lifecycle. The selection method IS the contract
+      // the chip and menu both invoke.
+      fixture.componentInstance.selectExercise('plank.standard');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      // Then — 90 s → "1:30" in the row, no trailing "Reps" label.
+      const root = fixture.nativeElement as HTMLElement;
+      const row = root.querySelector(
+        'ol[data-testid="leaderboard-list"] li:first-child strong'
+      ) as HTMLElement | null;
+      expect(row).not.toBeNull();
+      expect(row?.textContent?.replace(/\s+/g, ' ').trim()).toBe('1:30');
+    });
+  });
+
+  describe('Given a distance-time exercise like running', () => {
+    it('Formats the aggregated meters as km when ≥ 1000', async () => {
+      // Given — 5000 m aggregated to rank 1.
+      await setup([{ rank: 1, alias: 'Rita', reps: 5000, uid: 'rita1' }], {
+        exerciseId: 'cardio.running',
+      });
+
+      // When
+      fixture.componentInstance.selectExercise('cardio.running');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      // Then — formatted as "5.00 km", "Reps" label suppressed.
+      const root = fixture.nativeElement as HTMLElement;
+      const row = root.querySelector(
+        'ol[data-testid="leaderboard-list"] li:first-child strong'
+      ) as HTMLElement | null;
+      expect(row?.textContent?.replace(/\s+/g, ' ').trim()).toBe('5.00 km');
+    });
+  });
+
+  describe('Given pushups (the default)', () => {
+    it('Keeps the "Reps" label next to the value', async () => {
+      // Given
+      await setup([{ rank: 1, alias: 'Pia', reps: 25, uid: 'pia1' }]);
+
+      // Then — bare number + "Reps" suffix matches the legacy template.
+      const root = fixture.nativeElement as HTMLElement;
+      const row = root.querySelector(
+        'ol[data-testid="leaderboard-list"] li:first-child strong'
+      ) as HTMLElement | null;
+      expect(row?.textContent?.replace(/\s+/g, ' ').trim()).toBe('25 Reps');
     });
   });
 });

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.ts
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.ts
@@ -1,7 +1,6 @@
 import { Component, computed, inject, linkedSignal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
-import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { RouterLink } from '@angular/router';
@@ -57,7 +56,6 @@ const POPULAR_EXERCISE_IDS: ReadonlyArray<string> = [
   imports: [
     MatCardModule,
     MatButtonModule,
-    MatChipsModule,
     MatIconModule,
     MatMenuModule,
     RouterLink,
@@ -140,23 +138,6 @@ export class LeaderboardPageComponent {
     return exerciseDisplayName(id);
   });
 
-  /**
-   * Unit label that lives next to the rank value. For rep-counted
-   * exercises ("Reps") it carries the unit explicitly; for time and
-   * distance the formatted value (`1:30`, `5.00 km`) already includes
-   * its unit, so the trailing label collapses to an empty string.
-   */
-  readonly unitLabel = computed(() => {
-    const def = this.selectedDefinition();
-    if (!def) return $localize`:@@landing.leaderboard.reps:Reps`;
-    switch (def.unit) {
-      case 'reps':
-        return $localize`:@@landing.leaderboard.reps:Reps`;
-      default:
-        return '';
-    }
-  });
-
   readonly leaderboardEntries = this.store.entriesForPeriod(
     this.selectedExerciseId,
     this.period
@@ -182,18 +163,31 @@ export class LeaderboardPageComponent {
 
   /**
    * Renders the aggregated value for a row using the selected exercise's
-   * unit. Rep counts stay bare numbers (the i18n "Reps" label is appended
-   * in the template); seconds become `m:ss`; meters become `<n> m` or
-   * `<n.nn> km` for ≥1 km. Empty slot placeholders (`reps === 0` from
-   * `leaderboardSlots`) still render as `0` so the alignment stays stable.
+   * unit, INCLUDING the unit suffix. Rep counts get the localized "Reps"
+   * label appended (`"30 Reps"`); seconds render as `m:ss` (`"1:30"`);
+   * meters render as `<n> m` or `<n.nn> km` (the unit is already part of
+   * the formatExerciseValue output). Returning the complete display
+   * string here lets templates use a single i18n message with
+   * placeholders instead of splitting unit/label/value into separate
+   * bindings — which would prevent translators from re-ordering the
+   * pieces in target languages.
+   *
+   * Empty-slot placeholders (`reps === 0` from `leaderboardSlots`)
+   * still render as `0` (no unit) so the alignment stays stable.
    */
   readonly formatValue = (value: number): string => {
     const def = this.selectedDefinition();
-    if (!def) return String(value);
+    if (value === 0) return '0';
+    // Pushup default (`def === null`) and any other reps-unit exercise
+    // both need the explicit "Reps" suffix, since formatExerciseValue
+    // renders rep counts as bare numbers.
+    if (!def || def.unit === 'reps') {
+      const repsLabel = $localize`:@@landing.leaderboard.reps:Reps`;
+      return `${value} ${repsLabel}`;
+    }
     // formatExerciseValue returns '' for negative numbers — bucket the
     // placeholder zero through as a literal "0" so the empty-slot row
     // doesn't render an invisible value column.
-    if (value === 0) return '0';
     return formatExerciseValue(value, def.unit);
   };
 

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.ts
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.ts
@@ -1,19 +1,65 @@
 import { Component, computed, inject, linkedSignal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
 import { RouterLink } from '@angular/router';
 import { AuthStore, UserContextService } from '@pu-auth/auth';
-import { LeaderboardPeriod } from '@pu-stats/data-access';
+import {
+  LEADERBOARD_PUSHUP_ID,
+  LeaderboardPeriod,
+} from '@pu-stats/data-access';
 import { LeaderboardStore } from '@pu-stats/data-access-state';
+import {
+  EXERCISE_CATEGORIES,
+  type ExerciseCategoryInfo,
+  type ExerciseDefinition,
+  findExerciseDefinition,
+  exercisesByCategory,
+  formatExerciseValue,
+} from '@pu-stats/models';
+import {
+  categoryDisplayName,
+  exerciseDisplayName,
+} from '../../stats/i18n/exercise-display-names';
 import { PageHeaderComponent } from '../../core/page-header/page-header.component';
+
+/**
+ * Exercises surfaced as one-tap chips above the leaderboard list.
+ * Order is curated, not alphabetical, so the most-used variants stay
+ * left of the picker overflow. Pushups lead because the app is named
+ * after them and they have the only server-precomputed snapshot today.
+ */
+type PopularExercise = {
+  id: string;
+  /** Resolved label — pushup id needs the category label, others the catalog name. */
+  label: string;
+  icon: string;
+};
+
+const PUSHUP_CHIP: PopularExercise = {
+  id: LEADERBOARD_PUSHUP_ID,
+  label: $localize`:@@exercise.category.pushup:Liegestütze`,
+  icon: 'fitness_center',
+};
+
+const POPULAR_EXERCISE_IDS: ReadonlyArray<string> = [
+  'legs.squats',
+  'pull.pullups',
+  'plank.standard',
+  'abs.crunches',
+  'cardio.running',
+];
 
 @Component({
   selector: 'app-leaderboard-page',
   imports: [
     MatCardModule,
     MatButtonModule,
+    MatChipsModule,
     MatIconModule,
+    MatMenuModule,
     RouterLink,
     PageHeaderComponent,
   ],
@@ -37,9 +83,88 @@ export class LeaderboardPageComponent {
   );
 
   readonly period = linkedSignal<LeaderboardPeriod>(() => 'daily');
+  readonly selectedExerciseId = linkedSignal<string>(
+    () => LEADERBOARD_PUSHUP_ID
+  );
 
-  readonly leaderboardEntries = this.store.entriesForPeriod(this.period);
-  readonly currentUserEntry = this.store.currentUserForPeriod(this.period);
+  readonly selectedDefinition = computed(() => {
+    const id = this.selectedExerciseId();
+    if (id === LEADERBOARD_PUSHUP_ID) return null;
+    return findExerciseDefinition(id);
+  });
+
+  /**
+   * Static chip row. The "Mehr ▾" entry below opens a menu with the
+   * full catalog by category so users can still reach any exercise
+   * without polluting the chip row with 40+ entries.
+   */
+  readonly popularExercises = computed<ReadonlyArray<PopularExercise>>(() => {
+    const rest = POPULAR_EXERCISE_IDS.map<PopularExercise | null>((id) => {
+      const def = findExerciseDefinition(id);
+      if (!def) return null;
+      return {
+        id: def.id,
+        label: exerciseDisplayName(def.id),
+        icon: def.icon ?? 'fitness_center',
+      };
+    }).filter((c): c is PopularExercise => c !== null);
+    return [PUSHUP_CHIP, ...rest];
+  });
+
+  /**
+   * Catalog grouped by category for the overflow menu. Empty categories
+   * are dropped so the menu doesn't render section headers without any
+   * entries below them (forward-compat for future categories whose
+   * picker entries haven't shipped yet).
+   */
+  readonly categorySections = computed<
+    ReadonlyArray<{
+      category: ExerciseCategoryInfo;
+      exercises: ReadonlyArray<{ id: string; label: string }>;
+    }>
+  >(() => {
+    const grouped = exercisesByCategory();
+    return EXERCISE_CATEGORIES.flatMap((category) => {
+      const defs = grouped.get(category.id) ?? [];
+      const exercises = defs.map((def: ExerciseDefinition) => ({
+        id: def.id,
+        label: exerciseDisplayName(def.id),
+      }));
+      return exercises.length > 0 ? [{ category, exercises }] : [];
+    });
+  });
+
+  readonly selectedLabel = computed(() => {
+    const id = this.selectedExerciseId();
+    if (id === LEADERBOARD_PUSHUP_ID) return PUSHUP_CHIP.label;
+    return exerciseDisplayName(id);
+  });
+
+  /**
+   * Unit label that lives next to the rank value. For rep-counted
+   * exercises ("Reps") it carries the unit explicitly; for time and
+   * distance the formatted value (`1:30`, `5.00 km`) already includes
+   * its unit, so the trailing label collapses to an empty string.
+   */
+  readonly unitLabel = computed(() => {
+    const def = this.selectedDefinition();
+    if (!def) return $localize`:@@landing.leaderboard.reps:Reps`;
+    switch (def.unit) {
+      case 'reps':
+        return $localize`:@@landing.leaderboard.reps:Reps`;
+      default:
+        return '';
+    }
+  });
+
+  readonly leaderboardEntries = this.store.entriesForPeriod(
+    this.selectedExerciseId,
+    this.period
+  );
+  readonly currentUserEntry = this.store.currentUserForPeriod(
+    this.selectedExerciseId,
+    this.period
+  );
 
   readonly leaderboardSlots = computed(() => {
     const top = this.leaderboardEntries();
@@ -55,7 +180,46 @@ export class LeaderboardPageComponent {
     });
   });
 
-  constructor() {
-    this.store.load();
+  /**
+   * Renders the aggregated value for a row using the selected exercise's
+   * unit. Rep counts stay bare numbers (the i18n "Reps" label is appended
+   * in the template); seconds become `m:ss`; meters become `<n> m` or
+   * `<n.nn> km` for ≥1 km. Empty slot placeholders (`reps === 0` from
+   * `leaderboardSlots`) still render as `0` so the alignment stays stable.
+   */
+  readonly formatValue = (value: number): string => {
+    const def = this.selectedDefinition();
+    if (!def) return String(value);
+    // formatExerciseValue returns '' for negative numbers — bucket the
+    // placeholder zero through as a literal "0" so the empty-slot row
+    // doesn't render an invisible value column.
+    if (value === 0) return '0';
+    return formatExerciseValue(value, def.unit);
+  };
+
+  selectExercise(id: string): void {
+    this.selectedExerciseId.set(id);
+    void this.store.load(id);
   }
+
+  isActiveExercise(id: string): boolean {
+    return this.selectedExerciseId() === id;
+  }
+
+  /**
+   * True when the selected exercise has its own dedicated chip in the
+   * popular row. When false, the "Mehr ▾" entry should display the
+   * current selection as its active label so users see what's selected
+   * even if it's hidden behind the overflow menu.
+   */
+  readonly isOverflowSelection = computed(() => {
+    const id = this.selectedExerciseId();
+    return !this.popularExercises().some((chip) => chip.id === id);
+  });
+
+  constructor() {
+    void this.store.load(this.selectedExerciseId());
+  }
+
+  protected readonly categoryDisplayName = categoryDisplayName;
 }

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.ts
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.ts
@@ -162,32 +162,20 @@ export class LeaderboardPageComponent {
   });
 
   /**
-   * Renders the aggregated value for a row using the selected exercise's
-   * unit, INCLUDING the unit suffix. Rep counts get the localized "Reps"
-   * label appended (`"30 Reps"`); seconds render as `m:ss` (`"1:30"`);
-   * meters render as `<n> m` or `<n.nn> km` (the unit is already part of
-   * the formatExerciseValue output). Returning the complete display
-   * string here lets templates use a single i18n message with
-   * placeholders instead of splitting unit/label/value into separate
-   * bindings — which would prevent translators from re-ordering the
-   * pieces in target languages.
-   *
-   * Empty-slot placeholders (`reps === 0` from `leaderboardSlots`)
-   * still render as `0` (no unit) so the alignment stays stable.
+   * Returns the row's display value with the unit baked in
+   * (`"30 Reps"` / `"1:30"` / `"5.00 km"`). Keeping value+unit in one
+   * string lets the template use a single i18n message with
+   * placeholders — splitting them would block translators from
+   * re-ordering the pieces. Empty-slot placeholders (`reps === 0`)
+   * stay unitless so the column alignment doesn't jitter.
    */
   readonly formatValue = (value: number): string => {
     const def = this.selectedDefinition();
     if (value === 0) return '0';
-    // Pushup default (`def === null`) and any other reps-unit exercise
-    // both need the explicit "Reps" suffix, since formatExerciseValue
-    // renders rep counts as bare numbers.
     if (!def || def.unit === 'reps') {
       const repsLabel = $localize`:@@landing.leaderboard.reps:Reps`;
       return `${value} ${repsLabel}`;
     }
-    // formatExerciseValue returns '' for negative numbers — bucket the
-    // placeholder zero through as a literal "0" so the empty-slot row
-    // doesn't render an invisible value column.
     return formatExerciseValue(value, def.unit);
   };
 

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9645,10 +9645,10 @@
         <target>Δεν ήταν δυνατή η αποθήκευση της καταχώρησης.</target>
       </segment>
     </unit>
-    <unit id="leaderboard.exercise.ariaLabel">
+        <unit id="leaderboard.exercise.ariaLabel">
       <segment state="initial">
-        <source>Leaderboard Übung</source>
-        <target>Leaderboard Übung</target>
+        <source>Bestenlisten-Übung auswählen</source>
+        <target>Bestenlisten-Übung auswählen</target>
       </segment>
     </unit>
     <unit id="leaderboard.exercise.more">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9663,5 +9663,11 @@
         <target>Deine Position:</target>
       </segment>
     </unit>
+    <unit id="leaderboard.period.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Zeitraum</source>
+        <target>Leaderboard Zeitraum</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9645,5 +9645,23 @@
         <target>Δεν ήταν δυνατή η αποθήκευση της καταχώρησης.</target>
       </segment>
     </unit>
+    <unit id="leaderboard.exercise.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Übung</source>
+        <target>Leaderboard Übung</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.exercise.more">
+      <segment state="initial">
+        <source>Mehr</source>
+        <target>Mehr</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.ownPosition.prefix">
+      <segment state="initial">
+        <source>Deine Position:</source>
+        <target>Deine Position:</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9657,12 +9657,6 @@
         <target>Mehr</target>
       </segment>
     </unit>
-    <unit id="leaderboard.ownPosition.prefix">
-      <segment state="initial">
-        <source>Deine Position:</source>
-        <target>Deine Position:</target>
-      </segment>
-    </unit>
     <unit id="leaderboard.period.ariaLabel">
       <segment state="initial">
         <source>Leaderboard Zeitraum</source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -9829,5 +9829,11 @@ Deine Position: # ·  Reps        </source>
         <target>Deine Position:</target>
       </segment>
     </unit>
+    <unit id="leaderboard.period.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Zeitraum</source>
+        <target>Leaderboard Zeitraum</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -9811,10 +9811,10 @@ Deine Position: # ·  Reps        </source>
         <target>Two weeks of active recovery: daily mobility, yoga, and stretching sessions with light push-up volume. Ideal as a deload between two hard plans or to ease back in after a training break.</target>
       </segment>
     </unit>
-    <unit id="leaderboard.exercise.ariaLabel">
+        <unit id="leaderboard.exercise.ariaLabel">
       <segment state="initial">
-        <source>Leaderboard Übung</source>
-        <target>Leaderboard Übung</target>
+        <source>Bestenlisten-Übung auswählen</source>
+        <target>Bestenlisten-Übung auswählen</target>
       </segment>
     </unit>
     <unit id="leaderboard.exercise.more">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -9823,12 +9823,6 @@ Deine Position: # ·  Reps        </source>
         <target>Mehr</target>
       </segment>
     </unit>
-    <unit id="leaderboard.ownPosition.prefix">
-      <segment state="initial">
-        <source>Deine Position:</source>
-        <target>Deine Position:</target>
-      </segment>
-    </unit>
     <unit id="leaderboard.period.ariaLabel">
       <segment state="initial">
         <source>Leaderboard Zeitraum</source>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -9811,5 +9811,23 @@ Deine Position: # ·  Reps        </source>
         <target>Two weeks of active recovery: daily mobility, yoga, and stretching sessions with light push-up volume. Ideal as a deload between two hard plans or to ease back in after a training break.</target>
       </segment>
     </unit>
+    <unit id="leaderboard.exercise.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Übung</source>
+        <target>Leaderboard Übung</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.exercise.more">
+      <segment state="initial">
+        <source>Mehr</source>
+        <target>Mehr</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.ownPosition.prefix">
+      <segment state="initial">
+        <source>Deine Position:</source>
+        <target>Deine Position:</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9659,5 +9659,11 @@
         <target>Deine Position:</target>
       </segment>
     </unit>
+    <unit id="leaderboard.period.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Zeitraum</source>
+        <target>Leaderboard Zeitraum</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9641,10 +9641,10 @@
         <target>No se pudo guardar la entrada.</target>
       </segment>
     </unit>
-    <unit id="leaderboard.exercise.ariaLabel">
+        <unit id="leaderboard.exercise.ariaLabel">
       <segment state="initial">
-        <source>Leaderboard Übung</source>
-        <target>Leaderboard Übung</target>
+        <source>Bestenlisten-Übung auswählen</source>
+        <target>Bestenlisten-Übung auswählen</target>
       </segment>
     </unit>
     <unit id="leaderboard.exercise.more">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9653,12 +9653,6 @@
         <target>Mehr</target>
       </segment>
     </unit>
-    <unit id="leaderboard.ownPosition.prefix">
-      <segment state="initial">
-        <source>Deine Position:</source>
-        <target>Deine Position:</target>
-      </segment>
-    </unit>
     <unit id="leaderboard.period.ariaLabel">
       <segment state="initial">
         <source>Leaderboard Zeitraum</source>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9641,5 +9641,23 @@
         <target>No se pudo guardar la entrada.</target>
       </segment>
     </unit>
+    <unit id="leaderboard.exercise.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Übung</source>
+        <target>Leaderboard Übung</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.exercise.more">
+      <segment state="initial">
+        <source>Mehr</source>
+        <target>Mehr</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.ownPosition.prefix">
+      <segment state="initial">
+        <source>Deine Position:</source>
+        <target>Deine Position:</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9535,5 +9535,11 @@
         <target>Deine Position:</target>
       </segment>
     </unit>
+    <unit id="leaderboard.period.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Zeitraum</source>
+        <target>Leaderboard Zeitraum</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9529,12 +9529,6 @@
         <target>Mehr</target>
       </segment>
     </unit>
-    <unit id="leaderboard.ownPosition.prefix">
-      <segment state="initial">
-        <source>Deine Position:</source>
-        <target>Deine Position:</target>
-      </segment>
-    </unit>
     <unit id="leaderboard.period.ariaLabel">
       <segment state="initial">
         <source>Leaderboard Zeitraum</source>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9517,5 +9517,23 @@
         <target>Impossible d&apos;enregistrer l&apos;entrée.</target>
       </segment>
     </unit>
+    <unit id="leaderboard.exercise.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Übung</source>
+        <target>Leaderboard Übung</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.exercise.more">
+      <segment state="initial">
+        <source>Mehr</source>
+        <target>Mehr</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.ownPosition.prefix">
+      <segment state="initial">
+        <source>Deine Position:</source>
+        <target>Deine Position:</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9517,10 +9517,10 @@
         <target>Impossible d&apos;enregistrer l&apos;entrée.</target>
       </segment>
     </unit>
-    <unit id="leaderboard.exercise.ariaLabel">
+        <unit id="leaderboard.exercise.ariaLabel">
       <segment state="initial">
-        <source>Leaderboard Übung</source>
-        <target>Leaderboard Übung</target>
+        <source>Bestenlisten-Übung auswählen</source>
+        <target>Bestenlisten-Übung auswählen</target>
       </segment>
     </unit>
     <unit id="leaderboard.exercise.more">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9645,5 +9645,23 @@
         <target>Impossibile salvare la voce.</target>
       </segment>
     </unit>
+    <unit id="leaderboard.exercise.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Übung</source>
+        <target>Leaderboard Übung</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.exercise.more">
+      <segment state="initial">
+        <source>Mehr</source>
+        <target>Mehr</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.ownPosition.prefix">
+      <segment state="initial">
+        <source>Deine Position:</source>
+        <target>Deine Position:</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9663,5 +9663,11 @@
         <target>Deine Position:</target>
       </segment>
     </unit>
+    <unit id="leaderboard.period.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Zeitraum</source>
+        <target>Leaderboard Zeitraum</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9645,10 +9645,10 @@
         <target>Impossibile salvare la voce.</target>
       </segment>
     </unit>
-    <unit id="leaderboard.exercise.ariaLabel">
+        <unit id="leaderboard.exercise.ariaLabel">
       <segment state="initial">
-        <source>Leaderboard Übung</source>
-        <target>Leaderboard Übung</target>
+        <source>Bestenlisten-Übung auswählen</source>
+        <target>Bestenlisten-Übung auswählen</target>
       </segment>
     </unit>
     <unit id="leaderboard.exercise.more">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9657,12 +9657,6 @@
         <target>Mehr</target>
       </segment>
     </unit>
-    <unit id="leaderboard.ownPosition.prefix">
-      <segment state="initial">
-        <source>Deine Position:</source>
-        <target>Deine Position:</target>
-      </segment>
-    </unit>
     <unit id="leaderboard.period.ariaLabel">
       <segment state="initial">
         <source>Leaderboard Zeitraum</source>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9645,10 +9645,10 @@
         <target>Viscus salvus esse non potuit.</target>
       </segment>
     </unit>
-    <unit id="leaderboard.exercise.ariaLabel">
+        <unit id="leaderboard.exercise.ariaLabel">
       <segment state="initial">
-        <source>Leaderboard Übung</source>
-        <target>Leaderboard Übung</target>
+        <source>Bestenlisten-Übung auswählen</source>
+        <target>Bestenlisten-Übung auswählen</target>
       </segment>
     </unit>
     <unit id="leaderboard.exercise.more">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9663,5 +9663,11 @@
         <target>Deine Position:</target>
       </segment>
     </unit>
+    <unit id="leaderboard.period.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Zeitraum</source>
+        <target>Leaderboard Zeitraum</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9645,5 +9645,23 @@
         <target>Viscus salvus esse non potuit.</target>
       </segment>
     </unit>
+    <unit id="leaderboard.exercise.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Übung</source>
+        <target>Leaderboard Übung</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.exercise.more">
+      <segment state="initial">
+        <source>Mehr</source>
+        <target>Mehr</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.ownPosition.prefix">
+      <segment state="initial">
+        <source>Deine Position:</source>
+        <target>Deine Position:</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9657,12 +9657,6 @@
         <target>Mehr</target>
       </segment>
     </unit>
-    <unit id="leaderboard.ownPosition.prefix">
-      <segment state="initial">
-        <source>Deine Position:</source>
-        <target>Deine Position:</target>
-      </segment>
-    </unit>
     <unit id="leaderboard.period.ariaLabel">
       <segment state="initial">
         <source>Leaderboard Zeitraum</source>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9645,10 +9645,10 @@
         <target>De invoer kon niet worden opgeslagen.</target>
       </segment>
     </unit>
-    <unit id="leaderboard.exercise.ariaLabel">
+        <unit id="leaderboard.exercise.ariaLabel">
       <segment state="initial">
-        <source>Leaderboard Übung</source>
-        <target>Leaderboard Übung</target>
+        <source>Bestenlisten-Übung auswählen</source>
+        <target>Bestenlisten-Übung auswählen</target>
       </segment>
     </unit>
     <unit id="leaderboard.exercise.more">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9663,5 +9663,11 @@
         <target>Deine Position:</target>
       </segment>
     </unit>
+    <unit id="leaderboard.period.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Zeitraum</source>
+        <target>Leaderboard Zeitraum</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9645,5 +9645,23 @@
         <target>De invoer kon niet worden opgeslagen.</target>
       </segment>
     </unit>
+    <unit id="leaderboard.exercise.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Übung</source>
+        <target>Leaderboard Übung</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.exercise.more">
+      <segment state="initial">
+        <source>Mehr</source>
+        <target>Mehr</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.ownPosition.prefix">
+      <segment state="initial">
+        <source>Deine Position:</source>
+        <target>Deine Position:</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9657,12 +9657,6 @@
         <target>Mehr</target>
       </segment>
     </unit>
-    <unit id="leaderboard.ownPosition.prefix">
-      <segment state="initial">
-        <source>Deine Position:</source>
-        <target>Deine Position:</target>
-      </segment>
-    </unit>
     <unit id="leaderboard.period.ariaLabel">
       <segment state="initial">
         <source>Leaderboard Zeitraum</source>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -8905,5 +8905,23 @@ Deine Position: # ·  Reps        </source>
         <target>Kunne ikke lagre oppføringen.</target>
       </segment>
     </unit>
+    <unit id="leaderboard.exercise.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Übung</source>
+        <target>Leaderboard Übung</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.exercise.more">
+      <segment state="initial">
+        <source>Mehr</source>
+        <target>Mehr</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.ownPosition.prefix">
+      <segment state="initial">
+        <source>Deine Position:</source>
+        <target>Deine Position:</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -8917,12 +8917,6 @@ Deine Position: # ·  Reps        </source>
         <target>Mehr</target>
       </segment>
     </unit>
-    <unit id="leaderboard.ownPosition.prefix">
-      <segment state="initial">
-        <source>Deine Position:</source>
-        <target>Deine Position:</target>
-      </segment>
-    </unit>
     <unit id="leaderboard.period.ariaLabel">
       <segment state="initial">
         <source>Leaderboard Zeitraum</source>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -8923,5 +8923,11 @@ Deine Position: # ·  Reps        </source>
         <target>Deine Position:</target>
       </segment>
     </unit>
+    <unit id="leaderboard.period.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Zeitraum</source>
+        <target>Leaderboard Zeitraum</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -8905,10 +8905,10 @@ Deine Position: # ·  Reps        </source>
         <target>Kunne ikke lagre oppføringen.</target>
       </segment>
     </unit>
-    <unit id="leaderboard.exercise.ariaLabel">
+        <unit id="leaderboard.exercise.ariaLabel">
       <segment state="initial">
-        <source>Leaderboard Übung</source>
-        <target>Leaderboard Übung</target>
+        <source>Bestenlisten-Übung auswählen</source>
+        <target>Bestenlisten-Übung auswählen</target>
       </segment>
     </unit>
     <unit id="leaderboard.exercise.more">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4173,9 +4173,17 @@
         <source>Mehr</source>
       </segment>
     </unit>
+    <unit id="leaderboard.period.ariaLabel">
+      <notes>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:83,84</note>
+      </notes>
+      <segment>
+        <source>Leaderboard Zeitraum</source>
+      </segment>
+    </unit>
     <unit id="landing.leaderboard.daily">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:92,94</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:93,95</note>
       </notes>
       <segment>
         <source> Tag </source>
@@ -4183,7 +4191,7 @@
     </unit>
     <unit id="landing.leaderboard.last7">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:101,103</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:102,104</note>
       </notes>
       <segment>
         <source> Letzte 7 Tage </source>
@@ -4191,7 +4199,7 @@
     </unit>
     <unit id="landing.leaderboard.last30">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:110,113</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:111,114</note>
       </notes>
       <segment>
         <source> Letzte 30 Tage </source>
@@ -4199,8 +4207,8 @@
     </unit>
     <unit id="landing.leaderboard.ownPosition">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:152,153</note>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:162,164</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:153,154</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:163,165</note>
       </notes>
       <segment>
         <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ formatValue(me.reps) }}"/> </source>
@@ -4208,7 +4216,7 @@
     </unit>
     <unit id="leaderboard.visibilityHint">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:172,174</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:173,175</note>
       </notes>
       <segment>
         <source> Sichtbarkeit oder Anzeigename anpassen? </source>
@@ -4216,7 +4224,7 @@
     </unit>
     <unit id="leaderboard.visibilityHint.cta">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:178,181</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:179,182</note>
       </notes>
       <segment>
         <source>Einstellungen öffnen</source>
@@ -4224,7 +4232,7 @@
     </unit>
     <unit id="leaderboard.loginHint">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:185,187</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:186,188</note>
       </notes>
       <segment>
         <source> Mitmachen und auftauchen? </source>
@@ -4232,7 +4240,7 @@
     </unit>
     <unit id="leaderboard.loginHint.cta">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:188,191</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:189,192</note>
       </notes>
       <segment>
         <source>Anmelden</source>
@@ -4257,7 +4265,7 @@
     </unit>
     <unit id="landing.leaderboard.reps">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:185</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:176</note>
       </notes>
       <segment>
         <source>Reps</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -235,7 +235,7 @@
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:67,69</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:385,386</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:148,149</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:152,153</note>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:639,640</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:556,557</note>
       </notes>
@@ -756,17 +756,9 @@
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> bis zum Ziel</source>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.quickAddReps">
-      <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:83,84</note>
-      </notes>
-      <segment>
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> Reps</source>
-      </segment>
-    </unit>
     <unit id="quickAdd.fab.open">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:78</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:98</note>
       </notes>
       <segment>
         <source>Schnellerfassung öffnen</source>
@@ -774,7 +766,7 @@
     </unit>
     <unit id="quickAdd.fab.close">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:79</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:99</note>
       </notes>
       <segment>
         <source>Schnellerfassung schließen</source>
@@ -782,7 +774,7 @@
     </unit>
     <unit id="quickAdd.fab.goalReached">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:80</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:100</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -790,23 +782,15 @@
     </unit>
     <unit id="quickAdd.fab.goalReachedAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:81</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:101</note>
       </notes>
       <segment>
         <source>Tagesziel bereits erreicht</source>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.repAria">
-      <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:84</note>
-      </notes>
-      <segment>
-        <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
-      </segment>
-    </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:88</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:104</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="GAP" disp="gap"/> Liegestütze bis zum Tagesziel hinzufügen</source>
@@ -3553,7 +3537,7 @@
     </unit>
     <unit id="earlyAccess.text">
       <notes>
-        <note category="location">web/src/app/app.ts:173</note>
+        <note category="location">web/src/app/app.ts:176</note>
       </notes>
       <segment>
         <source>Early Access – pushup-stats.com befindet sich noch im Aufbau. Funktionen und Design können sich jederzeit ändern.</source>
@@ -3561,7 +3545,7 @@
     </unit>
     <unit id="earlyAccess.feedback">
       <notes>
-        <note category="location">web/src/app/app.ts:174</note>
+        <note category="location">web/src/app/app.ts:177</note>
       </notes>
       <segment>
         <source>Feedback</source>
@@ -3569,7 +3553,7 @@
     </unit>
     <unit id="seo.default.title">
       <notes>
-        <note category="location">web/src/app/app.ts:290</note>
+        <note category="location">web/src/app/app.ts:293</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -3577,7 +3561,7 @@
     </unit>
     <unit id="seo.default.description">
       <notes>
-        <note category="location">web/src/app/app.ts:293</note>
+        <note category="location">web/src/app/app.ts:296</note>
       </notes>
       <segment>
         <source>Tracke Reps, Trends und Streaks mit Pushup Tracker.</source>
@@ -3585,7 +3569,7 @@
     </unit>
     <unit id="sw.update.available">
       <notes>
-        <note category="location">web/src/app/app.ts:314</note>
+        <note category="location">web/src/app/app.ts:317</note>
       </notes>
       <segment>
         <source>Neue Version verfügbar</source>
@@ -3593,7 +3577,7 @@
     </unit>
     <unit id="sw.update.reload">
       <notes>
-        <note category="location">web/src/app/app.ts:315</note>
+        <note category="location">web/src/app/app.ts:318</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -3601,7 +3585,7 @@
     </unit>
     <unit id="toolbarDailyGoal.replayAria">
       <notes>
-        <note category="location">web/src/app/app.ts:390</note>
+        <note category="location">web/src/app/app.ts:393</note>
       </notes>
       <segment>
         <source>Tagesziel-Animation erneut abspielen</source>
@@ -3609,7 +3593,7 @@
     </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:419</note>
+        <note category="location">web/src/app/app.ts:422</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -3617,7 +3601,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:426</note>
+        <note category="location">web/src/app/app.ts:429</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>
@@ -4017,6 +4001,30 @@
         <source>Artikel lesen</source>
       </segment>
     </unit>
+    <unit id="quickAdd.fab.pushupRepsLabel">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts:34</note>
+      </notes>
+      <segment>
+        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.repAria">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts:35</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.exerciseRepAria">
+      <notes>
+        <note category="location">web/src/app/core/app-data.facade.ts:56</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="REPS" disp="cfg.reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
+      </segment>
+    </unit>
     <unit id="feedback.dialog.title">
       <notes>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:44,47</note>
@@ -4076,8 +4084,9 @@
     </unit>
     <unit id="quickAdd.success.create">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:114</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:342</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:140</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:164</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:392</note>
       </notes>
       <segment>
         <source>Eintrag gespeichert.</source>
@@ -4085,7 +4094,7 @@
     </unit>
     <unit id="quickAdd.success.goalReached">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:143</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:193</note>
       </notes>
       <segment>
         <source>Tagesziel erreicht 🎉</source>
@@ -4148,9 +4157,25 @@
         <source> Heute, letzte 7 Tage und letzte 30 Tage – wer schiebt die meisten Reps? </source>
       </segment>
     </unit>
+    <unit id="leaderboard.exercise.ariaLabel">
+      <notes>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:13,14</note>
+      </notes>
+      <segment>
+        <source>Leaderboard Übung</source>
+      </segment>
+    </unit>
+    <unit id="leaderboard.exercise.more">
+      <notes>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:42,45</note>
+      </notes>
+      <segment>
+        <source>Mehr</source>
+      </segment>
+    </unit>
     <unit id="landing.leaderboard.daily">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:22,24</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:86,88</note>
       </notes>
       <segment>
         <source> Tag </source>
@@ -4158,7 +4183,7 @@
     </unit>
     <unit id="landing.leaderboard.last7">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:31,33</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:95,97</note>
       </notes>
       <segment>
         <source> Letzte 7 Tage </source>
@@ -4166,32 +4191,24 @@
     </unit>
     <unit id="landing.leaderboard.last30">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:40,43</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:104,107</note>
       </notes>
       <segment>
         <source> Letzte 30 Tage </source>
       </segment>
     </unit>
-    <unit id="landing.leaderboard.reps">
+    <unit id="leaderboard.ownPosition.prefix">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:66,68</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:147,149</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:159,161</note>
       </notes>
       <segment>
-        <source>Reps</source>
-      </segment>
-    </unit>
-    <unit id="landing.leaderboard.ownPosition">
-      <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:80,81</note>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:86,88</note>
-      </notes>
-      <segment>
-        <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ me.reps }}"/> Reps </source>
+        <source>Deine Position:</source>
       </segment>
     </unit>
     <unit id="leaderboard.visibilityHint">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:96,98</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:174,176</note>
       </notes>
       <segment>
         <source> Sichtbarkeit oder Anzeigename anpassen? </source>
@@ -4199,7 +4216,7 @@
     </unit>
     <unit id="leaderboard.visibilityHint.cta">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:102,105</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:180,183</note>
       </notes>
       <segment>
         <source>Einstellungen öffnen</source>
@@ -4207,7 +4224,7 @@
     </unit>
     <unit id="leaderboard.loginHint">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:109,111</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:187,189</note>
       </notes>
       <segment>
         <source> Mitmachen und auftauchen? </source>
@@ -4215,10 +4232,36 @@
     </unit>
     <unit id="leaderboard.loginHint.cta">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:112,115</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:190,193</note>
       </notes>
       <segment>
         <source>Anmelden</source>
+      </segment>
+    </unit>
+    <unit id="exercise.category.pushup">
+      <notes>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:43</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:385</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:222</note>
+        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1288</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:79</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:197</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
+        <note category="location">web/src/app/stats/shell/entries-page.component.ts:289</note>
+        <note category="location">web/src/app/wiki/exercises-page.component.ts:393</note>
+      </notes>
+      <segment>
+        <source>Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="landing.leaderboard.reps">
+      <notes>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:153</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:156</note>
+      </notes>
+      <segment>
+        <source>Reps</source>
       </segment>
     </unit>
     <unit id="reminder.feature.eyebrow">
@@ -5651,22 +5694,6 @@
         <source>Alle Übungen</source>
       </segment>
     </unit>
-    <unit id="exercise.category.pushup">
-      <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:379</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:222</note>
-        <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1288</note>
-        <note category="location">web/src/app/stats/dashboard.store.ts:79</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:197</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
-        <note category="location">web/src/app/stats/shell/entries-page.component.ts:289</note>
-        <note category="location">web/src/app/wiki/exercises-page.component.ts:393</note>
-      </notes>
-      <segment>
-        <source>Liegestütze</source>
-      </segment>
-    </unit>
     <unit id="analysis.overview.comparison.title">
       <notes>
         <note category="location">web/src/app/stats/components/category-comparison-chart/category-comparison-chart.component.ts:30,32</note>
@@ -6238,7 +6265,7 @@
     </unit>
     <unit id="quickAddConfig.autoCount">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:123,125</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:125,127</note>
       </notes>
       <segment>
         <source>Auto-Messung</source>
@@ -6246,47 +6273,15 @@
     </unit>
     <unit id="quickAddConfig.inSpeedDial">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:133,136</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:137,140</note>
       </notes>
       <segment>
         <source>Im SpeedDial</source>
       </segment>
     </unit>
-    <unit id="quickAddConfig.autoCount.tooltip">
-      <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
-      </notes>
-      <segment>
-        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
-      </segment>
-    </unit>
-    <unit id="quickAddConfig.inSpeedDial.tooltip">
-      <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
-      </notes>
-      <segment>
-        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
-      </segment>
-    </unit>
-    <unit id="quickAdd.fab.exerciseRepAria">
-      <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts</note>
-      </notes>
-      <segment>
-        <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
-      </segment>
-    </unit>
-    <unit id="quickAdd.fab.pushupRepsLabel">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts</note>
-      </notes>
-      <segment>
-        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
-      </segment>
-    </unit>
     <unit id="save">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:157,158</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:161,162</note>
       </notes>
       <segment>
         <source> Speichern </source>
@@ -6294,15 +6289,31 @@
     </unit>
     <unit id="quickAddConfig.clearRowAria">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:212</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:216</note>
       </notes>
       <segment>
         <source>Schnellaktion löschen</source>
       </segment>
     </unit>
+    <unit id="quickAddConfig.autoCount.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:217</note>
+      </notes>
+      <segment>
+        <source>Verwendet die Kamera, um Wiederholungen automatisch zu zählen. Nur für unterstützte Übungen verfügbar.</source>
+      </segment>
+    </unit>
+    <unit id="quickAddConfig.inSpeedDial.tooltip">
+      <notes>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:218</note>
+      </notes>
+      <segment>
+        <source>Zeigt diese Schnellaktion im schwebenden Plus-Button (SpeedDial) zur Schnellerfassung an.</source>
+      </segment>
+    </unit>
     <unit id="quickAddConfig.wikiTooltip.pushup">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:239</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:245</note>
       </notes>
       <segment>
         <source>Liegestützvarianten ansehen</source>
@@ -6310,7 +6321,7 @@
     </unit>
     <unit id="quickAddConfig.wikiTooltip.exercise">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:241</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:247</note>
       </notes>
       <segment>
         <source>Anleitung zur Übung öffnen</source>
@@ -6318,7 +6329,7 @@
     </unit>
     <unit id="quickAddConfig.saveError">
       <notes>
-        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:361</note>
+        <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:367</note>
       </notes>
       <segment>
         <source>Speichern fehlgeschlagen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4159,15 +4159,15 @@
     </unit>
     <unit id="leaderboard.exercise.ariaLabel">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:13,14</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:17,18</note>
       </notes>
       <segment>
-        <source>Leaderboard Übung</source>
+        <source>Bestenlisten-Übung auswählen</source>
       </segment>
     </unit>
     <unit id="leaderboard.exercise.more">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:42,45</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:46,49</note>
       </notes>
       <segment>
         <source>Mehr</source>
@@ -4175,7 +4175,7 @@
     </unit>
     <unit id="landing.leaderboard.daily">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:86,88</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:92,94</note>
       </notes>
       <segment>
         <source> Tag </source>
@@ -4183,7 +4183,7 @@
     </unit>
     <unit id="landing.leaderboard.last7">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:95,97</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:101,103</note>
       </notes>
       <segment>
         <source> Letzte 7 Tage </source>
@@ -4191,24 +4191,24 @@
     </unit>
     <unit id="landing.leaderboard.last30">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:104,107</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:110,113</note>
       </notes>
       <segment>
         <source> Letzte 30 Tage </source>
       </segment>
     </unit>
-    <unit id="leaderboard.ownPosition.prefix">
+    <unit id="landing.leaderboard.ownPosition">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:147,149</note>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:159,161</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:152,153</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:162,164</note>
       </notes>
       <segment>
-        <source>Deine Position:</source>
+        <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ formatValue(me.reps) }}"/> </source>
       </segment>
     </unit>
     <unit id="leaderboard.visibilityHint">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:174,176</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:172,174</note>
       </notes>
       <segment>
         <source> Sichtbarkeit oder Anzeigename anpassen? </source>
@@ -4216,7 +4216,7 @@
     </unit>
     <unit id="leaderboard.visibilityHint.cta">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:180,183</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:178,181</note>
       </notes>
       <segment>
         <source>Einstellungen öffnen</source>
@@ -4224,7 +4224,7 @@
     </unit>
     <unit id="leaderboard.loginHint">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:187,189</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:185,187</note>
       </notes>
       <segment>
         <source> Mitmachen und auftauchen? </source>
@@ -4232,7 +4232,7 @@
     </unit>
     <unit id="leaderboard.loginHint.cta">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:190,193</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:188,191</note>
       </notes>
       <segment>
         <source>Anmelden</source>
@@ -4240,7 +4240,7 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:43</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:42</note>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:148</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:385</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:222</note>
@@ -4257,8 +4257,7 @@
     </unit>
     <unit id="landing.leaderboard.reps">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:153</note>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:156</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:185</note>
       </notes>
       <segment>
         <source>Reps</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9139,5 +9139,23 @@
         <target>无法保存条目。</target>
       </segment>
     </unit>
+    <unit id="leaderboard.exercise.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Übung</source>
+        <target>Leaderboard Übung</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.exercise.more">
+      <segment state="initial">
+        <source>Mehr</source>
+        <target>Mehr</target>
+      </segment>
+    </unit>
+    <unit id="leaderboard.ownPosition.prefix">
+      <segment state="initial">
+        <source>Deine Position:</source>
+        <target>Deine Position:</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9139,10 +9139,10 @@
         <target>无法保存条目。</target>
       </segment>
     </unit>
-    <unit id="leaderboard.exercise.ariaLabel">
+        <unit id="leaderboard.exercise.ariaLabel">
       <segment state="initial">
-        <source>Leaderboard Übung</source>
-        <target>Leaderboard Übung</target>
+        <source>Bestenlisten-Übung auswählen</source>
+        <target>Bestenlisten-Übung auswählen</target>
       </segment>
     </unit>
     <unit id="leaderboard.exercise.more">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9157,5 +9157,11 @@
         <target>Deine Position:</target>
       </segment>
     </unit>
+    <unit id="leaderboard.period.ariaLabel">
+      <segment state="initial">
+        <source>Leaderboard Zeitraum</source>
+        <target>Leaderboard Zeitraum</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9151,12 +9151,6 @@
         <target>Mehr</target>
       </segment>
     </unit>
-    <unit id="leaderboard.ownPosition.prefix">
-      <segment state="initial">
-        <source>Deine Position:</source>
-        <target>Deine Position:</target>
-      </segment>
-    </unit>
     <unit id="leaderboard.period.ariaLabel">
       <segment state="initial">
         <source>Leaderboard Zeitraum</source>


### PR DESCRIPTION
## Summary

Die Bestenliste rankt bisher ausschließlich Pushups. Diese PR macht sie multi-exercise-fähig: jede Katalog-Übung bekommt ihre eigene Rangliste, der Picker hält die UX kompakt und mobile-first.

### UX

- **Chip-Reihe** mit den 6 populärsten Übungen (Liegestütze als Default, dazu Kniebeugen, Klimmzüge, Plank, Crunches, Laufen) — One-Tap-Wechsel.
- **„Mehr ▾"-Menü** klappt den vollen Katalog nach Kategorien auf (Drücken / Ziehen / Kniebeuge / Hüftstreckung / Ausfallschritt / Rumpf / Ausdauer / Mobilität).
- **Kontextuelle Messgröße:** Reps bleiben Reps, Plank rendert `1:30` statt `90`, ein 5000-m-Lauf wird zu `5.00 km`. Das „Reps"-Label kollabiert für Nicht-Rep-Übungen.
- Zeitraum-Buttons (Tag / 7 Tage / 30 Tage) bleiben unverändert darunter.

### Datenpfad

- `LeaderboardService.load(exerciseId?)` verzweigt:
  - Pushup-Sentinel (`'pushup'`, Default) → legacy `pushups`-Collection + precomputed Snapshot bei `leaderboards/current` (Verhalten unverändert).
  - Jede andere Katalog-`exerciseId` → Query gegen `exerciseEntries`, Aggregation über den messungsspezifischen Wert-Feldnamen (`reps` / `durationSec` / `distanceM`), Snapshot wird übersprungen.
- `LeaderboardStore` cached pro `exerciseId` — Wechsel zwischen schon geladenen Übungen ist instant.
- Live-Snapshot-Reload invalidiert nur den Pushup-Bucket (die Cloud-Function schreibt keine Per-Exercise-Snapshots).

### Tests

- Service: 6 neue Tests (Query gegen `exerciseEntries`, Aggregation für `reps` / `time` / `distance-time`, Catalog-Miss-Fallback, Sentinel-Verhalten).
- Store: 4 neue Tests (Cache pro Exercise, kein Refetch bei Hit, `force`-Refresh, Default auf Pushup-Sentinel).
- Page: 6 neue/aktualisierte Tests (Chip-Click triggert Load, Formatierung pro Messgröße, Reps-Label-Verhalten, Privacy-Regression-Guards bleiben grün).

### Limitierungen (Follow-ups)

- Cloud-Function-Ranker erzeugt keine Per-Exercise-Snapshots → Non-Pushup-Aliase sind obfusziert (`A...E`). Sobald der Ranker erweitert wird, kann der Merge-Pfad gespiegelt werden.
- `weight`-gemessene Übungen (aktuell keine im Katalog) werden ausgenommen — `Σ(reps)` bei gemischter Last ist kein sinnvolles Ranking.

## Test plan

- [x] `pnpm nx affected -t test` (14 affected, alle grün)
- [x] `pnpm nx affected -t lint` (13 projects, clean)
- [x] `pnpm nx run web:build -c production` (2840 prerendered routes, nur preexisting Bundle-Budget-Warnungen)
- [x] `pnpm nx run web:extract-i18n && node tools/src/sync-xliff-locales.mjs` (3 neue Keys × 9 Locales)
- [ ] Manuell: Picker auf Mobile durchklicken (kann ich im Remote-Container nicht — Headless ohne Browser)
- [ ] Manuell: prüfen, ob das Chip-Set die richtige Auswahl trifft

https://claude.ai/code/session_011AQvCUwLkMT9w8E9cJVahh

---
_Generated by [Claude Code](https://claude.ai/code/session_011AQvCUwLkMT9w8E9cJVahh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-exercise leaderboards with an exercise selector (popular chips + categorized menu) and unit-aware value formatting (time, distance, numeric).
  * Per-exercise caching with force-refresh to speed switching and preserve cached buckets.

* **UI/UX**
  * Cleaner "Your Position" display and updated leaderboard list markup for testing/ARIA improvements.

* **Localization**
  * Added i18n entries for exercise selector and period controls in multiple languages.

* **Chores**
  * Added Firestore index to support exercise-based queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->