### PR TITLE
Add noindex support for auth pages and strip query params from canonicals

### DIFF
--- a/web/src/app/app.routes.ts
+++ b/web/src/app/app.routes.ts
@@ -43,6 +43,7 @@ export const appRoutes: Routes = [
     data: {
       seoTitle: $localize`:@@seo.login.title:Login – Pushup Tracker`,
       seoDescription: $localize`:@@seo.login.description:Melde dich an und tracke dein Pushup-Training über alle Geräte.`,
+      noindex: true,
     },
     component: LoginComponent,
   },
@@ -52,6 +53,7 @@ export const appRoutes: Routes = [
     data: {
       seoTitle: $localize`:@@seo.register.title:Registrierung – Pushup Tracker`,
       seoDescription: $localize`:@@seo.register.description:Erstelle dein Konto und richte Profil, Tagesziel und Einwilligungen ein.`,
+      noindex: true,
     },
     component: RegisterComponent,
   },

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -287,6 +287,7 @@ export class App {
         const data = leaf.snapshot.data as {
           seoTitle?: string;
           seoDescription?: string;
+          noindex?: boolean;
         };
 
         const title =
@@ -296,7 +297,7 @@ export class App {
           $localize`:@@seo.default.description:Tracke Reps, Trends und Streaks mit Pushup Tracker.`;
 
         const path = nav.urlAfterRedirects || nav.url;
-        this.seo.update(title, description, path);
+        this.seo.update(title, description, path, { noindex: data.noindex });
         this.trackAnalytics('page_view', { page_path: path });
       });
 

--- a/web/src/app/core/seo.service.spec.ts
+++ b/web/src/app/core/seo.service.spec.ts
@@ -17,7 +17,7 @@ describe('SeoService', () => {
     // Remove image meta tags so each test starts from a clean slate.
     document.head
       .querySelectorAll(
-        'meta[property="og:image"], meta[property="og:image:alt"], meta[name="twitter:image"], meta[name="twitter:image:alt"]'
+        'meta[property="og:image"], meta[property="og:image:alt"], meta[name="twitter:image"], meta[name="twitter:image:alt"], meta[name="robots"]'
       )
       .forEach((node) => node.remove());
     return TestBed.inject(SeoService);
@@ -68,6 +68,52 @@ describe('SeoService', () => {
       seo.update('Title', 'Description', '/de/blog/hello');
 
       expect(getCanonicalHref()).toBe(`${BASE_URL}/de/blog/hello`);
+    });
+
+    it('strips query strings so `?returnUrl=…` variants share one canonical', () => {
+      const seo = setup('de');
+      seo.update('Title', 'Description', '/login?returnUrl=/analysis');
+
+      expect(getCanonicalHref()).toBe(`${BASE_URL}/de/login`);
+    });
+
+    it('strips URL fragments from the canonical', () => {
+      const seo = setup('de');
+      seo.update('Title', 'Description', '/blog/hello#section');
+
+      expect(getCanonicalHref()).toBe(`${BASE_URL}/de/blog/hello`);
+    });
+  });
+
+  describe('robots meta', () => {
+    function getRobotsContent(): string | null {
+      return (
+        document.head
+          .querySelector<HTMLMetaElement>('meta[name="robots"]')
+          ?.getAttribute('content') ?? null
+      );
+    }
+
+    it('emits <meta name="robots" content="noindex,follow"> when noindex is true', () => {
+      const seo = setup('de');
+      seo.update('Title', 'Description', '/login', { noindex: true });
+
+      expect(getRobotsContent()).toBe('noindex,follow');
+    });
+
+    it('omits the robots meta by default', () => {
+      const seo = setup('de');
+      seo.update('Title', 'Description', '/blog/hello');
+
+      expect(document.head.querySelector('meta[name="robots"]')).toBeNull();
+    });
+
+    it('removes a stale robots meta when a subsequent update omits noindex', () => {
+      const seo = setup('de');
+      seo.update('Title', 'Description', '/login', { noindex: true });
+      seo.update('Title', 'Description', '/blog/hello');
+
+      expect(document.head.querySelector('meta[name="robots"]')).toBeNull();
     });
   });
 

--- a/web/src/app/core/seo.service.ts
+++ b/web/src/app/core/seo.service.ts
@@ -48,6 +48,14 @@ export class SeoService {
        * (e.g. a German blog slug under `/fr/blog/…`).
        */
       alternates?: Partial<Record<LocalePrefix, string>>;
+      /**
+       * When true, emits `<meta name="robots" content="noindex,follow">`
+       * so search engines skip the page (e.g. auth pages that have no
+       * SEO value and would otherwise pollute the index with
+       * `returnUrl`-parameterised duplicates). Tag is removed on the
+       * next `update()` that omits the flag.
+       */
+      noindex?: boolean;
     } = {}
   ): void {
     this.title.setTitle(seoTitle);
@@ -63,7 +71,13 @@ export class SeoService {
     const locale = this.detectLocale(path);
     this.setTag('property', 'og:locale', this.ogLocaleFor(locale));
 
-    const strippedPath = this.stripLocalePrefix(path);
+    // Drop query string + hash from the canonical. URLs only differing
+    // in tracking / `returnUrl` params point at the same content, so
+    // canonicalising them under the parameter-less URL prevents Google
+    // from picking its own canonical and flagging the variants as
+    // duplicates in Search Console.
+    const pathWithoutQuery = path.split(/[?#]/)[0] ?? path;
+    const strippedPath = this.stripLocalePrefix(pathWithoutQuery);
     const url = (lang: LocalePrefix, p: string): string =>
       `${BASE_URL}/${lang}${p.startsWith('/') ? p : `/${p}`}`;
 
@@ -109,6 +123,15 @@ export class SeoService {
 
     this.applyImage(options.imageUrl, options.imageAlt ?? seoTitle);
     this.applyArticleTimes(options.publishedTime, options.modifiedTime);
+    this.applyRobots(options.noindex === true);
+  }
+
+  private applyRobots(noindex: boolean): void {
+    if (noindex) {
+      this.setTag('name', 'robots', 'noindex,follow');
+    } else {
+      this.removeTag('name', 'robots');
+    }
   }
 
   private applyImage(imageUrl: string | undefined, alt: string): void {


### PR DESCRIPTION
## Summary
Adds support for marking pages as `noindex` via route metadata and improves canonical URL handling by stripping query strings and fragments. This prevents search engines from indexing auth pages and treats URL variants differing only in tracking parameters as duplicates.

## Changes
- **Robots meta tag support**: Added `noindex` option to `SeoService.update()` that emits `<meta name="robots" content="noindex,follow">` when enabled, and removes the tag when disabled
- **Canonical URL normalization**: Strip query strings and URL fragments from canonical URLs so variants like `/login?returnUrl=/analysis` and `/login` share the same canonical, preventing duplicate content issues in Search Console
- **Route metadata**: Marked login and register routes with `noindex: true` to prevent indexing of auth pages that have no SEO value and would otherwise pollute the index with parameterized duplicates
- **Test coverage**: Added comprehensive tests for robots meta tag behavior and canonical URL stripping

## Implementation Details
- Query strings and fragments are stripped using `path.split(/[?#]/)[0]` before canonical URL generation
- The `noindex` flag is passed through the route data → app component → `SeoService.update()` chain
- Robots meta tag is properly cleaned up when subsequent updates omit the `noindex` flag
- Test setup updated to include robots meta in the cleanup selector

https://claude.ai/code/session_01BjBGK4baJkwUGnryVrrffb