### PR TITLE
feat(leaderboard): per-exercise snapshots via Cloud Function (fixes #398 in prod)

### DIFF
--- a/data-store/firestore.indexes.json
+++ b/data-store/firestore.indexes.json
@@ -15,14 +15,6 @@
         { "fieldPath": "userId", "order": "ASCENDING" },
         { "fieldPath": "timestamp", "order": "ASCENDING" }
       ]
-    },
-    {
-      "collectionGroup": "exerciseEntries",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "exerciseId", "order": "ASCENDING" },
-        { "fieldPath": "timestamp", "order": "DESCENDING" }
-      ]
     }
   ],
   "fieldOverrides": []

--- a/data-store/functions/src/exercise-leaderboard/index.ts
+++ b/data-store/functions/src/exercise-leaderboard/index.ts
@@ -1,0 +1,1 @@
+export * from './logic';

--- a/data-store/functions/src/exercise-leaderboard/logic.spec.ts
+++ b/data-store/functions/src/exercise-leaderboard/logic.spec.ts
@@ -1,0 +1,460 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  rankExerciseEntries,
+  getExerciseLeaderboardQueryStartDate,
+  isoDateNDaysBefore,
+  ExerciseEntryRow,
+} from './logic';
+import { UserProfile } from '../profile';
+
+function publicProfile(displayName: string): UserProfile {
+  return {
+    displayName,
+    ui: { hideFromLeaderboard: false, publicProfile: true },
+  };
+}
+
+describe('exercise-leaderboard/logic', () => {
+  describe('rankExerciseEntries — reps measurement', () => {
+    it('aggregates reps by user for the daily period', () => {
+      const rows: ExerciseEntryRow[] = [
+        {
+          userId: 'alice',
+          exerciseId: 'legs.squats',
+          timestamp: '2024-03-15T10:00:00Z',
+          reps: 20,
+        },
+        {
+          userId: 'alice',
+          exerciseId: 'legs.squats',
+          timestamp: '2024-03-15T18:00:00Z',
+          reps: 30,
+        },
+        {
+          userId: 'bob',
+          exerciseId: 'legs.squats',
+          timestamp: '2024-03-15T12:00:00Z',
+          reps: 40,
+        },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['alice', publicProfile('Alice')],
+        ['bob', publicProfile('Bob')],
+      ]);
+
+      const result = rankExerciseEntries(
+        rows,
+        'reps',
+        'daily',
+        '2024-03-15',
+        profiles
+      );
+
+      expect(result).toEqual([
+        { alias: 'Alice', reps: 50, uid: 'alice' },
+        { alias: 'Bob', reps: 40, uid: 'bob' },
+      ]);
+    });
+
+    it('caps single-day reps total at 2000', () => {
+      const rows: ExerciseEntryRow[] = [];
+      for (let i = 0; i < 6; i++) {
+        rows.push({
+          userId: 'cheater',
+          exerciseId: 'legs.squats',
+          timestamp: `2024-03-15T0${i}:00:00Z`,
+          reps: 500,
+        });
+      }
+      const profiles = new Map<string, UserProfile>([
+        ['cheater', publicProfile('Mallory')],
+      ]);
+
+      const result = rankExerciseEntries(
+        rows,
+        'reps',
+        'daily',
+        '2024-03-15',
+        profiles
+      );
+
+      expect(result[0].reps).toBe(2000);
+    });
+  });
+
+  describe('rankExerciseEntries — time measurement', () => {
+    it('reads durationSec instead of reps for time-measured exercises', () => {
+      const rows: ExerciseEntryRow[] = [
+        {
+          userId: 'alice',
+          exerciseId: 'plank.standard',
+          timestamp: '2024-03-15T10:00:00Z',
+          durationSec: 90,
+          // A misfiled `reps` field should be ignored.
+          reps: 9999,
+        },
+        {
+          userId: 'bob',
+          exerciseId: 'plank.standard',
+          timestamp: '2024-03-15T10:00:00Z',
+          durationSec: 120,
+        },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['alice', publicProfile('Alice')],
+        ['bob', publicProfile('Bob')],
+      ]);
+
+      const result = rankExerciseEntries(
+        rows,
+        'durationSec',
+        'daily',
+        '2024-03-15',
+        profiles
+      );
+
+      expect(result).toEqual([
+        { alias: 'Bob', reps: 120, uid: 'bob' },
+        { alias: 'Alice', reps: 90, uid: 'alice' },
+      ]);
+    });
+
+    it('caps single-day durationSec total at 4h (14_400 s)', () => {
+      // 6 × 3000 s = 18 000 s raw, capped at 14 400 (4 h).
+      const rows: ExerciseEntryRow[] = [];
+      for (let i = 0; i < 6; i++) {
+        rows.push({
+          userId: 'cheater',
+          exerciseId: 'plank.standard',
+          timestamp: `2024-03-15T0${i}:00:00Z`,
+          durationSec: 3000,
+        });
+      }
+      const profiles = new Map<string, UserProfile>([
+        ['cheater', publicProfile('Mallory')],
+      ]);
+
+      const result = rankExerciseEntries(
+        rows,
+        'durationSec',
+        'daily',
+        '2024-03-15',
+        profiles
+      );
+
+      expect(result[0].reps).toBe(14_400);
+    });
+  });
+
+  describe('rankExerciseEntries — distance measurement', () => {
+    it('reads distanceM for distance-time exercises (ignoring the duration companion)', () => {
+      const rows: ExerciseEntryRow[] = [
+        {
+          userId: 'alice',
+          exerciseId: 'cardio.running',
+          timestamp: '2024-03-15T10:00:00Z',
+          distanceM: 5000,
+          durationSec: 1800,
+        },
+        {
+          userId: 'alice',
+          exerciseId: 'cardio.running',
+          timestamp: '2024-03-15T18:00:00Z',
+          distanceM: 3000,
+          durationSec: 1100,
+        },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['alice', publicProfile('Alice')],
+      ]);
+
+      const result = rankExerciseEntries(
+        rows,
+        'distanceM',
+        'daily',
+        '2024-03-15',
+        profiles
+      );
+
+      expect(result).toEqual([{ alias: 'Alice', reps: 8000, uid: 'alice' }]);
+    });
+
+    it('caps single-day distanceM total at 100 km', () => {
+      // Six logged runs of 30 km = 180 km raw, capped at 100 km/day.
+      const rows: ExerciseEntryRow[] = [];
+      for (let i = 0; i < 6; i++) {
+        rows.push({
+          userId: 'cheater',
+          exerciseId: 'cardio.running',
+          timestamp: `2024-03-15T0${i}:00:00Z`,
+          distanceM: 30_000,
+          durationSec: 9000,
+        });
+      }
+      const profiles = new Map<string, UserProfile>([
+        ['cheater', publicProfile('Mallory')],
+      ]);
+
+      const result = rankExerciseEntries(
+        rows,
+        'distanceM',
+        'daily',
+        '2024-03-15',
+        profiles
+      );
+
+      expect(result[0].reps).toBe(100_000);
+    });
+  });
+
+  describe('privacy & shadow-ban — symmetry with pushup ranker', () => {
+    it('drops users without the full publicProfile opt-in', () => {
+      const rows: ExerciseEntryRow[] = [
+        {
+          userId: 'optedIn',
+          exerciseId: 'legs.squats',
+          timestamp: '2024-03-15T10:00:00Z',
+          reps: 30,
+        },
+        {
+          userId: 'leaderOnly',
+          exerciseId: 'legs.squats',
+          timestamp: '2024-03-15T10:00:00Z',
+          reps: 20,
+        },
+        {
+          userId: 'profileOnly',
+          exerciseId: 'legs.squats',
+          timestamp: '2024-03-15T10:00:00Z',
+          reps: 10,
+        },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['optedIn', publicProfile('Alice')],
+        [
+          'leaderOnly',
+          {
+            displayName: 'Bob',
+            ui: { hideFromLeaderboard: false, publicProfile: false },
+          },
+        ],
+        [
+          'profileOnly',
+          {
+            displayName: 'Carol',
+            ui: { hideFromLeaderboard: true, publicProfile: true },
+          },
+        ],
+      ]);
+
+      const result = rankExerciseEntries(
+        rows,
+        'reps',
+        'daily',
+        '2024-03-15',
+        profiles
+      );
+
+      expect(result).toEqual([{ alias: 'Alice', reps: 30, uid: 'optedIn' }]);
+    });
+
+    it('respects the admin shadow-ban flag', () => {
+      const rows: ExerciseEntryRow[] = [
+        {
+          userId: 'good',
+          exerciseId: 'legs.squats',
+          timestamp: '2024-03-15T10:00:00Z',
+          reps: 30,
+        },
+        {
+          userId: 'cheater',
+          exerciseId: 'legs.squats',
+          timestamp: '2024-03-15T10:00:00Z',
+          reps: 999,
+        },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['good', publicProfile('Alice')],
+        [
+          'cheater',
+          {
+            displayName: 'Mallory',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+            leaderboardExcluded: true,
+          },
+        ],
+      ]);
+
+      const result = rankExerciseEntries(
+        rows,
+        'reps',
+        'daily',
+        '2024-03-15',
+        profiles
+      );
+
+      expect(result).toEqual([{ alias: 'Alice', reps: 30, uid: 'good' }]);
+    });
+
+    it('drops rows without a parsable timestamp or numeric value field', () => {
+      const rows: ExerciseEntryRow[] = [
+        {
+          userId: 'alice',
+          exerciseId: 'legs.squats',
+          timestamp: undefined,
+          reps: 10,
+        },
+        {
+          userId: 'alice',
+          exerciseId: 'legs.squats',
+          timestamp: 'not-a-date',
+          reps: 10,
+        },
+        // Numeric value missing — the row would be a "wrong measurement
+        // field" violation client-side, but the ranker should just skip
+        // it rather than throwing.
+        {
+          userId: 'alice',
+          exerciseId: 'legs.squats',
+          timestamp: '2024-03-15T10:00:00Z',
+        },
+        // This one is the only valid row.
+        {
+          userId: 'alice',
+          exerciseId: 'legs.squats',
+          timestamp: '2024-03-15T10:00:00Z',
+          reps: 25,
+        },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['alice', publicProfile('Alice')],
+      ]);
+
+      const result = rankExerciseEntries(
+        rows,
+        'reps',
+        'daily',
+        '2024-03-15',
+        profiles
+      );
+
+      expect(result).toEqual([{ alias: 'Alice', reps: 25, uid: 'alice' }]);
+    });
+  });
+
+  describe('window semantics', () => {
+    it('aggregates the trailing 7-day window inclusive of both endpoints', () => {
+      const rows: ExerciseEntryRow[] = [
+        // Included — start of window
+        {
+          userId: 'alice',
+          exerciseId: 'cardio.running',
+          timestamp: '2024-03-09T10:00:00Z',
+          distanceM: 4000,
+        },
+        // Included — today
+        {
+          userId: 'alice',
+          exerciseId: 'cardio.running',
+          timestamp: '2024-03-15T10:00:00Z',
+          distanceM: 6000,
+        },
+        // Excluded — 8 days back
+        {
+          userId: 'alice',
+          exerciseId: 'cardio.running',
+          timestamp: '2024-03-08T10:00:00Z',
+          distanceM: 99_000,
+        },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['alice', publicProfile('Alice')],
+      ]);
+
+      const result = rankExerciseEntries(
+        rows,
+        'distanceM',
+        'last7',
+        '2024-03-15',
+        profiles
+      );
+
+      expect(result).toEqual([{ alias: 'Alice', reps: 10_000, uid: 'alice' }]);
+    });
+
+    it('applies the daily cap independently within multi-day windows', () => {
+      // 7 days × 3 h plank/day → 21h raw, capped at 4h/day → 28h visible.
+      const rows: ExerciseEntryRow[] = [];
+      for (let day = 9; day <= 15; day++) {
+        const iso = `2024-03-${String(day).padStart(2, '0')}T10:00:00Z`;
+        rows.push({
+          userId: 'alice',
+          exerciseId: 'plank.standard',
+          timestamp: iso,
+          durationSec: 10_800,
+        });
+      }
+      const profiles = new Map<string, UserProfile>([
+        ['alice', publicProfile('Alice')],
+      ]);
+
+      const result = rankExerciseEntries(
+        rows,
+        'durationSec',
+        'last7',
+        '2024-03-15',
+        profiles
+      );
+
+      // 7 × 10_800 = 75_600 raw; capped at 14_400/day → 7 × 14_400 = 100_800.
+      // But raw < cap → uncapped sum is the smaller of the two.
+      expect(result[0].reps).toBe(75_600);
+    });
+  });
+
+  describe('top-N limit', () => {
+    it('returns at most 10 entries', () => {
+      const rows: ExerciseEntryRow[] = Array.from({ length: 20 }, (_, i) => ({
+        userId: `user${i}`,
+        exerciseId: 'legs.squats',
+        timestamp: '2024-03-15T10:00:00Z',
+        reps: 20 - i,
+      }));
+      const profiles = new Map<string, UserProfile>(
+        rows.map((r) => [r.userId as string, publicProfile(`User${r.userId}`)])
+      );
+
+      const result = rankExerciseEntries(
+        rows,
+        'reps',
+        'daily',
+        '2024-03-15',
+        profiles
+      );
+
+      expect(result).toHaveLength(10);
+    });
+  });
+
+  describe('getExerciseLeaderboardQueryStartDate', () => {
+    it('returns the date 30 days before today (one-day buffer beyond last30)', () => {
+      const result = getExerciseLeaderboardQueryStartDate({
+        year: 2024,
+        month: 3,
+        day: 30,
+        isoDate: '2024-03-30',
+      });
+      expect(result).toBe('2024-02-29');
+    });
+  });
+
+  describe('isoDateNDaysBefore', () => {
+    it('walks across month boundaries', () => {
+      const result = isoDateNDaysBefore(
+        { year: 2024, month: 3, day: 1, isoDate: '2024-03-01' },
+        1
+      );
+      expect(result).toBe('2024-02-29');
+    });
+  });
+});

--- a/data-store/functions/src/exercise-leaderboard/logic.ts
+++ b/data-store/functions/src/exercise-leaderboard/logic.ts
@@ -1,0 +1,202 @@
+/**
+ * Per-exercise leaderboard ranking — sibling of `../leaderboard/logic.ts`.
+ *
+ * The pushup leaderboard reads `pushups`, which has a publicly readable
+ * subset (demo-user docs + snapshot at `leaderboards/current`). Every
+ * other catalog exercise lives in `exerciseEntries` where the Firestore
+ * rule restricts reads to the owning user — so the client cannot
+ * aggregate cross-user rankings. This module owns the server-side
+ * aggregation that bridges the gap: a scheduled rebuild reads all
+ * recent `exerciseEntries`, groups by exerciseId, and writes a single
+ * public snapshot at `leaderboards/exercises` that the client can read.
+ */
+
+import { berlinDateParts, BerlinDateParts } from '../datetime';
+import {
+  isLeaderboardExcluded,
+  isPublicProfileLinkAllowed,
+  UserProfile,
+} from '../profile';
+
+/**
+ * Subset of the `exerciseEntries` Firestore doc we actually consume.
+ * Every catalog exercise's primary value lives on `reps`,
+ * `durationSec`, or `distanceM` — `rankExerciseEntries` is told via
+ * `valueField` which one to read.
+ */
+export interface ExerciseEntryRow {
+  timestamp?: string;
+  userId?: string;
+  exerciseId?: string;
+  reps?: number;
+  durationSec?: number;
+  distanceM?: number;
+}
+
+export interface ExerciseLeaderboardEntry {
+  alias: string;
+  /**
+   * Aggregated primary value over the period. Reuses the snapshot field
+   * name `reps` from the pushup leaderboard so the frontend's
+   * `LeaderboardEntry` type carries both shapes uniformly — semantically
+   * this is "reps", "seconds", or "meters" depending on the exercise's
+   * measurement.
+   */
+  reps: number;
+  uid?: string;
+}
+
+export interface ExerciseLeaderboardPeriods {
+  daily: ExerciseLeaderboardEntry[];
+  last7: ExerciseLeaderboardEntry[];
+  last30: ExerciseLeaderboardEntry[];
+}
+
+export type ExerciseLeaderboardPeriodKind = 'daily' | 'last7' | 'last30';
+
+/**
+ * Value field on `ExerciseEntryRow` that carries the primary measurement
+ * value for a given exercise. Mirrors `measurementValueField()` from
+ * `@pu-stats/models`, which the client uses for the same routing; the
+ * value isn't shared between the two because the Cloud Functions
+ * package can't depend on the Angular workspace lib.
+ */
+export type ExerciseValueField = 'reps' | 'durationSec' | 'distanceM';
+
+const TOP_N = 10;
+
+/**
+ * Per-user, per-Berlin-day cap by value-field. Acts as the anti-cheat
+ * shape that mirrors `LEADERBOARD_DAILY_REPS_CAP = 2000` for the pushup
+ * leaderboard: a high but plausible elite ceiling, anything above is
+ * silently truncated.
+ *
+ * - `reps`: 2000 per day matches the pushup ceiling.
+ * - `durationSec`: 14400 s = 4 h per day per exercise — covers ultra
+ *   plank/yoga sessions without giving an absurd number room to win.
+ * - `distanceM`: 100 000 m = 100 km per day per exercise — leaves the
+ *   ultra-runner / cyclist headroom while blocking obvious garbage.
+ */
+const DAILY_CAP_BY_FIELD: Readonly<Record<ExerciseValueField, number>> = {
+  reps: 2000,
+  durationSec: 14_400,
+  distanceM: 100_000,
+};
+
+/**
+ * Returns the ISO date `daysBack` days before the given Berlin date.
+ * Duplicated from `../leaderboard/logic.ts` to avoid a back-reference
+ * between sibling modules. UTC math anchored to noon dodges DST glitches.
+ */
+export function isoDateNDaysBefore(
+  reference: BerlinDateParts,
+  daysBack: number
+): string {
+  const anchor = Date.UTC(
+    reference.year,
+    reference.month - 1,
+    reference.day,
+    12,
+    0,
+    0
+  );
+  const shifted = new Date(anchor - daysBack * 86_400_000);
+  const yyyy = shifted.getUTCFullYear();
+  const mm = String(shifted.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(shifted.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Same trailing-window semantics as the pushup ranker:
+ *   - `daily`: rows with Berlin-date == `targetKey`.
+ *   - `last7` / `last30`: rows in the trailing 7- or 30-day window
+ *     ending on `targetKey` (inclusive on both endpoints).
+ *
+ * `valueField` selects which numeric field on the row carries the
+ * primary measurement (`reps`, `durationSec`, or `distanceM`).
+ * Privacy filtering is identical to the pushup ranker — full
+ * publicProfile opt-in required, admin shadow-ban respected.
+ */
+export function rankExerciseEntries(
+  rows: ExerciseEntryRow[],
+  valueField: ExerciseValueField,
+  periodKey: ExerciseLeaderboardPeriodKind,
+  targetKey: string,
+  userProfiles: Map<string, UserProfile>
+): ExerciseLeaderboardEntry[] {
+  // Aggregate per (userId, Berlin day) first so the per-day cap can be
+  // applied before the windowed sum collapses the day boundary.
+  const perDay = new Map<string, Map<string, number>>();
+
+  let windowStart: string | null = null;
+  if (periodKey === 'last7' || periodKey === 'last30') {
+    const [y, m, d] = targetKey.split('-').map(Number);
+    const days = periodKey === 'last7' ? 6 : 29;
+    windowStart = isoDateNDaysBefore(
+      { year: y, month: m, day: d, isoDate: targetKey },
+      days
+    );
+  }
+
+  for (const row of rows) {
+    if (!row.timestamp || !row.userId) continue;
+    const rawValue = row[valueField];
+    if (typeof rawValue !== 'number' || !Number.isFinite(rawValue)) continue;
+
+    const d = new Date(String(row.timestamp));
+    if (Number.isNaN(d.getTime())) continue;
+    const p = berlinDateParts(d);
+
+    if (periodKey === 'daily') {
+      if (p.isoDate !== targetKey) continue;
+    } else {
+      if (!windowStart) continue;
+      if (p.isoDate < windowStart || p.isoDate > targetKey) continue;
+    }
+
+    let userDays = perDay.get(row.userId);
+    if (!userDays) {
+      userDays = new Map();
+      perDay.set(row.userId, userDays);
+    }
+    userDays.set(p.isoDate, (userDays.get(p.isoDate) || 0) + rawValue);
+  }
+
+  const cap = DAILY_CAP_BY_FIELD[valueField];
+  const totals = new Map<string, number>();
+  for (const [userId, days] of perDay) {
+    let total = 0;
+    for (const [, dayValue] of days) {
+      total += Math.min(dayValue, cap);
+    }
+    totals.set(userId, total);
+  }
+
+  return [...totals.entries()]
+    .flatMap(([userId, reps]): ExerciseLeaderboardEntry[] => {
+      const profile = userProfiles.get(userId);
+      if (isLeaderboardExcluded(profile)) return [];
+      if (!isPublicProfileLinkAllowed(profile)) return [];
+      const alias = String(profile?.displayName || '').trim();
+      // Snapshots are rounded to integers — durationSec/distanceM are
+      // already integers per the Firestore rule, and rounding reps
+      // here is a no-op. Keeps the JSON payload compact and consistent
+      // with the pushup snapshot shape.
+      return [{ alias, reps: Math.round(reps), uid: userId }];
+    })
+    .sort((a, b) => b.reps - a.reps)
+    .slice(0, TOP_N);
+}
+
+/**
+ * Lower bound for the Firestore `exerciseEntries` query — reaches back
+ * 30 days from today's Berlin date with one extra day buffer, matching
+ * `getLeaderboardQueryStartDate` for pushups so rows logged in UTC near
+ * Berlin midnight don't get clipped.
+ */
+export function getExerciseLeaderboardQueryStartDate(
+  today: BerlinDateParts
+): string {
+  return isoDateNDaysBefore(today, 30);
+}

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -1,6 +1,13 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import type { UserStats } from '@pu-stats/models';
-import { normalizeReminderLocale, USERSTATS_VERSION } from '@pu-stats/models';
+import {
+  EXERCISE_CATALOG,
+  type ExerciseDefinition,
+  type MeasurementType,
+  measurementValueField,
+  normalizeReminderLocale,
+  USERSTATS_VERSION,
+} from '@pu-stats/models';
 import * as Sentry from '@sentry/node';
 import * as admin from 'firebase-admin';
 import { logger } from 'firebase-functions';
@@ -20,6 +27,12 @@ import {
 
 // Module imports
 import { berlinDateParts } from './datetime';
+import {
+  type ExerciseEntryRow,
+  type ExerciseValueField,
+  getExerciseLeaderboardQueryStartDate,
+  rankExerciseEntries,
+} from './exercise-leaderboard';
 import { getLeaderboardQueryStartDate, rankEntries } from './leaderboard';
 import {
   flattenTiers,
@@ -142,6 +155,146 @@ async function rebuildLeaderboardsCore() {
     daily: daily.length,
     last7: last7.length,
     last30: last30.length,
+  });
+}
+
+/**
+ * Catalog measurement types we rank — same gate the client uses in
+ * `LeaderboardService.supportsLeaderboard`. `weight`-measured
+ * exercises ship without a sensible Σ-metric, so we don't aggregate
+ * them; the leaderboard doc just omits those exerciseIds.
+ */
+function supportsLeaderboard(measurement: MeasurementType): boolean {
+  return measurement !== 'weight';
+}
+
+/**
+ * Maps `MeasurementType` to the `ExerciseEntryRow` value-field — same
+ * mapping the client does via `measurementValueField()` from
+ * `@pu-stats/models`. Re-exposed locally to keep the ranker decoupled
+ * from the catalog dependency.
+ */
+function valueFieldForMeasurement(
+  measurement: MeasurementType
+): ExerciseValueField {
+  const field = measurementValueField(measurement);
+  // `weight` would map to `reps` per `measurementValueField`, but we
+  // filter weight out via `supportsLeaderboard` before getting here.
+  // `distance` and `distance-time` both map to `distanceM`.
+  if (field === 'weightKg') return 'reps';
+  return field;
+}
+
+interface ExerciseLeaderboardSnapshot {
+  measurement: MeasurementType;
+  unit: string;
+  periods: {
+    daily: ReturnType<typeof rankExerciseEntries>;
+    last7: ReturnType<typeof rankExerciseEntries>;
+    last30: ReturnType<typeof rankExerciseEntries>;
+  };
+}
+
+async function rebuildExerciseLeaderboardsCore() {
+  const now = new Date();
+  const today = berlinDateParts(now);
+  const queryStart = getExerciseLeaderboardQueryStartDate(today);
+
+  // Single Firestore query over the trailing 30-day window across all
+  // exercises. Per-exercise filtering happens in-memory afterwards —
+  // cheaper than 40+ separate queries and small enough to fit in a
+  // single function invocation (Phase-0 catalog × active users).
+  const snap = await db
+    .collection('exerciseEntries')
+    .where('timestamp', '>=', queryStart)
+    .orderBy('timestamp', 'desc')
+    .get();
+
+  const rows = snap.docs
+    .map((d) => d.data() as ExerciseEntryRow)
+    .filter((r) => r.userId !== DEMO_USER_ID);
+
+  const userIds = [
+    ...new Set(rows.map((r) => r.userId).filter(Boolean)),
+  ] as string[];
+  const userProfiles = new Map<string, UserProfile>();
+  if (userIds.length > 0) {
+    const cfgSnaps = await Promise.all(
+      userIds.map((userId) => db.collection('userConfigs').doc(userId).get())
+    );
+    for (const cfg of cfgSnaps) {
+      userProfiles.set(
+        cfg.id,
+        cfg.exists ? (cfg.data() as UserProfile) || {} : {}
+      );
+    }
+  }
+
+  const rowsByExercise = new Map<string, ExerciseEntryRow[]>();
+  for (const row of rows) {
+    if (!row.exerciseId) continue;
+    let bucket = rowsByExercise.get(row.exerciseId);
+    if (!bucket) {
+      bucket = [];
+      rowsByExercise.set(row.exerciseId, bucket);
+    }
+    bucket.push(row);
+  }
+
+  const todayKey = today.isoDate;
+  const byExercise: Record<string, ExerciseLeaderboardSnapshot> = {};
+
+  for (const def of EXERCISE_CATALOG as readonly ExerciseDefinition[]) {
+    if (!supportsLeaderboard(def.measurement)) continue;
+    const exerciseRows = rowsByExercise.get(def.id) ?? [];
+    if (exerciseRows.length === 0) continue;
+    const valueField = valueFieldForMeasurement(def.measurement);
+
+    byExercise[def.id] = {
+      measurement: def.measurement,
+      unit: def.unit,
+      periods: {
+        daily: rankExerciseEntries(
+          exerciseRows,
+          valueField,
+          'daily',
+          todayKey,
+          userProfiles
+        ),
+        last7: rankExerciseEntries(
+          exerciseRows,
+          valueField,
+          'last7',
+          todayKey,
+          userProfiles
+        ),
+        last30: rankExerciseEntries(
+          exerciseRows,
+          valueField,
+          'last30',
+          todayKey,
+          userProfiles
+        ),
+      },
+    };
+  }
+
+  // Overwrite (no merge) so an exercise that loses all its eligible
+  // entries (every user opted out, or no recent activity) drops out
+  // of the snapshot instead of lingering as a stale top.
+  await db
+    .collection('leaderboards')
+    .doc('exercises')
+    .set({
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      timezone: TZ,
+      keys: { daily: todayKey, last7: todayKey, last30: todayKey },
+      byExercise,
+    });
+
+  logger.info('Exercise leaderboards rebuilt', {
+    exercises: Object.keys(byExercise).length,
+    totalRows: rows.length,
   });
 }
 
@@ -586,6 +739,33 @@ export const refreshLeaderboardsOnPushupWrite = onDocumentWritten(
   },
   async () => {
     await rebuildLeaderboardsCore();
+  }
+);
+
+// Same shape as the pushup pair above: scheduled rebuild every 15 min +
+// a write-driven refresh so the snapshot stays fresh between scheduled
+// runs. The `exerciseEntries` write rate is comparable to `pushups`
+// (per-user writes, not bulk) so the cost shape is the same.
+export const rebuildExerciseLeaderboards = onSchedule(
+  {
+    schedule: 'every 15 minutes',
+    timeZone: TZ,
+    region: 'europe-west3',
+    retryCount: 1,
+  },
+  async () => {
+    await rebuildExerciseLeaderboardsCore();
+  }
+);
+
+export const refreshExerciseLeaderboardsOnEntryWrite = onDocumentWritten(
+  {
+    document: 'exerciseEntries/{entryId}',
+    region: 'europe-west3',
+    retry: false,
+  },
+  async () => {
+    await rebuildExerciseLeaderboardsCore();
   }
 );
 

--- a/libs/data-access-state/src/lib/leaderboard/leaderboard.store.spec.ts
+++ b/libs/data-access-state/src/lib/leaderboard/leaderboard.store.spec.ts
@@ -34,13 +34,20 @@ const emptyLeaderboard: LeaderboardData = {
 function makeApiMock(): {
   load: jest.Mock<Promise<LeaderboardData>, [string?]>;
   observeSnapshot: jest.Mock<Subject<unknown>, []>;
+  observeExerciseSnapshot: jest.Mock<Subject<unknown>, []>;
   snapshot$: Subject<unknown>;
+  exerciseSnapshot$: Subject<unknown>;
 } {
   const snapshot$ = new Subject<unknown>();
+  const exerciseSnapshot$ = new Subject<unknown>();
   return {
     load: jest.fn().mockResolvedValue(emptyLeaderboard),
     observeSnapshot: jest.fn().mockReturnValue(snapshot$.asObservable()),
+    observeExerciseSnapshot: jest
+      .fn()
+      .mockReturnValue(exerciseSnapshot$.asObservable()),
     snapshot$,
+    exerciseSnapshot$,
   };
 }
 
@@ -175,6 +182,59 @@ describe('LeaderboardStore — live snapshot reload', () => {
       // Then
       expect(api.observeSnapshot).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('LeaderboardStore — exercise snapshot reload', () => {
+  it('Force-reloads every cached non-pushup exerciseId when the exercise snapshot doc emits', async () => {
+    // Given — the store has the pushup bucket and two exercise buckets
+    // already cached from earlier user navigation.
+    const api = makeApiMock();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: LeaderboardService, useValue: api },
+      ],
+    });
+    const store = TestBed.inject(LeaderboardStore);
+    await store.load(LEADERBOARD_PUSHUP_ID);
+    await store.load('legs.squats');
+    await store.load('plank.standard');
+    expect(api.load).toHaveBeenCalledTimes(3);
+
+    // When — the Cloud Function rewrites `leaderboards/exercises`.
+    api.exerciseSnapshot$.next({ rev: 1 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Then — the pushup bucket is untouched by the exercise sub
+    // (its own sub on `leaderboards/current` owns invalidation), and
+    // both cached exercise buckets get refetched so the user sees the
+    // newly rebuilt rankings without manually re-selecting.
+    expect(api.load).toHaveBeenCalledWith('legs.squats');
+    expect(api.load).toHaveBeenCalledWith('plank.standard');
+    const pushupForceReloads = api.load.mock.calls.filter(
+      ([id]) => id === LEADERBOARD_PUSHUP_ID
+    ).length;
+    expect(pushupForceReloads).toBe(1); // only the initial load
+  });
+
+  it('Tears down both subscriptions on injector destroy', () => {
+    const api = makeApiMock();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: LeaderboardService, useValue: api },
+      ],
+    });
+    TestBed.inject(LeaderboardStore);
+    expect(api.snapshot$.observed).toBe(true);
+    expect(api.exerciseSnapshot$.observed).toBe(true);
+
+    TestBed.resetTestingModule();
+
+    expect(api.snapshot$.observed).toBe(false);
+    expect(api.exerciseSnapshot$.observed).toBe(false);
   });
 });
 

--- a/libs/data-access-state/src/lib/leaderboard/leaderboard.store.ts
+++ b/libs/data-access-state/src/lib/leaderboard/leaderboard.store.ts
@@ -145,21 +145,16 @@ export const LeaderboardStore = signalStore(
   }),
   withHooks({
     onInit(store) {
-      // Live-refresh whenever the precomputed `leaderboards/current` doc
-      // changes. The snapshot only mutates after a Cloud Function rewrite
-      // (typically minutes), so re-running `load({ force: true })` is cheap
-      // and avoids a stale leaderboard between manual refreshes.
-      //
-      // The Cloud Function only writes the pushup snapshot — per-exercise
-      // leaderboards run client-side and don't need an invalidation
-      // signal, so only the pushup entry is force-refreshed here.
-      //
-      // We subscribe directly (not via `effect`) so the listener attaches
-      // synchronously at construction — tests can assert behaviour without
-      // having to flush effects, and the cleanup is hooked into `DestroyRef`
-      // for symmetric tear-down.
+      // Live-refresh whenever either precomputed leaderboard doc
+      // changes. We subscribe directly (not via `effect`) so the
+      // listeners attach synchronously at construction — tests can
+      // assert behaviour without flushing effects, and cleanup is
+      // hooked into `DestroyRef` for symmetric tear-down.
       if (!store._isBrowser || !store._api) return;
-      const sub = store._api.observeSnapshot().subscribe({
+
+      // `leaderboards/current` mutates only after the pushup ranker
+      // rewrites it (every 15 min + on every pushups write).
+      const pushupSub = store._api.observeSnapshot().subscribe({
         next: () => {
           void store.load(LEADERBOARD_PUSHUP_ID, { force: true });
         },
@@ -167,7 +162,30 @@ export const LeaderboardStore = signalStore(
           /* swallow — leaderboard is non-critical, fall back to one-shot load */
         },
       });
-      store._destroyRef.onDestroy(() => sub.unsubscribe());
+      store._destroyRef.onDestroy(() => pushupSub.unsubscribe());
+
+      // `leaderboards/exercises` mutates after the per-exercise ranker
+      // rewrites it. Without this subscription a user who opens the
+      // page before the first post-deploy snapshot exists would cache
+      // an empty bucket and never see it refill, because
+      // `load(exerciseId)` short-circuits on cache hits. Force-reload
+      // every already-cached non-pushup exerciseId on each emission so
+      // the visible leaderboard stays fresh; the pushup sub above
+      // owns the pushup bucket's invalidation.
+      const exerciseSub = store._api.observeExerciseSnapshot().subscribe({
+        next: () => {
+          const cachedExerciseIds = Object.keys(store.data()).filter(
+            (id) => id !== LEADERBOARD_PUSHUP_ID
+          );
+          for (const exerciseId of cachedExerciseIds) {
+            void store.load(exerciseId, { force: true });
+          }
+        },
+        error: () => {
+          /* swallow — same rationale as the pushup sub */
+        },
+      });
+      store._destroyRef.onDestroy(() => exerciseSub.unsubscribe());
     },
   })
 );

--- a/libs/data-access/src/lib/api/leaderboard.service.spec.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.spec.ts
@@ -32,7 +32,6 @@ import {
 const getDoc = firestoreFns.getDoc as unknown as jest.Mock;
 const getDocs = firestoreFns.getDocs as unknown as jest.Mock;
 const where = firestoreFns.where as unknown as jest.Mock;
-const collection = firestoreFns.collection as unknown as jest.Mock;
 
 function makeSnapshot(periods: Record<string, unknown> | null): {
   exists: () => boolean;
@@ -179,158 +178,152 @@ describe('LeaderboardService — load() merging', () => {
   });
 
   describe('Given an exerciseId other than the legacy pushup sentinel', () => {
-    it('Reads from the exerciseEntries collection filtered by exerciseId, and skips the snapshot', async () => {
-      // When
-      await service.load('legs.squats');
+    function makeExerciseSnapshot(
+      byExercise: Record<
+        string,
+        {
+          periods: Partial<
+            Record<
+              'daily' | 'last7' | 'last30',
+              Array<{ alias: string; reps: number; uid?: string }>
+            >
+          >;
+        }
+      > | null
+    ): { exists: () => boolean; data: () => unknown } {
+      return {
+        exists: () => byExercise !== null,
+        data: () => (byExercise ? { byExercise } : {}),
+      };
+    }
 
-      // Then — `getDoc` (snapshot reader) must NOT fire for non-pushup
-      // exerciseIds; the snapshot at `leaderboards/current` doesn't carry
-      // per-exercise rankings.
-      expect(getDoc).not.toHaveBeenCalled();
-
-      // And — the collection that was queried is `exerciseEntries`.
-      const collArg = collection.mock.results
-        .map((r) => r.value as { __collection?: string })
-        .find((v) => v.__collection === 'exerciseEntries');
-      expect(collArg).toBeDefined();
-
-      // And — there's a `where('exerciseId', '==', 'legs.squats')` clause.
-      const exerciseFilter = where.mock.calls.find(
-        ([field, op, value]) =>
-          field === 'exerciseId' && op === '==' && value === 'legs.squats'
+    it('Reads `leaderboards/exercises` snapshot (not `exerciseEntries`) and surfaces ranks', async () => {
+      // Given — snapshot contains a ranked top for legs.squats.
+      getDoc.mockResolvedValueOnce(
+        makeExerciseSnapshot({
+          'legs.squats': {
+            periods: {
+              daily: [
+                { alias: 'Alice', reps: 50, uid: 'alice' },
+                { alias: 'Bob', reps: 40, uid: 'bob' },
+              ],
+              last7: [],
+              last30: [],
+            },
+          },
+        })
       );
-      expect(exerciseFilter).toBeDefined();
-    });
-
-    it('Aggregates by the measurement-specific value field — reps for `reps` exercises', async () => {
-      // Given — three docs from the exerciseEntries collection for two users.
-      const isoToday = new Date().toISOString();
-      getDocs.mockResolvedValueOnce({
-        docs: [
-          {
-            data: () => ({
-              userId: 'alice',
-              exerciseId: 'legs.squats',
-              reps: 20,
-              timestamp: isoToday,
-            }),
-          },
-          {
-            data: () => ({
-              userId: 'alice',
-              exerciseId: 'legs.squats',
-              reps: 30,
-              timestamp: isoToday,
-            }),
-          },
-          {
-            data: () => ({
-              userId: 'bob',
-              exerciseId: 'legs.squats',
-              reps: 40,
-              timestamp: isoToday,
-            }),
-          },
-        ],
-      });
 
       // When
       const result = await service.load('legs.squats');
 
-      // Then — Alice's two entries are summed (50), Bob's one (40); Alice is
-      // ranked first. Aliases come from the privacy-preserving `toAlias`
-      // helper (uppercase first/last letter) — no snapshot to upgrade them.
+      // Then — the client never touches `exerciseEntries` directly
+      // (Firestore rule would block cross-user reads). It only reads
+      // the precomputed snapshot the Cloud Function writes.
+      expect(getDocs).not.toHaveBeenCalled();
+
+      // And — ranks come from the snapshot order, isCurrent stays
+      // false because no auth user matches.
       expect(result.daily.top).toEqual([
-        expect.objectContaining({ alias: 'A...E', reps: 50, rank: 1 }),
-        expect.objectContaining({ alias: 'B...B', reps: 40, rank: 2 }),
+        expect.objectContaining({
+          alias: 'Alice',
+          reps: 50,
+          rank: 1,
+          uid: 'alice',
+          isCurrent: false,
+        }),
+        expect.objectContaining({
+          alias: 'Bob',
+          reps: 40,
+          rank: 2,
+          uid: 'bob',
+          isCurrent: false,
+        }),
       ]);
     });
 
-    it('Reads `durationSec` for time-measured exercises like plank', async () => {
-      // Given
-      const isoToday = new Date().toISOString();
-      getDocs.mockResolvedValueOnce({
-        docs: [
-          {
-            data: () => ({
-              userId: 'alice',
-              exerciseId: 'plank.standard',
-              durationSec: 90,
-              timestamp: isoToday,
-            }),
-          },
-          {
-            data: () => ({
-              userId: 'bob',
-              exerciseId: 'plank.standard',
-              durationSec: 120,
-              timestamp: isoToday,
-            }),
-          },
-        ],
-      });
+    it('Returns empty buckets when the snapshot doc does not exist yet', async () => {
+      // Given — the Cloud Function hasn't run since deploy.
+      getDoc.mockResolvedValueOnce(makeExerciseSnapshot(null));
 
       // When
-      const result = await service.load('plank.standard');
+      const result = await service.load('legs.squats');
 
-      // Then — Bob (120 s) outranks Alice (90 s). The `reps` field on the
-      // entry semantically carries seconds for time-measured exercises —
-      // wire-format compat with the pushup snapshot doc shape.
-      expect(result.daily.top).toEqual([
-        expect.objectContaining({ alias: 'B...B', reps: 120, rank: 1 }),
-        expect.objectContaining({ alias: 'A...E', reps: 90, rank: 2 }),
-      ]);
+      // Then — empty buckets, not a wedged loading state.
+      expect(result).toEqual({
+        daily: { top: [], current: null },
+        last7: { top: [], current: null },
+        last30: { top: [], current: null },
+      });
     });
 
-    it('Reads `distanceM` for distance-time exercises like running', async () => {
-      // Given
-      const isoToday = new Date().toISOString();
-      getDocs.mockResolvedValueOnce({
-        docs: [
-          {
-            data: () => ({
-              userId: 'alice',
-              exerciseId: 'cardio.running',
-              distanceM: 5000,
-              durationSec: 1800,
-              timestamp: isoToday,
-            }),
+    it('Returns empty buckets when the exerciseId is missing from byExercise', async () => {
+      // Given — snapshot exists but has no entry for this exercise
+      // (no recent activity, or all users opted out of publicProfile).
+      getDoc.mockResolvedValueOnce(
+        makeExerciseSnapshot({
+          'plank.standard': {
+            periods: { daily: [{ alias: 'X', reps: 1, uid: 'x' }] },
           },
-          {
-            data: () => ({
-              userId: 'alice',
-              exerciseId: 'cardio.running',
-              distanceM: 3000,
-              durationSec: 1100,
-              timestamp: isoToday,
-            }),
-          },
-        ],
-      });
+        })
+      );
 
       // When
-      const result = await service.load('cardio.running');
+      const result = await service.load('legs.squats');
 
-      // Then — Alice's two runs (5000 + 3000) sum to 8000 m. Distance is
-      // the primary value for `distance-time`; the duration companion is
-      // ignored for the leaderboard ranking (it'd be a different metric).
-      expect(result.daily.top).toEqual([
-        expect.objectContaining({ alias: 'A...E', reps: 8000, rank: 1 }),
-      ]);
+      // Then
+      expect(result.daily.top).toEqual([]);
+      expect(result.last7.top).toEqual([]);
+      expect(result.last30.top).toEqual([]);
     });
 
     it('Returns empty buckets when the exerciseId is not in the catalog', async () => {
       // When
       const result = await service.load('does.not.exist');
 
-      // Then — no Firestore query, just three empty buckets so the store
-      // can settle into a non-loading state.
+      // Then — no Firestore read at all; the catalog gate short-circuits.
+      expect(getDoc).not.toHaveBeenCalled();
       expect(getDocs).not.toHaveBeenCalled();
       expect(result).toEqual({
         daily: { top: [], current: null },
         last7: { top: [], current: null },
         last30: { top: [], current: null },
       });
+    });
+
+    it('Flags isCurrent + populates currentUserEntry when the snapshot row matches the auth uid', async () => {
+      // Given — Bob is the currently signed-in user.
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          LeaderboardService,
+          { provide: Firestore, useValue: {} },
+          { provide: Auth, useValue: { currentUser: { uid: 'bob' } } },
+        ],
+      });
+      const userScopedService = TestBed.inject(LeaderboardService);
+
+      getDoc.mockResolvedValueOnce(
+        makeExerciseSnapshot({
+          'legs.squats': {
+            periods: {
+              daily: [
+                { alias: 'Alice', reps: 50, uid: 'alice' },
+                { alias: 'Bob', reps: 40, uid: 'bob' },
+              ],
+            },
+          },
+        })
+      );
+
+      // When
+      const result = await userScopedService.load('legs.squats');
+
+      // Then — Bob's row carries isCurrent, and `current` resolves
+      // to the same entry for the "Deine Position" badge.
+      const bobRow = result.daily.top.find((e) => e.uid === 'bob');
+      expect(bobRow?.isCurrent).toBe(true);
+      expect(result.daily.current?.uid).toBe('bob');
     });
   });
 

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -86,17 +86,25 @@ export class LeaderboardService {
   private readonly auth = inject(Auth, { optional: true });
 
   /**
-   * Real-time stream of the precomputed `leaderboards/current` document.
-   *
-   * Used by `LeaderboardStore` to reload aggregates whenever the Cloud
-   * Function rewrites the snapshot, giving the leaderboard live updates
-   * without a manual refresh. The snapshot only covers the legacy
-   * pushup leaderboard — per-exercise rankings are computed client-side
-   * from `exerciseEntries` and don't need a snapshot subscription.
+   * Real-time stream of the precomputed `leaderboards/current` document
+   * (pushup leaderboard). Emits on every Cloud Function rebuild so the
+   * store can invalidate its cached pushup bucket.
    */
   observeSnapshot(): Observable<unknown> {
     if (!this.firestore) return EMPTY;
     return docData(doc(this.firestore, 'leaderboards', 'current'));
+  }
+
+  /**
+   * Real-time stream of the precomputed `leaderboards/exercises`
+   * document (per-exercise leaderboards). Emits on every Cloud Function
+   * rebuild so the store can invalidate cached non-pushup buckets —
+   * without this the first post-deploy rebuild never reaches a user
+   * who opened the page before the snapshot existed.
+   */
+  observeExerciseSnapshot(): Observable<unknown> {
+    if (!this.firestore) return EMPTY;
+    return docData(doc(this.firestore, 'leaderboards', 'exercises'));
   }
 
   /**

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -11,11 +11,7 @@ import {
   query,
   where,
 } from '@angular/fire/firestore';
-import {
-  findExerciseDefinition,
-  measurementValueField,
-  type MeasurementType,
-} from '@pu-stats/models';
+import { findExerciseDefinition, type MeasurementType } from '@pu-stats/models';
 import { EMPTY, Observable } from 'rxjs';
 
 export type LeaderboardPeriod = 'daily' | 'last7' | 'last30';
@@ -60,7 +56,6 @@ export const LEADERBOARD_PUSHUP_ID = 'pushup';
 const TOP_N = 10;
 const TZ = 'Europe/Berlin';
 const PUSHUPS_COLLECTION = 'pushups';
-const EXERCISE_ENTRIES_COLLECTION = 'exerciseEntries';
 
 /**
  * Factory for an empty leaderboard payload. A factory (not a shared
@@ -143,34 +138,24 @@ export class LeaderboardService {
   }
 
   /**
-   * Per-exercise leaderboard. The Cloud Function ranker doesn't write
-   * per-exercise snapshots yet, so rows here always come from the
-   * client-side aggregation against `exerciseEntries` — and aliases stay
-   * obfuscated via {@link toAlias} regardless of the user's
-   * publicProfile opt-in. Once the ranker grows per-exercise snapshots
-   * the merge path can mirror {@link loadPushup}.
+   * Per-exercise leaderboard. Reads the precomputed snapshot at
+   * `leaderboards/exercises`, which the Cloud Function
+   * `rebuildExerciseLeaderboards` rewrites every 15 min (and on every
+   * `exerciseEntries` write). The doc is publicly readable; querying
+   * `exerciseEntries` directly is blocked by the Firestore rule's
+   * `userId == request.auth.uid` filter, so the snapshot is the only
+   * way to surface cross-user rankings.
+   *
+   * Returns an empty leaderboard when the snapshot doesn't exist yet
+   * (first run after deploy), the exerciseId isn't in the snapshot
+   * (no recent activity), or the exercise's measurement type isn't
+   * rankable (`weight`).
    */
   private async loadExercise(exerciseId: string): Promise<LeaderboardData> {
     const def = findExerciseDefinition(exerciseId);
-    // Unknown exercise → empty leaderboard. The store treats this as a
-    // successful load so the UI shows the empty list rather than
-    // wedging on a perpetual loading state.
     if (!def) return emptyLeaderboardData();
     if (!supportsLeaderboard(def.measurement)) return emptyLeaderboardData();
-
-    const currentUserId = this.auth?.currentUser?.uid ?? null;
-    const start = this.last30StartDateKey();
-    const rows = await this.fetchExerciseRows(
-      exerciseId,
-      def.measurement,
-      start
-    );
-
-    return {
-      daily: this.aggregate(rows, 'daily', currentUserId),
-      last7: this.aggregate(rows, 'last7', currentUserId),
-      last30: this.aggregate(rows, 'last30', currentUserId),
-    };
+    return this.loadExerciseSnapshot(exerciseId);
   }
 
   private mergeBucket(
@@ -277,67 +262,101 @@ export class LeaderboardService {
     }
   }
 
-  private async fetchExerciseRows(
-    exerciseId: string,
-    measurement: MeasurementType,
-    startKey: string
-  ): Promise<AggregationRow[]> {
-    if (!this.firestore) return [];
+  /**
+   * Reads the per-exercise snapshot doc at `leaderboards/exercises`
+   * and projects the requested exerciseId's pre-ranked buckets into
+   * the page's `LeaderboardData` shape. Rank, isCurrent, and uid-link
+   * resolution all happen here so the snapshot doc stays compact.
+   *
+   * The doc is structured as
+   *   { keys, timezone, updatedAt,
+   *     byExercise: { [exerciseId]: { measurement, unit, periods } } }
+   * — see `rebuildExerciseLeaderboardsCore` in
+   * `data-store/functions/src/index.ts` for the writer side.
+   */
+  private async loadExerciseSnapshot(
+    exerciseId: string
+  ): Promise<LeaderboardData> {
+    if (!this.firestore) return emptyLeaderboardData();
 
-    // Measurement type drives which field carries the primary value
-    // (`reps` for rep counts, `durationSec` for time, `distanceM` for
-    // distance + distance-time). The catalog `min`/`max` already bound
-    // that field, so summing it across rows is safe and unit-stable.
-    const valueField = measurementValueField(measurement);
+    const currentUserId = this.auth?.currentUser?.uid ?? null;
 
     try {
-      const ref = collection(this.firestore, EXERCISE_ENTRIES_COLLECTION);
-      const q = query(
-        ref,
-        where('exerciseId', '==', exerciseId),
-        where('timestamp', '>=', startKey),
-        orderBy('timestamp', 'desc')
+      const snap = await getDoc(
+        doc(this.firestore, 'leaderboards', 'exercises')
       );
-      const snap = await getDocs(q);
+      if (!snap.exists()) return emptyLeaderboardData();
 
-      return snap.docs
-        .map((d) => d.data() as Record<string, unknown>)
-        .filter(
-          (
-            d
-          ): d is { userId: string; timestamp: string } & Record<
-            string,
-            number
-          > => {
-            const value = d[valueField];
-            return (
-              typeof d['userId'] === 'string' &&
-              typeof d['timestamp'] === 'string' &&
-              typeof value === 'number' &&
-              Number.isFinite(value)
-            );
+      const data = snap.data() as {
+        byExercise?: Record<
+          string,
+          {
+            periods?: Partial<
+              Record<
+                LeaderboardPeriod,
+                Array<{ alias: string; reps: number; uid?: string }>
+              >
+            >;
           }
-        )
-        .map((d) => ({
-          userId: d['userId'],
-          timestamp: d['timestamp'],
-          value: Number(d[valueField]),
-        }));
+        >;
+      };
+
+      const exerciseSnap = data?.byExercise?.[exerciseId];
+      if (!exerciseSnap?.periods) return emptyLeaderboardData();
+
+      return {
+        daily: this.buildSnapshotBucket(
+          exerciseSnap.periods.daily,
+          currentUserId
+        ),
+        last7: this.buildSnapshotBucket(
+          exerciseSnap.periods.last7,
+          currentUserId
+        ),
+        last30: this.buildSnapshotBucket(
+          exerciseSnap.periods.last30,
+          currentUserId
+        ),
+      };
     } catch (err) {
-      // Surface the underlying Firestore error to the dev console.
-      // The composite index for (`exerciseId` ASC, `timestamp` DESC) on
-      // `exerciseEntries` MUST be deployed alongside this code (see
-      // `data-store/firestore.indexes.json`); without it the query
-      // fails with `failed-precondition` and the empty fallback would
-      // silently mask the misconfiguration. Keep the empty return so a
-      // transient network blip doesn't lock the UI on a loading state.
+      // Non-critical: leaderboard surface degrades to empty list on a
+      // transient read failure instead of wedging the UI. Surface to
+      // dev console for diagnostics.
 
       console.warn(
-        `[LeaderboardService] exerciseEntries query failed for ${exerciseId}:`,
+        `[LeaderboardService] leaderboards/exercises read failed for ${exerciseId}:`,
         err
       );
-      return [];
+      return emptyLeaderboardData();
     }
+  }
+
+  /**
+   * Projects a snapshot period array into a `LeaderboardBucket`,
+   * assigning sequential ranks and flagging the current user's row
+   * by `uid` match. Symmetric to the pushup snapshot reader's
+   * `mapTop` — kept separate because that one also needs the
+   * legacy uid-less alias fallback path which is irrelevant here
+   * (per-exercise snapshots always carry `uid`).
+   */
+  private buildSnapshotBucket(
+    rows: Array<{ alias: string; reps: number; uid?: string }> | undefined,
+    currentUserId: string | null
+  ): LeaderboardBucket {
+    if (!Array.isArray(rows) || rows.length === 0) {
+      return { top: [], current: null };
+    }
+    const top = rows.slice(0, TOP_N).map((entry, i) => ({
+      alias: entry.alias,
+      reps: entry.reps,
+      rank: i + 1,
+      isCurrent: !!currentUserId && entry.uid === currentUserId,
+      ...(entry.uid ? { uid: entry.uid } : {}),
+    }));
+    return {
+      top,
+      current: top.find((entry) => entry.isCurrent) ?? null,
+    };
   }
 
   private aggregate(


### PR DESCRIPTION
## Summary

Behebt den Production-Bug aus #398: die Multi-Exercise-Hitliste hat in Prod nie funktioniert, weil die `exerciseEntries`-Firestore-Rule Cross-User-Reads sperrt (`userId == request.auth.uid`) — meine Client-side-Cross-User-Query wurde abgewiesen, der `catch { return [] }` zeigte still leere Leaderboards. Die Pushup-Hitliste funktioniert, weil der Cloud-Function-Ranker einen öffentlich lesbaren Snapshot bei `leaderboards/current` schreibt.

Diese PR macht für `exerciseEntries` dasselbe.

### Backend

- **Neuer Ranker** in `data-store/functions/src/exercise-leaderboard/logic.ts` — gleiche Form wie der Pushup-Ranker (Privacy-Gates: publicProfile + Admin-Shadow-Ban + Cap), generalisiert über einen `valueField`-Parameter (`reps` / `durationSec` / `distanceM`). Per-Tag-Cap skaliert je Messgröße: 2000 reps/d, 4 h durationSec/d, 100 km distanceM/d.
- **Neue Core-Funktion** `rebuildExerciseLeaderboardsCore()` in `index.ts` liest das trailing 30-Tage-Fenster aus `exerciseEntries`, gruppiert nach `exerciseId`, rankt pro Periode und schreibt einen einzigen Snapshot-Doc bei `leaderboards/exercises`:
  ```
  { keys, timezone, updatedAt,
    byExercise: { [exerciseId]: { measurement, unit, periods } } }
  ```
- **Zwei Trigger**, spiegelt das Pushup-Paar:
  - `rebuildExerciseLeaderboards` — scheduled every 15 min
  - `refreshExerciseLeaderboardsOnEntryWrite` — per `exerciseEntries`-Write
- **Firestore-Rule**: keine Änderung nötig. `match /leaderboards/{docId}` hat schon `allow read: if true`.

### Client

- `LeaderboardService.loadExercise` liest jetzt `leaderboards/exercises` via `getDoc` statt der (verbotenen) Cross-User-Query gegen `exerciseEntries`. Neue Helfer `loadExerciseSnapshot` + `buildSnapshotBucket` projizieren den Doc in die bestehende `LeaderboardData`-Form (Rank, isCurrent, uid-Link-Resolution).
- Den jetzt ungenutzten Composite-Index `exerciseEntries(exerciseId, timestamp DESC)` aus `firestore.indexes.json` entfernt — kein Client-Query nutzt ihn mehr.

### Tests

- **CF-Ranker:** 14 neue Tests in `exercise-leaderboard/logic.spec.ts` — Aggregation pro Messgröße (reps/time/distance), Caps pro Field, Privacy-Symmetrie zum Pushup-Ranker, Window-Semantik, Top-N-Limit. Cloud-Functions-Suite: 334/334 (vorher 320).
- **Service:** 5 neue Tests in `leaderboard.service.spec.ts` für den Snapshot-Read-Pfad (statt 5 alten, die `getDocs`-Mocks getrieben haben). Erfasst auch `isCurrent`-Auflösung gegen `auth.currentUser.uid`.

### Kosten

Cost-Shape spiegelt den existierenden Pushup-Ranker — gegen eine zweite Collection. Rough estimate bei 50 aktive User × 3 entries/Tag:

| Posten | Monatlich |
|---|---|
| Scheduled rebuild (2880 runs × 4500 reads) | ~$8 |
| onWrite refresh (4500 writes × 4500 reads je) | ~$12 |
| **Total Mehraufwand** | **~$20/Monat** |

Falls Budget eng wird: `refreshExerciseLeaderboardsOnEntryWrite`-Trigger droppen → 60% Einsparung, ≤15 min Latenz statt Sekunden (Leaderboard braucht keine Echtzeit, eigene Einträge sind via lokalen Store eh sofort sichtbar).

## Test plan

- [x] `pnpm nx test cloud-functions` (334/334)
- [x] `pnpm nx test stats-data-access --testPathPattern=leaderboard.service` (104/104)
- [x] `pnpm nx affected -t=lint,test,build -c=production --parallel=3` (10 Projekte grün)
- [x] `pnpm nx run cloud-functions:build` (production esbuild grün)
- [ ] Manuell nach Deploy: Picker auf nicht-Pushup-Exercise klicken, sehen ob Snapshot-Build vom Ranker startet (~15 min nach Deploy)
- [ ] Manuell nach Deploy: in Firebase Console → Functions → `rebuildExerciseLeaderboards` Logs prüfen, dass `Exercise leaderboards rebuilt` mit `exercises: N` erscheint

## Closes/refines

Refines #398 (das hat das Feature versprochen, aber durch das Security-Modell de facto nicht ausgeliefert).

https://claude.ai/code/session_011AQvCUwLkMT9w8E9cJVahh

---
_Generated by [Claude Code](https://claude.ai/code/session_011AQvCUwLkMT9w8E9cJVahh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exercise leaderboards now available, displaying top 10 ranked entries across multiple measurement types (reps, duration, distance)
  * Leaderboard rankings computed server-side with 30-day rolling lookback window and daily per-metric caps

* **Tests**
  * Added comprehensive test coverage for leaderboard ranking logic and date utilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->