### PR TITLE
feat(auth): track registration funnel drop-offs via Firebase Analytics

### DIFF
--- a/libs/auth/src/lib/core/registration-analytics.service.spec.ts
+++ b/libs/auth/src/lib/core/registration-analytics.service.spec.ts
@@ -1,0 +1,160 @@
+import { TestBed } from '@angular/core/testing';
+import { Analytics, logEvent } from '@angular/fire/analytics';
+import {
+  RegistrationAnalyticsService,
+  REGISTRATION_STEPS,
+} from './registration-analytics.service';
+
+jest.mock('@angular/fire/analytics', () => {
+  const actual = jest.requireActual('@angular/fire/analytics');
+  return {
+    ...actual,
+    logEvent: jest.fn(),
+  };
+});
+
+const ANALYTICS_CONSENT_KEY = 'pus_analytics_consent';
+
+describe('RegistrationAnalyticsService', () => {
+  const analyticsToken = { __type: 'analytics' } as unknown as Analytics;
+
+  function setupWithAnalytics(): RegistrationAnalyticsService {
+    TestBed.configureTestingModule({
+      providers: [
+        RegistrationAnalyticsService,
+        { provide: Analytics, useValue: analyticsToken },
+      ],
+    });
+    return TestBed.inject(RegistrationAnalyticsService);
+  }
+
+  function setupWithoutAnalytics(): RegistrationAnalyticsService {
+    TestBed.configureTestingModule({
+      providers: [RegistrationAnalyticsService],
+    });
+    return TestBed.inject(RegistrationAnalyticsService);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('Given no consent When tracking an event Then logEvent is not called', () => {
+    const service = setupWithAnalytics();
+
+    service.trackStarted({ plan_preselected: false });
+
+    expect(logEvent).not.toHaveBeenCalled();
+  });
+
+  it('Given consent denied When tracking an event Then logEvent is not called', () => {
+    localStorage.setItem(ANALYTICS_CONSENT_KEY, 'denied');
+    const service = setupWithAnalytics();
+
+    service.trackStarted({ plan_preselected: false });
+
+    expect(logEvent).not.toHaveBeenCalled();
+  });
+
+  it('Given consent granted but no Analytics provider Then logEvent is not called', () => {
+    localStorage.setItem(ANALYTICS_CONSENT_KEY, 'granted');
+    const service = setupWithoutAnalytics();
+
+    service.trackStarted({ plan_preselected: false });
+
+    expect(logEvent).not.toHaveBeenCalled();
+  });
+
+  describe('with consent granted and analytics provider', () => {
+    let service: RegistrationAnalyticsService;
+
+    beforeEach(() => {
+      localStorage.setItem(ANALYTICS_CONSENT_KEY, 'granted');
+      service = setupWithAnalytics();
+    });
+
+    it('trackStarted sends register_started with plan_preselected flag', () => {
+      service.trackStarted({ plan_preselected: true });
+
+      expect(logEvent).toHaveBeenCalledWith(
+        analyticsToken,
+        'register_started',
+        {
+          plan_preselected: true,
+        }
+      );
+    });
+
+    it('trackStepView sends step name and index', () => {
+      service.trackStepView('username', { is_google: false });
+
+      expect(logEvent).toHaveBeenCalledWith(
+        analyticsToken,
+        'register_step_view',
+        {
+          step_name: 'username',
+          step_index: REGISTRATION_STEPS.indexOf('username'),
+          is_google: false,
+        }
+      );
+    });
+
+    it('trackStepCompleted sends step name and index', () => {
+      service.trackStepCompleted('email', { is_google: true });
+
+      expect(logEvent).toHaveBeenCalledWith(
+        analyticsToken,
+        'register_step_completed',
+        {
+          step_name: 'email',
+          step_index: 0,
+          is_google: true,
+        }
+      );
+    });
+
+    it('trackSubmitted sends register_submitted with is_google', () => {
+      service.trackSubmitted({ is_google: true });
+
+      expect(logEvent).toHaveBeenCalledWith(
+        analyticsToken,
+        'register_submitted',
+        { is_google: true }
+      );
+    });
+
+    it('trackSucceeded sends register_succeeded', () => {
+      service.trackSucceeded({ is_google: false });
+
+      expect(logEvent).toHaveBeenCalledWith(
+        analyticsToken,
+        'register_succeeded',
+        { is_google: false }
+      );
+    });
+
+    it('trackFailed sends register_failed with reason', () => {
+      service.trackFailed({ is_google: false, reason: 'sign_up' });
+
+      expect(logEvent).toHaveBeenCalledWith(analyticsToken, 'register_failed', {
+        is_google: false,
+        reason: 'sign_up',
+      });
+    });
+
+    it('trackAbandoned includes last_step and its index', () => {
+      service.trackAbandoned({ last_step: 'daily_goal', is_google: true });
+
+      expect(logEvent).toHaveBeenCalledWith(
+        analyticsToken,
+        'register_abandoned',
+        {
+          last_step: 'daily_goal',
+          last_step_index: REGISTRATION_STEPS.indexOf('daily_goal'),
+          is_google: true,
+        }
+      );
+    });
+  });
+});

--- a/libs/auth/src/lib/core/registration-analytics.service.ts
+++ b/libs/auth/src/lib/core/registration-analytics.service.ts
@@ -1,0 +1,81 @@
+import { inject, Injectable } from '@angular/core';
+import { Analytics, logEvent } from '@angular/fire/analytics';
+
+export const REGISTRATION_STEPS = [
+  'email',
+  'password',
+  'username',
+  'daily_goal',
+  'consent',
+] as const;
+
+export type RegistrationStep = (typeof REGISTRATION_STEPS)[number];
+
+type RegistrationVariant = { is_google: boolean };
+
+type RegistrationFailureReason = 'sign_up' | 'persist_profile';
+
+@Injectable({ providedIn: 'root' })
+export class RegistrationAnalyticsService {
+  private readonly analytics = inject(Analytics, { optional: true });
+
+  trackStarted(params: { plan_preselected: boolean }): void {
+    this.track('register_started', params);
+  }
+
+  trackStepView(step: RegistrationStep, variant: RegistrationVariant): void {
+    this.track('register_step_view', {
+      step_name: step,
+      step_index: REGISTRATION_STEPS.indexOf(step),
+      is_google: variant.is_google,
+    });
+  }
+
+  trackStepCompleted(
+    step: RegistrationStep,
+    variant: RegistrationVariant
+  ): void {
+    this.track('register_step_completed', {
+      step_name: step,
+      step_index: REGISTRATION_STEPS.indexOf(step),
+      is_google: variant.is_google,
+    });
+  }
+
+  trackSubmitted(variant: RegistrationVariant): void {
+    this.track('register_submitted', variant);
+  }
+
+  trackSucceeded(variant: RegistrationVariant): void {
+    this.track('register_succeeded', variant);
+  }
+
+  trackFailed(
+    variant: RegistrationVariant & { reason: RegistrationFailureReason }
+  ): void {
+    this.track('register_failed', variant);
+  }
+
+  trackAbandoned(
+    params: RegistrationVariant & { last_step: RegistrationStep }
+  ): void {
+    this.track('register_abandoned', {
+      ...params,
+      last_step_index: REGISTRATION_STEPS.indexOf(params.last_step),
+    });
+  }
+
+  private consentGranted(): boolean {
+    const storage = globalThis.localStorage;
+    if (typeof storage?.getItem !== 'function') return false;
+    return storage.getItem('pus_analytics_consent') === 'granted';
+  }
+
+  private track(
+    eventName: string,
+    params: Record<string, string | number | boolean>
+  ): void {
+    if (!this.analytics || !this.consentGranted()) return;
+    logEvent(this.analytics, eventName, params);
+  }
+}

--- a/libs/auth/src/lib/ui/register/register.component.html
+++ b/libs/auth/src/lib/ui/register/register.component.html
@@ -48,6 +48,7 @@
           class="register-stepper"
           #registerStepper
           [orientation]="(stepperOrientation | async) ?? 'horizontal'"
+          (selectionChange)="onStepperSelectionChange($event)"
         >
           <mat-step
             [completed]="

--- a/libs/auth/src/lib/ui/register/register.component.spec.ts
+++ b/libs/auth/src/lib/ui/register/register.component.spec.ts
@@ -7,13 +7,15 @@ import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { of } from 'rxjs';
 import { AuthStore } from '../../core/state/auth.store';
 import { RegisterOnboardingStore } from '../../core/state/register-onboarding.store';
+import { RegistrationAnalyticsService } from '../../core/registration-analytics.service';
 import { RegisterComponent } from './register.component';
+import { RegisterUiStore } from './register-ui.store';
 
 const authStoreMock = {
   loading: signal(false),
   error: signal<Error | null>(null),
   isAuthenticated: signal(false),
-  user: signal(null),
+  user: signal<{ uid: string } | null>(null),
   signUpWithEmail: jest.fn(),
   upgradeWithGoogle: jest.fn(),
   logout: jest.fn(),
@@ -22,12 +24,21 @@ const authStoreMock = {
 const onboardingStoreMock = {
   saving: signal(false),
   error: signal<string | null>(null),
-  registerSuccess: signal(false),
   saveProfile: jest.fn(),
 };
 
 const breakpointObserverMock = {
   observe: jest.fn().mockReturnValue(of({ matches: true } as BreakpointState)),
+};
+
+const analyticsMock = {
+  trackStarted: jest.fn(),
+  trackStepView: jest.fn(),
+  trackStepCompleted: jest.fn(),
+  trackSubmitted: jest.fn(),
+  trackSucceeded: jest.fn(),
+  trackFailed: jest.fn(),
+  trackAbandoned: jest.fn(),
 };
 
 async function renderRegister(queryParams: Record<string, string> = {}) {
@@ -47,6 +58,7 @@ async function renderRegister(queryParams: Record<string, string> = {}) {
       { provide: RegisterOnboardingStore, useValue: onboardingStoreMock },
       { provide: Auth, useValue: null },
       { provide: BreakpointObserver, useValue: breakpointObserverMock },
+      { provide: RegistrationAnalyticsService, useValue: analyticsMock },
     ],
   });
 }
@@ -55,6 +67,11 @@ describe('RegisterComponent', () => {
   beforeEach(() => {
     authStoreMock.error.set(null);
     onboardingStoreMock.error.set(null);
+    authStoreMock.user.set(null);
+    onboardingStoreMock.saveProfile.mockReset().mockResolvedValue(undefined);
+    authStoreMock.signUpWithEmail.mockReset().mockResolvedValue(true);
+    authStoreMock.upgradeWithGoogle.mockReset().mockResolvedValue(true);
+    Object.values(analyticsMock).forEach((spy) => spy.mockReset());
   });
 
   it('renders registration title', async () => {
@@ -123,6 +140,90 @@ describe('RegisterComponent', () => {
         '[data-testid="register-plan-banner"]'
       );
       expect(banner).toBeNull();
+    });
+  });
+
+  describe('analytics tracking', () => {
+    it('Given the register page is opened Then register_started and the email step view are tracked', async () => {
+      await renderRegister();
+
+      expect(analyticsMock.trackStarted).toHaveBeenCalledWith({
+        plan_preselected: false,
+      });
+      expect(analyticsMock.trackStepView).toHaveBeenCalledWith('email', {
+        is_google: false,
+      });
+    });
+
+    it('Given a preselected plan When opening the register page Then plan_preselected is true', async () => {
+      await renderRegister({ planId: 'recruit-6w-v1' });
+
+      expect(analyticsMock.trackStarted).toHaveBeenCalledWith({
+        plan_preselected: true,
+      });
+    });
+
+    it('Given the user destroys the page before success Then register_abandoned is tracked with the last step', async () => {
+      const view = await renderRegister();
+      analyticsMock.trackAbandoned.mockClear();
+
+      view.fixture.destroy();
+
+      expect(analyticsMock.trackAbandoned).toHaveBeenCalledWith({
+        last_step: 'email',
+        is_google: false,
+      });
+    });
+
+    it('Given the registration succeeded When the page is destroyed Then no abandoned event is tracked', async () => {
+      authStoreMock.user.set({ uid: 'uid-1' });
+      const view = await renderRegister();
+      const uiStore = view.fixture.debugElement.injector.get(RegisterUiStore);
+      uiStore.setDisplayName('Alex');
+      uiStore.setDailyGoal(10);
+      await uiStore.persistProfile();
+      expect(uiStore.registerSuccess()).toBe(true);
+      analyticsMock.trackAbandoned.mockClear();
+
+      view.fixture.destroy();
+
+      expect(analyticsMock.trackAbandoned).not.toHaveBeenCalled();
+    });
+
+    it('Given the user moves forward in the stepper Then step_completed for the previous and step_view for the next are tracked', async () => {
+      const view = await renderRegister();
+      const component = view.fixture.componentInstance;
+      analyticsMock.trackStepCompleted.mockClear();
+      analyticsMock.trackStepView.mockClear();
+
+      component.onStepperSelectionChange({
+        previouslySelectedIndex: 0,
+        selectedIndex: 1,
+      } as never);
+
+      expect(analyticsMock.trackStepCompleted).toHaveBeenCalledWith('email', {
+        is_google: false,
+      });
+      expect(analyticsMock.trackStepView).toHaveBeenCalledWith('password', {
+        is_google: false,
+      });
+    });
+
+    it('Given the user navigates back in the stepper Then only step_view fires, not step_completed', async () => {
+      const view = await renderRegister();
+      const component = view.fixture.componentInstance;
+      analyticsMock.trackStepCompleted.mockClear();
+      analyticsMock.trackStepView.mockClear();
+
+      component.onStepperSelectionChange({
+        previouslySelectedIndex: 2,
+        selectedIndex: 1,
+      } as never);
+
+      expect(analyticsMock.trackStepCompleted).not.toHaveBeenCalled();
+      expect(analyticsMock.trackStepView).toHaveBeenCalledWith('password', {
+        is_google: false,
+      });
     });
   });
 });

--- a/libs/auth/src/lib/ui/register/register.component.ts
+++ b/libs/auth/src/lib/ui/register/register.component.ts
@@ -1,3 +1,4 @@
+import { StepperSelectionEvent } from '@angular/cdk/stepper';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { CommonModule } from '@angular/common';
 import {
@@ -5,6 +6,7 @@ import {
   Component,
   computed,
   inject,
+  OnDestroy,
   OnInit,
   signal,
 } from '@angular/core';
@@ -32,6 +34,11 @@ import {
 import { ActivatedRoute, Router } from '@angular/router';
 import { map, Observable } from 'rxjs';
 import { AuthStore } from '../../core/state/auth.store';
+import {
+  RegistrationAnalyticsService,
+  REGISTRATION_STEPS,
+  RegistrationStep,
+} from '../../core/registration-analytics.service';
 import { RegisterSuccessComponent } from './components/register-success';
 import { RegisterUiStore } from './register-ui.store';
 @Component({
@@ -55,10 +62,11 @@ import { RegisterUiStore } from './register-ui.store';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [RegisterUiStore],
 })
-export class RegisterComponent implements OnInit {
+export class RegisterComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly breakpointObserver = inject(BreakpointObserver);
+  private readonly analytics = inject(RegistrationAnalyticsService);
   readonly authState = inject(AuthStore);
   readonly registerUiStore = inject(RegisterUiStore);
 
@@ -66,11 +74,41 @@ export class RegisterComponent implements OnInit {
     () => this.registerUiStore.selectedPlan()?.title ?? null
   );
 
+  private currentStepIndex = 0;
+
   ngOnInit(): void {
     const planId = this.route.snapshot.queryParamMap.get('planId');
     if (planId) {
       this.registerUiStore.setSelectedPlanId(planId);
     }
+    this.analytics.trackStarted({
+      plan_preselected: this.registerUiStore.selectedPlan() !== null,
+    });
+    this.analytics.trackStepView('email', { is_google: false });
+  }
+
+  ngOnDestroy(): void {
+    if (this.registerUiStore.registerSuccess()) return;
+    const lastStep = REGISTRATION_STEPS[this.currentStepIndex] ?? 'email';
+    this.analytics.trackAbandoned({
+      last_step: lastStep,
+      is_google: this.registerUiStore.isGoogleRegistration(),
+    });
+  }
+
+  onStepperSelectionChange(event: StepperSelectionEvent): void {
+    const isGoogle = this.registerUiStore.isGoogleRegistration();
+    const previous: RegistrationStep | undefined =
+      REGISTRATION_STEPS[event.previouslySelectedIndex];
+    const next: RegistrationStep | undefined =
+      REGISTRATION_STEPS[event.selectedIndex];
+    if (previous && event.selectedIndex > event.previouslySelectedIndex) {
+      this.analytics.trackStepCompleted(previous, { is_google: isGoogle });
+    }
+    if (next) {
+      this.analytics.trackStepView(next, { is_google: isGoogle });
+    }
+    this.currentStepIndex = event.selectedIndex;
   }
 
   private readonly registerData = signal({
@@ -154,18 +192,35 @@ export class RegisterComponent implements OnInit {
       )
     )
       return;
-    if (!this.registerUiStore.isGoogleRegistration()) {
+    const isGoogle = this.registerUiStore.isGoogleRegistration();
+    this.analytics.trackSubmitted({ is_google: isGoogle });
+    if (!isGoogle) {
       const signedUp = await this.registerUiStore.signUpWithEmail(
         email,
         password
       );
-      if (!signedUp) return;
+      if (!signedUp) {
+        this.analytics.trackFailed({ is_google: false, reason: 'sign_up' });
+        return;
+      }
     }
     try {
-      await this.registerUiStore.persistProfile();
+      const persisted = await this.registerUiStore.persistProfile();
+      if (persisted) {
+        this.analytics.trackSucceeded({ is_google: isGoogle });
+      } else {
+        this.analytics.trackFailed({
+          is_google: isGoogle,
+          reason: 'persist_profile',
+        });
+      }
     } catch {
       // RegisterOnboardingStore already exposes a localized error state.
       // Prevent unhandled promise rejections in the click handler.
+      this.analytics.trackFailed({
+        is_google: isGoogle,
+        reason: 'persist_profile',
+      });
     }
   }
 


### PR DESCRIPTION
Add a small RegistrationAnalyticsService that emits events for each step
of the registration stepper (started, step_view, step_completed,
submitted, succeeded, failed, abandoned). Wire it into RegisterComponent
so the 5-step funnel (email → password → username → daily_goal →
consent) becomes visible in the Firebase console.

Tracking respects the existing analytics consent flag
('pus_analytics_consent') and degrades to a no-op when consent has not
been granted or Firebase Analytics is not provided (e.g. SSR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking throughout the registration flow, capturing registration started, step views, step completions, submission, success/failure, and abandonment events.
  * Analytics respect user consent settings and only log when consent is granted.

* **Tests**
  * Added comprehensive test coverage for analytics tracking with Firebase Analytics integration and consent validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->