### PR TITLE
refactor(auth): drop the consent step from registration

### DIFF
--- a/libs/auth/src/lib/core/registration-analytics.service.ts
+++ b/libs/auth/src/lib/core/registration-analytics.service.ts
@@ -6,7 +6,6 @@ export const REGISTRATION_STEPS = [
   'password',
   'username',
   'daily_goal',
-  'consent',
 ] as const;
 
 export type RegistrationStep = (typeof REGISTRATION_STEPS)[number];

--- a/libs/auth/src/lib/ui/register/register-ui.store.spec.ts
+++ b/libs/auth/src/lib/ui/register/register-ui.store.spec.ts
@@ -63,11 +63,10 @@ describe('RegisterUiStore', () => {
     expect(store.displayName()).toBe('Tester');
   });
 
-  it('Given profile and consent When submitting via email Then sign up and persist profile are executed', async () => {
+  it('Given a complete profile When submitting via email Then sign up and persist profile are executed', async () => {
     const store = await setup();
     store.setDisplayName('Alex');
     store.setDailyGoal(120);
-    store.setConsentAccepted(true);
 
     const canSubmit = store.canSubmit(false, false, 'Secret#123', 'Secret#123');
     const signedUp = await store.signUpWithEmail('mail@test.de', 'Secret#123');
@@ -135,7 +134,6 @@ describe('RegisterUiStore', () => {
       const store = await setup();
       store.setDisplayName('A');
       store.setDailyGoal(10);
-      store.setConsentAccepted(true);
 
       expect(store.displayNameViolation()).toBe('too-short');
       expect(store.isProfileStepValid()).toBe(false);

--- a/libs/auth/src/lib/ui/register/register-ui.store.ts
+++ b/libs/auth/src/lib/ui/register/register-ui.store.ts
@@ -22,7 +22,6 @@ type RegisterUiState = {
   hidePassword: boolean;
   displayName: string;
   dailyGoal: number;
-  consentAccepted: boolean;
   isGoogleRegistration: boolean;
   registeringCredentials: boolean;
   registerSuccess: boolean;
@@ -39,7 +38,6 @@ const initialState: RegisterUiState = {
   hidePassword: true,
   displayName: '',
   dailyGoal: 10,
-  consentAccepted: false,
   isGoogleRegistration: false,
   registeringCredentials: false,
   registerSuccess: false,
@@ -75,8 +73,6 @@ export const RegisterUiStore = signalStore(
     setDisplayName: (value: string) =>
       patchState(store, { displayName: value }),
     setDailyGoal: (value: number) => patchState(store, { dailyGoal: value }),
-    setConsentAccepted: (value: boolean) =>
-      patchState(store, { consentAccepted: value }),
     setSelectedPlanId: (planId: string | null) => {
       // Only accept ids that resolve to a real plan; ignore stale or
       // malformed query-param values silently — better than redirecting
@@ -119,7 +115,6 @@ export const RegisterUiStore = signalStore(
       password: string,
       repeatPassword: string
     ) =>
-      store.consentAccepted() &&
       validateDisplayName(store.displayName()) === null &&
       store.dailyGoal() >= 1 &&
       (store.isGoogleRegistration() ||

--- a/libs/auth/src/lib/ui/register/register.component.html
+++ b/libs/auth/src/lib/ui/register/register.component.html
@@ -320,44 +320,6 @@
                 type="button"
                 i18n="@@auth.register.back"
               >
-                Zurück</button
-              ><button
-                mat-raised-button
-                color="primary"
-                matStepperNext
-                type="button"
-                [disabled]="registerUiStore.dailyGoal() < 1"
-                i18n="@@auth.next"
-              >
-                Weiter
-              </button>
-            </div>
-          </mat-step>
-
-          <mat-step>
-            <ng-template
-              matStepLabel
-              i18n="@@auth.onboarding.google.consent.checkbox"
-              >Einwilligung erteilen</ng-template
-            >
-            <p i18n="@@auth.onboarding.google.consent.text">
-              Ich willige in die Datenverarbeitung zum Erheben technisch
-              notwendiger Daten, statistischer Auswertungen und zum Ausspielen
-              gezielter Werbung ein.
-            </p>
-            <mat-checkbox
-              [checked]="registerUiStore.consentAccepted()"
-              (change)="registerUiStore.setConsentAccepted($event.checked)"
-              i18n="@@auth.onboarding.google.consent.checkbox"
-              >Einwilligung erteilen</mat-checkbox
-            >
-            <div class="form-actions">
-              <button
-                mat-stroked-button
-                matStepperPrevious
-                type="button"
-                i18n="@@auth.register.back"
-              >
                 Zurück
               </button>
               <button

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9663,13 +9663,13 @@
         <target>Περίοδος κατάταξης</target>
       </segment>
     </unit>
-    <unit id="leaderboard.lastUpdated">
+        <unit id="leaderboard.lastUpdated">
       <segment state="initial">
         <source> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></source>
         <target> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></target>
       </segment>
     </unit>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -9829,13 +9829,13 @@ Deine Position: # ·  Reps        </source>
         <target>Leaderboard period</target>
       </segment>
     </unit>
-    <unit id="leaderboard.lastUpdated">
+        <unit id="leaderboard.lastUpdated">
       <segment state="initial">
         <source> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></source>
         <target> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></target>
       </segment>
     </unit>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9659,13 +9659,13 @@
         <target>Período del marcador</target>
       </segment>
     </unit>
-    <unit id="leaderboard.lastUpdated">
+        <unit id="leaderboard.lastUpdated">
       <segment state="initial">
         <source> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></source>
         <target> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></target>
       </segment>
     </unit>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9535,13 +9535,13 @@
         <target>Période du classement</target>
       </segment>
     </unit>
-    <unit id="leaderboard.lastUpdated">
+        <unit id="leaderboard.lastUpdated">
       <segment state="initial">
         <source> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></source>
         <target> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></target>
       </segment>
     </unit>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9663,13 +9663,13 @@
         <target>Periodo della classifica</target>
       </segment>
     </unit>
-    <unit id="leaderboard.lastUpdated">
+        <unit id="leaderboard.lastUpdated">
       <segment state="initial">
         <source> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></source>
         <target> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></target>
       </segment>
     </unit>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9663,13 +9663,13 @@
         <target>Tempus tabulae principum</target>
       </segment>
     </unit>
-    <unit id="leaderboard.lastUpdated">
+        <unit id="leaderboard.lastUpdated">
       <segment state="initial">
         <source> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></source>
         <target> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></target>
       </segment>
     </unit>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9663,13 +9663,13 @@
         <target>Leaderboard periode</target>
       </segment>
     </unit>
-    <unit id="leaderboard.lastUpdated">
+        <unit id="leaderboard.lastUpdated">
       <segment state="initial">
         <source> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></source>
         <target> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></target>
       </segment>
     </unit>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -8923,13 +8923,13 @@ Deine Position: # ·  Reps        </source>
         <target>Toppliste-periode</target>
       </segment>
     </unit>
-    <unit id="leaderboard.lastUpdated">
+        <unit id="leaderboard.lastUpdated">
       <segment state="initial">
         <source> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></source>
         <target> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></target>
       </segment>
     </unit>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -182,8 +182,8 @@
     <unit id="auth.onboarding.google.username">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:8,11</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:234,236</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:238,240</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:235,237</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:239,241</note>
       </notes>
       <segment>
         <source>Benutzername</source>
@@ -192,8 +192,8 @@
     <unit id="auth.onboarding.google.goal">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:19,21</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:301,303</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:305,307</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:302,304</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:306,308</note>
       </notes>
       <segment>
         <source>Tagesziel</source>
@@ -202,8 +202,6 @@
     <unit id="auth.onboarding.google.consent.checkbox">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:36,39</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:340,342</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:351,353</note>
       </notes>
       <segment>
         <source>Einwilligung erteilen</source>
@@ -220,11 +218,10 @@
     <unit id="auth.next">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:62,65</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:81,82</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:153,154</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:224,225</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:294,295</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:331,332</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:82,83</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:154,155</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:225,226</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:295,296</note>
       </notes>
       <segment>
         <source> Weiter </source>
@@ -233,7 +230,7 @@
     <unit id="cancel">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:67,69</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:385,386</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:348,349</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:152,153</note>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:639,640</note>
@@ -294,8 +291,8 @@
     <unit id="auth.email">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:27,28</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:58,59</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:60,61</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:59,60</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:61,62</note>
       </notes>
       <segment>
         <source>E-Mail</source>
@@ -304,8 +301,8 @@
     <unit id="auth.password">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:41,42</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:132,134</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:161,162</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:133,135</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:162,163</note>
       </notes>
       <segment>
         <source>Passwort</source>
@@ -322,7 +319,7 @@
     <unit id="auth.or">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:80,81</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:84,85</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:85,86</note>
       </notes>
       <segment>
         <source>oder</source>
@@ -355,7 +352,7 @@
     <unit id="validate.email.required">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:61</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:85</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:123</note>
       </notes>
       <segment>
         <source>Bitte E-Mail eingeben!</source>
@@ -364,7 +361,7 @@
     <unit id="validate.email.email">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:64</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:88</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:126</note>
       </notes>
       <segment>
         <source>Bitte gültige E-Mail eingeben!</source>
@@ -373,7 +370,7 @@
     <unit id="validate.password.required">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:67</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:91</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:129</note>
       </notes>
       <segment>
         <source>Bitte Passwort eingeben!</source>
@@ -382,7 +379,7 @@
     <unit id="validate.password.minLength">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.ts:70</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:94</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:132</note>
       </notes>
       <segment>
         <source>Passwort muss mindestens 8 Zeichen lang sein!</source>
@@ -454,7 +451,7 @@
     </unit>
     <unit id="auth.google.signup">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:116,118</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:117,119</note>
       </notes>
       <segment>
         <source>Mit Google registrieren</source>
@@ -462,7 +459,7 @@
     </unit>
     <unit id="auth.register.google.skipPassword">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:136,138</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:137,139</note>
       </notes>
       <segment>
         <source> Passwort-Schritt übersprungen (Google Registrierung). </source>
@@ -470,11 +467,10 @@
     </unit>
     <unit id="auth.register.back">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:145,146</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:208,209</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:285,286</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:322,323</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:360,361</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:146,147</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:209,210</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:286,287</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:323,324</note>
       </notes>
       <segment>
         <source> Zurück</source>
@@ -482,7 +478,7 @@
     </unit>
     <unit id="auth.register.password.hint">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:185,187</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:186,188</note>
       </notes>
       <segment>
         <source> Mindestens 8 Zeichen, Groß- und Kleinbuchstaben, Zahl und Sonderzeichen. </source>
@@ -490,7 +486,7 @@
     </unit>
     <unit id="auth.register.password.repeat">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:193,195</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:194,196</note>
       </notes>
       <segment>
         <source>Passwort wiederholen</source>
@@ -498,7 +494,7 @@
     </unit>
     <unit id="displayName.violation.tooShort">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:254,256</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:255,257</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:184,186</note>
       </notes>
       <segment>
@@ -507,7 +503,7 @@
     </unit>
     <unit id="displayName.violation.tooLong">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:264,266</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:265,267</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:194,196</note>
       </notes>
       <segment>
@@ -516,24 +512,16 @@
     </unit>
     <unit id="displayName.violation.invalidCharacters">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:274,276</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:275,277</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:204,207</note>
       </notes>
       <segment>
         <source> Nur Buchstaben, Ziffern, Leerzeichen, sowie _ . - erlaubt. </source>
       </segment>
     </unit>
-    <unit id="auth.onboarding.google.consent.text">
-      <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:343,346</note>
-      </notes>
-      <segment>
-        <source> Ich willige in die Datenverarbeitung zum Erheben technisch notwendiger Daten, statistischer Auswertungen und zum Ausspielen gezielter Werbung ein. </source>
-      </segment>
-    </unit>
     <unit id="auth.register.submit">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:377,378</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:340,341</note>
       </notes>
       <segment>
         <source> Registrieren </source>
@@ -541,7 +529,7 @@
     </unit>
     <unit id="validate.password.policy">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:100</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.ts:138</note>
       </notes>
       <segment>
         <source>Passwort braucht Groß-/Kleinbuchstaben, Zahl und Sonderzeichen.</source>
@@ -4219,7 +4207,7 @@
       </notes>
       <segment>
         <source> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></source>
       </segment>
     </unit>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9157,13 +9157,13 @@
         <target>排行榜时间段</target>
       </segment>
     </unit>
-    <unit id="leaderboard.lastUpdated">
+        <unit id="leaderboard.lastUpdated">
       <segment state="initial">
         <source> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></source>
         <target> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
-            updatedAt | date: &apos;dd.MM.yyyy, HH:mm&apos;
+            updatedAt | date: &apos;short&apos;
           }}"/></pc></target>
       </segment>
     </unit>


### PR DESCRIPTION
## Summary

Der Cookie-Consent-Banner ist jetzt die einzige Quelle für die Werbe-/Analytics-Einwilligung. Die zusätzliche Consent-Stufe im Registrierungs-Stepper hat den gleichen Vorgang dupliziert und war ein unnötiger Reibungspunkt direkt vor dem Abschluss.

- Den Consent-`<mat-step>` aus `register.component.html` entfernt und die Buttons (Zurück / Registrieren / Abbrechen) auf den Tagesziel-Step verschoben — der ist jetzt der letzte Schritt.
- `consentAccepted`-State, Setter und das `canSubmit`-Gate aus `RegisterUiStore` entfernt. `canSubmit` prüft jetzt nur noch Displayname-Validierung, Tagesziel ≥ 1 und (für E-Mail-Flow) die Credentials.
- `'consent'` aus `REGISTRATION_STEPS` in `registration-analytics.service` entfernt — der Funnel hat jetzt 4 statt 5 Stufen, Indizes 0–3 bleiben stabil.
- i18n neu extrahiert (`web/src/locale/messages.xlf`): `auth.onboarding.google.consent.text` ist verschwunden, `.checkbox` bleibt drin (wird noch vom Google-Onboarding-Dialog genutzt). Stale Übersetzungs-Targets bleiben harmlos in den `messages.<lang>.xlf`.

## Test plan

- [x] `pnpm nx test auth` — 122 Tests grün (RegisterUiStore-Spec passt ohne `setConsentAccepted`-Aufrufe; RegisterComponent-Specs unverändert).
- [x] `pnpm nx affected -t=lint,test,build -c=production` über 14 Projekte.
- [x] i18n: `pnpm nx run web:extract-i18n && node tools/src/sync-xliff-locales.mjs`.
- [ ] Manuell prüfen, dass der Submit-Button im Tagesziel-Step erscheint und der bisherige Flow durchläuft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqYdTLcsvnvXfQLKWCC1W)_