### PR TITLE
Add all-time leaderboard ranking for per-exercise leaderboards

### DIFF
--- a/data-store/functions/src/exercise-leaderboard/logic.spec.ts
+++ b/data-store/functions/src/exercise-leaderboard/logic.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 import {
+  ExerciseUserTotalRow,
+  rankExerciseAllTime,
   rankExerciseEntries,
   getExerciseLeaderboardQueryStartDate,
   isoDateNDaysBefore,
@@ -455,6 +457,136 @@ describe('exercise-leaderboard/logic', () => {
         1
       );
       expect(result).toBe('2024-02-29');
+    });
+  });
+
+  describe('rankExerciseAllTime', () => {
+    it('Given lifetime totals, When ranking, Then sorts desc and rounds to ints', () => {
+      const rows: ExerciseUserTotalRow[] = [
+        { userId: 'alice', total: 12_345.7 },
+        { userId: 'bob', total: 50_000 },
+        { userId: 'carol', total: 12_345.2 },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['alice', publicProfile('Alice')],
+        ['bob', publicProfile('Bob')],
+        ['carol', publicProfile('Carol')],
+      ]);
+
+      const result = rankExerciseAllTime(rows, profiles);
+
+      expect(result).toEqual([
+        { alias: 'Bob', reps: 50_000, uid: 'bob' },
+        { alias: 'Alice', reps: 12_346, uid: 'alice' },
+        { alias: 'Carol', reps: 12_345, uid: 'carol' },
+      ]);
+    });
+
+    it('Given a user without the full publicProfile opt-in, When ranking, Then drops them', () => {
+      const rows: ExerciseUserTotalRow[] = [
+        { userId: 'optedIn', total: 500 },
+        { userId: 'leaderOnly', total: 9000 },
+        { userId: 'profileOnly', total: 8000 },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['optedIn', publicProfile('Alice')],
+        [
+          'leaderOnly',
+          {
+            displayName: 'Bob',
+            ui: { hideFromLeaderboard: false, publicProfile: false },
+          },
+        ],
+        [
+          'profileOnly',
+          {
+            displayName: 'Carol',
+            ui: { hideFromLeaderboard: true, publicProfile: true },
+          },
+        ],
+      ]);
+
+      const result = rankExerciseAllTime(rows, profiles);
+
+      expect(result).toEqual([{ alias: 'Alice', reps: 500, uid: 'optedIn' }]);
+    });
+
+    it('Given a shadow-banned user with the highest total, When ranking, Then they are excluded', () => {
+      const rows: ExerciseUserTotalRow[] = [
+        { userId: 'good', total: 500 },
+        { userId: 'cheater', total: 99_999 },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['good', publicProfile('Alice')],
+        [
+          'cheater',
+          {
+            displayName: 'Mallory',
+            ui: { hideFromLeaderboard: false, publicProfile: true },
+            leaderboardExcluded: true,
+          },
+        ],
+      ]);
+
+      const result = rankExerciseAllTime(rows, profiles);
+
+      expect(result).toEqual([{ alias: 'Alice', reps: 500, uid: 'good' }]);
+    });
+
+    it('Given a zero or negative total, When ranking, Then drops the row', () => {
+      const rows: ExerciseUserTotalRow[] = [
+        { userId: 'alice', total: 0 },
+        { userId: 'bob', total: -50 },
+        { userId: 'carol', total: 10 },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['alice', publicProfile('Alice')],
+        ['bob', publicProfile('Bob')],
+        ['carol', publicProfile('Carol')],
+      ]);
+
+      const result = rankExerciseAllTime(rows, profiles);
+
+      expect(result).toEqual([{ alias: 'Carol', reps: 10, uid: 'carol' }]);
+    });
+
+    it('Given a non-finite total, When ranking, Then drops the row', () => {
+      const rows: ExerciseUserTotalRow[] = [
+        { userId: 'alice', total: Number.NaN },
+        { userId: 'bob', total: Number.POSITIVE_INFINITY },
+        { userId: 'carol', total: 42 },
+      ];
+      const profiles = new Map<string, UserProfile>([
+        ['alice', publicProfile('Alice')],
+        ['bob', publicProfile('Bob')],
+        ['carol', publicProfile('Carol')],
+      ]);
+
+      const result = rankExerciseAllTime(rows, profiles);
+
+      expect(result).toEqual([{ alias: 'Carol', reps: 42, uid: 'carol' }]);
+    });
+
+    it('Given more than 10 eligible rows, When ranking, Then truncates to top 10', () => {
+      const rows: ExerciseUserTotalRow[] = Array.from(
+        { length: 20 },
+        (_, i) => ({
+          userId: `user${i}`,
+          total: 100 - i,
+        })
+      );
+      const profiles = new Map<string, UserProfile>(
+        rows.map((r) => [r.userId, publicProfile(`User${r.userId}`)])
+      );
+
+      const result = rankExerciseAllTime(rows, profiles);
+
+      expect(result).toHaveLength(10);
+      expect(result[0]).toEqual({
+        alias: 'Useruser0',
+        reps: 100,
+        uid: 'user0',
+      });
     });
   });
 });

--- a/data-store/functions/src/exercise-leaderboard/logic.ts
+++ b/data-store/functions/src/exercise-leaderboard/logic.ts
@@ -50,9 +50,28 @@ export interface ExerciseLeaderboardPeriods {
   daily: ExerciseLeaderboardEntry[];
   last7: ExerciseLeaderboardEntry[];
   last30: ExerciseLeaderboardEntry[];
+  allTime: ExerciseLeaderboardEntry[];
 }
 
-export type ExerciseLeaderboardPeriodKind = 'daily' | 'last7' | 'last30';
+export type ExerciseLeaderboardPeriodKind =
+  | 'daily'
+  | 'last7'
+  | 'last30'
+  | 'allTime';
+
+/**
+ * Subset of {@link ExerciseLeaderboardPeriodKind} that
+ * {@link rankExerciseEntries} actually supports — the windowed periods.
+ * `'allTime'` is sourced from a different aggregate
+ * (`userStats/{uid}/perExercise/{exerciseId}.total` via
+ * {@link rankExerciseAllTime}) and must not flow into the windowed ranker
+ * where it would silently drop every row. Mirrors
+ * `WindowedLeaderboardPeriodKind` for the pushup leaderboard.
+ */
+export type WindowedExerciseLeaderboardPeriodKind = Exclude<
+  ExerciseLeaderboardPeriodKind,
+  'allTime'
+>;
 
 /**
  * Value field on `ExerciseEntryRow` that carries the primary measurement
@@ -121,7 +140,7 @@ export function isoDateNDaysBefore(
 export function rankExerciseEntries(
   rows: ExerciseEntryRow[],
   valueField: ExerciseValueField,
-  periodKey: ExerciseLeaderboardPeriodKind,
+  periodKey: WindowedExerciseLeaderboardPeriodKind,
   targetKey: string,
   userProfiles: Map<string, UserProfile>
 ): ExerciseLeaderboardEntry[] {
@@ -199,4 +218,43 @@ export function getExerciseLeaderboardQueryStartDate(
   today: BerlinDateParts
 ): string {
   return isoDateNDaysBefore(today, 30);
+}
+
+/**
+ * Per-(user, exercise) lifetime cumulative measurement, sourced from
+ * `userStats/{userId}/perExercise/{exerciseId}.total`. The slot is
+ * exercise-scoped, so `total` carries reps for rep-measured exercises,
+ * seconds for time-measured ones, and meters for distance-measured ones
+ * — the unit is implied by the exercise the row belongs to. Mirrors
+ * `UserTotalRow` from the pushup ranker.
+ */
+export interface ExerciseUserTotalRow {
+  userId: string;
+  total: number;
+}
+
+/**
+ * Ranks lifetime cumulative measurements for a single exercise. Sibling
+ * of `rankAllTime` for the pushup leaderboard. No per-day cap is applied
+ * — the cumulative total already encompasses arbitrarily many days, and
+ * the windowed cap is meant to defend against single-day outliers. The
+ * privacy contract matches the windowed ranker: admin shadow-ban is
+ * respected and the full publicProfile opt-in is required.
+ */
+export function rankExerciseAllTime(
+  rows: ExerciseUserTotalRow[],
+  userProfiles: Map<string, UserProfile>
+): ExerciseLeaderboardEntry[] {
+  return rows
+    .flatMap(({ userId, total }): ExerciseLeaderboardEntry[] => {
+      if (!userId) return [];
+      if (!Number.isFinite(total) || total <= 0) return [];
+      const profile = userProfiles.get(userId);
+      if (isLeaderboardExcluded(profile)) return [];
+      if (!isPublicProfileLinkAllowed(profile)) return [];
+      const alias = String(profile?.displayName || '').trim();
+      return [{ alias, reps: Math.round(total), uid: userId }];
+    })
+    .sort((a, b) => b.reps - a.reps)
+    .slice(0, TOP_N);
 }

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -29,6 +29,7 @@ import {
 import { berlinDateParts } from './datetime';
 import {
   type ExerciseEntryRow,
+  type ExerciseLeaderboardEntry,
   type ExerciseUserTotalRow,
   type ExerciseValueField,
   getExerciseLeaderboardQueryStartDate,
@@ -233,7 +234,27 @@ interface ExerciseLeaderboardSnapshot {
   };
 }
 
-async function rebuildExerciseLeaderboardsCore() {
+async function rebuildExerciseLeaderboardsCore(opts: {
+  /**
+   * `true` only on the scheduled rebuild — recomputes `allTime` from
+   * the lifetime `userStats/{uid}/perExercise/{exerciseId}.total`
+   * aggregates. `false` for the entry-write trigger, which carries
+   * forward the previous snapshot's `allTime` instead. Two reasons:
+   *
+   * 1. Race-safety: the write-driven trigger fires in parallel with
+   *    `updateExerciseStatsOnEntryWrite`. Reading `perExercise.total`
+   *    on every entry write can land on the pre-write value and
+   *    publish a stale allTime that never self-corrects (no rebuild
+   *    is scheduled in response to the later aggregate write). Letting
+   *    the schedule own allTime moves the read to a point where the
+   *    aggregate is guaranteed-consistent and matches the existing
+   *    freshness contract (≤15 min lag).
+   * 2. Read amplification: a collection-group scan over all lifetime
+   *    aggregates is unbounded in the user base; we don't want to pay
+   *    it on every `exerciseEntries` write.
+   */
+  includeAllTime: boolean;
+}) {
   const now = new Date();
   const today = berlinDateParts(now);
   const queryStart = getExerciseLeaderboardQueryStartDate(today);
@@ -252,32 +273,63 @@ async function rebuildExerciseLeaderboardsCore() {
     .map((d) => d.data() as ExerciseEntryRow)
     .filter((r) => r.userId !== DEMO_USER_ID);
 
-  // Pull lifetime cumulative totals per (user, exercise) from the
-  // `userStats/{userId}/perExercise/{exerciseId}` subcollection for the
-  // allTime ranking. Mirrors the pushup path that sources `allTime` from
-  // `userStats.total`. A 30-day `exerciseEntries` query can't power this
-  // bucket — users whose last entry is older than 30 days would silently
-  // drop off an "all time" leaderboard. The collection-group read is
-  // unfiltered (no orderBy) so it works against the default single-field
-  // index; per-exercise ranking and top-N truncation happen in-memory.
-  const allTimeSnap = await db.collectionGroup('perExercise').get();
-  const allTimeByExercise = new Map<string, ExerciseUserTotalRow[]>();
+  // Lifetime cumulative totals per (user, exercise), sourced from the
+  // `userStats/{userId}/perExercise/{exerciseId}` subcollection. Only
+  // populated on the scheduled rebuild; the on-write path carries the
+  // existing snapshot's allTime forward instead — see the `opts` doc
+  // above for why. The collection-group read is unfiltered (no
+  // orderBy) so it works against the default single-field index;
+  // per-exercise ranking and top-N truncation happen in-memory.
+  let allTimeByExercise: Map<string, ExerciseUserTotalRow[]> | null = null;
   const allTimeUserIds = new Set<string>();
-  for (const docSnap of allTimeSnap.docs) {
-    const userId = docSnap.ref.parent.parent?.id;
-    const exerciseId = docSnap.id;
-    if (!userId || !exerciseId) continue;
-    if (userId === DEMO_USER_ID) continue;
-    const data = docSnap.data() as { total?: unknown };
-    const total = Number(data?.total ?? 0);
-    if (!Number.isFinite(total) || total <= 0) continue;
-    let bucket = allTimeByExercise.get(exerciseId);
-    if (!bucket) {
-      bucket = [];
-      allTimeByExercise.set(exerciseId, bucket);
+  let totalAllTimeDocs = 0;
+  if (opts.includeAllTime) {
+    const allTimeSnap = await db.collectionGroup('perExercise').get();
+    totalAllTimeDocs = allTimeSnap.size;
+    allTimeByExercise = new Map<string, ExerciseUserTotalRow[]>();
+    for (const docSnap of allTimeSnap.docs) {
+      const userId = docSnap.ref.parent.parent?.id;
+      const exerciseId = docSnap.id;
+      if (!userId || !exerciseId) continue;
+      if (userId === DEMO_USER_ID) continue;
+      const data = docSnap.data() as { total?: unknown };
+      const total = Number(data?.total ?? 0);
+      if (!Number.isFinite(total) || total <= 0) continue;
+      let bucket = allTimeByExercise.get(exerciseId);
+      if (!bucket) {
+        bucket = [];
+        allTimeByExercise.set(exerciseId, bucket);
+      }
+      bucket.push({ userId, total });
+      allTimeUserIds.add(userId);
     }
-    bucket.push({ userId, total });
-    allTimeUserIds.add(userId);
+  }
+
+  // On the write-driven path, carry forward the previous snapshot's
+  // ranked allTime arrays per exercise. The scheduled rebuild will
+  // refresh them at the next 15-min tick. Reads `byExercise[*].periods
+  // .allTime` straight off the doc — no profile resolution needed
+  // because the ranks were already filtered and aliased the last time
+  // the schedule wrote them.
+  const carryForwardAllTime: Record<string, ExerciseLeaderboardEntry[]> = {};
+  if (!opts.includeAllTime) {
+    const existing = await db.collection('leaderboards').doc('exercises').get();
+    if (existing.exists) {
+      const data = existing.data() as {
+        byExercise?: Record<
+          string,
+          { periods?: { allTime?: ExerciseLeaderboardEntry[] } }
+        >;
+      };
+      for (const [exerciseId, exSnap] of Object.entries(
+        data.byExercise ?? {}
+      )) {
+        const allTime = exSnap?.periods?.allTime;
+        if (Array.isArray(allTime) && allTime.length > 0) {
+          carryForwardAllTime[exerciseId] = allTime;
+        }
+      }
+    }
   }
 
   const userIds = [
@@ -316,12 +368,14 @@ async function rebuildExerciseLeaderboardsCore() {
   for (const def of EXERCISE_CATALOG as readonly ExerciseDefinition[]) {
     if (!supportsLeaderboard(def.measurement)) continue;
     const exerciseRows = rowsByExercise.get(def.id) ?? [];
-    const allTimeRows = allTimeByExercise.get(def.id) ?? [];
+    const allTimeBucket: ExerciseLeaderboardEntry[] = opts.includeAllTime
+      ? rankExerciseAllTime(allTimeByExercise?.get(def.id) ?? [], userProfiles)
+      : (carryForwardAllTime[def.id] ?? []);
     // Drop the exercise from the snapshot only when neither the 30-day
     // window nor the lifetime aggregates carry anything for it. An
     // exercise with only old activity should still surface a populated
     // allTime bucket (with empty daily/last7/last30).
-    if (exerciseRows.length === 0 && allTimeRows.length === 0) continue;
+    if (exerciseRows.length === 0 && allTimeBucket.length === 0) continue;
     const valueField = valueFieldForMeasurement(def.measurement);
 
     byExercise[def.id] = {
@@ -349,7 +403,7 @@ async function rebuildExerciseLeaderboardsCore() {
           todayKey,
           userProfiles
         ),
-        allTime: rankExerciseAllTime(allTimeRows, userProfiles),
+        allTime: allTimeBucket,
       },
     };
   }
@@ -375,7 +429,8 @@ async function rebuildExerciseLeaderboardsCore() {
   logger.info('Exercise leaderboards rebuilt', {
     exercises: Object.keys(byExercise).length,
     totalRows: rows.length,
-    allTimeRows: allTimeSnap.size,
+    allTimeRows: totalAllTimeDocs,
+    includeAllTime: opts.includeAllTime,
   });
 }
 
@@ -835,7 +890,7 @@ export const rebuildExerciseLeaderboards = onSchedule(
     retryCount: 1,
   },
   async () => {
-    await rebuildExerciseLeaderboardsCore();
+    await rebuildExerciseLeaderboardsCore({ includeAllTime: true });
   }
 );
 
@@ -846,7 +901,10 @@ export const refreshExerciseLeaderboardsOnEntryWrite = onDocumentWritten(
     retry: false,
   },
   async () => {
-    await rebuildExerciseLeaderboardsCore();
+    // Carry the previous snapshot's allTime forward and let the
+    // scheduled rebuild refresh it. See `rebuildExerciseLeaderboardsCore`
+    // for the race-safety + cost rationale.
+    await rebuildExerciseLeaderboardsCore({ includeAllTime: false });
   }
 );
 

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -29,8 +29,10 @@ import {
 import { berlinDateParts } from './datetime';
 import {
   type ExerciseEntryRow,
+  type ExerciseUserTotalRow,
   type ExerciseValueField,
   getExerciseLeaderboardQueryStartDate,
+  rankExerciseAllTime,
   rankExerciseEntries,
 } from './exercise-leaderboard';
 import {
@@ -227,6 +229,7 @@ interface ExerciseLeaderboardSnapshot {
     daily: ReturnType<typeof rankExerciseEntries>;
     last7: ReturnType<typeof rankExerciseEntries>;
     last30: ReturnType<typeof rankExerciseEntries>;
+    allTime: ReturnType<typeof rankExerciseAllTime>;
   };
 }
 
@@ -249,9 +252,40 @@ async function rebuildExerciseLeaderboardsCore() {
     .map((d) => d.data() as ExerciseEntryRow)
     .filter((r) => r.userId !== DEMO_USER_ID);
 
+  // Pull lifetime cumulative totals per (user, exercise) from the
+  // `userStats/{userId}/perExercise/{exerciseId}` subcollection for the
+  // allTime ranking. Mirrors the pushup path that sources `allTime` from
+  // `userStats.total`. A 30-day `exerciseEntries` query can't power this
+  // bucket — users whose last entry is older than 30 days would silently
+  // drop off an "all time" leaderboard. The collection-group read is
+  // unfiltered (no orderBy) so it works against the default single-field
+  // index; per-exercise ranking and top-N truncation happen in-memory.
+  const allTimeSnap = await db.collectionGroup('perExercise').get();
+  const allTimeByExercise = new Map<string, ExerciseUserTotalRow[]>();
+  const allTimeUserIds = new Set<string>();
+  for (const docSnap of allTimeSnap.docs) {
+    const userId = docSnap.ref.parent.parent?.id;
+    const exerciseId = docSnap.id;
+    if (!userId || !exerciseId) continue;
+    if (userId === DEMO_USER_ID) continue;
+    const data = docSnap.data() as { total?: unknown };
+    const total = Number(data?.total ?? 0);
+    if (!Number.isFinite(total) || total <= 0) continue;
+    let bucket = allTimeByExercise.get(exerciseId);
+    if (!bucket) {
+      bucket = [];
+      allTimeByExercise.set(exerciseId, bucket);
+    }
+    bucket.push({ userId, total });
+    allTimeUserIds.add(userId);
+  }
+
   const userIds = [
-    ...new Set(rows.map((r) => r.userId).filter(Boolean)),
-  ] as string[];
+    ...new Set([
+      ...(rows.map((r) => r.userId).filter(Boolean) as string[]),
+      ...allTimeUserIds,
+    ]),
+  ];
   const userProfiles = new Map<string, UserProfile>();
   if (userIds.length > 0) {
     const cfgSnaps = await Promise.all(
@@ -282,7 +316,12 @@ async function rebuildExerciseLeaderboardsCore() {
   for (const def of EXERCISE_CATALOG as readonly ExerciseDefinition[]) {
     if (!supportsLeaderboard(def.measurement)) continue;
     const exerciseRows = rowsByExercise.get(def.id) ?? [];
-    if (exerciseRows.length === 0) continue;
+    const allTimeRows = allTimeByExercise.get(def.id) ?? [];
+    // Drop the exercise from the snapshot only when neither the 30-day
+    // window nor the lifetime aggregates carry anything for it. An
+    // exercise with only old activity should still surface a populated
+    // allTime bucket (with empty daily/last7/last30).
+    if (exerciseRows.length === 0 && allTimeRows.length === 0) continue;
     const valueField = valueFieldForMeasurement(def.measurement);
 
     byExercise[def.id] = {
@@ -310,6 +349,7 @@ async function rebuildExerciseLeaderboardsCore() {
           todayKey,
           userProfiles
         ),
+        allTime: rankExerciseAllTime(allTimeRows, userProfiles),
       },
     };
   }
@@ -323,13 +363,19 @@ async function rebuildExerciseLeaderboardsCore() {
     .set({
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       timezone: TZ,
-      keys: { daily: todayKey, last7: todayKey, last30: todayKey },
+      keys: {
+        daily: todayKey,
+        last7: todayKey,
+        last30: todayKey,
+        allTime: todayKey,
+      },
       byExercise,
     });
 
   logger.info('Exercise leaderboards rebuilt', {
     exercises: Object.keys(byExercise).length,
     totalRows: rows.length,
+    allTimeRows: allTimeSnap.size,
   });
 }
 

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -48,10 +48,14 @@ export type LeaderboardData = {
   last7: LeaderboardBucket;
   last30: LeaderboardBucket;
   /**
-   * Cumulative ranking with no time window. For the pushup leaderboard
-   * it's sourced from the Cloud Function ranker reading `userStats.total`;
-   * for per-exercise leaderboards it's computed client-side from the
-   * unbounded `exerciseEntries` query.
+   * Cumulative ranking with no time window. Pushup is sourced from the
+   * Cloud Function ranker reading `userStats.total`; per-exercise is
+   * sourced from `byExercise[id].periods.allTime` in the same writer's
+   * snapshot, which reads
+   * `userStats/{userId}/perExercise/{exerciseId}.total` across users.
+   * The Firestore rule blocks cross-user `exerciseEntries` reads, so a
+   * client-side fallback isn't possible — when the snapshot is missing
+   * the bucket the UI shows empty.
    */
   allTime: LeaderboardBucket;
   /**

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.html
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.html
@@ -122,31 +122,6 @@
         </button>
       </div>
 
-      <ol data-testid="leaderboard-list">
-        @for (entry of leaderboardSlots(); track entry.rank) {
-          <li>
-            <span class="rank">#{{ entry.rank }}</span>
-            <!-- Link the alias to /u/<uid> when the row carries a uid.
-                 The ranker now requires the full publicProfile opt-in,
-                 so every fresh row has a uid. uid-less rows can only
-                 come from older cached snapshots and stay plain text
-                 for forward-compat. -->
-            @if (entry.uid) {
-              <a
-                class="alias alias-link"
-                [routerLink]="['/u', entry.uid]"
-                [attr.data-testid]="'leaderboard-link-' + entry.rank"
-              >
-                {{ entry.alias }}
-              </a>
-            } @else {
-              <span class="alias">{{ entry.alias }}</span>
-            }
-            <strong>{{ formatValue(entry.reps) }}</strong>
-          </li>
-        }
-      </ol>
-
       @if (lastUpdated(); as updatedAt) {
         <p
           class="last-updated"
@@ -159,6 +134,33 @@
           }}</time>
         </p>
       }
+
+      <div class="leaderboard-list-scroll">
+        <ol data-testid="leaderboard-list">
+          @for (entry of leaderboardSlots(); track entry.rank) {
+            <li>
+              <span class="rank">#{{ entry.rank }}</span>
+              <!-- Link the alias to /u/<uid> when the row carries a uid.
+                   The ranker now requires the full publicProfile opt-in,
+                   so every fresh row has a uid. uid-less rows can only
+                   come from older cached snapshots and stay plain text
+                   for forward-compat. -->
+              @if (entry.uid) {
+                <a
+                  class="alias alias-link"
+                  [routerLink]="['/u', entry.uid]"
+                  [attr.data-testid]="'leaderboard-link-' + entry.rank"
+                >
+                  {{ entry.alias }}
+                </a>
+              } @else {
+                <span class="alias">{{ entry.alias }}</span>
+              }
+              <strong>{{ formatValue(entry.reps) }}</strong>
+            </li>
+          }
+        </ol>
+      </div>
 
       @if (currentUserEntry(); as me) {
         @if (me.uid) {

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.scss
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.scss
@@ -57,6 +57,22 @@
   }
 }
 
+// Fixed-height scroll viewport — keeps the page layout stable when the
+// list grows past the visible window (25 rendered slots) and stops the
+// "own rank" / hint footer from drifting down the page. `min()` lets
+// the panel shrink on short viewports (mobile landscape) without going
+// taller than the configured cap.
+.leaderboard-list-scroll {
+  height: min(480px, 60vh);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  // Inset the scrollbar with a thin neutral border so the rounded
+  // corners read cleanly inside the mat-card.
+  border: 1px solid rgba(123, 159, 255, 0.18);
+  border-radius: 8px;
+  padding: 8px 12px;
+}
+
 ol {
   margin: 0;
   padding-left: 20px;
@@ -99,7 +115,7 @@ li {
 }
 
 .last-updated {
-  margin: 12px 0 0;
+  margin: 0 0 8px;
   font-size: 0.82rem;
   opacity: 0.75;
 
@@ -201,6 +217,10 @@ li {
 
   .exercise-switch {
     border-bottom-color: rgba(37, 99, 235, 0.22);
+  }
+
+  .leaderboard-list-scroll {
+    border-color: rgba(37, 99, 235, 0.22);
   }
 
   // Dark-theme link colours (`#cfe0ff` etc.) are unreadable against the


### PR DESCRIPTION
## Summary
Adds support for all-time (lifetime cumulative) leaderboard rankings for per-exercise leaderboards, sourced from the `userStats/{userId}/perExercise/{exerciseId}.total` aggregates. This mirrors the existing all-time ranking functionality for the pushup leaderboard.

## Key Changes
- **New `rankExerciseAllTime()` function**: Ranks lifetime cumulative exercise measurements with the same privacy controls as windowed rankings (shadow-ban exclusion and full publicProfile opt-in requirement). Filters out non-finite, zero, and negative totals, and truncates results to top 10.
- **New `ExerciseUserTotalRow` interface**: Represents per-(user, exercise) lifetime cumulative data sourced from the stats subcollection.
- **Updated `ExerciseLeaderboardPeriods`**: Added `allTime` field to include all-time rankings alongside daily/last7/last30.
- **New `WindowedExerciseLeaderboardPeriodKind` type**: Excludes `'allTime'` to prevent accidental misuse with the windowed ranker, which would silently drop all rows.
- **Cloud Function changes**: 
  - Queries the `perExercise` subcollection across all users to build lifetime totals per exercise
  - Merges user IDs from both windowed entries and all-time aggregates for profile lookups
  - Includes all-time rankings in the snapshot even when an exercise has no recent activity (30-day window is empty)
  - Logs all-time row count in rebuild metrics
- **Documentation updates**: Added clarifying comments about data sources and privacy contracts for the new functionality.

## Implementation Details
- The all-time data is pulled via an unfiltered collection-group query on `perExercise` documents, which uses the default single-field index and requires no additional index configuration.
- Exercises with only old activity (no entries in the 30-day window) will now appear in the snapshot with populated `allTime` buckets and empty windowed buckets.
- The privacy model is consistent: both windowed and all-time rankings respect admin shadow-bans and require explicit publicProfile opt-in.

https://claude.ai/code/session_01QQwvoRSUTxgPHVFNgs6TBb