### PR TITLE
chore(i18n): fill missing translations (369 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9680,249 +9680,249 @@
       </segment>
     </unit>
     <unit id="user.menu.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Ημερήσιοι στόχοι</target>
       </segment>
     </unit>
     <unit id="seo.goals.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele – Pushup Tracker</source>
-        <target>Tagesziele – Pushup Tracker</target>
+        <target>Ημερήσιοι στόχοι – Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="seo.goals.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</source>
-        <target>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</target>
+        <target>Σχεδίασε διάφορες ασκήσεις ανά ημέρα, εβδομάδα και μήνα – με φίλτρο ημέρας εβδομάδας.</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Δευ</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Τρί</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Τετ</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Πέμ</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Παρ</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Σάβ</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Κυρ</target>
       </segment>
     </unit>
     <unit id="goalsHeaderTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Ημερήσιοι στόχοι</target>
       </segment>
     </unit>
     <unit id="goalsHeaderSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </source>
-        <target> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </target>
+        <target> Διάφορες ασκήσεις ανά ημέρα, εβδομάδα, μήνα. </target>
       </segment>
     </unit>
     <unit id="goals.status.saving">
-      <segment state="initial">
+      <segment state="translated">
         <source>Speichert…</source>
-        <target>Speichert…</target>
+        <target>Αποθήκευση…</target>
       </segment>
     </unit>
     <unit id="goals.status.saved">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gespeichert</source>
-        <target>Gespeichert</target>
+        <target>Αποθηκεύτηκε</target>
       </segment>
     </unit>
     <unit id="goals.status.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fehler beim Speichern</source>
-        <target>Fehler beim Speichern</target>
+        <target>Σφάλμα αποθήκευσης</target>
       </segment>
     </unit>
     <unit id="goals.status.retry">
-      <segment state="initial">
+      <segment state="translated">
         <source> Erneut versuchen </source>
-        <target> Erneut versuchen </target>
+        <target> Επανάληψη </target>
       </segment>
     </unit>
     <unit id="goals.status.pending">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ungespeicherte Änderungen…</source>
-        <target>Ungespeicherte Änderungen…</target>
+        <target>Μη αποθηκευμένες αλλαγές…</target>
       </segment>
     </unit>
     <unit id="goals.status.synced">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Ziele gespeichert</source>
-        <target>Alle Ziele gespeichert</target>
+        <target>Όλοι οι στόχοι αποθηκεύτηκαν</target>
       </segment>
     </unit>
     <unit id="goals.intro">
-      <segment state="initial">
+      <segment state="translated">
         <source> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </source>
-        <target> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </target>
+        <target> Δημιούργησε μια λίστα ασκήσεων με τιμές στόχους για κάθε ημέρα, εβδομάδα και μήνα. Για τους ημερήσιους στόχους, μπορείς επίσης να ορίσεις ποιες μέρες της εβδομάδας ισχύει ο στόχος — ιδανικό για ένα πρόγραμμα push/pull/πόδια. </target>
       </segment>
     </unit>
     <unit id="goals.section.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </source>
-        <target> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </target>
+        <target> Δεν υπάρχουν ακόμα στόχοι. Πρόσθεσε τον πρώτο σου στόχο παρακάτω. </target>
       </segment>
     </unit>
     <unit id="goals.field.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Άσκηση</target>
       </segment>
     </unit>
     <unit id="goals.weekdayLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv an:</source>
-        <target>Aktiv an:</target>
+        <target>Ενεργό την:</target>
       </segment>
     </unit>
     <unit id="goals.weekdayEveryDayHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Auswahl = gilt jeden Tag.</source>
-        <target>Keine Auswahl = gilt jeden Tag.</target>
+        <target>Χωρίς επιλογή = ισχύει κάθε μέρα.</target>
       </segment>
     </unit>
     <unit id="goals.addEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel hinzufügen</source>
-        <target>Ziel hinzufügen</target>
+        <target>Προσθήκη στόχου</target>
       </segment>
     </unit>
     <unit id="goals.limitHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
-        <target> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </target>
+        <target> Μέγιστο <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> στόχοι ανά ενότητα. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Andere Einstellungen</source>
-        <target>Andere Einstellungen</target>
+        <target>Άλλες ρυθμίσεις</target>
       </segment>
     </unit>
     <unit id="goals.linkBack.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
-        <target> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </target>
+        <target> Διαχείριση προφίλ, ορατότητας, υπενθυμίσεων και διαφημίσεων. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.cta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Άνοιγμα ρυθμίσεων </target>
       </segment>
     </unit>
     <unit id="goals.removeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel entfernen</source>
-        <target>Ziel entfernen</target>
+        <target>Αφαίρεση στόχου</target>
       </segment>
     </unit>
     <unit id="goals.weekdayAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Ημέρες εβδομάδας</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Ημερήσιοι στόχοι</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
-        <target>Was du an einzelnen Wochentagen schaffen willst.</target>
+        <target>Τι θέλεις να επιτύχεις μεμονωμένες ημέρες της εβδομάδας.</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochenziele</source>
-        <target>Wochenziele</target>
+        <target>Εβδομαδιαίοι στόχοι</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Summen pro Übung über die ganze Woche.</source>
-        <target>Summen pro Übung über die ganze Woche.</target>
+        <target>Σύνολα ανά άσκηση σε όλη την εβδομάδα.</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Monatsziele</source>
-        <target>Monatsziele</target>
+        <target>Μηνιαίοι στόχοι</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
-        <target>Größere Ziele über den ganzen Monat verteilt.</target>
+        <target>Μεγαλύτεροι στόχοι κατανεμημένοι σε όλο τον μήνα.</target>
       </segment>
     </unit>
     <unit id="goals.field.target.time">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Sekunden)</source>
-        <target>Ziel (Sekunden)</target>
+        <target>Στόχος (δευτερόλεπτα)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.distance">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Meter)</source>
-        <target>Ziel (Meter)</target>
+        <target>Στόχος (μέτρα)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.reps">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel</source>
-        <target>Ziel</target>
+        <target>Στόχος</target>
       </segment>
     </unit>
     <unit id="settings.section.goals.linkSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </source>
-        <target> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </target>
+        <target> Οι ημερήσιοι, εβδομαδιαίοι και μηνιαίοι στόχοι με διάφορες ασκήσεις διαχειρίζονται πλέον στη δική τους σελίδα. </target>
       </segment>
     </unit>
     <unit id="settings.goals.openPageCta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Άνοιγμα ημερήσιων στόχων </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -9846,249 +9846,249 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="user.menu.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Daily Goals</target>
       </segment>
     </unit>
     <unit id="seo.goals.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele – Pushup Tracker</source>
-        <target>Tagesziele – Pushup Tracker</target>
+        <target>Daily Goals – Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="seo.goals.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</source>
-        <target>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</target>
+        <target>Plan different exercises per day, per week, and per month – with weekday filter.</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Mon</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Tue</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Wed</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Thu</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Fri</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Sat</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Sun</target>
       </segment>
     </unit>
     <unit id="goalsHeaderTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Daily Goals</target>
       </segment>
     </unit>
     <unit id="goalsHeaderSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </source>
-        <target> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </target>
+        <target> Different exercises per day, per week, per month. </target>
       </segment>
     </unit>
     <unit id="goals.status.saving">
-      <segment state="initial">
+      <segment state="translated">
         <source>Speichert…</source>
-        <target>Speichert…</target>
+        <target>Saving…</target>
       </segment>
     </unit>
     <unit id="goals.status.saved">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gespeichert</source>
-        <target>Gespeichert</target>
+        <target>Saved</target>
       </segment>
     </unit>
     <unit id="goals.status.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fehler beim Speichern</source>
-        <target>Fehler beim Speichern</target>
+        <target>Save error</target>
       </segment>
     </unit>
     <unit id="goals.status.retry">
-      <segment state="initial">
+      <segment state="translated">
         <source> Erneut versuchen </source>
-        <target> Erneut versuchen </target>
+        <target> Retry </target>
       </segment>
     </unit>
     <unit id="goals.status.pending">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ungespeicherte Änderungen…</source>
-        <target>Ungespeicherte Änderungen…</target>
+        <target>Unsaved changes…</target>
       </segment>
     </unit>
     <unit id="goals.status.synced">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Ziele gespeichert</source>
-        <target>Alle Ziele gespeichert</target>
+        <target>All goals saved</target>
       </segment>
     </unit>
     <unit id="goals.intro">
-      <segment state="initial">
+      <segment state="translated">
         <source> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </source>
-        <target> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </target>
+        <target> Set up a list of exercises with target values for each day, week, and month. For daily goals, you can also specify which weekdays the goal applies to — perfect for a push/pull/legs split. </target>
       </segment>
     </unit>
     <unit id="goals.section.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </source>
-        <target> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </target>
+        <target> No goals yet. Add your first goal below. </target>
       </segment>
     </unit>
     <unit id="goals.field.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Exercise</target>
       </segment>
     </unit>
     <unit id="goals.weekdayLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv an:</source>
-        <target>Aktiv an:</target>
+        <target>Active on:</target>
       </segment>
     </unit>
     <unit id="goals.weekdayEveryDayHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Auswahl = gilt jeden Tag.</source>
-        <target>Keine Auswahl = gilt jeden Tag.</target>
+        <target>No selection = applies every day.</target>
       </segment>
     </unit>
     <unit id="goals.addEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel hinzufügen</source>
-        <target>Ziel hinzufügen</target>
+        <target>Add goal</target>
       </segment>
     </unit>
     <unit id="goals.limitHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
-        <target> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </target>
+        <target> Maximum <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> goals per section. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Andere Einstellungen</source>
-        <target>Andere Einstellungen</target>
+        <target>Other Settings</target>
       </segment>
     </unit>
     <unit id="goals.linkBack.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
-        <target> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </target>
+        <target> Manage profile, visibility, reminders, and ads. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.cta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Open settings </target>
       </segment>
     </unit>
     <unit id="goals.removeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel entfernen</source>
-        <target>Ziel entfernen</target>
+        <target>Remove goal</target>
       </segment>
     </unit>
     <unit id="goals.weekdayAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Weekdays</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Daily Goals</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
-        <target>Was du an einzelnen Wochentagen schaffen willst.</target>
+        <target>What you want to achieve on individual weekdays.</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochenziele</source>
-        <target>Wochenziele</target>
+        <target>Weekly Goals</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Summen pro Übung über die ganze Woche.</source>
-        <target>Summen pro Übung über die ganze Woche.</target>
+        <target>Totals per exercise over the whole week.</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Monatsziele</source>
-        <target>Monatsziele</target>
+        <target>Monthly Goals</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
-        <target>Größere Ziele über den ganzen Monat verteilt.</target>
+        <target>Bigger goals spread across the whole month.</target>
       </segment>
     </unit>
     <unit id="goals.field.target.time">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Sekunden)</source>
-        <target>Ziel (Sekunden)</target>
+        <target>Target (seconds)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.distance">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Meter)</source>
-        <target>Ziel (Meter)</target>
+        <target>Target (metres)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.reps">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel</source>
-        <target>Ziel</target>
+        <target>Target</target>
       </segment>
     </unit>
     <unit id="settings.section.goals.linkSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </source>
-        <target> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </target>
+        <target> Daily, weekly, and monthly goals with different exercises are now managed on their own page. </target>
       </segment>
     </unit>
     <unit id="settings.goals.openPageCta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Open daily goals </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9676,249 +9676,249 @@
       </segment>
     </unit>
     <unit id="user.menu.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Objetivos diarios</target>
       </segment>
     </unit>
     <unit id="seo.goals.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele – Pushup Tracker</source>
-        <target>Tagesziele – Pushup Tracker</target>
+        <target>Objetivos diarios – Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="seo.goals.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</source>
-        <target>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</target>
+        <target>Planifica distintos ejercicios por día, por semana y por mes – con filtro de día de la semana.</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Lun</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Mar</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Mié</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Jue</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Vie</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Sáb</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Dom</target>
       </segment>
     </unit>
     <unit id="goalsHeaderTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Objetivos diarios</target>
       </segment>
     </unit>
     <unit id="goalsHeaderSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </source>
-        <target> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </target>
+        <target> Distintos ejercicios por día, por semana, por mes. </target>
       </segment>
     </unit>
     <unit id="goals.status.saving">
-      <segment state="initial">
+      <segment state="translated">
         <source>Speichert…</source>
-        <target>Speichert…</target>
+        <target>Guardando…</target>
       </segment>
     </unit>
     <unit id="goals.status.saved">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gespeichert</source>
-        <target>Gespeichert</target>
+        <target>Guardado</target>
       </segment>
     </unit>
     <unit id="goals.status.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fehler beim Speichern</source>
-        <target>Fehler beim Speichern</target>
+        <target>Error al guardar</target>
       </segment>
     </unit>
     <unit id="goals.status.retry">
-      <segment state="initial">
+      <segment state="translated">
         <source> Erneut versuchen </source>
-        <target> Erneut versuchen </target>
+        <target> Reintentar </target>
       </segment>
     </unit>
     <unit id="goals.status.pending">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ungespeicherte Änderungen…</source>
-        <target>Ungespeicherte Änderungen…</target>
+        <target>Cambios sin guardar…</target>
       </segment>
     </unit>
     <unit id="goals.status.synced">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Ziele gespeichert</source>
-        <target>Alle Ziele gespeichert</target>
+        <target>Todos los objetivos guardados</target>
       </segment>
     </unit>
     <unit id="goals.intro">
-      <segment state="initial">
+      <segment state="translated">
         <source> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </source>
-        <target> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </target>
+        <target> Crea una lista de ejercicios con valores objetivo para cada día, semana y mes. Para los objetivos diarios, también puedes especificar qué días de la semana aplica el objetivo — perfecto para una rutina de empuje/jalón/piernas. </target>
       </segment>
     </unit>
     <unit id="goals.section.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </source>
-        <target> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </target>
+        <target> Aún no hay objetivos. Añade tu primer objetivo abajo. </target>
       </segment>
     </unit>
     <unit id="goals.field.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Ejercicio</target>
       </segment>
     </unit>
     <unit id="goals.weekdayLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv an:</source>
-        <target>Aktiv an:</target>
+        <target>Activo en:</target>
       </segment>
     </unit>
     <unit id="goals.weekdayEveryDayHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Auswahl = gilt jeden Tag.</source>
-        <target>Keine Auswahl = gilt jeden Tag.</target>
+        <target>Sin selección = aplica todos los días.</target>
       </segment>
     </unit>
     <unit id="goals.addEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel hinzufügen</source>
-        <target>Ziel hinzufügen</target>
+        <target>Añadir objetivo</target>
       </segment>
     </unit>
     <unit id="goals.limitHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
-        <target> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </target>
+        <target> Máximo <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> objetivos por sección. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Andere Einstellungen</source>
-        <target>Andere Einstellungen</target>
+        <target>Otros ajustes</target>
       </segment>
     </unit>
     <unit id="goals.linkBack.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
-        <target> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </target>
+        <target> Gestionar perfil, visibilidad, recordatorios y anuncios. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.cta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Abrir ajustes </target>
       </segment>
     </unit>
     <unit id="goals.removeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel entfernen</source>
-        <target>Ziel entfernen</target>
+        <target>Eliminar objetivo</target>
       </segment>
     </unit>
     <unit id="goals.weekdayAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Días de la semana</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Objetivos diarios</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
-        <target>Was du an einzelnen Wochentagen schaffen willst.</target>
+        <target>Lo que quieres lograr en días de la semana individuales.</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochenziele</source>
-        <target>Wochenziele</target>
+        <target>Objetivos semanales</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Summen pro Übung über die ganze Woche.</source>
-        <target>Summen pro Übung über die ganze Woche.</target>
+        <target>Totales por ejercicio durante toda la semana.</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Monatsziele</source>
-        <target>Monatsziele</target>
+        <target>Objetivos mensuales</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
-        <target>Größere Ziele über den ganzen Monat verteilt.</target>
+        <target>Objetivos más grandes distribuidos a lo largo del mes.</target>
       </segment>
     </unit>
     <unit id="goals.field.target.time">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Sekunden)</source>
-        <target>Ziel (Sekunden)</target>
+        <target>Objetivo (segundos)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.distance">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Meter)</source>
-        <target>Ziel (Meter)</target>
+        <target>Objetivo (metros)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.reps">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel</source>
-        <target>Ziel</target>
+        <target>Objetivo</target>
       </segment>
     </unit>
     <unit id="settings.section.goals.linkSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </source>
-        <target> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </target>
+        <target> Los objetivos diarios, semanales y mensuales con distintos ejercicios ahora se gestionan en su propia página. </target>
       </segment>
     </unit>
     <unit id="settings.goals.openPageCta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Abrir objetivos diarios </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9552,249 +9552,249 @@
       </segment>
     </unit>
     <unit id="user.menu.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Objectifs quotidiens</target>
       </segment>
     </unit>
     <unit id="seo.goals.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele – Pushup Tracker</source>
-        <target>Tagesziele – Pushup Tracker</target>
+        <target>Objectifs quotidiens – Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="seo.goals.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</source>
-        <target>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</target>
+        <target>Planifiez différents exercices par jour, par semaine et par mois – avec filtre par jour de la semaine.</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Lun</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Mar</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Mer</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Jeu</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Ven</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Sam</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Dim</target>
       </segment>
     </unit>
     <unit id="goalsHeaderTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Objectifs quotidiens</target>
       </segment>
     </unit>
     <unit id="goalsHeaderSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </source>
-        <target> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </target>
+        <target> Différents exercices par jour, par semaine, par mois. </target>
       </segment>
     </unit>
     <unit id="goals.status.saving">
-      <segment state="initial">
+      <segment state="translated">
         <source>Speichert…</source>
-        <target>Speichert…</target>
+        <target>Enregistrement…</target>
       </segment>
     </unit>
     <unit id="goals.status.saved">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gespeichert</source>
-        <target>Gespeichert</target>
+        <target>Enregistré</target>
       </segment>
     </unit>
     <unit id="goals.status.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fehler beim Speichern</source>
-        <target>Fehler beim Speichern</target>
+        <target>Erreur lors de l'enregistrement</target>
       </segment>
     </unit>
     <unit id="goals.status.retry">
-      <segment state="initial">
+      <segment state="translated">
         <source> Erneut versuchen </source>
-        <target> Erneut versuchen </target>
+        <target> Réessayer </target>
       </segment>
     </unit>
     <unit id="goals.status.pending">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ungespeicherte Änderungen…</source>
-        <target>Ungespeicherte Änderungen…</target>
+        <target>Modifications non enregistrées…</target>
       </segment>
     </unit>
     <unit id="goals.status.synced">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Ziele gespeichert</source>
-        <target>Alle Ziele gespeichert</target>
+        <target>Tous les objectifs enregistrés</target>
       </segment>
     </unit>
     <unit id="goals.intro">
-      <segment state="initial">
+      <segment state="translated">
         <source> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </source>
-        <target> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </target>
+        <target> Créez une liste d'exercices avec des valeurs cibles pour chaque jour, semaine et mois. Pour les objectifs quotidiens, vous pouvez également spécifier quels jours de la semaine l'objectif s'applique — parfait pour un programme push/pull/jambes. </target>
       </segment>
     </unit>
     <unit id="goals.section.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </source>
-        <target> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </target>
+        <target> Aucun objectif encore. Ajoutez votre premier objectif ci-dessous. </target>
       </segment>
     </unit>
     <unit id="goals.field.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Exercice</target>
       </segment>
     </unit>
     <unit id="goals.weekdayLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv an:</source>
-        <target>Aktiv an:</target>
+        <target>Actif le :</target>
       </segment>
     </unit>
     <unit id="goals.weekdayEveryDayHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Auswahl = gilt jeden Tag.</source>
-        <target>Keine Auswahl = gilt jeden Tag.</target>
+        <target>Aucune sélection = s'applique tous les jours.</target>
       </segment>
     </unit>
     <unit id="goals.addEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel hinzufügen</source>
-        <target>Ziel hinzufügen</target>
+        <target>Ajouter un objectif</target>
       </segment>
     </unit>
     <unit id="goals.limitHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
-        <target> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </target>
+        <target> Maximum <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> objectifs par section. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Andere Einstellungen</source>
-        <target>Andere Einstellungen</target>
+        <target>Autres paramètres</target>
       </segment>
     </unit>
     <unit id="goals.linkBack.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
-        <target> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </target>
+        <target> Gérer le profil, la visibilité, les rappels et la publicité. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.cta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Ouvrir les paramètres </target>
       </segment>
     </unit>
     <unit id="goals.removeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel entfernen</source>
-        <target>Ziel entfernen</target>
+        <target>Supprimer l'objectif</target>
       </segment>
     </unit>
     <unit id="goals.weekdayAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Jours de la semaine</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Objectifs quotidiens</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
-        <target>Was du an einzelnen Wochentagen schaffen willst.</target>
+        <target>Ce que vous souhaitez accomplir les jours de semaine individuels.</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochenziele</source>
-        <target>Wochenziele</target>
+        <target>Objectifs hebdomadaires</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Summen pro Übung über die ganze Woche.</source>
-        <target>Summen pro Übung über die ganze Woche.</target>
+        <target>Totaux par exercice sur toute la semaine.</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Monatsziele</source>
-        <target>Monatsziele</target>
+        <target>Objectifs mensuels</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
-        <target>Größere Ziele über den ganzen Monat verteilt.</target>
+        <target>Des objectifs plus ambitieux répartis sur tout le mois.</target>
       </segment>
     </unit>
     <unit id="goals.field.target.time">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Sekunden)</source>
-        <target>Ziel (Sekunden)</target>
+        <target>Objectif (secondes)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.distance">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Meter)</source>
-        <target>Ziel (Meter)</target>
+        <target>Objectif (mètres)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.reps">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel</source>
-        <target>Ziel</target>
+        <target>Objectif</target>
       </segment>
     </unit>
     <unit id="settings.section.goals.linkSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </source>
-        <target> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </target>
+        <target> Les objectifs quotidiens, hebdomadaires et mensuels avec différents exercices sont désormais gérés sur leur propre page. </target>
       </segment>
     </unit>
     <unit id="settings.goals.openPageCta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Ouvrir les objectifs quotidiens </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9680,249 +9680,249 @@
       </segment>
     </unit>
     <unit id="user.menu.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Obiettivi giornalieri</target>
       </segment>
     </unit>
     <unit id="seo.goals.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele – Pushup Tracker</source>
-        <target>Tagesziele – Pushup Tracker</target>
+        <target>Obiettivi giornalieri – Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="seo.goals.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</source>
-        <target>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</target>
+        <target>Pianifica diversi esercizi al giorno, alla settimana e al mese – con filtro per giorno della settimana.</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Lun</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Mar</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Mer</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Gio</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Ven</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Sab</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Dom</target>
       </segment>
     </unit>
     <unit id="goalsHeaderTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Obiettivi giornalieri</target>
       </segment>
     </unit>
     <unit id="goalsHeaderSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </source>
-        <target> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </target>
+        <target> Diversi esercizi al giorno, alla settimana, al mese. </target>
       </segment>
     </unit>
     <unit id="goals.status.saving">
-      <segment state="initial">
+      <segment state="translated">
         <source>Speichert…</source>
-        <target>Speichert…</target>
+        <target>Salvataggio…</target>
       </segment>
     </unit>
     <unit id="goals.status.saved">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gespeichert</source>
-        <target>Gespeichert</target>
+        <target>Salvato</target>
       </segment>
     </unit>
     <unit id="goals.status.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fehler beim Speichern</source>
-        <target>Fehler beim Speichern</target>
+        <target>Errore durante il salvataggio</target>
       </segment>
     </unit>
     <unit id="goals.status.retry">
-      <segment state="initial">
+      <segment state="translated">
         <source> Erneut versuchen </source>
-        <target> Erneut versuchen </target>
+        <target> Riprova </target>
       </segment>
     </unit>
     <unit id="goals.status.pending">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ungespeicherte Änderungen…</source>
-        <target>Ungespeicherte Änderungen…</target>
+        <target>Modifiche non salvate…</target>
       </segment>
     </unit>
     <unit id="goals.status.synced">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Ziele gespeichert</source>
-        <target>Alle Ziele gespeichert</target>
+        <target>Tutti gli obiettivi salvati</target>
       </segment>
     </unit>
     <unit id="goals.intro">
-      <segment state="initial">
+      <segment state="translated">
         <source> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </source>
-        <target> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </target>
+        <target> Crea un elenco di esercizi con valori target per ogni giorno, settimana e mese. Per gli obiettivi giornalieri, puoi anche specificare in quali giorni della settimana si applica l'obiettivo — perfetto per una routine push/pull/gambe. </target>
       </segment>
     </unit>
     <unit id="goals.section.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </source>
-        <target> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </target>
+        <target> Nessun obiettivo ancora. Aggiungi il tuo primo obiettivo qui sotto. </target>
       </segment>
     </unit>
     <unit id="goals.field.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Esercizio</target>
       </segment>
     </unit>
     <unit id="goals.weekdayLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv an:</source>
-        <target>Aktiv an:</target>
+        <target>Attivo il:</target>
       </segment>
     </unit>
     <unit id="goals.weekdayEveryDayHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Auswahl = gilt jeden Tag.</source>
-        <target>Keine Auswahl = gilt jeden Tag.</target>
+        <target>Nessuna selezione = vale ogni giorno.</target>
       </segment>
     </unit>
     <unit id="goals.addEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel hinzufügen</source>
-        <target>Ziel hinzufügen</target>
+        <target>Aggiungi obiettivo</target>
       </segment>
     </unit>
     <unit id="goals.limitHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
-        <target> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </target>
+        <target> Massimo <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> obiettivi per sezione. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Andere Einstellungen</source>
-        <target>Andere Einstellungen</target>
+        <target>Altre impostazioni</target>
       </segment>
     </unit>
     <unit id="goals.linkBack.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
-        <target> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </target>
+        <target> Gestisci profilo, visibilità, promemoria e pubblicità. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.cta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Apri impostazioni </target>
       </segment>
     </unit>
     <unit id="goals.removeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel entfernen</source>
-        <target>Ziel entfernen</target>
+        <target>Rimuovi obiettivo</target>
       </segment>
     </unit>
     <unit id="goals.weekdayAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Giorni della settimana</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Obiettivi giornalieri</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
-        <target>Was du an einzelnen Wochentagen schaffen willst.</target>
+        <target>Quello che vuoi raggiungere nei singoli giorni della settimana.</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochenziele</source>
-        <target>Wochenziele</target>
+        <target>Obiettivi settimanali</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Summen pro Übung über die ganze Woche.</source>
-        <target>Summen pro Übung über die ganze Woche.</target>
+        <target>Totali per esercizio nell'intera settimana.</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Monatsziele</source>
-        <target>Monatsziele</target>
+        <target>Obiettivi mensili</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
-        <target>Größere Ziele über den ganzen Monat verteilt.</target>
+        <target>Obiettivi più grandi distribuiti nell'intero mese.</target>
       </segment>
     </unit>
     <unit id="goals.field.target.time">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Sekunden)</source>
-        <target>Ziel (Sekunden)</target>
+        <target>Obiettivo (secondi)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.distance">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Meter)</source>
-        <target>Ziel (Meter)</target>
+        <target>Obiettivo (metri)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.reps">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel</source>
-        <target>Ziel</target>
+        <target>Obiettivo</target>
       </segment>
     </unit>
     <unit id="settings.section.goals.linkSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </source>
-        <target> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </target>
+        <target> Gli obiettivi giornalieri, settimanali e mensili con diversi esercizi sono ora gestiti nella loro pagina dedicata. </target>
       </segment>
     </unit>
     <unit id="settings.goals.openPageCta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Apri obiettivi giornalieri </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9680,249 +9680,249 @@
       </segment>
     </unit>
     <unit id="user.menu.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Proposita diurna</target>
       </segment>
     </unit>
     <unit id="seo.goals.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele – Pushup Tracker</source>
-        <target>Tagesziele – Pushup Tracker</target>
+        <target>Proposita diurna – Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="seo.goals.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</source>
-        <target>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</target>
+        <target>Pone varias exercitationes per diem, per hebdomadem et per mensem – cum selectore diei.</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Lun</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Mar</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Mer</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Iov</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Ven</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Sat</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Sol</target>
       </segment>
     </unit>
     <unit id="goalsHeaderTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Proposita diurna</target>
       </segment>
     </unit>
     <unit id="goalsHeaderSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </source>
-        <target> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </target>
+        <target> Variae exercitationes per diem, per hebdomadem, per mensem. </target>
       </segment>
     </unit>
     <unit id="goals.status.saving">
-      <segment state="initial">
+      <segment state="translated">
         <source>Speichert…</source>
-        <target>Speichert…</target>
+        <target>Salvatur…</target>
       </segment>
     </unit>
     <unit id="goals.status.saved">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gespeichert</source>
-        <target>Gespeichert</target>
+        <target>Salvatum</target>
       </segment>
     </unit>
     <unit id="goals.status.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fehler beim Speichern</source>
-        <target>Fehler beim Speichern</target>
+        <target>Error in salvando</target>
       </segment>
     </unit>
     <unit id="goals.status.retry">
-      <segment state="initial">
+      <segment state="translated">
         <source> Erneut versuchen </source>
-        <target> Erneut versuchen </target>
+        <target> Iterum conare </target>
       </segment>
     </unit>
     <unit id="goals.status.pending">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ungespeicherte Änderungen…</source>
-        <target>Ungespeicherte Änderungen…</target>
+        <target>Mutationes non servatae…</target>
       </segment>
     </unit>
     <unit id="goals.status.synced">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Ziele gespeichert</source>
-        <target>Alle Ziele gespeichert</target>
+        <target>Omnia proposita servata</target>
       </segment>
     </unit>
     <unit id="goals.intro">
-      <segment state="initial">
+      <segment state="translated">
         <source> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </source>
-        <target> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </target>
+        <target> Crea indicem exercitationum cum valoribus propositis pro die, hebdomade et mense. Pro propositis diurnis etiam potes statuere, quibus diebus hebdomadis propositum valeat — perfectum ad programma push/pull/crura. </target>
       </segment>
     </unit>
     <unit id="goals.section.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </source>
-        <target> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </target>
+        <target> Nulla proposita adhuc. Adde propositum primum infra. </target>
       </segment>
     </unit>
     <unit id="goals.field.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Exercitatio</target>
       </segment>
     </unit>
     <unit id="goals.weekdayLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv an:</source>
-        <target>Aktiv an:</target>
+        <target>Activum in:</target>
       </segment>
     </unit>
     <unit id="goals.weekdayEveryDayHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Auswahl = gilt jeden Tag.</source>
-        <target>Keine Auswahl = gilt jeden Tag.</target>
+        <target>Nulla selectio = valet quotidie.</target>
       </segment>
     </unit>
     <unit id="goals.addEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel hinzufügen</source>
-        <target>Ziel hinzufügen</target>
+        <target>Propositum addere</target>
       </segment>
     </unit>
     <unit id="goals.limitHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
-        <target> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </target>
+        <target> Maximum <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> proposita per sectionem. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Andere Einstellungen</source>
-        <target>Andere Einstellungen</target>
+        <target>Aliae optiones</target>
       </segment>
     </unit>
     <unit id="goals.linkBack.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
-        <target> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </target>
+        <target> Profilum, visibilitatem, admonitiones et publicitas administrare. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.cta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Optiones aperire </target>
       </segment>
     </unit>
     <unit id="goals.removeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel entfernen</source>
-        <target>Ziel entfernen</target>
+        <target>Propositum removere</target>
       </segment>
     </unit>
     <unit id="goals.weekdayAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Dies hebdomadis</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Proposita diurna</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
-        <target>Was du an einzelnen Wochentagen schaffen willst.</target>
+        <target>Quid singulis diebus hebdomadis efficere velis.</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochenziele</source>
-        <target>Wochenziele</target>
+        <target>Proposita hebdomadalia</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Summen pro Übung über die ganze Woche.</source>
-        <target>Summen pro Übung über die ganze Woche.</target>
+        <target>Summae per exercitationem per totam hebdomadem.</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Monatsziele</source>
-        <target>Monatsziele</target>
+        <target>Proposita menstrua</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
-        <target>Größere Ziele über den ganzen Monat verteilt.</target>
+        <target>Maiora proposita per totum mensem distributa.</target>
       </segment>
     </unit>
     <unit id="goals.field.target.time">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Sekunden)</source>
-        <target>Ziel (Sekunden)</target>
+        <target>Propositum (secundae)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.distance">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Meter)</source>
-        <target>Ziel (Meter)</target>
+        <target>Propositum (metra)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.reps">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel</source>
-        <target>Ziel</target>
+        <target>Propositum</target>
       </segment>
     </unit>
     <unit id="settings.section.goals.linkSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </source>
-        <target> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </target>
+        <target> Proposita diurna, hebdomadalia et menstrua cum variis exercitationibus iam in propria pagina administrantur. </target>
       </segment>
     </unit>
     <unit id="settings.goals.openPageCta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Proposita diurna aperire </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9680,249 +9680,249 @@
       </segment>
     </unit>
     <unit id="user.menu.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Dagelijkse doelen</target>
       </segment>
     </unit>
     <unit id="seo.goals.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele – Pushup Tracker</source>
-        <target>Tagesziele – Pushup Tracker</target>
+        <target>Dagelijkse doelen – Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="seo.goals.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</source>
-        <target>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</target>
+        <target>Plan verschillende oefeningen per dag, per week en per maand – met weekdagfilter.</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Ma</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
         <target>Di</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Wo</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
         <target>Do</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Vr</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Za</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Zo</target>
       </segment>
     </unit>
     <unit id="goalsHeaderTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Dagelijkse doelen</target>
       </segment>
     </unit>
     <unit id="goalsHeaderSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </source>
-        <target> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </target>
+        <target> Verschillende oefeningen per dag, per week, per maand. </target>
       </segment>
     </unit>
     <unit id="goals.status.saving">
-      <segment state="initial">
+      <segment state="translated">
         <source>Speichert…</source>
-        <target>Speichert…</target>
+        <target>Opslaan…</target>
       </segment>
     </unit>
     <unit id="goals.status.saved">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gespeichert</source>
-        <target>Gespeichert</target>
+        <target>Opgeslagen</target>
       </segment>
     </unit>
     <unit id="goals.status.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fehler beim Speichern</source>
-        <target>Fehler beim Speichern</target>
+        <target>Fout bij opslaan</target>
       </segment>
     </unit>
     <unit id="goals.status.retry">
-      <segment state="initial">
+      <segment state="translated">
         <source> Erneut versuchen </source>
-        <target> Erneut versuchen </target>
+        <target> Opnieuw proberen </target>
       </segment>
     </unit>
     <unit id="goals.status.pending">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ungespeicherte Änderungen…</source>
-        <target>Ungespeicherte Änderungen…</target>
+        <target>Niet-opgeslagen wijzigingen…</target>
       </segment>
     </unit>
     <unit id="goals.status.synced">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Ziele gespeichert</source>
-        <target>Alle Ziele gespeichert</target>
+        <target>Alle doelen opgeslagen</target>
       </segment>
     </unit>
     <unit id="goals.intro">
-      <segment state="initial">
+      <segment state="translated">
         <source> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </source>
-        <target> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </target>
+        <target> Maak een lijst van oefeningen met doelwaarden aan voor elke dag, week en maand. Voor dagelijkse doelen kun je ook instellen op welke weekdagen het doel van toepassing is — perfect voor een push/pull/benen-schema. </target>
       </segment>
     </unit>
     <unit id="goals.section.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </source>
-        <target> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </target>
+        <target> Nog geen doelen. Voeg hieronder je eerste doel toe. </target>
       </segment>
     </unit>
     <unit id="goals.field.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Oefening</target>
       </segment>
     </unit>
     <unit id="goals.weekdayLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv an:</source>
-        <target>Aktiv an:</target>
+        <target>Actief op:</target>
       </segment>
     </unit>
     <unit id="goals.weekdayEveryDayHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Auswahl = gilt jeden Tag.</source>
-        <target>Keine Auswahl = gilt jeden Tag.</target>
+        <target>Geen selectie = geldt elke dag.</target>
       </segment>
     </unit>
     <unit id="goals.addEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel hinzufügen</source>
-        <target>Ziel hinzufügen</target>
+        <target>Doel toevoegen</target>
       </segment>
     </unit>
     <unit id="goals.limitHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
-        <target> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </target>
+        <target> Maximaal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> doelen per sectie. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Andere Einstellungen</source>
-        <target>Andere Einstellungen</target>
+        <target>Andere instellingen</target>
       </segment>
     </unit>
     <unit id="goals.linkBack.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
-        <target> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </target>
+        <target> Profiel, zichtbaarheid, herinneringen en advertenties beheren. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.cta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Instellingen openen </target>
       </segment>
     </unit>
     <unit id="goals.removeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel entfernen</source>
-        <target>Ziel entfernen</target>
+        <target>Doel verwijderen</target>
       </segment>
     </unit>
     <unit id="goals.weekdayAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Weekdagen</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Dagelijkse doelen</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
-        <target>Was du an einzelnen Wochentagen schaffen willst.</target>
+        <target>Wat je op individuele weekdagen wilt bereiken.</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochenziele</source>
-        <target>Wochenziele</target>
+        <target>Wekelijkse doelen</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Summen pro Übung über die ganze Woche.</source>
-        <target>Summen pro Übung über die ganze Woche.</target>
+        <target>Totalen per oefening over de hele week.</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Monatsziele</source>
-        <target>Monatsziele</target>
+        <target>Maandelijkse doelen</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
-        <target>Größere Ziele über den ganzen Monat verteilt.</target>
+        <target>Grotere doelen verspreid over de hele maand.</target>
       </segment>
     </unit>
     <unit id="goals.field.target.time">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Sekunden)</source>
-        <target>Ziel (Sekunden)</target>
+        <target>Doel (seconden)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.distance">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Meter)</source>
-        <target>Ziel (Meter)</target>
+        <target>Doel (meter)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.reps">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel</source>
-        <target>Ziel</target>
+        <target>Doel</target>
       </segment>
     </unit>
     <unit id="settings.section.goals.linkSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </source>
-        <target> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </target>
+        <target> Dagelijkse, wekelijkse en maandelijkse doelen met verschillende oefeningen worden nu beheerd op hun eigen pagina. </target>
       </segment>
     </unit>
     <unit id="settings.goals.openPageCta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Dagelijkse doelen openen </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -8940,249 +8940,249 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="user.menu.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Daglige mål</target>
       </segment>
     </unit>
     <unit id="seo.goals.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele – Pushup Tracker</source>
-        <target>Tagesziele – Pushup Tracker</target>
+        <target>Daglige mål – Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="seo.goals.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</source>
-        <target>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</target>
+        <target>Planlegg ulike øvelser per dag, per uke og per måned – med ukedagfilter.</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Man</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Tir</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Ons</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Tor</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Fre</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Lør</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Søn</target>
       </segment>
     </unit>
     <unit id="goalsHeaderTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Daglige mål</target>
       </segment>
     </unit>
     <unit id="goalsHeaderSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </source>
-        <target> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </target>
+        <target> Ulike øvelser per dag, per uke, per måned. </target>
       </segment>
     </unit>
     <unit id="goals.status.saving">
-      <segment state="initial">
+      <segment state="translated">
         <source>Speichert…</source>
-        <target>Speichert…</target>
+        <target>Lagrer…</target>
       </segment>
     </unit>
     <unit id="goals.status.saved">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gespeichert</source>
-        <target>Gespeichert</target>
+        <target>Lagret</target>
       </segment>
     </unit>
     <unit id="goals.status.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fehler beim Speichern</source>
-        <target>Fehler beim Speichern</target>
+        <target>Feil ved lagring</target>
       </segment>
     </unit>
     <unit id="goals.status.retry">
-      <segment state="initial">
+      <segment state="translated">
         <source> Erneut versuchen </source>
-        <target> Erneut versuchen </target>
+        <target> Prøv igjen </target>
       </segment>
     </unit>
     <unit id="goals.status.pending">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ungespeicherte Änderungen…</source>
-        <target>Ungespeicherte Änderungen…</target>
+        <target>Ulagrede endringer…</target>
       </segment>
     </unit>
     <unit id="goals.status.synced">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Ziele gespeichert</source>
-        <target>Alle Ziele gespeichert</target>
+        <target>Alle mål lagret</target>
       </segment>
     </unit>
     <unit id="goals.intro">
-      <segment state="initial">
+      <segment state="translated">
         <source> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </source>
-        <target> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </target>
+        <target> Opprett en liste med øvelser og målverdier for hver dag, uke og måned. For daglige mål kan du også velge hvilke ukedager målet gjelder — perfekt for et push/pull/bein-opplegg. </target>
       </segment>
     </unit>
     <unit id="goals.section.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </source>
-        <target> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </target>
+        <target> Ingen mål ennå. Legg til ditt første mål nedenfor. </target>
       </segment>
     </unit>
     <unit id="goals.field.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Øvelse</target>
       </segment>
     </unit>
     <unit id="goals.weekdayLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv an:</source>
-        <target>Aktiv an:</target>
+        <target>Aktiv på:</target>
       </segment>
     </unit>
     <unit id="goals.weekdayEveryDayHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Auswahl = gilt jeden Tag.</source>
-        <target>Keine Auswahl = gilt jeden Tag.</target>
+        <target>Intet valg = gjelder hver dag.</target>
       </segment>
     </unit>
     <unit id="goals.addEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel hinzufügen</source>
-        <target>Ziel hinzufügen</target>
+        <target>Legg til mål</target>
       </segment>
     </unit>
     <unit id="goals.limitHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
-        <target> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </target>
+        <target> Maksimalt <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> mål per seksjon. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Andere Einstellungen</source>
-        <target>Andere Einstellungen</target>
+        <target>Andre innstillinger</target>
       </segment>
     </unit>
     <unit id="goals.linkBack.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
-        <target> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </target>
+        <target> Administrer profil, synlighet, påminnelser og annonser. </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.cta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Åpne innstillinger </target>
       </segment>
     </unit>
     <unit id="goals.removeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel entfernen</source>
-        <target>Ziel entfernen</target>
+        <target>Fjern mål</target>
       </segment>
     </unit>
     <unit id="goals.weekdayAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Ukedager</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Daglige mål</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
-        <target>Was du an einzelnen Wochentagen schaffen willst.</target>
+        <target>Det du vil oppnå på individuelle ukedager.</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochenziele</source>
-        <target>Wochenziele</target>
+        <target>Ukentlige mål</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Summen pro Übung über die ganze Woche.</source>
-        <target>Summen pro Übung über die ganze Woche.</target>
+        <target>Totaler per øvelse for hele uken.</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Monatsziele</source>
-        <target>Monatsziele</target>
+        <target>Månedlige mål</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
-        <target>Größere Ziele über den ganzen Monat verteilt.</target>
+        <target>Større mål fordelt over hele måneden.</target>
       </segment>
     </unit>
     <unit id="goals.field.target.time">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Sekunden)</source>
-        <target>Ziel (Sekunden)</target>
+        <target>Mål (sekunder)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.distance">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Meter)</source>
-        <target>Ziel (Meter)</target>
+        <target>Mål (meter)</target>
       </segment>
     </unit>
     <unit id="goals.field.target.reps">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel</source>
-        <target>Ziel</target>
+        <target>Mål</target>
       </segment>
     </unit>
     <unit id="settings.section.goals.linkSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </source>
-        <target> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </target>
+        <target> Daglige, ukentlige og månedlige mål med ulike øvelser administreres nå på sin egen side. </target>
       </segment>
     </unit>
     <unit id="settings.goals.openPageCta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Åpne daglige mål </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4335,7 +4335,7 @@
     </unit>
     <unit id="goals.weekdayLabel">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:252,254</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:253,255</note>
       </notes>
       <segment>
         <source>Aktiv an:</source>
@@ -4343,7 +4343,7 @@
     </unit>
     <unit id="goals.weekdayEveryDayHint">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:273,275</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:274,276</note>
       </notes>
       <segment>
         <source>Keine Auswahl = gilt jeden Tag.</source>
@@ -4351,7 +4351,7 @@
     </unit>
     <unit id="goals.addEntry">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:288,289</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:289,290</note>
       </notes>
       <segment>
         <source>Ziel hinzufügen</source>
@@ -4359,7 +4359,7 @@
     </unit>
     <unit id="goals.limitHint">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:292,293</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:293,294</note>
       </notes>
       <segment>
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
@@ -4367,7 +4367,7 @@
     </unit>
     <unit id="goals.linkBack.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:303,305</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:304,306</note>
       </notes>
       <segment>
         <source>Andere Einstellungen</source>
@@ -4375,7 +4375,7 @@
     </unit>
     <unit id="goals.linkBack.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:306,307</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:307,308</note>
       </notes>
       <segment>
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
@@ -4383,7 +4383,7 @@
     </unit>
     <unit id="goals.linkBack.cta">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:315,317</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:316,318</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
@@ -4391,7 +4391,7 @@
     </unit>
     <unit id="goals.removeAria">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:460</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:461</note>
       </notes>
       <segment>
         <source>Ziel entfernen</source>
@@ -4399,7 +4399,7 @@
     </unit>
     <unit id="goals.weekdayAria">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:461</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:462</note>
       </notes>
       <segment>
         <source>Wochentage</source>
@@ -4407,7 +4407,7 @@
     </unit>
     <unit id="goals.section.daily.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:472</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:473</note>
       </notes>
       <segment>
         <source>Tagesziele</source>
@@ -4415,7 +4415,7 @@
     </unit>
     <unit id="goals.section.daily.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:473</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:474</note>
       </notes>
       <segment>
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
@@ -4423,7 +4423,7 @@
     </unit>
     <unit id="goals.section.weekly.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:478</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:479</note>
       </notes>
       <segment>
         <source>Wochenziele</source>
@@ -4431,7 +4431,7 @@
     </unit>
     <unit id="goals.section.weekly.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:479</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:480</note>
       </notes>
       <segment>
         <source>Summen pro Übung über die ganze Woche.</source>
@@ -4439,7 +4439,7 @@
     </unit>
     <unit id="goals.section.monthly.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:484</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:485</note>
       </notes>
       <segment>
         <source>Monatsziele</source>
@@ -4447,7 +4447,7 @@
     </unit>
     <unit id="goals.section.monthly.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:485</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:486</note>
       </notes>
       <segment>
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
@@ -4455,7 +4455,7 @@
     </unit>
     <unit id="goals.field.target.time">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:630</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:650</note>
       </notes>
       <segment>
         <source>Ziel (Sekunden)</source>
@@ -4463,7 +4463,7 @@
     </unit>
     <unit id="goals.field.target.distance">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:633</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:653</note>
       </notes>
       <segment>
         <source>Ziel (Meter)</source>
@@ -4471,7 +4471,7 @@
     </unit>
     <unit id="goals.field.target.reps">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:637</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:657</note>
       </notes>
       <segment>
         <source>Ziel</source>
@@ -4551,7 +4551,7 @@
     </unit>
     <unit id="leaderboard.lastUpdated">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:156,161</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:131,136</note>
       </notes>
       <segment>
         <source> Zuletzt aktualisiert: <pc id="0" equivStart="START_TAG_TIME" equivEnd="CLOSE_TAG_TIME" type="other" dispStart="&lt;time [attr.datetime]=&quot;updatedAt.toISOString()&quot;&gt;" dispEnd="&lt;/time&gt;"><ph id="1" equiv="INTERPOLATION" disp="{{
@@ -4561,8 +4561,8 @@
     </unit>
     <unit id="landing.leaderboard.ownPosition">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:176,177</note>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:186,188</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:178,179</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:188,190</note>
       </notes>
       <segment>
         <source> Deine Position: #<ph id="0" equiv="INTERPOLATION" disp="{{ me.rank }}"/> · <ph id="1" equiv="INTERPOLATION_1" disp="{{ formatValue(me.reps) }}"/> </source>
@@ -4570,7 +4570,7 @@
     </unit>
     <unit id="leaderboard.visibilityHint">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:196,198</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:198,200</note>
       </notes>
       <segment>
         <source> Sichtbarkeit oder Anzeigename anpassen? </source>
@@ -4578,7 +4578,7 @@
     </unit>
     <unit id="leaderboard.visibilityHint.cta">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:202,205</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:204,207</note>
       </notes>
       <segment>
         <source>Einstellungen öffnen</source>
@@ -4586,7 +4586,7 @@
     </unit>
     <unit id="leaderboard.loginHint">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:209,211</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:211,213</note>
       </notes>
       <segment>
         <source> Mitmachen und auftauchen? </source>
@@ -4594,7 +4594,7 @@
     </unit>
     <unit id="leaderboard.loginHint.cta">
       <notes>
-        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:212,215</note>
+        <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.html:214,217</note>
       </notes>
       <segment>
         <source>Anmelden</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9174,249 +9174,249 @@
       </segment>
     </unit>
     <unit id="user.menu.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>每日目标</target>
       </segment>
     </unit>
     <unit id="seo.goals.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele – Pushup Tracker</source>
-        <target>Tagesziele – Pushup Tracker</target>
+        <target>每日目标 – Pushup Tracker</target>
       </segment>
     </unit>
     <unit id="seo.goals.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</source>
-        <target>Plane verschiedene Übungen pro Tag, pro Woche und pro Monat – mit Wochentag-Filter.</target>
+        <target>按天、周、月规划不同练习 – 支持星期筛选。</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>周一</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>周二</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>周三</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>周四</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>周五</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>周六</target>
       </segment>
     </unit>
     <unit id="goals.weekday.short.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>周日</target>
       </segment>
     </unit>
     <unit id="goalsHeaderTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>每日目标</target>
       </segment>
     </unit>
     <unit id="goalsHeaderSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </source>
-        <target> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </target>
+        <target> 每天、每周、每月的各种练习。 </target>
       </segment>
     </unit>
     <unit id="goals.status.saving">
-      <segment state="initial">
+      <segment state="translated">
         <source>Speichert…</source>
-        <target>Speichert…</target>
+        <target>保存中…</target>
       </segment>
     </unit>
     <unit id="goals.status.saved">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gespeichert</source>
-        <target>Gespeichert</target>
+        <target>已保存</target>
       </segment>
     </unit>
     <unit id="goals.status.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fehler beim Speichern</source>
-        <target>Fehler beim Speichern</target>
+        <target>保存出错</target>
       </segment>
     </unit>
     <unit id="goals.status.retry">
-      <segment state="initial">
+      <segment state="translated">
         <source> Erneut versuchen </source>
-        <target> Erneut versuchen </target>
+        <target> 重试 </target>
       </segment>
     </unit>
     <unit id="goals.status.pending">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ungespeicherte Änderungen…</source>
-        <target>Ungespeicherte Änderungen…</target>
+        <target>未保存的更改…</target>
       </segment>
     </unit>
     <unit id="goals.status.synced">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Ziele gespeichert</source>
-        <target>Alle Ziele gespeichert</target>
+        <target>所有目标已保存</target>
       </segment>
     </unit>
     <unit id="goals.intro">
-      <segment state="initial">
+      <segment state="translated">
         <source> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </source>
-        <target> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </target>
+        <target> 为每天、每周、每月创建包含目标值的练习列表。对于每日目标，您还可以指定目标适用的星期几 — 非常适合推/拉/腿分化训练。 </target>
       </segment>
     </unit>
     <unit id="goals.section.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </source>
-        <target> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </target>
+        <target> 暂无目标。请在下方添加您的第一个目标。 </target>
       </segment>
     </unit>
     <unit id="goals.field.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>练习</target>
       </segment>
     </unit>
     <unit id="goals.weekdayLabel">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv an:</source>
-        <target>Aktiv an:</target>
+        <target>有效于：</target>
       </segment>
     </unit>
     <unit id="goals.weekdayEveryDayHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine Auswahl = gilt jeden Tag.</source>
-        <target>Keine Auswahl = gilt jeden Tag.</target>
+        <target>不选择 = 每天有效。</target>
       </segment>
     </unit>
     <unit id="goals.addEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel hinzufügen</source>
-        <target>Ziel hinzufügen</target>
+        <target>添加目标</target>
       </segment>
     </unit>
     <unit id="goals.limitHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
-        <target> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </target>
+        <target> 每个区域最多 <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> 个目标。 </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Andere Einstellungen</source>
-        <target>Andere Einstellungen</target>
+        <target>其他设置</target>
       </segment>
     </unit>
     <unit id="goals.linkBack.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
-        <target> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </target>
+        <target> 管理个人资料、可见性、提醒和广告。 </target>
       </segment>
     </unit>
     <unit id="goals.linkBack.cta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> 打开设置 </target>
       </segment>
     </unit>
     <unit id="goals.removeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel entfernen</source>
-        <target>Ziel entfernen</target>
+        <target>删除目标</target>
       </segment>
     </unit>
     <unit id="goals.weekdayAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>星期</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>每日目标</target>
       </segment>
     </unit>
     <unit id="goals.section.daily.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
-        <target>Was du an einzelnen Wochentagen schaffen willst.</target>
+        <target>您希望在特定星期几完成的内容。</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochenziele</source>
-        <target>Wochenziele</target>
+        <target>每周目标</target>
       </segment>
     </unit>
     <unit id="goals.section.weekly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Summen pro Übung über die ganze Woche.</source>
-        <target>Summen pro Übung über die ganze Woche.</target>
+        <target>整周每项练习的总和。</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Monatsziele</source>
-        <target>Monatsziele</target>
+        <target>每月目标</target>
       </segment>
     </unit>
     <unit id="goals.section.monthly.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
-        <target>Größere Ziele über den ganzen Monat verteilt.</target>
+        <target>分布在整个月的较大目标。</target>
       </segment>
     </unit>
     <unit id="goals.field.target.time">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Sekunden)</source>
-        <target>Ziel (Sekunden)</target>
+        <target>目标（秒）</target>
       </segment>
     </unit>
     <unit id="goals.field.target.distance">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel (Meter)</source>
-        <target>Ziel (Meter)</target>
+        <target>目标（米）</target>
       </segment>
     </unit>
     <unit id="goals.field.target.reps">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel</source>
-        <target>Ziel</target>
+        <target>目标</target>
       </segment>
     </unit>
     <unit id="settings.section.goals.linkSubtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </source>
-        <target> Tägliche, wöchentliche und monatliche Ziele mit verschiedenen Übungen werden jetzt auf der eigenen Seite verwaltet. </target>
+        <target> 每日、每周和每月的各种练习目标现在在专属页面上管理。 </target>
       </segment>
     </unit>
     <unit id="settings.goals.openPageCta">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </source>
-        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Tagesziele öffnen </target>
+        <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> 打开每日目标 </target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
## Summary

Fills all 369 XLIFF translation gaps detected by `tools/src/detect-translation-gaps.mjs` on 2026-05-28. The same 41 goals-feature units were missing in every target locale and are now translated with state flipped from `initial` to `translated`.

## Touched locales

- `el`: 41 unit(s), 0 blog post(s), 0 wiki entry/entries
- `en`: 41 unit(s), 0 blog post(s), 0 wiki entry/entries
- `es`: 41 unit(s), 0 blog post(s), 0 wiki entry/entries
- `fr`: 41 unit(s), 0 blog post(s), 0 wiki entry/entries
- `it`: 41 unit(s), 0 blog post(s), 0 wiki entry/entries
- `la`: 41 unit(s), 0 blog post(s), 0 wiki entry/entries
- `nl`: 41 unit(s), 0 blog post(s), 0 wiki entry/entries
- `no`: 41 unit(s), 0 blog post(s), 0 wiki entry/entries
- `zh`: 41 unit(s), 0 blog post(s), 0 wiki entry/entries

**All 369 units translated — 0 skipped.**

## Detector summary

```
Detected 369 gap(s) — xliff:369 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, la, no, zh
```

Post-translation verification:

```
Detected 0 gap(s) — xliff:0 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, la, no, zh
```

## Skipped

None — all 369 units were translated successfully.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqzGnaipSePEpqkrnvQNXK)_