### PR TITLE
feat(auth): streamline onboarding, complete registration without daily goal

### DIFF
--- a/libs/auth/src/lib/core/registration-analytics.service.spec.ts
+++ b/libs/auth/src/lib/core/registration-analytics.service.spec.ts
@@ -144,17 +144,30 @@ describe('RegistrationAnalyticsService', () => {
     });
 
     it('trackAbandoned includes last_step and its index', () => {
-      service.trackAbandoned({ last_step: 'daily_goal', is_google: true });
+      service.trackAbandoned({ last_step: 'username', is_google: true });
 
       expect(logEvent).toHaveBeenCalledWith(
         analyticsToken,
         'register_abandoned',
         {
-          last_step: 'daily_goal',
-          last_step_index: REGISTRATION_STEPS.indexOf('daily_goal'),
+          last_step: 'username',
+          last_step_index: REGISTRATION_STEPS.indexOf('username'),
           is_google: true,
         }
       );
     });
+
+    it.each(['dashboard', 'training_plans', 'daily_goal'] as const)(
+      'trackSuccessCta sends register_success_cta with target "%s"',
+      (target) => {
+        service.trackSuccessCta(target);
+
+        expect(logEvent).toHaveBeenCalledWith(
+          analyticsToken,
+          'register_success_cta',
+          { target }
+        );
+      }
+    );
   });
 });

--- a/libs/auth/src/lib/core/registration-analytics.service.ts
+++ b/libs/auth/src/lib/core/registration-analytics.service.ts
@@ -1,18 +1,18 @@
 import { inject, Injectable } from '@angular/core';
 import { Analytics, logEvent } from '@angular/fire/analytics';
 
-export const REGISTRATION_STEPS = [
-  'email',
-  'password',
-  'username',
-  'daily_goal',
-] as const;
+export const REGISTRATION_STEPS = ['email', 'password', 'username'] as const;
 
 export type RegistrationStep = (typeof REGISTRATION_STEPS)[number];
 
 type RegistrationVariant = { is_google: boolean };
 
 type RegistrationFailureReason = 'sign_up' | 'persist_profile';
+
+export type RegistrationSuccessCta =
+  | 'dashboard'
+  | 'training_plans'
+  | 'daily_goal';
 
 @Injectable({ providedIn: 'root' })
 export class RegistrationAnalyticsService {
@@ -47,6 +47,10 @@ export class RegistrationAnalyticsService {
 
   trackSucceeded(variant: RegistrationVariant): void {
     this.track('register_succeeded', variant);
+  }
+
+  trackSuccessCta(target: RegistrationSuccessCta): void {
+    this.track('register_success_cta', { target });
   }
 
   trackFailed(

--- a/libs/auth/src/lib/ui/register/components/register-success.html
+++ b/libs/auth/src/lib/ui/register/components/register-success.html
@@ -3,10 +3,36 @@
   <p i18n="@@auth.register.success.text">
     Dein Account ist bereit. Zeit für die ersten Liegestütze 💪
   </p>
+  <p class="register-success-next" i18n="@@auth.register.success.next">
+    Such dir einen Trainingsplan aus oder leg dein Tagesziel fest:
+  </p>
+  <div class="register-success-actions">
+    <button
+      mat-stroked-button
+      type="button"
+      data-testid="register-success-training-plans"
+      (click)="trainingPlans.emit()"
+    >
+      <mat-icon>fitness_center</mat-icon>
+      <span i18n="@@auth.register.success.trainingPlans"
+        >Trainingsplan wählen</span
+      >
+    </button>
+    <button
+      mat-stroked-button
+      type="button"
+      data-testid="register-success-daily-goal"
+      (click)="dailyGoal.emit()"
+    >
+      <mat-icon>flag</mat-icon>
+      <span i18n="@@auth.register.success.dailyGoal">Tagesziel festlegen</span>
+    </button>
+  </div>
   <button
     mat-raised-button
     color="primary"
     type="button"
+    data-testid="register-success-dashboard"
     (click)="dashboard.emit()"
     i18n="@@auth.register.success.dashboard"
   >

--- a/libs/auth/src/lib/ui/register/components/register-success.scss
+++ b/libs/auth/src/lib/ui/register/components/register-success.scss
@@ -2,3 +2,19 @@
   display: grid;
   gap: 0.75rem;
 }
+
+.register-success-next {
+  margin-bottom: 0;
+}
+
+.register-success-actions {
+  display: grid;
+  gap: 0.5rem;
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+  }
+}

--- a/libs/auth/src/lib/ui/register/components/register-success.ts
+++ b/libs/auth/src/lib/ui/register/components/register-success.ts
@@ -1,14 +1,17 @@
 import { ChangeDetectionStrategy, Component, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   standalone: true,
   selector: 'pus-register-success',
-  imports: [MatButtonModule],
+  imports: [MatButtonModule, MatIconModule],
   templateUrl: './register-success.html',
   styleUrl: './register-success.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RegisterSuccessComponent {
   readonly dashboard = output<void>();
+  readonly trainingPlans = output<void>();
+  readonly dailyGoal = output<void>();
 }

--- a/libs/auth/src/lib/ui/register/register-ui.store.spec.ts
+++ b/libs/auth/src/lib/ui/register/register-ui.store.spec.ts
@@ -63,10 +63,9 @@ describe('RegisterUiStore', () => {
     expect(store.displayName()).toBe('Tester');
   });
 
-  it('Given a complete profile When submitting via email Then sign up and persist profile are executed', async () => {
+  it('Given a complete profile When submitting via email Then sign up and persist profile with the default daily goal', async () => {
     const store = await setup();
     store.setDisplayName('Alex');
-    store.setDailyGoal(120);
 
     const canSubmit = store.canSubmit(false, false, 'Secret#123', 'Secret#123');
     const signedUp = await store.signUpWithEmail('mail@test.de', 'Secret#123');
@@ -83,10 +82,19 @@ describe('RegisterUiStore', () => {
       expect.objectContaining({
         uid: 'uid-1',
         displayName: 'Alex',
-        dailyGoal: 120,
-        weeklyGoal: 600,
-        monthlyGoal: 2400,
+        dailyGoal: 10,
+        weeklyGoal: 50,
+        monthlyGoal: 200,
       })
+    );
+  });
+
+  it('Given only a valid username (no daily goal step) Then canSubmit is true', async () => {
+    const store = await setup();
+    store.setDisplayName('Alex');
+
+    expect(store.canSubmit(false, false, 'Secret#123', 'Secret#123')).toBe(
+      true
     );
   });
 
@@ -121,7 +129,6 @@ describe('RegisterUiStore', () => {
     onboardingMock.saveProfile.mockRejectedValueOnce(new Error('api-failed'));
     const store = await setup();
     store.setDisplayName('Alex');
-    store.setDailyGoal(120);
 
     const persisted = await store.persistProfile();
 
@@ -133,7 +140,6 @@ describe('RegisterUiStore', () => {
     it('Given a too-short displayName Then violation is "too-short" and submission is blocked', async () => {
       const store = await setup();
       store.setDisplayName('A');
-      store.setDailyGoal(10);
 
       expect(store.displayNameViolation()).toBe('too-short');
       expect(store.isProfileStepValid()).toBe(false);
@@ -161,7 +167,6 @@ describe('RegisterUiStore', () => {
     it('Given a valid displayName Then violation is null and isProfileStepValid is true', async () => {
       const store = await setup();
       store.setDisplayName('Alex');
-      store.setDailyGoal(10);
 
       expect(store.displayNameViolation()).toBeNull();
       expect(store.isProfileStepValid()).toBe(true);

--- a/libs/auth/src/lib/ui/register/register-ui.store.ts
+++ b/libs/auth/src/lib/ui/register/register-ui.store.ts
@@ -21,6 +21,11 @@ import { hasStrongPasswordPolicy } from '../password-policy';
 type RegisterUiState = {
   hidePassword: boolean;
   displayName: string;
+  /**
+   * Onboarding no longer asks for a daily goal — registration completes after
+   * the username step. This default is persisted so the new account has
+   * sensible goals; the success screen links to `/goals` to fine-tune it.
+   */
   dailyGoal: number;
   isGoogleRegistration: boolean;
   registeringCredentials: boolean;
@@ -72,7 +77,6 @@ export const RegisterUiStore = signalStore(
       patchState(store, { hidePassword: !store.hidePassword() }),
     setDisplayName: (value: string) =>
       patchState(store, { displayName: value }),
-    setDailyGoal: (value: number) => patchState(store, { dailyGoal: value }),
     setSelectedPlanId: (planId: string | null) => {
       // Only accept ids that resolve to a real plan; ignore stale or
       // malformed query-param values silently — better than redirecting
@@ -106,9 +110,7 @@ export const RegisterUiStore = signalStore(
       !emailInvalid &&
       hasStrongPasswordPolicy(password) &&
       password === repeatPassword,
-    isProfileStepValid: () =>
-      validateDisplayName(store.displayName()) === null &&
-      store.dailyGoal() >= 1,
+    isProfileStepValid: () => validateDisplayName(store.displayName()) === null,
     canSubmit: (
       emailInvalid: boolean,
       passwordInvalid: boolean,
@@ -116,7 +118,6 @@ export const RegisterUiStore = signalStore(
       repeatPassword: string
     ) =>
       validateDisplayName(store.displayName()) === null &&
-      store.dailyGoal() >= 1 &&
       (store.isGoogleRegistration() ||
         (!emailInvalid &&
           !passwordInvalid &&

--- a/libs/auth/src/lib/ui/register/register.component.html
+++ b/libs/auth/src/lib/ui/register/register.component.html
@@ -41,7 +41,11 @@
       }
 
       @if (registerUiStore.registerSuccess()) {
-        <pus-register-success (dashboard)="goToDashboard()" />
+        <pus-register-success
+          (dashboard)="goToDashboard()"
+          (trainingPlans)="goToTrainingPlans()"
+          (dailyGoal)="goToDailyGoalSettings()"
+        />
       } @else {
         <mat-stepper
           linear
@@ -276,43 +280,6 @@
                 </p>
               }
             }
-            <div class="form-actions">
-              <button
-                mat-stroked-button
-                matStepperPrevious
-                type="button"
-                i18n="@@auth.register.back"
-              >
-                Zurück</button
-              ><button
-                mat-raised-button
-                color="primary"
-                matStepperNext
-                type="button"
-                [disabled]="registerUiStore.displayNameViolation() !== null"
-                i18n="@@auth.next"
-              >
-                Weiter
-              </button>
-            </div>
-          </mat-step>
-
-          <mat-step [completed]="registerUiStore.dailyGoal() >= 1">
-            <ng-template matStepLabel i18n="@@auth.onboarding.google.goal"
-              >Tagesziel</ng-template
-            >
-            <mat-form-field appearance="outline" class="full-width step-field"
-              ><mat-label i18n="@@auth.onboarding.google.goal"
-                >Tagesziel</mat-label
-              ><input
-                matInput
-                type="number"
-                min="1"
-                [value]="registerUiStore.dailyGoal()"
-                (input)="
-                  registerUiStore.setDailyGoal(+$any($event.target).value || 1)
-                "
-            /></mat-form-field>
             <div class="form-actions">
               <button
                 mat-stroked-button

--- a/libs/auth/src/lib/ui/register/register.component.spec.ts
+++ b/libs/auth/src/lib/ui/register/register.component.spec.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { signal } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Auth } from '@angular/fire/auth';
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { of } from 'rxjs';
@@ -37,6 +37,7 @@ const analyticsMock = {
   trackStepCompleted: jest.fn(),
   trackSubmitted: jest.fn(),
   trackSucceeded: jest.fn(),
+  trackSuccessCta: jest.fn(),
   trackFailed: jest.fn(),
   trackAbandoned: jest.fn(),
 };
@@ -180,7 +181,6 @@ describe('RegisterComponent', () => {
       const view = await renderRegister();
       const uiStore = view.fixture.debugElement.injector.get(RegisterUiStore);
       uiStore.setDisplayName('Alex');
-      uiStore.setDailyGoal(10);
       await uiStore.persistProfile();
       expect(uiStore.registerSuccess()).toBe(true);
       analyticsMock.trackAbandoned.mockClear();
@@ -224,6 +224,52 @@ describe('RegisterComponent', () => {
       expect(analyticsMock.trackStepView).toHaveBeenCalledWith('password', {
         is_google: false,
       });
+    });
+  });
+
+  describe('success-screen onboarding CTAs', () => {
+    async function renderSucceeded() {
+      authStoreMock.user.set({ uid: 'uid-1' });
+      const view = await renderRegister();
+      const uiStore = view.fixture.debugElement.injector.get(RegisterUiStore);
+      uiStore.setDisplayName('Alex');
+      await uiStore.persistProfile();
+      view.fixture.detectChanges();
+      const router = view.fixture.debugElement.injector.get(Router);
+      jest.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+      return { router };
+    }
+
+    it('Given success When "Trainingsplan wählen" is clicked Then tracks the CTA and navigates to /training-plans', async () => {
+      const user = userEvent.setup();
+      const { router } = await renderSucceeded();
+
+      await user.click(screen.getByTestId('register-success-training-plans'));
+
+      expect(analyticsMock.trackSuccessCta).toHaveBeenCalledWith(
+        'training_plans'
+      );
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/training-plans');
+    });
+
+    it('Given success When "Tagesziel festlegen" is clicked Then tracks the CTA and navigates to /goals', async () => {
+      const user = userEvent.setup();
+      const { router } = await renderSucceeded();
+
+      await user.click(screen.getByTestId('register-success-daily-goal'));
+
+      expect(analyticsMock.trackSuccessCta).toHaveBeenCalledWith('daily_goal');
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/goals');
+    });
+
+    it('Given success When "Zum Dashboard" is clicked Then tracks the CTA and navigates to /app', async () => {
+      const user = userEvent.setup();
+      const { router } = await renderSucceeded();
+
+      await user.click(screen.getByTestId('register-success-dashboard'));
+
+      expect(analyticsMock.trackSuccessCta).toHaveBeenCalledWith('dashboard');
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/app');
     });
   });
 });

--- a/libs/auth/src/lib/ui/register/register.component.ts
+++ b/libs/auth/src/lib/ui/register/register.component.ts
@@ -225,8 +225,19 @@ export class RegisterComponent implements OnInit, OnDestroy {
   }
 
   async goToDashboard(): Promise<void> {
+    this.analytics.trackSuccessCta('dashboard');
     const planReturnUrl = this.registerUiStore.selectedPlanReturnUrl();
     const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl');
     await this.router.navigateByUrl(planReturnUrl ?? returnUrl ?? '/app');
+  }
+
+  async goToTrainingPlans(): Promise<void> {
+    this.analytics.trackSuccessCta('training_plans');
+    await this.router.navigateByUrl('/training-plans');
+  }
+
+  async goToDailyGoalSettings(): Promise<void> {
+    this.analytics.trackSuccessCta('daily_goal');
+    await this.router.navigateByUrl('/goals');
   }
 }

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9925,5 +9925,23 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Άνοιγμα ημερήσιων στόχων </target>
       </segment>
     </unit>
+    <unit id="auth.register.success.next">
+      <segment state="initial">
+        <source> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </source>
+        <target> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.trainingPlans">
+      <segment state="initial">
+        <source>Trainingsplan wählen</source>
+        <target>Trainingsplan wählen</target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.dailyGoal">
+      <segment state="initial">
+        <source>Tagesziel festlegen</source>
+        <target>Tagesziel festlegen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10091,5 +10091,23 @@ Deine Position: # ·  Reps        </source>
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Open daily goals </target>
       </segment>
     </unit>
+    <unit id="auth.register.success.next">
+      <segment state="initial">
+        <source> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </source>
+        <target> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.trainingPlans">
+      <segment state="initial">
+        <source>Trainingsplan wählen</source>
+        <target>Trainingsplan wählen</target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.dailyGoal">
+      <segment state="initial">
+        <source>Tagesziel festlegen</source>
+        <target>Tagesziel festlegen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9921,5 +9921,23 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Abrir objetivos diarios </target>
       </segment>
     </unit>
+    <unit id="auth.register.success.next">
+      <segment state="initial">
+        <source> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </source>
+        <target> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.trainingPlans">
+      <segment state="initial">
+        <source>Trainingsplan wählen</source>
+        <target>Trainingsplan wählen</target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.dailyGoal">
+      <segment state="initial">
+        <source>Tagesziel festlegen</source>
+        <target>Tagesziel festlegen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9797,5 +9797,23 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Ouvrir les objectifs quotidiens </target>
       </segment>
     </unit>
+    <unit id="auth.register.success.next">
+      <segment state="initial">
+        <source> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </source>
+        <target> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.trainingPlans">
+      <segment state="initial">
+        <source>Trainingsplan wählen</source>
+        <target>Trainingsplan wählen</target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.dailyGoal">
+      <segment state="initial">
+        <source>Tagesziel festlegen</source>
+        <target>Tagesziel festlegen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9925,5 +9925,23 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Apri obiettivi giornalieri </target>
       </segment>
     </unit>
+    <unit id="auth.register.success.next">
+      <segment state="initial">
+        <source> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </source>
+        <target> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.trainingPlans">
+      <segment state="initial">
+        <source>Trainingsplan wählen</source>
+        <target>Trainingsplan wählen</target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.dailyGoal">
+      <segment state="initial">
+        <source>Tagesziel festlegen</source>
+        <target>Tagesziel festlegen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9925,5 +9925,23 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Proposita diurna aperire </target>
       </segment>
     </unit>
+    <unit id="auth.register.success.next">
+      <segment state="initial">
+        <source> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </source>
+        <target> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.trainingPlans">
+      <segment state="initial">
+        <source>Trainingsplan wählen</source>
+        <target>Trainingsplan wählen</target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.dailyGoal">
+      <segment state="initial">
+        <source>Tagesziel festlegen</source>
+        <target>Tagesziel festlegen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9925,5 +9925,23 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Dagelijkse doelen openen </target>
       </segment>
     </unit>
+    <unit id="auth.register.success.next">
+      <segment state="initial">
+        <source> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </source>
+        <target> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.trainingPlans">
+      <segment state="initial">
+        <source>Trainingsplan wählen</source>
+        <target>Trainingsplan wählen</target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.dailyGoal">
+      <segment state="initial">
+        <source>Tagesziel festlegen</source>
+        <target>Tagesziel festlegen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9185,5 +9185,23 @@ Deine Position: # ·  Reps        </source>
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> Åpne daglige mål </target>
       </segment>
     </unit>
+    <unit id="auth.register.success.next">
+      <segment state="initial">
+        <source> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </source>
+        <target> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.trainingPlans">
+      <segment state="initial">
+        <source>Trainingsplan wählen</source>
+        <target>Trainingsplan wählen</target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.dailyGoal">
+      <segment state="initial">
+        <source>Tagesziel festlegen</source>
+        <target>Tagesziel festlegen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -182,8 +182,8 @@
     <unit id="auth.onboarding.google.username">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:8,11</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:235,237</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.html:239,241</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:243,245</note>
       </notes>
       <segment>
         <source>Benutzername</source>
@@ -192,8 +192,6 @@
     <unit id="auth.onboarding.google.goal">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:19,21</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:302,304</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:306,308</note>
       </notes>
       <segment>
         <source>Tagesziel</source>
@@ -218,10 +216,9 @@
     <unit id="auth.next">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:62,65</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:82,83</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:154,155</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:225,226</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:295,296</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:86,87</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:158,159</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:229,230</note>
       </notes>
       <segment>
         <source> Weiter </source>
@@ -230,7 +227,7 @@
     <unit id="cancel">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/google-onboarding-dialog/google-onboarding-dialog.component.html:67,69</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:348,349</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:315,316</note>
         <note category="location">web/src/app/core/feedback/feedback-dialog.component.ts:96,97</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:152,153</note>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:639,640</note>
@@ -291,8 +288,8 @@
     <unit id="auth.email">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:27,28</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:59,60</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:61,62</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:63,64</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:65,66</note>
       </notes>
       <segment>
         <source>E-Mail</source>
@@ -301,8 +298,8 @@
     <unit id="auth.password">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:41,42</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:133,135</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:162,163</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:137,139</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:166,167</note>
       </notes>
       <segment>
         <source>Passwort</source>
@@ -319,7 +316,7 @@
     <unit id="auth.or">
       <notes>
         <note category="location">libs/auth/src/lib/ui/login/login.component.html:80,81</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:85,86</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:89,90</note>
       </notes>
       <segment>
         <source>oder</source>
@@ -403,15 +400,39 @@
     </unit>
     <unit id="auth.register.success.text">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/components/register-success.html:4,7</note>
+        <note category="location">libs/auth/src/lib/ui/register/components/register-success.html:4,6</note>
       </notes>
       <segment>
         <source> Dein Account ist bereit. Zeit für die ersten Liegestütze 💪 </source>
       </segment>
     </unit>
+    <unit id="auth.register.success.next">
+      <notes>
+        <note category="location">libs/auth/src/lib/ui/register/components/register-success.html:7,9</note>
+      </notes>
+      <segment>
+        <source> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </source>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.trainingPlans">
+      <notes>
+        <note category="location">libs/auth/src/lib/ui/register/components/register-success.html:18,22</note>
+      </notes>
+      <segment>
+        <source>Trainingsplan wählen</source>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.dailyGoal">
+      <notes>
+        <note category="location">libs/auth/src/lib/ui/register/components/register-success.html:28,32</note>
+      </notes>
+      <segment>
+        <source>Tagesziel festlegen</source>
+      </segment>
+    </unit>
     <unit id="auth.register.success.dashboard">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/components/register-success.html:13,16</note>
+        <note category="location">libs/auth/src/lib/ui/register/components/register-success.html:39,42</note>
       </notes>
       <segment>
         <source> Zum Dashboard </source>
@@ -451,7 +472,7 @@
     </unit>
     <unit id="auth.google.signup">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:117,119</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:121,123</note>
       </notes>
       <segment>
         <source>Mit Google registrieren</source>
@@ -459,7 +480,7 @@
     </unit>
     <unit id="auth.register.google.skipPassword">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:137,139</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:141,143</note>
       </notes>
       <segment>
         <source> Passwort-Schritt übersprungen (Google Registrierung). </source>
@@ -467,10 +488,9 @@
     </unit>
     <unit id="auth.register.back">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:146,147</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:209,210</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:286,287</note>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:323,324</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:150,151</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:213,214</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:290,291</note>
       </notes>
       <segment>
         <source> Zurück</source>
@@ -478,7 +498,7 @@
     </unit>
     <unit id="auth.register.password.hint">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:186,188</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:190,192</note>
       </notes>
       <segment>
         <source> Mindestens 8 Zeichen, Groß- und Kleinbuchstaben, Zahl und Sonderzeichen. </source>
@@ -486,7 +506,7 @@
     </unit>
     <unit id="auth.register.password.repeat">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:194,196</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:198,200</note>
       </notes>
       <segment>
         <source>Passwort wiederholen</source>
@@ -494,7 +514,7 @@
     </unit>
     <unit id="displayName.violation.tooShort">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:255,257</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:259,261</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:178,180</note>
       </notes>
       <segment>
@@ -503,7 +523,7 @@
     </unit>
     <unit id="displayName.violation.tooLong">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:265,267</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:269,271</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:188,190</note>
       </notes>
       <segment>
@@ -512,7 +532,7 @@
     </unit>
     <unit id="displayName.violation.invalidCharacters">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:275,277</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:279,281</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:198,201</note>
       </notes>
       <segment>
@@ -521,7 +541,7 @@
     </unit>
     <unit id="auth.register.submit">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/register/register.component.html:340,341</note>
+        <note category="location">libs/auth/src/lib/ui/register/register.component.html:307,308</note>
       </notes>
       <segment>
         <source> Registrieren </source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9419,5 +9419,23 @@
         <target><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">flag</pc> 打开每日目标 </target>
       </segment>
     </unit>
+    <unit id="auth.register.success.next">
+      <segment state="initial">
+        <source> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </source>
+        <target> Such dir einen Trainingsplan aus oder leg dein Tagesziel fest: </target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.trainingPlans">
+      <segment state="initial">
+        <source>Trainingsplan wählen</source>
+        <target>Trainingsplan wählen</target>
+      </segment>
+    </unit>
+    <unit id="auth.register.success.dailyGoal">
+      <segment state="initial">
+        <source>Tagesziel festlegen</source>
+        <target>Tagesziel festlegen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>


### PR DESCRIPTION
## Was

Verbessert den Onboarding-Prozess:

1. **Registrierung ohne festgesetztes Tagesziel abschließen** — Der Tagesziel-Schritt wurde aus dem Registrierungs-Stepper entfernt. Die Registrierung schließt jetzt nach dem Benutzername-Schritt ab. Ein sinnvolles Default-Tagesziel (10 → Woche 50, Monat 200) wird weiterhin angelegt, damit das neue Konto auf einem funktionierenden Dashboard landet.
2. **Trainingspläne & Tageszieleinstellung in der Erfolgsmeldung verlinkt** — Die Erfolgsseite hat jetzt zwei zusätzliche CTAs: „Trainingsplan wählen" (→ `/training-plans`) und „Tagesziel festlegen" (→ `/goals`), zusätzlich zum bestehenden „Zum Dashboard".
3. **Clicks messbar für den Onboarding-Funnel** — Neues Analytics-Event `register_success_cta` mit `target: 'dashboard' | 'training_plans' | 'daily_goal'`. Jeder Klick auf der Erfolgsseite wird vor der Navigation getrackt. `REGISTRATION_STEPS` wurde auf `email/password/username` reduziert, sodass die Funnel-Indizes konsistent bleiben.

## Warum

Der bisherige Pflicht-Schritt „Tagesziel" hat den Onboarding-Funnel verlängert. Durch frühen Abschluss und gezielte Verlinkung der nächsten Schritte (Plan/Ziel) sinkt die Drop-off-Wahrscheinlichkeit; die CTA-Tracking-Events machen den Effekt messbar.

## Tests & Verifikation

- 129 Unit-Tests in `auth` grün, inkl. neuer Tests für CTA-Clicks (Tracking + Navigation), Default-Tagesziel und das neue Analytics-Event
- `nx lint auth` ✓
- i18n: `web:extract-i18n` + `sync-xliff-locales.mjs` ausgeführt (3 neue deutsche Strings, Fallbacks für alle Locales)
- Production-Web-Build inkl. Prerendering (2840 Routen) ✓

https://claude.ai/code/session_01PDLua2VfgBC9vGHTK1wqGq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDLua2VfgBC9vGHTK1wqGq)_