### PR TITLE
fix(dashboard): apply light theme to recent-exercise tiles

### DIFF
--- a/web/src/app/stats/shell/stats-dashboard.component.scss
+++ b/web/src/app/stats/shell/stats-dashboard.component.scss
@@ -770,7 +770,7 @@ h1 {
   }
 
   .latest-entries {
-    .recent-exercise-tile {
+    .recent-exercise-tile mat-card {
       border-color: rgba(59, 130, 246, 0.2);
       background: linear-gradient(
         160deg,

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { of } from 'rxjs';
@@ -1585,5 +1587,51 @@ describe('StatsDashboardComponent', () => {
       expect(href).toContain('/training-plans/recruit-6w');
       expect(href).toContain('day=1');
     });
+  });
+});
+
+describe('StatsDashboardComponent latest-entries light theme styling', () => {
+  // jsdom does not resolve `:host-context()` / the SCSS cascade, so we guard
+  // the regression at the source level instead. Regression: the dark gradient
+  // is painted on `.recent-exercise-tile mat-card` (the opaque card), but the
+  // light-theme override used to set its light background on the
+  // `.recent-exercise-tile` wrapper link. The opaque card stayed dark in light
+  // mode and the dark text overrides became unreadable on it.
+  // The test runner executes with the Nx workspace root as cwd; read the
+  // component stylesheet from there (the esbuild-based unit-test pipeline
+  // does not support Vite's `?raw` import suffix).
+  const scss = readFileSync(
+    join(
+      process.cwd(),
+      'web/src/app/stats/shell/stats-dashboard.component.scss'
+    ),
+    'utf8'
+  );
+
+  const lightThemeBlock = (() => {
+    const start = scss.indexOf(':host-context(html.light-theme)');
+    expect(start).toBeGreaterThanOrEqual(0);
+    return scss.slice(start);
+  })();
+
+  it('Given light mode, Then the recent-exercise card background is overridden on the mat-card, not the wrapper link', () => {
+    const latestStart = lightThemeBlock.indexOf('.latest-entries');
+    expect(latestStart).toBeGreaterThanOrEqual(0);
+    const latestBlock = lightThemeBlock.slice(latestStart);
+
+    // The override must reach the opaque card element that carries the dark
+    // gradient in dark mode — otherwise the tile never adopts light mode.
+    expect(latestBlock).toContain('.recent-exercise-tile mat-card {');
+  });
+
+  it('Given dark mode, Then the recent-exercise gradient is defined on the mat-card so the light override has a matching target', () => {
+    const darkStart = scss.indexOf('.recent-exercise-tile {');
+    expect(darkStart).toBeGreaterThanOrEqual(0);
+    const darkTile = scss.slice(
+      darkStart,
+      scss.indexOf('}', scss.indexOf('mat-card {', darkStart))
+    );
+    expect(darkTile).toContain('mat-card {');
+    expect(darkTile).toContain('background: linear-gradient(');
   });
 });


### PR DESCRIPTION
## Problem

On the dashboard, the **"Letzte Übungen"** (Recent Exercises) tiles did not adopt light mode — they stayed dark even with the light theme active.

## Root cause

In dark mode the dark gradient + border are painted on the inner `mat-card` of each `.recent-exercise-tile`. The light-theme override, however, set its light background on the `.recent-exercise-tile` wrapper `<a>` instead of the `mat-card`. Because the `mat-card` is opaque and sits on top of the wrapper, it kept its dark gradient in light mode — and the dark text overrides (`#1e293b`, etc.) then became unreadable on the dark card.

## Fix

Target the `mat-card` in the light-theme override (`.recent-exercise-tile mat-card`) so the override reaches the element that actually carries the background, matching the dark-mode selector structure.

## Tests

Added a source-level regression guard in `stats-dashboard.component.spec.ts`. jsdom cannot evaluate the `:host-context` cascade, so the test asserts on the SCSS source that the light override targets `.recent-exercise-tile mat-card` (and that the dark gradient is defined on the `mat-card` so the override has a matching target). Verified red→green: the test fails on the old selector and passes with the fix.

- `pnpm nx test web` → 952 passed
- `pnpm nx lint web` → pass

https://claude.ai/code/session_01YYSYshjpu6wXsQ58eSM4aU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYSYshjpu6wXsQ58eSM4aU)_