### PR TITLE
Format time durations with hours field when exceeding one hour

### DIFF
--- a/libs/stats/src/lib/models/exercise-format.spec.ts
+++ b/libs/stats/src/lib/models/exercise-format.spec.ts
@@ -26,8 +26,11 @@ describe('formatExerciseValue', () => {
       [60, '1:00'],
       [90, '1:30'],
       [125, '2:05'],
-      [3600, '60:00'],
-      [7200, '120:00'],
+      [3599, '59:59'],
+      [3600, '1:00:00'],
+      [3661, '1:01:01'],
+      [7200, '2:00:00'],
+      [100_800, '28:00:00'],
     ])('renders %i s as %s', (value, expected) => {
       expect(formatExerciseValue(value, 's')).toBe(expected);
     });
@@ -139,9 +142,9 @@ describe('formatEntryDisplay', () => {
   });
 
   it('reads durationSec for time-only exercises', () => {
-    expect(
-      formatEntryDisplay({ durationSec: 90 }, def('time', 's'))
-    ).toBe('1:30');
+    expect(formatEntryDisplay({ durationSec: 90 }, def('time', 's'))).toBe(
+      '1:30'
+    );
   });
 
   it('reads reps for rep-based exercises', () => {
@@ -149,9 +152,9 @@ describe('formatEntryDisplay', () => {
   });
 
   it('reads reps for weight exercises (the rep count is the primary)', () => {
-    expect(formatEntryDisplay({ reps: 5, weightKg: 80 }, def('weight', 'reps'))).toBe(
-      '5'
-    );
+    expect(
+      formatEntryDisplay({ reps: 5, weightKg: 80 }, def('weight', 'reps'))
+    ).toBe('5');
   });
 
   it('reads distanceM for plain distance exercises', () => {
@@ -174,7 +177,7 @@ describe('formatEntryTotal', () => {
         { primary: 42_000, companion: 12_600 },
         def('distance-time', 'm')
       )
-    ).toBe('42.00 km · 210:00 (5:00 /km)');
+    ).toBe('42.00 km · 3:30:00 (5:00 /km)');
   });
 
   it('falls back to single-value formatting for other measurements', () => {
@@ -183,8 +186,8 @@ describe('formatEntryTotal', () => {
   });
 
   it('handles distance-time without a companion total (cardio with 0 s)', () => {
-    expect(
-      formatEntryTotal({ primary: 5000 }, def('distance-time', 'm'))
-    ).toBe('5.00 km');
+    expect(formatEntryTotal({ primary: 5000 }, def('distance-time', 'm'))).toBe(
+      '5.00 km'
+    );
   });
 });

--- a/libs/stats/src/lib/models/exercise-format.ts
+++ b/libs/stats/src/lib/models/exercise-format.ts
@@ -6,7 +6,11 @@ import { measurementValueField } from './exercise.models';
  * driven by `ExerciseDefinition.unit`. The shape is:
  *
  *   - `'reps'`  → bare number (`"30"`)
- *   - `'s'`     → `m:ss` so a 90 s plank reads `"1:30"`
+ *   - `'s'`     → `m:ss` so a 90 s plank reads `"1:30"`; once the
+ *                 duration reaches an hour it grows an hours field
+ *                 (`h:mm:ss`) so aggregated time-exercise totals don't
+ *                 read as a runaway minute count (28 h → `"28:00:00"`,
+ *                 not `"1680:00"`)
  *   - `'kg'`    → `"<n> kg"`
  *   - `'m'`     → `"<n> m"` for short distances; ≥1000 m render as
  *                 `"<n.nn> km"` so a 5 km run reads cleanly
@@ -43,8 +47,12 @@ export function formatExerciseValue(value: number, unit: string): string {
 
 function formatSecondsAsMmSs(totalSec: number): string {
   if (!Number.isFinite(totalSec) || totalSec < 0) return '';
-  const m = Math.floor(totalSec / 60);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
   const s = Math.floor(totalSec % 60);
+  if (h > 0) {
+    return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  }
   return `${m}:${String(s).padStart(2, '0')}`;
 }
 
@@ -118,10 +126,7 @@ export function formatDistanceTime(
  * themselves — keeps the composite/single switch in one place.
  */
 export function formatEntryDisplay(
-  entry: Pick<
-    ExerciseEntry,
-    'reps' | 'durationSec' | 'distanceM' | 'weightKg'
-  >,
+  entry: Pick<ExerciseEntry, 'reps' | 'durationSec' | 'distanceM' | 'weightKg'>,
   def: Pick<ExerciseDefinition, 'measurement' | 'unit'>
 ): string {
   if (def.measurement === 'distance-time') {
@@ -147,4 +152,3 @@ export function formatEntryTotal(
   }
   return formatExerciseValue(totals.primary, def.unit);
 }
-

--- a/web/src/app/leaderboard/shell/leaderboard-page.component.spec.ts
+++ b/web/src/app/leaderboard/shell/leaderboard-page.component.spec.ts
@@ -251,6 +251,28 @@ describe('LeaderboardPageComponent', () => {
       expect(row).not.toBeNull();
       expect(row?.textContent?.replace(/\s+/g, ' ').trim()).toBe('1:30');
     });
+
+    it('Grows an hours field once the aggregated total passes an hour', async () => {
+      // Given — a last-30 plank total of 9000 s (2.5 h). Aggregated
+      // time totals routinely exceed an hour (the ranker caps a single
+      // day at 4 h and sums up to 30 of them), so the bare m:ss form
+      // would render an unreadable "150:00" minute count here.
+      await setup([{ rank: 1, alias: 'Tom', reps: 9000, uid: 'tom1' }], {
+        exerciseId: 'plank.standard',
+      });
+
+      fixture.componentInstance.selectExercise('plank.standard');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      // Then — 9000 s → "2:30:00", not "150:00".
+      const root = fixture.nativeElement as HTMLElement;
+      const row = root.querySelector(
+        'ol[data-testid="leaderboard-list"] li:first-child strong'
+      ) as HTMLElement | null;
+      expect(row?.textContent?.replace(/\s+/g, ' ').trim()).toBe('2:30:00');
+    });
   });
 
   describe('Given a distance-time exercise like running', () => {


### PR DESCRIPTION
## Summary
Updates the time duration formatter to display hours when durations exceed one hour, preventing unreadable minute counts in aggregated time-exercise totals.

## Changes
- **Time formatting logic**: Modified `formatSecondsAsMmSs()` to return `h:mm:ss` format when duration ≥ 3600 seconds, instead of always using `m:ss` format
  - Durations under 1 hour continue to display as `m:ss` (e.g., 90s → "1:30")
  - Durations ≥ 1 hour now display as `h:mm:ss` (e.g., 3600s → "1:00:00", 9000s → "2:30:00")
  - Properly handles edge cases like 3599s → "59:59" and 3661s → "1:01:01"

- **Test coverage**: Updated and expanded test cases to verify the new formatting behavior
  - Added test cases for boundary conditions (3599s, 3600s, 3661s)
  - Added test case for large durations (100,800s → "28:00:00")
  - Updated existing test expectations to match new format

- **Integration test**: Added leaderboard component test verifying that aggregated time totals (9000s) display correctly as "2:30:00" instead of the unreadable "150:00"

- **Documentation**: Updated JSDoc comments to explain the new formatting behavior for time-based exercises

## Implementation Details
The formatter now calculates hours, minutes, and seconds separately:
- Hours: `totalSec / 3600`
- Minutes: `(totalSec % 3600) / 60`
- Seconds: `totalSec % 60`

The hours field is only included in the output when the duration is at least one hour, maintaining backward compatibility for shorter durations while improving readability for aggregated totals.

https://claude.ai/code/session_01HKZV7jKuZnkrXgZ78SXR35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time formatting for exercises with durations exceeding one hour, now displaying in hours:minutes:seconds format (e.g., "2:30:00") instead of minute overflow display.
  * Enhanced duration total formatting for distance-time exercises.

* **Tests**
  * Updated and added test coverage for time-measured exercises, including verification of hour-inclusive time formatting for extended durations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WolfSoko/pushup-stats-service/pull/423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->