### PR TITLE
chore(i18n): fill missing translations (9 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9950,9 +9950,9 @@
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziel-Einzelpositionen anzeigen</source>
-        <target>Tagesziel-Einzelpositionen anzeigen</target>
+        <target>Εμφάνιση λεπτομερειών ημερήσιου στόχου</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10116,9 +10116,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziel-Einzelpositionen anzeigen</source>
-        <target>Tagesziel-Einzelpositionen anzeigen</target>
+        <target>Show daily goal details</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9946,9 +9946,9 @@
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziel-Einzelpositionen anzeigen</source>
-        <target>Tagesziel-Einzelpositionen anzeigen</target>
+        <target>Ver detalles del objetivo diario</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9822,9 +9822,9 @@
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziel-Einzelpositionen anzeigen</source>
-        <target>Tagesziel-Einzelpositionen anzeigen</target>
+        <target>Afficher les détails de l'objectif quotidien</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9950,9 +9950,9 @@
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziel-Einzelpositionen anzeigen</source>
-        <target>Tagesziel-Einzelpositionen anzeigen</target>
+        <target>Mostra i dettagli dell'obiettivo giornaliero</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9950,9 +9950,9 @@
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziel-Einzelpositionen anzeigen</source>
-        <target>Tagesziel-Einzelpositionen anzeigen</target>
+        <target>Singulas partes propositi diurni ostendere</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9950,9 +9950,9 @@
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziel-Einzelpositionen anzeigen</source>
-        <target>Tagesziel-Einzelpositionen anzeigen</target>
+        <target>Dagelijkse doeldetails weergeven</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9210,9 +9210,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziel-Einzelpositionen anzeigen</source>
-        <target>Tagesziel-Einzelpositionen anzeigen</target>
+        <target>Vis detaljer for daglig mål</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -3104,8 +3104,8 @@
     <unit id="nav.dashboard">
       <notes>
         <note category="location">web/src/app/app.html:23,26</note>
-        <note category="location">web/src/app/app.html:239,241</note>
-        <note category="location">web/src/app/app.html:301,303</note>
+        <note category="location">web/src/app/app.html:251,253</note>
+        <note category="location">web/src/app/app.html:313,315</note>
       </notes>
       <segment>
         <source>Dashboard</source>
@@ -3114,8 +3114,8 @@
     <unit id="nav.analysis">
       <notes>
         <note category="location">web/src/app/app.html:33,36</note>
-        <note category="location">web/src/app/app.html:243,245</note>
-        <note category="location">web/src/app/app.html:305,307</note>
+        <note category="location">web/src/app/app.html:255,257</note>
+        <note category="location">web/src/app/app.html:317,319</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -3124,8 +3124,8 @@
     <unit id="nav.leaderboard">
       <notes>
         <note category="location">web/src/app/app.html:43,47</note>
-        <note category="location">web/src/app/app.html:247,249</note>
-        <note category="location">web/src/app/app.html:309,311</note>
+        <note category="location">web/src/app/app.html:259,261</note>
+        <note category="location">web/src/app/app.html:321,323</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3134,8 +3134,8 @@
     <unit id="nav.blog">
       <notes>
         <note category="location">web/src/app/app.html:53,56</note>
-        <note category="location">web/src/app/app.html:255,257</note>
-        <note category="location">web/src/app/app.html:317,319</note>
+        <note category="location">web/src/app/app.html:267,269</note>
+        <note category="location">web/src/app/app.html:329,331</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3144,8 +3144,8 @@
     <unit id="nav.trainingPlans">
       <notes>
         <note category="location">web/src/app/app.html:63,67</note>
-        <note category="location">web/src/app/app.html:251,253</note>
-        <note category="location">web/src/app/app.html:313,315</note>
+        <note category="location">web/src/app/app.html:263,265</note>
+        <note category="location">web/src/app/app.html:325,327</note>
       </notes>
       <segment>
         <source>Trainingspläne</source>
@@ -3217,7 +3217,7 @@
     </unit>
     <unit id="toolbarDailyGoal">
       <notes>
-        <note category="location">web/src/app/app.html:169,170</note>
+        <note category="location">web/src/app/app.html:178,179</note>
       </notes>
       <segment>
         <source>Tagesziel</source>
@@ -3225,7 +3225,7 @@
     </unit>
     <unit id="nav.admin">
       <notes>
-        <note category="location">web/src/app/app.html:219,220</note>
+        <note category="location">web/src/app/app.html:231,232</note>
       </notes>
       <segment>
         <source>Admin-Bereich</source>
@@ -3233,7 +3233,7 @@
     </unit>
     <unit id="nav.desktop.aria">
       <notes>
-        <note category="location">web/src/app/app.html:230,231</note>
+        <note category="location">web/src/app/app.html:242,243</note>
       </notes>
       <segment>
         <source>Hauptnavigation</source>
@@ -3241,7 +3241,7 @@
     </unit>
     <unit id="footer.aria">
       <notes>
-        <note category="location">web/src/app/app.html:264</note>
+        <note category="location">web/src/app/app.html:276</note>
       </notes>
       <segment>
         <source>Rechtliches</source>
@@ -3249,7 +3249,7 @@
     </unit>
     <unit id="footer.pushupTypes">
       <notes>
-        <note category="location">web/src/app/app.html:269,271</note>
+        <note category="location">web/src/app/app.html:281,283</note>
       </notes>
       <segment>
         <source>Liegestütztypen</source>
@@ -3257,7 +3257,7 @@
     </unit>
     <unit id="footer.exercises">
       <notes>
-        <note category="location">web/src/app/app.html:272,274</note>
+        <note category="location">web/src/app/app.html:284,286</note>
       </notes>
       <segment>
         <source>Übungen</source>
@@ -3265,7 +3265,7 @@
     </unit>
     <unit id="footer.impressum">
       <notes>
-        <note category="location">web/src/app/app.html:275,277</note>
+        <note category="location">web/src/app/app.html:287,289</note>
       </notes>
       <segment>
         <source>Impressum</source>
@@ -3273,7 +3273,7 @@
     </unit>
     <unit id="footer.datenschutz">
       <notes>
-        <note category="location">web/src/app/app.html:278,281</note>
+        <note category="location">web/src/app/app.html:290,293</note>
       </notes>
       <segment>
         <source>Datenschutz</source>
@@ -3281,7 +3281,7 @@
     </unit>
     <unit id="footer.cookies">
       <notes>
-        <note category="location">web/src/app/app.html:285,287</note>
+        <note category="location">web/src/app/app.html:297,299</note>
       </notes>
       <segment>
         <source> Cookie-Einstellungen </source>
@@ -3289,7 +3289,7 @@
     </unit>
     <unit id="nav.bottom.aria">
       <notes>
-        <note category="location">web/src/app/app.html:292,293</note>
+        <note category="location">web/src/app/app.html:304,305</note>
       </notes>
       <segment>
         <source>Mobile-Navigation</source>
@@ -3569,7 +3569,7 @@
     </unit>
     <unit id="earlyAccess.text">
       <notes>
-        <note category="location">web/src/app/app.ts:178</note>
+        <note category="location">web/src/app/app.ts:180</note>
       </notes>
       <segment>
         <source>Early Access – pushup-stats.com befindet sich noch im Aufbau. Funktionen und Design können sich jederzeit ändern.</source>
@@ -3577,7 +3577,7 @@
     </unit>
     <unit id="earlyAccess.feedback">
       <notes>
-        <note category="location">web/src/app/app.ts:179</note>
+        <note category="location">web/src/app/app.ts:181</note>
       </notes>
       <segment>
         <source>Feedback</source>
@@ -3585,7 +3585,7 @@
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
       <notes>
-        <note category="location">web/src/app/app.ts:257</note>
+        <note category="location">web/src/app/app.ts:259</note>
       </notes>
       <segment>
         <source>Tagesziel-Einzelpositionen anzeigen</source>
@@ -3593,7 +3593,7 @@
     </unit>
     <unit id="seo.default.title">
       <notes>
-        <note category="location">web/src/app/app.ts:315</note>
+        <note category="location">web/src/app/app.ts:370</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -3601,7 +3601,7 @@
     </unit>
     <unit id="seo.default.description">
       <notes>
-        <note category="location">web/src/app/app.ts:318</note>
+        <note category="location">web/src/app/app.ts:373</note>
       </notes>
       <segment>
         <source>Tracke Reps, Trends und Streaks mit Pushup Tracker.</source>
@@ -3609,7 +3609,7 @@
     </unit>
     <unit id="sw.update.available">
       <notes>
-        <note category="location">web/src/app/app.ts:339</note>
+        <note category="location">web/src/app/app.ts:394</note>
       </notes>
       <segment>
         <source>Neue Version verfügbar</source>
@@ -3617,7 +3617,7 @@
     </unit>
     <unit id="sw.update.reload">
       <notes>
-        <note category="location">web/src/app/app.ts:340</note>
+        <note category="location">web/src/app/app.ts:395</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -3625,7 +3625,7 @@
     </unit>
     <unit id="toolbarDailyGoal.replayAria">
       <notes>
-        <note category="location">web/src/app/app.ts:415</note>
+        <note category="location">web/src/app/app.ts:470</note>
       </notes>
       <segment>
         <source>Tagesziel-Animation erneut abspielen</source>
@@ -3633,7 +3633,7 @@
     </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:444</note>
+        <note category="location">web/src/app/app.ts:499</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -3641,7 +3641,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:451</note>
+        <note category="location">web/src/app/app.ts:506</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>
@@ -9335,7 +9335,7 @@
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:246,248</note>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:273</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:290,291</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:292,293</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -9351,7 +9351,7 @@
     </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:300,301</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:302,303</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -9359,7 +9359,7 @@
     </unit>
     <unit id="dashboard.monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:309,310</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:311,312</note>
       </notes>
       <segment>
         <source>Monat</source>
@@ -9367,7 +9367,7 @@
     </unit>
     <unit id="dashboard.lastEntryLinkAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:334,335</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:336,337</note>
       </notes>
       <segment>
         <source>Letzten Eintrag in der Historie öffnen</source>
@@ -9375,7 +9375,7 @@
     </unit>
     <unit id="lastEntryTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:338,339</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:340,341</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -9383,8 +9383,8 @@
     </unit>
     <unit id="latEntryReps">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:344,346</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:408,409</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:346,348</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:410,411</note>
       </notes>
       <segment>
         <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ pushupTypeLabel(latest) }}"/> </source>
@@ -9392,8 +9392,8 @@
     </unit>
     <unit id="dashboard.noEntryYet">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:354,356</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:431,434</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:356,358</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:433,436</note>
       </notes>
       <segment>
         <source>Noch kein Eintrag.</source>
@@ -9401,7 +9401,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:375,379</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:377,381</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -9409,7 +9409,7 @@
     </unit>
     <unit id="dashboard.latestExercises">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:380,381</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:382,383</note>
       </notes>
       <segment>
         <source>Letzte Übungen</source>
@@ -9417,7 +9417,7 @@
     </unit>
     <unit id="dashboard.tile.pushupTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:405,407</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:407,409</note>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:115</note>
       </notes>
       <segment>
@@ -9426,7 +9426,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:438,439</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:440,441</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -9434,7 +9434,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:443,446</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:445,448</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -9442,7 +9442,7 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:449</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:451</note>
       </notes>
       <segment>
         <source>Werbung</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9444,9 +9444,9 @@
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziel-Einzelpositionen anzeigen</source>
-        <target>Tagesziel-Einzelpositionen anzeigen</target>
+        <target>显示每日目标详情</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
## Summary

Translates the `toolbarDailyGoal.detailsAria` XLIFF unit (ARIA label for the daily goal detail expander in the app toolbar) into all 9 target locales.

**Detector summary:** Detected 9 gap(s) — xliff:9 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, la, no, zh

## Touched locales

- `en`: 1 unit
- `el`: 1 unit
- `es`: 1 unit
- `fr`: 1 unit
- `it`: 1 unit
- `la`: 1 unit
- `nl`: 1 unit
- `no`: 1 unit
- `zh`: 1 unit

**Translations applied** (German source: _Tagesziel-Einzelpositionen anzeigen_):

| Locale | Translation |
|--------|-------------|
| `en` | Show daily goal details |
| `el` | Εμφάνιση λεπτομερειών ημερήσιου στόχου |
| `es` | Ver detalles del objetivo diario |
| `fr` | Afficher les détails de l'objectif quotidien |
| `it` | Mostra i dettagli dell'obiettivo giornaliero |
| `la` | Singulas partes propositi diurni ostendere |
| `nl` | Dagelijkse doeldetails weergeven |
| `no` | Vis detaljer for daglig mål |
| `zh` | 显示每日目标详情 |

## Skipped

None — all 9 units were translated successfully.

https://claude.ai/code/session_016TQpDEBTmgBSew2nrKSfDe

---
_Generated by [Claude Code](https://claude.ai/code/session_016TQpDEBTmgBSew2nrKSfDe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated translations for daily goal details across 9 languages: Greek, English, Spanish, French, Italian, Latin, Dutch, Norwegian, and Chinese, ensuring proper localization for all supported regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->