### PR TITLE
Exercises/categories single source of truth: drift guards + training-plan binding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ When making changes, always write or update relevant tests as part of the same c
 - **Mock providers via Angular DI** (`{ provide: ..., useValue: ... }`), not by patching `inject()` directly.
 - **External functions** (e.g. `deleteUser` from Firebase) are mocked on the imported module — never with dynamic `import()` or `require()`. Use `import * as ns from '@angular/fire/firestore'` and reference `ns.doc`/`ns.docData` after `jest.mock(...)`.
 - **`PLATFORM_ID: 'server'`** in tests for stores that start a `setInterval` / browser-only timer in `withHooks`. Otherwise the timer leaks across `TestBed.resetTestingModule()`.
-- **Given-When-Then** style tests are preferred — new tests follow it (`it('Given …, When …, Then …')`) even in files whose older tests predate the convention; don't match the legacy plain-descriptive style.
+- **Given-When-Then** style tests are preferred — the test title is a `should …` sentence (`it('should …')`); `// given` / `// when` / `// then` are marker comments inside the body that flag where each phase starts, **not** part of the title. New tests follow this even in files whose older tests predate the convention.
 
 More test pitfalls: [`docs/gotchas/testing.md`](docs/gotchas/testing.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ When making changes, always write or update relevant tests as part of the same c
 - **Mock providers via Angular DI** (`{ provide: ..., useValue: ... }`), not by patching `inject()` directly.
 - **External functions** (e.g. `deleteUser` from Firebase) are mocked on the imported module — never with dynamic `import()` or `require()`. Use `import * as ns from '@angular/fire/firestore'` and reference `ns.doc`/`ns.docData` after `jest.mock(...)`.
 - **`PLATFORM_ID: 'server'`** in tests for stores that start a `setInterval` / browser-only timer in `withHooks`. Otherwise the timer leaks across `TestBed.resetTestingModule()`.
-- **Given-When-Then** style tests are preferred.
+- **Given-When-Then** style tests are preferred — new tests follow it (`it('Given …, When …, Then …')`) even in files whose older tests predate the convention; don't match the legacy plain-descriptive style.
 
 More test pitfalls: [`docs/gotchas/testing.md`](docs/gotchas/testing.md).
 
@@ -56,6 +56,7 @@ More test pitfalls: [`docs/gotchas/testing.md`](docs/gotchas/testing.md).
 - **Prefer Angular Material components** (`mat-button`, `mat-icon`, `mat-form-field`, `mat-dialog`, etc.) over plain HTML for buttons, inputs, dialogs, and other interactive controls.
 - **No `@angular/animations`** — it is deprecated and not a project dependency. Use CSS animations/transitions instead.
 - **State management:** see [`docs/architecture.md`](docs/architecture.md) for the signal-store / API-service split and where state belongs. Short version: stores own state, components only bind, services are stateless.
+- **Exercises & categories — one source:** `EXERCISE_CATALOG` / `EXERCISE_CATEGORIES` in `@pu-stats/models` are the only list of available exercises/categories. Goals, entries, analysis, the Cloud Function leaderboard rebuild, and training plans (`TrainingPlanDay.exerciseId`, default `'pushup'`) all read from it. Consumers that can't import it — the `firestore.rules` allowlists and the `$localize` display-name registry — are pinned to the catalog by guard tests, so adding/renaming an exercise fails CI until they match. Only `firestore.rules` needs a manual edit; everything else derives. Details: [`docs/architecture.md`](docs/architecture.md) → "Single source of truth: exercises & categories".
 - **No RxJS for state** — RxJS is allowed only inside the data-access layer for Firestore Observables, then bridged via `toSignal()`.
 - **Don't introduce backwards-compatibility shims** for code paths you are certain are unused — delete instead. No `// removed`, no re-exports of removed types, no renamed `_unused` vars.
 

--- a/data-store/functions/src/exercise-leaderboard/catalog-coupling.spec.ts
+++ b/data-store/functions/src/exercise-leaderboard/catalog-coupling.spec.ts
@@ -22,7 +22,7 @@ describe('exercise leaderboard ⇄ catalog measurement coupling', () => {
     'distanceM',
   ]);
 
-  it('routes every leaderboard-eligible catalog exercise to a ranked value field', () => {
+  it('Given a leaderboard-eligible catalog exercise, When exerciseValueFieldFor maps its measurement, Then the value field is one the ranker caps', () => {
     for (const def of EXERCISE_CATALOG) {
       if (!supportsExerciseLeaderboard(def.measurement)) continue;
       expect(VALUE_FIELDS.has(exerciseValueFieldFor(def.measurement))).toBe(
@@ -31,7 +31,7 @@ describe('exercise leaderboard ⇄ catalog measurement coupling', () => {
     }
   });
 
-  it('excludes only weight-measured exercises from leaderboards', () => {
+  it('Given each measurement type, When supportsExerciseLeaderboard is checked, Then only weight is excluded', () => {
     const measurements: MeasurementType[] = [
       'reps',
       'time',
@@ -44,7 +44,7 @@ describe('exercise leaderboard ⇄ catalog measurement coupling', () => {
     }
   });
 
-  it('derives the value field the same way the client does', () => {
+  it('Given each measurement type, When exerciseValueFieldFor maps it, Then it matches the client value-field routing', () => {
     expect(exerciseValueFieldFor('reps')).toBe('reps');
     expect(exerciseValueFieldFor('time')).toBe('durationSec');
     expect(exerciseValueFieldFor('distance')).toBe('distanceM');

--- a/data-store/functions/src/exercise-leaderboard/catalog-coupling.spec.ts
+++ b/data-store/functions/src/exercise-leaderboard/catalog-coupling.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from '@jest/globals';
+import { EXERCISE_CATALOG, type MeasurementType } from '@pu-stats/models';
+
+import {
+  exerciseValueFieldFor,
+  supportsExerciseLeaderboard,
+  type ExerciseValueField,
+} from './logic';
+
+/**
+ * Locks the server leaderboard's measurement → value-field routing to the
+ * catalog. `exerciseValueFieldFor` derives from `measurementValueField()`
+ * in `@pu-stats/models`, so a new `MeasurementType` the ranker doesn't
+ * understand surfaces here (and at compile time via the exhaustive switch
+ * in the model helper) instead of silently dropping every entry of the
+ * new kind from the per-exercise leaderboards.
+ */
+describe('exercise leaderboard ⇄ catalog measurement coupling', () => {
+  const VALUE_FIELDS: ReadonlySet<ExerciseValueField> = new Set([
+    'reps',
+    'durationSec',
+    'distanceM',
+  ]);
+
+  it('routes every leaderboard-eligible catalog exercise to a ranked value field', () => {
+    for (const def of EXERCISE_CATALOG) {
+      if (!supportsExerciseLeaderboard(def.measurement)) continue;
+      expect(VALUE_FIELDS.has(exerciseValueFieldFor(def.measurement))).toBe(
+        true
+      );
+    }
+  });
+
+  it('excludes only weight-measured exercises from leaderboards', () => {
+    const measurements: MeasurementType[] = [
+      'reps',
+      'time',
+      'distance',
+      'distance-time',
+      'weight',
+    ];
+    for (const m of measurements) {
+      expect(supportsExerciseLeaderboard(m)).toBe(m !== 'weight');
+    }
+  });
+
+  it('derives the value field the same way the client does', () => {
+    expect(exerciseValueFieldFor('reps')).toBe('reps');
+    expect(exerciseValueFieldFor('time')).toBe('durationSec');
+    expect(exerciseValueFieldFor('distance')).toBe('distanceM');
+    expect(exerciseValueFieldFor('distance-time')).toBe('distanceM');
+    // `weight` is filtered out upstream by supportsExerciseLeaderboard;
+    // the fold only keeps the return type total.
+    expect(exerciseValueFieldFor('weight')).toBe('reps');
+  });
+});

--- a/data-store/functions/src/exercise-leaderboard/catalog-coupling.spec.ts
+++ b/data-store/functions/src/exercise-leaderboard/catalog-coupling.spec.ts
@@ -22,16 +22,19 @@ describe('exercise leaderboard ⇄ catalog measurement coupling', () => {
     'distanceM',
   ]);
 
-  it('Given a leaderboard-eligible catalog exercise, When exerciseValueFieldFor maps its measurement, Then the value field is one the ranker caps', () => {
+  it('should route every leaderboard-eligible catalog exercise to a ranked value field', () => {
+    // given each catalog exercise
     for (const def of EXERCISE_CATALOG) {
       if (!supportsExerciseLeaderboard(def.measurement)) continue;
-      expect(VALUE_FIELDS.has(exerciseValueFieldFor(def.measurement))).toBe(
-        true
-      );
+      // when
+      const field = exerciseValueFieldFor(def.measurement);
+      // then
+      expect(VALUE_FIELDS.has(field)).toBe(true);
     }
   });
 
-  it('Given each measurement type, When supportsExerciseLeaderboard is checked, Then only weight is excluded', () => {
+  it('should exclude only weight-measured exercises from leaderboards', () => {
+    // given
     const measurements: MeasurementType[] = [
       'reps',
       'time',
@@ -39,18 +42,20 @@ describe('exercise leaderboard ⇄ catalog measurement coupling', () => {
       'distance-time',
       'weight',
     ];
+    // when / then
     for (const m of measurements) {
       expect(supportsExerciseLeaderboard(m)).toBe(m !== 'weight');
     }
   });
 
-  it('Given each measurement type, When exerciseValueFieldFor maps it, Then it matches the client value-field routing', () => {
+  it('should derive the value field the same way the client does', () => {
+    // given each measurement type / when mapped / then it matches the client
+    // routing. `weight` is filtered out upstream by
+    // supportsExerciseLeaderboard; the fold only keeps the return type total.
     expect(exerciseValueFieldFor('reps')).toBe('reps');
     expect(exerciseValueFieldFor('time')).toBe('durationSec');
     expect(exerciseValueFieldFor('distance')).toBe('distanceM');
     expect(exerciseValueFieldFor('distance-time')).toBe('distanceM');
-    // `weight` is filtered out upstream by supportsExerciseLeaderboard;
-    // the fold only keeps the return type total.
     expect(exerciseValueFieldFor('weight')).toBe('reps');
   });
 });

--- a/data-store/functions/src/exercise-leaderboard/logic.ts
+++ b/data-store/functions/src/exercise-leaderboard/logic.ts
@@ -11,6 +11,8 @@
  * public snapshot at `leaderboards/exercises` that the client can read.
  */
 
+import { measurementValueField, type MeasurementType } from '@pu-stats/models';
+
 import { berlinDateParts, BerlinDateParts } from '../datetime';
 import {
   isLeaderboardExcluded,
@@ -75,10 +77,12 @@ export type WindowedExerciseLeaderboardPeriodKind = Exclude<
 
 /**
  * Value field on `ExerciseEntryRow` that carries the primary measurement
- * value for a given exercise. Mirrors `measurementValueField()` from
- * `@pu-stats/models`, which the client uses for the same routing; the
- * value isn't shared between the two because the Cloud Functions
- * package can't depend on the Angular workspace lib.
+ * value for a given exercise — the leaderboard-eligible subset of the
+ * model's measurement value fields (`weightKg` is excluded; see
+ * {@link supportsExerciseLeaderboard}). The measurement → field routing
+ * itself is NOT duplicated here: {@link exerciseValueFieldFor} derives it
+ * from `measurementValueField()` in `@pu-stats/models` — the same source
+ * the client uses — so the server ranker can never drift from the catalog.
  */
 export type ExerciseValueField = 'reps' | 'durationSec' | 'distanceM';
 
@@ -101,6 +105,35 @@ const DAILY_CAP_BY_FIELD: Readonly<Record<ExerciseValueField, number>> = {
   durationSec: 14_400,
   distanceM: 100_000,
 };
+
+/**
+ * Catalog measurement types we rank — same gate the client uses in
+ * `LeaderboardService.supportsLeaderboard`. `weight`-measured exercises
+ * ship without a sensible Σ-metric (load-per-rep isn't a volume to rank),
+ * so we don't aggregate them; the leaderboard doc just omits those
+ * exerciseIds.
+ */
+export function supportsExerciseLeaderboard(
+  measurement: MeasurementType
+): boolean {
+  return measurement !== 'weight';
+}
+
+/**
+ * Maps a catalog `MeasurementType` to the `ExerciseEntryRow` value-field
+ * the ranker reads. Derived from `measurementValueField()` in
+ * `@pu-stats/models` so it can never drift from how the client routes the
+ * same value. `weight` maps to `reps` there, but it's filtered out by
+ * {@link supportsExerciseLeaderboard} before reaching this function — the
+ * `weightKg` fold below only keeps the return type total.
+ */
+export function exerciseValueFieldFor(
+  measurement: MeasurementType
+): ExerciseValueField {
+  const field = measurementValueField(measurement);
+  if (field === 'weightKg') return 'reps';
+  return field;
+}
 
 /**
  * Returns the ISO date `daysBack` days before the given Berlin date.

--- a/data-store/functions/src/exercise-rules-sync.spec.ts
+++ b/data-store/functions/src/exercise-rules-sync.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { EXERCISE_CATALOG, type MeasurementType } from '@pu-stats/models';
+
+/**
+ * Guards the hand-maintained exercise-id allowlists in
+ * `data-store/firestore.rules` against `EXERCISE_CATALOG` — the single
+ * source of truth in `@pu-stats/models`.
+ *
+ * Firestore rules can't import TypeScript, so the rule enumerates literal
+ * ids in three allowlists grouped by the field a measurement writes:
+ * `isRepsExerciseId` (reps), `isTimeExerciseId` (time),
+ * `isDistanceTimeExerciseId` (distance-time). The rule's own comment says
+ * "keep these in sync with the catalog" — this test makes that
+ * machine-enforced instead of a promise. Without it, a freshly added
+ * catalog exercise passes every other test yet hits permission-denied on
+ * save in production because the rule never learned its id.
+ *
+ * Pushup variants are intentionally absent: they live in the legacy
+ * `pushups` collection behind their own rule, not in `exerciseEntries`.
+ */
+
+const RULES_PATH = join(__dirname, '..', '..', 'firestore.rules');
+
+/**
+ * Extracts the single-quoted ids listed inside a `function <name>(id) { … }`
+ * block in the rules file. Brace-matched so a trailing `}` inside a comment
+ * can't truncate the body early.
+ */
+function ruleAllowlist(rules: string, fnName: string): Set<string> {
+  const start = rules.indexOf(`function ${fnName}`);
+  if (start < 0) throw new Error(`rule function "${fnName}" not found`);
+  const open = rules.indexOf('{', start);
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < rules.length; i++) {
+    if (rules[i] === '{') depth++;
+    else if (rules[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end < 0) throw new Error(`unbalanced braces in "${fnName}"`);
+  return new Set(
+    [...rules.slice(open, end).matchAll(/'([^']+)'/g)].map((m) => m[1])
+  );
+}
+
+function catalogIds(measurement: MeasurementType): string[] {
+  return EXERCISE_CATALOG.filter((d) => d.measurement === measurement)
+    .map((d) => d.id)
+    .sort();
+}
+
+describe('firestore.rules exercise allowlists ⇄ EXERCISE_CATALOG', () => {
+  const rules = readFileSync(RULES_PATH, 'utf8');
+
+  it('isRepsExerciseId lists exactly the catalog reps exercises', () => {
+    expect([...ruleAllowlist(rules, 'isRepsExerciseId')].sort()).toEqual(
+      catalogIds('reps')
+    );
+  });
+
+  it('isTimeExerciseId lists exactly the catalog time exercises', () => {
+    expect([...ruleAllowlist(rules, 'isTimeExerciseId')].sort()).toEqual(
+      catalogIds('time')
+    );
+  });
+
+  it('isDistanceTimeExerciseId lists exactly the catalog distance-time exercises', () => {
+    expect(
+      [...ruleAllowlist(rules, 'isDistanceTimeExerciseId')].sort()
+    ).toEqual(catalogIds('distance-time'));
+  });
+
+  it('ships no catalog measurement the rules would silently reject', () => {
+    // `distance` (carry) and `weight` (strength) have no rule allowlist
+    // yet, so the catalog must not surface them — a saved entry would hit
+    // no matching rule branch and be denied. This is the rules-coverage
+    // mirror of the EXERCISE_CATALOG spec's "does not yet ship
+    // distance/weight" guard.
+    const ruleCovered = new Set<MeasurementType>([
+      'reps',
+      'time',
+      'distance-time',
+    ]);
+    const uncovered = EXERCISE_CATALOG.filter(
+      (d) => !ruleCovered.has(d.measurement)
+    ).map((d) => d.id);
+    expect(uncovered).toEqual([]);
+  });
+});

--- a/data-store/functions/src/exercise-rules-sync.spec.ts
+++ b/data-store/functions/src/exercise-rules-sync.spec.ts
@@ -33,6 +33,8 @@ function ruleAllowlist(rules: string, fnName: string): Set<string> {
   const start = rules.indexOf(`function ${fnName}`);
   if (start < 0) throw new Error(`rule function "${fnName}" not found`);
   const open = rules.indexOf('{', start);
+  if (open < 0)
+    throw new Error(`no opening brace for rule function "${fnName}"`);
   let depth = 0;
   let end = -1;
   for (let i = open; i < rules.length; i++) {
@@ -60,25 +62,25 @@ function catalogIds(measurement: MeasurementType): string[] {
 describe('firestore.rules exercise allowlists ⇄ EXERCISE_CATALOG', () => {
   const rules = readFileSync(RULES_PATH, 'utf8');
 
-  it('isRepsExerciseId lists exactly the catalog reps exercises', () => {
+  it('Given the catalog reps exercises, When isRepsExerciseId is parsed from the rules, Then the id sets match', () => {
     expect([...ruleAllowlist(rules, 'isRepsExerciseId')].sort()).toEqual(
       catalogIds('reps')
     );
   });
 
-  it('isTimeExerciseId lists exactly the catalog time exercises', () => {
+  it('Given the catalog time exercises, When isTimeExerciseId is parsed from the rules, Then the id sets match', () => {
     expect([...ruleAllowlist(rules, 'isTimeExerciseId')].sort()).toEqual(
       catalogIds('time')
     );
   });
 
-  it('isDistanceTimeExerciseId lists exactly the catalog distance-time exercises', () => {
+  it('Given the catalog distance-time exercises, When isDistanceTimeExerciseId is parsed from the rules, Then the id sets match', () => {
     expect(
       [...ruleAllowlist(rules, 'isDistanceTimeExerciseId')].sort()
     ).toEqual(catalogIds('distance-time'));
   });
 
-  it('ships no catalog measurement the rules would silently reject', () => {
+  it('Given a measurement with no rule allowlist, When the catalog is scanned, Then no exercise uses it', () => {
     // `distance` (carry) and `weight` (strength) have no rule allowlist
     // yet, so the catalog must not surface them — a saved entry would hit
     // no matching rule branch and be denied. This is the rules-coverage

--- a/data-store/functions/src/exercise-rules-sync.spec.ts
+++ b/data-store/functions/src/exercise-rules-sync.spec.ts
@@ -62,38 +62,48 @@ function catalogIds(measurement: MeasurementType): string[] {
 describe('firestore.rules exercise allowlists ⇄ EXERCISE_CATALOG', () => {
   const rules = readFileSync(RULES_PATH, 'utf8');
 
-  it('Given the catalog reps exercises, When isRepsExerciseId is parsed from the rules, Then the id sets match', () => {
-    expect([...ruleAllowlist(rules, 'isRepsExerciseId')].sort()).toEqual(
-      catalogIds('reps')
-    );
+  it('should list exactly the catalog reps exercises in isRepsExerciseId', () => {
+    // given
+    const catalog = catalogIds('reps');
+    // when
+    const rule = [...ruleAllowlist(rules, 'isRepsExerciseId')].sort();
+    // then
+    expect(rule).toEqual(catalog);
   });
 
-  it('Given the catalog time exercises, When isTimeExerciseId is parsed from the rules, Then the id sets match', () => {
-    expect([...ruleAllowlist(rules, 'isTimeExerciseId')].sort()).toEqual(
-      catalogIds('time')
-    );
+  it('should list exactly the catalog time exercises in isTimeExerciseId', () => {
+    // given
+    const catalog = catalogIds('time');
+    // when
+    const rule = [...ruleAllowlist(rules, 'isTimeExerciseId')].sort();
+    // then
+    expect(rule).toEqual(catalog);
   });
 
-  it('Given the catalog distance-time exercises, When isDistanceTimeExerciseId is parsed from the rules, Then the id sets match', () => {
-    expect(
-      [...ruleAllowlist(rules, 'isDistanceTimeExerciseId')].sort()
-    ).toEqual(catalogIds('distance-time'));
+  it('should list exactly the catalog distance-time exercises in isDistanceTimeExerciseId', () => {
+    // given
+    const catalog = catalogIds('distance-time');
+    // when
+    const rule = [...ruleAllowlist(rules, 'isDistanceTimeExerciseId')].sort();
+    // then
+    expect(rule).toEqual(catalog);
   });
 
-  it('Given a measurement with no rule allowlist, When the catalog is scanned, Then no exercise uses it', () => {
-    // `distance` (carry) and `weight` (strength) have no rule allowlist
-    // yet, so the catalog must not surface them — a saved entry would hit
-    // no matching rule branch and be denied. This is the rules-coverage
-    // mirror of the EXERCISE_CATALOG spec's "does not yet ship
-    // distance/weight" guard.
+  it('should not ship a catalog measurement the rules have no allowlist for', () => {
+    // given — `distance` (carry) and `weight` (strength) have no rule
+    // allowlist yet, so a saved entry would hit no matching rule branch and
+    // be denied. Mirrors the EXERCISE_CATALOG spec's "does not yet ship
+    // distance/weight" guard from the rules-coverage side.
     const ruleCovered = new Set<MeasurementType>([
       'reps',
       'time',
       'distance-time',
     ]);
+    // when
     const uncovered = EXERCISE_CATALOG.filter(
       (d) => !ruleCovered.has(d.measurement)
     ).map((d) => d.id);
+    // then
     expect(uncovered).toEqual([]);
   });
 });

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -4,7 +4,6 @@ import {
   EXERCISE_CATALOG,
   type ExerciseDefinition,
   type MeasurementType,
-  measurementValueField,
   normalizeReminderLocale,
   USERSTATS_VERSION,
 } from '@pu-stats/models';
@@ -31,10 +30,11 @@ import {
   type ExerciseEntryRow,
   type ExerciseLeaderboardEntry,
   type ExerciseUserTotalRow,
-  type ExerciseValueField,
+  exerciseValueFieldFor,
   getExerciseLeaderboardQueryStartDate,
   rankExerciseAllTime,
   rankExerciseEntries,
+  supportsExerciseLeaderboard,
 } from './exercise-leaderboard';
 import {
   getLeaderboardQueryStartDate,
@@ -196,33 +196,6 @@ async function rebuildLeaderboardsCore() {
   });
 }
 
-/**
- * Catalog measurement types we rank — same gate the client uses in
- * `LeaderboardService.supportsLeaderboard`. `weight`-measured
- * exercises ship without a sensible Σ-metric, so we don't aggregate
- * them; the leaderboard doc just omits those exerciseIds.
- */
-function supportsLeaderboard(measurement: MeasurementType): boolean {
-  return measurement !== 'weight';
-}
-
-/**
- * Maps `MeasurementType` to the `ExerciseEntryRow` value-field — same
- * mapping the client does via `measurementValueField()` from
- * `@pu-stats/models`. Re-exposed locally to keep the ranker decoupled
- * from the catalog dependency.
- */
-function valueFieldForMeasurement(
-  measurement: MeasurementType
-): ExerciseValueField {
-  const field = measurementValueField(measurement);
-  // `weight` would map to `reps` per `measurementValueField`, but we
-  // filter weight out via `supportsLeaderboard` before getting here.
-  // `distance` and `distance-time` both map to `distanceM`.
-  if (field === 'weightKg') return 'reps';
-  return field;
-}
-
 interface ExerciseLeaderboardSnapshot {
   measurement: MeasurementType;
   unit: string;
@@ -366,7 +339,7 @@ async function rebuildExerciseLeaderboardsCore(opts: {
   const byExercise: Record<string, ExerciseLeaderboardSnapshot> = {};
 
   for (const def of EXERCISE_CATALOG as readonly ExerciseDefinition[]) {
-    if (!supportsLeaderboard(def.measurement)) continue;
+    if (!supportsExerciseLeaderboard(def.measurement)) continue;
     const exerciseRows = rowsByExercise.get(def.id) ?? [];
     const allTimeBucket: ExerciseLeaderboardEntry[] = opts.includeAllTime
       ? rankExerciseAllTime(allTimeByExercise?.get(def.id) ?? [], userProfiles)
@@ -376,7 +349,7 @@ async function rebuildExerciseLeaderboardsCore(opts: {
     // exercise with only old activity should still surface a populated
     // allTime bucket (with empty daily/last7/last30).
     if (exerciseRows.length === 0 && allTimeBucket.length === 0) continue;
-    const valueField = valueFieldForMeasurement(def.measurement);
+    const valueField = exerciseValueFieldFor(def.measurement);
 
     byExercise[def.id] = {
       measurement: def.measurement,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,3 +170,24 @@ Split into focused files under `libs/stats/src/lib/models/`:
 - For everything else: reads the field that `measurementValueField(measurement)` returns and pipes it through `formatExerciseValue(value, def.unit)`.
 
 `measurementCompanionValueField(measurement)` returns the secondary display field for composite measurements (currently only `'durationSec'` for `'distance-time'`). Aggregation paths use it to sum a second total alongside the primary, so a 30-day card for a tracked run can show `"42.00 km · 3:30:00 (5:00 /km)"`. The first composite catalog entry is `cardio.running`; later cardio types (cycling, swimming, …) and tighter per-exercise companion bounds plug into the same path without further infrastructure work.
+
+### Single source of truth: exercises & categories
+
+`@pu-stats/models` owns the **only** list of available exercises and categories — `EXERCISE_CATALOG` and `EXERCISE_CATEGORIES` in `exercise.catalog.ts`, typed by `exercise.models.ts`. Everything that needs to know "which exercises/categories exist" reads from here:
+
+- **Goals** — `ComplexGoalEntry.exerciseId` (`user-config.models.ts`).
+- **User entries** — `exerciseEntries` docs carry a catalog `exerciseId`; pushups stay on the legacy `pushups` collection behind the `'pushup'` sentinel until the Phase-7 merge (see `plans/multi-exercise-roadmap.md`).
+- **Analysis & statistics** — the client resolves categories via `unifiedEntryCategoryId`; the Cloud Function leaderboard rebuild iterates `EXERCISE_CATALOG` and derives each exercise's value field from `measurementValueField` (`exercise-leaderboard/logic.ts` → `exerciseValueFieldFor`).
+- **Training plans** — `TrainingPlanDay.exerciseId` (defaults to `'pushup'`), resolved via `trainingPlanDayExerciseId`.
+
+A few consumers **cannot** import the catalog at runtime, so they keep a shadow copy. Each is pinned to the catalog by a **guard test** rather than a "keep in sync" comment:
+
+| Shadow copy                                             | Why it can't just derive             | Guard                                                    |
+| ------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------- |
+| `data-store/firestore.rules` exercise allowlists        | Firestore rules can't import TS      | `data-store/functions/src/exercise-rules-sync.spec.ts`   |
+| `exercise-display-names.ts` (`$localize` name registry) | `$localize` needs literal call sites | `exercise-display-names.spec.ts`                         |
+| `AUTO_COUNT_QUICK_ADD_EXERCISE_IDS` + web profile maps  | profile unions are type-only in web  | `exercise.catalog.spec.ts` + derivation from the catalog |
+
+The web auto-count/hold-timer mapping derives from each catalog entry's `autoCountProfileId` / `holdTimerProfileId` (opaque profile-id strings the web adapter resolves to its typed unions) — no hardcoded catalog ids in the feature layer.
+
+**When you add or change a catalog exercise:** the guard tests tell you exactly what to touch. Only `firestore.rules` needs a manual edit (the test fails until it matches); the display-name registry needs a new `$localize` entry (its test fails until the key set matches); everything else derives.

--- a/docs/gotchas/build-and-tooling.md
+++ b/docs/gotchas/build-and-tooling.md
@@ -29,6 +29,10 @@ pnpm nx-cloud start-ci-run --distribute-on=".nx/workflows/distribution-config.ya
 
 To scale further (bigger agents for e2e specifically, or higher ceilings), edit the YAML — the CI workflow doesn't need to change.
 
+## Generated `*.generated.ts` files rewrite on `nx build web`
+
+`pnpm nx build web` runs the `generate-content` target first, which rewrites the build-time content files (`libs/stats/src/lib/models/*-content.generated.ts`) and the sitemap from `content/**`. After a local build your working tree may show a large diff in those files — a stale committed copy or a non-deterministic generation order, **not** part of your change. Revert it (`git checkout -- libs/stats/src/lib/models/exercise-wiki-content.generated.ts`) instead of committing the churn; CI regenerates them from the committed sources. Never hand-edit a file whose header says `AUTO-GENERATED`.
+
 ## Angular SSR `NG_ALLOWED_HOSTS` must include `*.run.app`
 
 Angular SSR (`@angular/ssr` v19+) rejects requests whose `Host` header isn't in `NG_ALLOWED_HOSTS` as an SSRF guard. Firebase App Hosting forwards traffic through Cloud Run, so during rolling deploys traffic-tag URLs like `t-<id>---<service>-<hash>-<region>.a.run.app` reach the SSR with that internal hostname — Angular returns `400: Header "host" with value "..." is not allowed`, and the affected page (most visibly `/u/:uid`, which is `RenderMode.Server`) refuses to render.

--- a/libs/stats/src/lib/models/exercise.catalog.spec.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.spec.ts
@@ -5,6 +5,10 @@ import {
   findExerciseCategory,
   findExerciseDefinition,
 } from './exercise.catalog';
+import {
+  AUTO_COUNT_QUICK_ADD_EXERCISE_IDS,
+  PUSHUP_QUICK_ADD_EXERCISE_ID,
+} from './user-config.models';
 
 describe('EXERCISE_CATEGORIES', () => {
   it('declares each category id at most once', () => {
@@ -215,5 +219,55 @@ describe('exercisesByCategory', () => {
     for (const cat of EXERCISE_CATEGORIES) {
       expect(map.has(cat.id)).toBe(true);
     }
+  });
+});
+
+describe('auto-count / hold-timer catalog capabilities', () => {
+  it('marks exactly the camera-countable exercises with an autoCountProfileId', () => {
+    const profiles = EXERCISE_CATALOG.filter((d) => d.autoCountProfileId);
+    expect(profiles.map((d) => [d.id, d.autoCountProfileId]).sort()).toEqual([
+      ['abs.situps', 'situp'],
+      ['legs.squats', 'squat'],
+      ['pull.pullups', 'pullup'],
+    ]);
+  });
+
+  it('uses only auto-count profile ids the web AutoCountExerciseId union supports', () => {
+    // The union is type-only in web/auto-count, so this bounded set is the
+    // catalog-side half of the contract; the orchestration spec covers the
+    // round-trip through autoCountProfileForCatalogId.
+    const allowed = new Set(['squat', 'pullup', 'situp']);
+    for (const def of EXERCISE_CATALOG) {
+      if (def.autoCountProfileId) {
+        expect(allowed.has(def.autoCountProfileId)).toBe(true);
+      }
+    }
+  });
+
+  it('marks the hold-timer exercises with a time-measured holdTimerProfileId', () => {
+    expect(findExerciseDefinition('plank.standard')?.holdTimerProfileId).toBe(
+      'plank'
+    );
+    expect(findExerciseDefinition('core.hollowhold')?.holdTimerProfileId).toBe(
+      'hollowhold'
+    );
+    const allowed = new Set(['plank', 'hollowhold']);
+    for (const def of EXERCISE_CATALOG) {
+      if (def.holdTimerProfileId) {
+        expect(def.measurement).toBe('time');
+        expect(allowed.has(def.holdTimerProfileId)).toBe(true);
+      }
+    }
+  });
+
+  it('keeps AUTO_COUNT_QUICK_ADD_EXERCISE_IDS derivable from the catalog', () => {
+    // The quick-add subset must equal the pushup sentinel plus every
+    // catalog exercise that declares a camera profile — no hand-maintained
+    // drift from the catalog's autoCountProfileId flags.
+    const derived = [
+      PUSHUP_QUICK_ADD_EXERCISE_ID,
+      ...EXERCISE_CATALOG.filter((d) => d.autoCountProfileId).map((d) => d.id),
+    ].sort();
+    expect([...AUTO_COUNT_QUICK_ADD_EXERCISE_IDS].sort()).toEqual(derived);
   });
 });

--- a/libs/stats/src/lib/models/exercise.catalog.spec.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.spec.ts
@@ -223,7 +223,7 @@ describe('exercisesByCategory', () => {
 });
 
 describe('auto-count / hold-timer catalog capabilities', () => {
-  it('marks exactly the camera-countable exercises with an autoCountProfileId', () => {
+  it('Given EXERCISE_CATALOG, When filtering by autoCountProfileId, Then exactly situps, squats and pullups are marked', () => {
     const profiles = EXERCISE_CATALOG.filter((d) => d.autoCountProfileId);
     expect(profiles.map((d) => [d.id, d.autoCountProfileId]).sort()).toEqual([
       ['abs.situps', 'situp'],
@@ -232,7 +232,7 @@ describe('auto-count / hold-timer catalog capabilities', () => {
     ]);
   });
 
-  it('uses only auto-count profile ids the web AutoCountExerciseId union supports', () => {
+  it('Given a catalog autoCountProfileId, When checked against the web union, Then it is squat, pullup or situp', () => {
     // The union is type-only in web/auto-count, so this bounded set is the
     // catalog-side half of the contract; the orchestration spec covers the
     // round-trip through autoCountProfileForCatalogId.
@@ -244,7 +244,7 @@ describe('auto-count / hold-timer catalog capabilities', () => {
     }
   });
 
-  it('marks the hold-timer exercises with a time-measured holdTimerProfileId', () => {
+  it('Given the hold-timer exercises, When inspected, Then plank and hollowhold carry a time-measured holdTimerProfileId', () => {
     expect(findExerciseDefinition('plank.standard')?.holdTimerProfileId).toBe(
       'plank'
     );
@@ -260,7 +260,7 @@ describe('auto-count / hold-timer catalog capabilities', () => {
     }
   });
 
-  it('keeps AUTO_COUNT_QUICK_ADD_EXERCISE_IDS derivable from the catalog', () => {
+  it('Given the catalog auto-count flags, When the quick-add subset is derived, Then it equals AUTO_COUNT_QUICK_ADD_EXERCISE_IDS', () => {
     // The quick-add subset must equal the pushup sentinel plus every
     // catalog exercise that declares a camera profile — no hand-maintained
     // drift from the catalog's autoCountProfileId flags.

--- a/libs/stats/src/lib/models/exercise.catalog.spec.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.spec.ts
@@ -223,20 +223,25 @@ describe('exercisesByCategory', () => {
 });
 
 describe('auto-count / hold-timer catalog capabilities', () => {
-  it('Given EXERCISE_CATALOG, When filtering by autoCountProfileId, Then exactly situps, squats and pullups are marked', () => {
-    const profiles = EXERCISE_CATALOG.filter((d) => d.autoCountProfileId);
-    expect(profiles.map((d) => [d.id, d.autoCountProfileId]).sort()).toEqual([
+  it('should mark exactly situps, squats and pullups with an autoCountProfileId', () => {
+    // given / when
+    const profiles = EXERCISE_CATALOG.filter((d) => d.autoCountProfileId).map(
+      (d) => [d.id, d.autoCountProfileId]
+    );
+    // then
+    expect(profiles.sort()).toEqual([
       ['abs.situps', 'situp'],
       ['legs.squats', 'squat'],
       ['pull.pullups', 'pullup'],
     ]);
   });
 
-  it('Given a catalog autoCountProfileId, When checked against the web union, Then it is squat, pullup or situp', () => {
-    // The union is type-only in web/auto-count, so this bounded set is the
-    // catalog-side half of the contract; the orchestration spec covers the
-    // round-trip through autoCountProfileForCatalogId.
+  it('should use only auto-count profile ids the web AutoCountExerciseId union supports', () => {
+    // given — the union is type-only in web/auto-count, so this bounded set
+    // is the catalog-side half of the contract; the orchestration spec
+    // covers the round-trip through autoCountProfileForCatalogId.
     const allowed = new Set(['squat', 'pullup', 'situp']);
+    // when / then
     for (const def of EXERCISE_CATALOG) {
       if (def.autoCountProfileId) {
         expect(allowed.has(def.autoCountProfileId)).toBe(true);
@@ -244,7 +249,8 @@ describe('auto-count / hold-timer catalog capabilities', () => {
     }
   });
 
-  it('Given the hold-timer exercises, When inspected, Then plank and hollowhold carry a time-measured holdTimerProfileId', () => {
+  it('should mark plank and hollow hold with a time-measured holdTimerProfileId', () => {
+    // given / when / then
     expect(findExerciseDefinition('plank.standard')?.holdTimerProfileId).toBe(
       'plank'
     );
@@ -260,10 +266,10 @@ describe('auto-count / hold-timer catalog capabilities', () => {
     }
   });
 
-  it('Given the catalog auto-count flags, When the quick-add subset is derived, Then it equals AUTO_COUNT_QUICK_ADD_EXERCISE_IDS', () => {
-    // The quick-add subset must equal the pushup sentinel plus every
-    // catalog exercise that declares a camera profile — no hand-maintained
-    // drift from the catalog's autoCountProfileId flags.
+  it('should keep AUTO_COUNT_QUICK_ADD_EXERCISE_IDS derivable from the catalog flags', () => {
+    // given the catalog auto-count flags, when the quick-add subset is
+    // derived, then it equals the pushup sentinel plus every catalog
+    // exercise that declares a camera profile — no hand-maintained drift.
     const derived = [
       PUSHUP_QUICK_ADD_EXERCISE_ID,
       ...EXERCISE_CATALOG.filter((d) => d.autoCountProfileId).map((d) => d.id),

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -105,6 +105,7 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     // the `categoryId` moves them from `abs` → `core`.
     id: 'abs.situps',
     categoryId: 'core',
+    autoCountProfileId: 'situp',
     measurement: 'reps',
     min: 1,
     max: 500,
@@ -245,6 +246,7 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
   {
     id: 'core.hollowhold',
     categoryId: 'core',
+    holdTimerProfileId: 'hollowhold',
     measurement: 'time',
     min: 1,
     max: 1200,
@@ -258,6 +260,7 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
     // them under "Plank" inside the core picker.
     id: 'plank.standard',
     categoryId: 'core',
+    holdTimerProfileId: 'plank',
     measurement: 'time',
     min: 1,
     max: 7200,
@@ -291,6 +294,7 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
   {
     id: 'legs.squats',
     categoryId: 'squat',
+    autoCountProfileId: 'squat',
     measurement: 'reps',
     min: 1,
     max: 500,
@@ -540,6 +544,7 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
   {
     id: 'pull.pullups',
     categoryId: 'pull',
+    autoCountProfileId: 'pullup',
     measurement: 'reps',
     min: 1,
     max: 200,

--- a/libs/stats/src/lib/models/exercise.models.ts
+++ b/libs/stats/src/lib/models/exercise.models.ts
@@ -88,6 +88,21 @@ export interface ExerciseDefinition {
   customName?: string;
   /** Optional Material icon name. */
   icon?: string;
+  /**
+   * Pose-detector profile id for camera-based auto-count (e.g. `'squat'`).
+   * Opaque to the model — the web auto-count adapter maps it to its typed
+   * profile union. Absent ⇒ the exercise has no camera rep-counter. This
+   * is the single source for which catalog exercises are auto-countable;
+   * the quick-add subset and the web profile↔catalog mapping derive from
+   * it instead of hardcoding ids.
+   */
+  autoCountProfileId?: string;
+  /**
+   * Stopwatch/hold-timer profile id for time-measured exercises
+   * (e.g. `'plank'`). Opaque to the model; mapped by the web timer
+   * adapter. Absent ⇒ no guided hold-timer entry path.
+   */
+  holdTimerProfileId?: string;
   variants?: readonly ExerciseVariant[];
 }
 

--- a/libs/stats/src/lib/models/training-plan.models.spec.ts
+++ b/libs/stats/src/lib/models/training-plan.models.spec.ts
@@ -207,7 +207,7 @@ describe('training-plan models', () => {
       expect(findPlanById('does-not-exist')).toBeNull();
     });
 
-    it('references only catalog exercises (or the pushup sentinel)', () => {
+    it('Given every plan day, When its exercise is resolved, Then it is pushup or a real catalog id', () => {
       // Binds plans to the exercise SSOT: any day naming an exercise must
       // name a real catalog entry. 'pushup' is the legacy-collection
       // sentinel (no catalog entry by design).
@@ -220,7 +220,7 @@ describe('training-plan models', () => {
       }
     });
 
-    it('ships only pushup days the store can log idempotently', () => {
+    it('Given every plan day, When its exercise is resolved, Then it is the pushup the store can log today', () => {
       // logPlanDay reasons about reps through LiveDataStore, which is
       // pushup-only, so a non-pushup plan day would be silently skipped.
       // Guard against shipping one the store can't honor.
@@ -233,13 +233,13 @@ describe('training-plan models', () => {
   });
 
   describe('trainingPlanDayExerciseId', () => {
-    it('defaults to the pushup sentinel when a day names no exercise', () => {
+    it('Given a day with no exerciseId, When trainingPlanDayExerciseId is called, Then it returns the pushup sentinel', () => {
       expect(trainingPlanDayExerciseId({ exerciseId: undefined })).toBe(
         'pushup'
       );
     });
 
-    it('passes through an explicit catalog exercise id', () => {
+    it('Given a day with an explicit exerciseId, When trainingPlanDayExerciseId is called, Then it returns that id', () => {
       expect(trainingPlanDayExerciseId({ exerciseId: 'legs.squats' })).toBe(
         'legs.squats'
       );

--- a/libs/stats/src/lib/models/training-plan.models.spec.ts
+++ b/libs/stats/src/lib/models/training-plan.models.spec.ts
@@ -220,11 +220,10 @@ describe('training-plan models', () => {
       }
     });
 
-    it('ships only pushup days until per-exercise logging lands', () => {
-      // TrainingPlanStore.logPlanDay can only log pushup days idempotently
-      // today (LiveDataStore is pushup-only); a non-pushup day would be
-      // skipped. Guard against shipping one before the "history for all
-      // exercises" track wires the per-exercise write/idempotency path.
+    it('ships only pushup days the store can log idempotently', () => {
+      // logPlanDay reasons about reps through LiveDataStore, which is
+      // pushup-only, so a non-pushup plan day would be silently skipped.
+      // Guard against shipping one the store can't honor.
       for (const plan of TRAINING_PLANS) {
         for (const day of plan.days) {
           expect(trainingPlanDayExerciseId(day)).toBe('pushup');

--- a/libs/stats/src/lib/models/training-plan.models.spec.ts
+++ b/libs/stats/src/lib/models/training-plan.models.spec.ts
@@ -4,7 +4,9 @@ import {
   planDayByIndex,
   startDateForTargetDay,
   TrainingPlan,
+  trainingPlanDayExerciseId,
 } from './training-plan.models';
+import { findExerciseDefinition } from './exercise.catalog';
 import { findPlanById, TRAINING_PLANS } from './training-plan.catalog';
 
 describe('training-plan models', () => {
@@ -203,6 +205,45 @@ describe('training-plan models', () => {
     it('findPlanById returns the matching plan', () => {
       expect(findPlanById('challenge-30d-v1')?.totalDays).toBe(30);
       expect(findPlanById('does-not-exist')).toBeNull();
+    });
+
+    it('references only catalog exercises (or the pushup sentinel)', () => {
+      // Binds plans to the exercise SSOT: any day naming an exercise must
+      // name a real catalog entry. 'pushup' is the legacy-collection
+      // sentinel (no catalog entry by design).
+      for (const plan of TRAINING_PLANS) {
+        for (const day of plan.days) {
+          const id = trainingPlanDayExerciseId(day);
+          if (id === 'pushup') continue;
+          expect(findExerciseDefinition(id)).not.toBeNull();
+        }
+      }
+    });
+
+    it('ships only pushup days until per-exercise logging lands', () => {
+      // TrainingPlanStore.logPlanDay can only log pushup days idempotently
+      // today (LiveDataStore is pushup-only); a non-pushup day would be
+      // skipped. Guard against shipping one before the "history for all
+      // exercises" track wires the per-exercise write/idempotency path.
+      for (const plan of TRAINING_PLANS) {
+        for (const day of plan.days) {
+          expect(trainingPlanDayExerciseId(day)).toBe('pushup');
+        }
+      }
+    });
+  });
+
+  describe('trainingPlanDayExerciseId', () => {
+    it('defaults to the pushup sentinel when a day names no exercise', () => {
+      expect(trainingPlanDayExerciseId({ exerciseId: undefined })).toBe(
+        'pushup'
+      );
+    });
+
+    it('passes through an explicit catalog exercise id', () => {
+      expect(trainingPlanDayExerciseId({ exerciseId: 'legs.squats' })).toBe(
+        'legs.squats'
+      );
     });
   });
 });

--- a/libs/stats/src/lib/models/training-plan.models.spec.ts
+++ b/libs/stats/src/lib/models/training-plan.models.spec.ts
@@ -207,23 +207,26 @@ describe('training-plan models', () => {
       expect(findPlanById('does-not-exist')).toBeNull();
     });
 
-    it('Given every plan day, When its exercise is resolved, Then it is pushup or a real catalog id', () => {
-      // Binds plans to the exercise SSOT: any day naming an exercise must
-      // name a real catalog entry. 'pushup' is the legacy-collection
+    it('should reference only catalog exercises or the pushup sentinel', () => {
+      // given — binds plans to the exercise SSOT: any day naming an exercise
+      // must name a real catalog entry. 'pushup' is the legacy-collection
       // sentinel (no catalog entry by design).
       for (const plan of TRAINING_PLANS) {
         for (const day of plan.days) {
+          // when
           const id = trainingPlanDayExerciseId(day);
+          // then
           if (id === 'pushup') continue;
           expect(findExerciseDefinition(id)).not.toBeNull();
         }
       }
     });
 
-    it('Given every plan day, When its exercise is resolved, Then it is the pushup the store can log today', () => {
-      // logPlanDay reasons about reps through LiveDataStore, which is
-      // pushup-only, so a non-pushup plan day would be silently skipped.
-      // Guard against shipping one the store can't honor.
+    it('should ship only pushup days the store can log idempotently today', () => {
+      // given — logPlanDay reasons about reps through LiveDataStore, which is
+      // pushup-only, so a non-pushup plan day would be silently skipped;
+      // guard against shipping one the store can't honor.
+      // when / then
       for (const plan of TRAINING_PLANS) {
         for (const day of plan.days) {
           expect(trainingPlanDayExerciseId(day)).toBe('pushup');
@@ -233,16 +236,22 @@ describe('training-plan models', () => {
   });
 
   describe('trainingPlanDayExerciseId', () => {
-    it('Given a day with no exerciseId, When trainingPlanDayExerciseId is called, Then it returns the pushup sentinel', () => {
-      expect(trainingPlanDayExerciseId({ exerciseId: undefined })).toBe(
-        'pushup'
-      );
+    it('should default to the pushup sentinel when a day names no exercise', () => {
+      // given
+      const day = { exerciseId: undefined };
+      // when
+      const resolved = trainingPlanDayExerciseId(day);
+      // then
+      expect(resolved).toBe('pushup');
     });
 
-    it('Given a day with an explicit exerciseId, When trainingPlanDayExerciseId is called, Then it returns that id', () => {
-      expect(trainingPlanDayExerciseId({ exerciseId: 'legs.squats' })).toBe(
-        'legs.squats'
-      );
+    it('should pass through an explicit catalog exercise id', () => {
+      // given
+      const day = { exerciseId: 'legs.squats' };
+      // when
+      const resolved = trainingPlanDayExerciseId(day);
+      // then
+      expect(resolved).toBe('legs.squats');
     });
   });
 });

--- a/libs/stats/src/lib/models/training-plan.models.ts
+++ b/libs/stats/src/lib/models/training-plan.models.ts
@@ -37,6 +37,18 @@ export interface TrainingPlanDay {
    * the UI shows just the total target.
    */
   sets?: number[];
+  /**
+   * Catalog exercise this day prescribes. Absent ⇒ the `'pushup'`
+   * sentinel: every existing plan is a pushup plan, and Liegestütze live
+   * in the legacy `pushups` collection with no catalog entry. A present
+   * value MUST be a real `ExerciseDefinition.id` — the catalog is the
+   * single source of valid exercises and the plan spec guards this — so
+   * plans reference the same exercise catalog as goals, entries, and
+   * analysis. Resolve via {@link trainingPlanDayExerciseId}.
+   */
+  exerciseId?: string;
+  /** Optional catalog variant id (e.g. a specific plank/pushup variant). */
+  variantId?: string;
   /** Localized short description shown in the day card. */
   description: string;
 }
@@ -145,6 +157,19 @@ export function planDayByIndex(
   dayIndex: number
 ): TrainingPlanDay | null {
   return plan.days.find((d) => d.dayIndex === dayIndex) ?? null;
+}
+
+/**
+ * Catalog exercise id a plan day prescribes. Defaults to the `'pushup'`
+ * sentinel (matching `PUSHUP_QUICK_ADD_EXERCISE_ID`) when the day names no
+ * exercise, so every existing pushup plan keeps working unchanged while
+ * new plans can target any catalog exercise. The returned id is guaranteed
+ * by the plan spec to be either `'pushup'` or a real `ExerciseDefinition.id`.
+ */
+export function trainingPlanDayExerciseId(
+  day: Pick<TrainingPlanDay, 'exerciseId'>
+): string {
+  return day.exerciseId ?? 'pushup';
 }
 
 /**

--- a/web/src/app/core/quick-add-orchestration.service.ts
+++ b/web/src/app/core/quick-add-orchestration.service.ts
@@ -9,7 +9,9 @@ import {
   StatsApiService,
 } from '@pu-stats/data-access';
 import {
+  EXERCISE_CATALOG,
   type ExerciseEntryCreate,
+  findExerciseDefinition,
   PUSHUP_QUICK_ADD_EXERCISE_ID,
 } from '@pu-stats/models';
 import { nowLocalIsoTimestamp } from '@pu-stats/date';
@@ -41,48 +43,54 @@ import type {
 } from '../stats/components/training-entry-dialog/training-entry-dialog.component';
 
 /**
- * Maps the auto-count profile id to the catalog `exerciseId` used by
- * the training-entry dialog and `ExerciseFirestoreService`. `pushup`
- * is special because it lives in the legacy `pushups` collection and
- * is the only auto-count target that flows through `StatsApiService`.
+ * Resolves an auto-count pose-detector profile id to the catalog
+ * `exerciseId` used by the training-entry dialog and
+ * `ExerciseFirestoreService`. Derived from each catalog entry's
+ * `autoCountProfileId`, so the profile↔catalog mapping has a single
+ * source (the catalog) instead of a hardcoded id list duplicated here.
+ * `'pushup'` is special: it has no catalog entry (it lives in the legacy
+ * `pushups` collection), so it maps to the `PUSHUP_QUICK_ADD_EXERCISE_ID`
+ * sentinel.
  */
-const EXERCISE_CATALOG_ID: Record<
-  Exclude<AutoCountExerciseId, 'pushup'>,
-  string
-> = {
-  squat: 'legs.squats',
-  pullup: 'pull.pullups',
-  situp: 'abs.situps',
-};
+function catalogIdForAutoCountProfile(profile: AutoCountExerciseId): string {
+  if (profile === 'pushup') return PUSHUP_QUICK_ADD_EXERCISE_ID;
+  return (
+    EXERCISE_CATALOG.find((d) => d.autoCountProfileId === profile)?.id ??
+    profile
+  );
+}
 
 /**
- * Inverse of {@link EXERCISE_CATALOG_ID} — resolves a catalog exerciseId
- * (or the `'pushup'` sentinel) to the auto-count profile id understood by
- * the camera dialog. Returns `null` for catalog ids without a detector
- * profile so the dashboard can fail closed instead of opening the wrong
- * detector. Kept colocated with `EXERCISE_CATALOG_ID` so the two stay in
- * sync when a new pose profile lands.
+ * Inverse of {@link catalogIdForAutoCountProfile} — resolves a catalog
+ * exerciseId (or the `'pushup'` sentinel) to the auto-count profile the
+ * camera dialog understands, reading `autoCountProfileId` straight off the
+ * catalog. Returns `null` for catalog ids without a detector profile so
+ * the dashboard fails closed instead of opening the wrong detector.
  */
 export function autoCountProfileForCatalogId(
   catalogId: string
 ): AutoCountExerciseId | null {
   if (catalogId === PUSHUP_QUICK_ADD_EXERCISE_ID) return 'pushup';
-  if (catalogId === 'legs.squats') return 'squat';
-  if (catalogId === 'pull.pullups') return 'pullup';
-  if (catalogId === 'abs.situps') return 'situp';
-  return null;
+  return (
+    (findExerciseDefinition(catalogId)?.autoCountProfileId as
+      | AutoCountExerciseId
+      | undefined) ?? null
+  );
 }
 
 /**
- * Maps the hold-timer profile id (lives in `libs/auto-count`) to the
- * catalog `exerciseId` used by `ExerciseFirestoreService`. Plank uses
- * the legacy id that was migrated into the `core` category; hollow
- * hold lives there too.
+ * Resolves a hold-timer profile id (defined in `libs/auto-count`) to the
+ * catalog `exerciseId` used by `ExerciseFirestoreService`, derived from
+ * each catalog entry's `holdTimerProfileId`.
  */
-const HOLD_TIMER_CATALOG_ID: Record<ExerciseTimerExerciseId, string> = {
-  plank: 'plank.standard',
-  hollowhold: 'core.hollowhold',
-};
+function catalogIdForHoldTimerProfile(
+  profile: ExerciseTimerExerciseId
+): string {
+  return (
+    EXERCISE_CATALOG.find((d) => d.holdTimerProfileId === profile)?.id ??
+    profile
+  );
+}
 
 @Injectable({ providedIn: 'root' })
 export class QuickAddOrchestrationService {
@@ -293,7 +301,7 @@ export class QuickAddOrchestrationService {
     const data: ExerciseEntryDialogData = {
       kind: 'exercise',
       timestamp: nowLocalIsoTimestamp(),
-      exerciseId: HOLD_TIMER_CATALOG_ID[result.exerciseId],
+      exerciseId: catalogIdForHoldTimerProfile(result.exerciseId),
       durationSec: result.durationSec,
     };
     this.dialog
@@ -349,7 +357,7 @@ export class QuickAddOrchestrationService {
     return {
       kind: 'exercise',
       timestamp: nowLocalIsoTimestamp(),
-      exerciseId: EXERCISE_CATALOG_ID[result.exerciseId],
+      exerciseId: catalogIdForAutoCountProfile(result.exerciseId),
       reps: result.reps,
       sets: [result.reps],
     } satisfies ExerciseEntryDialogData;

--- a/web/src/app/core/quick-add-orchestration.service.ts
+++ b/web/src/app/core/quick-add-orchestration.service.ts
@@ -52,11 +52,15 @@ import type {
  * `pushups` collection), so it maps to the `PUSHUP_QUICK_ADD_EXERCISE_ID`
  * sentinel.
  */
-function catalogIdForAutoCountProfile(profile: AutoCountExerciseId): string {
+function catalogIdForAutoCountProfile(
+  profile: AutoCountExerciseId
+): string | null {
   if (profile === 'pushup') return PUSHUP_QUICK_ADD_EXERCISE_ID;
+  // Fail closed (null) on a profile with no catalog entry rather than
+  // emitting the raw profile string as an exerciseId — a non-catalog id
+  // would only fail later at save time. Callers guard before persisting.
   return (
-    EXERCISE_CATALOG.find((d) => d.autoCountProfileId === profile)?.id ??
-    profile
+    EXERCISE_CATALOG.find((d) => d.autoCountProfileId === profile)?.id ?? null
   );
 }
 
@@ -85,10 +89,10 @@ export function autoCountProfileForCatalogId(
  */
 function catalogIdForHoldTimerProfile(
   profile: ExerciseTimerExerciseId
-): string {
+): string | null {
+  // Same fail-closed contract as catalogIdForAutoCountProfile.
   return (
-    EXERCISE_CATALOG.find((d) => d.holdTimerProfileId === profile)?.id ??
-    profile
+    EXERCISE_CATALOG.find((d) => d.holdTimerProfileId === profile)?.id ?? null
   );
 }
 
@@ -296,12 +300,17 @@ export class QuickAddOrchestrationService {
   private async confirmExerciseTimer(
     result: ExerciseTimerResult
   ): Promise<void> {
+    const exerciseId = catalogIdForHoldTimerProfile(result.exerciseId);
+    if (!exerciseId) {
+      this.openErrorSnackbar();
+      return;
+    }
     const { TrainingEntryDialogComponent } =
       await import('../stats/components/training-entry-dialog/training-entry-dialog.component');
     const data: ExerciseEntryDialogData = {
       kind: 'exercise',
       timestamp: nowLocalIsoTimestamp(),
-      exerciseId: catalogIdForHoldTimerProfile(result.exerciseId),
+      exerciseId,
       durationSec: result.durationSec,
     };
     this.dialog
@@ -322,9 +331,13 @@ export class QuickAddOrchestrationService {
   }
 
   private async confirmAutoCount(result: AutoCountResult): Promise<void> {
+    const data = this.buildPrefill(result);
+    if (!data) {
+      this.openErrorSnackbar();
+      return;
+    }
     const { TrainingEntryDialogComponent } =
       await import('../stats/components/training-entry-dialog/training-entry-dialog.component');
-    const data = this.buildPrefill(result);
 
     this.dialog
       .open<
@@ -343,7 +356,9 @@ export class QuickAddOrchestrationService {
       });
   }
 
-  private buildPrefill(result: AutoCountResult): TrainingEntryDialogData {
+  private buildPrefill(
+    result: AutoCountResult
+  ): TrainingEntryDialogData | null {
     if (result.exerciseId === 'pushup') {
       return {
         kind: 'pushup',
@@ -354,10 +369,12 @@ export class QuickAddOrchestrationService {
         type: 'standard',
       } satisfies PushupEntryDialogData;
     }
+    const exerciseId = catalogIdForAutoCountProfile(result.exerciseId);
+    if (!exerciseId) return null;
     return {
       kind: 'exercise',
       timestamp: nowLocalIsoTimestamp(),
-      exerciseId: catalogIdForAutoCountProfile(result.exerciseId),
+      exerciseId,
       reps: result.reps,
       sets: [result.reps],
     } satisfies ExerciseEntryDialogData;

--- a/web/src/app/core/quick-add-orchestration.service.ts
+++ b/web/src/app/core/quick-add-orchestration.service.ts
@@ -65,21 +65,35 @@ function catalogIdForAutoCountProfile(
 }
 
 /**
+ * Runtime allowlist for the `AutoCountExerciseId` union (type-only in the
+ * dialog component) — validates a catalog `autoCountProfileId` string before
+ * it is treated as a detector profile, so an unexpected catalog value can't
+ * slip through an unchecked cast and open the dialog with an invalid id.
+ */
+function isAutoCountProfile(
+  value: string | undefined
+): value is AutoCountExerciseId {
+  return (
+    value === 'pushup' ||
+    value === 'squat' ||
+    value === 'pullup' ||
+    value === 'situp'
+  );
+}
+
+/**
  * Inverse of {@link catalogIdForAutoCountProfile} — resolves a catalog
  * exerciseId (or the `'pushup'` sentinel) to the auto-count profile the
  * camera dialog understands, reading `autoCountProfileId` straight off the
- * catalog. Returns `null` for catalog ids without a detector profile so
- * the dashboard fails closed instead of opening the wrong detector.
+ * catalog. Returns `null` for catalog ids without a valid detector profile
+ * so the dashboard fails closed instead of opening the wrong detector.
  */
 export function autoCountProfileForCatalogId(
   catalogId: string
 ): AutoCountExerciseId | null {
   if (catalogId === PUSHUP_QUICK_ADD_EXERCISE_ID) return 'pushup';
-  return (
-    (findExerciseDefinition(catalogId)?.autoCountProfileId as
-      | AutoCountExerciseId
-      | undefined) ?? null
-  );
+  const profile = findExerciseDefinition(catalogId)?.autoCountProfileId;
+  return isAutoCountProfile(profile) ? profile : null;
 }
 
 /**

--- a/web/src/app/stats/i18n/exercise-display-names.spec.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.spec.ts
@@ -88,22 +88,25 @@ describe('categoryDisplayName', () => {
 });
 
 describe('EXERCISE_DISPLAY_NAMES ⇄ EXERCISE_CATALOG', () => {
-  it('Given a catalog exercise, When looked up in EXERCISE_DISPLAY_NAMES, Then it has a localized name', () => {
-    // A catalog id without an entry silently renders its raw id
+  it('should have a localized display name for every catalog exercise', () => {
+    // given — a catalog id without an entry silently renders its raw id
     // (e.g. "abs.situps") in the stats table and history filter.
+    // when / then
     for (const def of EXERCISE_CATALOG) {
       expect(EXERCISE_DISPLAY_NAMES[def.id]).toBeTruthy();
     }
   });
 
-  it('Given an EXERCISE_DISPLAY_NAMES key, When checked against the catalog, Then no orphan ids remain', () => {
-    // Orphan entries (e.g. the old forward-compat carry/strength labels)
-    // drift from the catalog and emit dead `$localize` units. The catalog
-    // is the single source of which exercises exist.
+  it('should carry no display name for ids the catalog does not ship', () => {
+    // given — orphan entries (e.g. the old forward-compat carry/strength
+    // labels) drift from the catalog and emit dead `$localize` units; the
+    // catalog is the single source of which exercises exist.
     const catalogIds = new Set(EXERCISE_CATALOG.map((d) => d.id));
+    // when
     const orphans = Object.keys(EXERCISE_DISPLAY_NAMES).filter(
       (id) => !catalogIds.has(id)
     );
+    // then
     expect(orphans).toEqual([]);
   });
 });

--- a/web/src/app/stats/i18n/exercise-display-names.spec.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.spec.ts
@@ -1,7 +1,8 @@
-import type { ExerciseVariant } from '@pu-stats/models';
+import { EXERCISE_CATALOG, type ExerciseVariant } from '@pu-stats/models';
 
 import {
   categoryDisplayName,
+  EXERCISE_DISPLAY_NAMES,
   exerciseDisplayName,
   kindDisplayName,
   variantDisplayName,
@@ -83,5 +84,26 @@ describe('categoryDisplayName', () => {
     // entries to one of those categories before the labels ship.
     expect(categoryDisplayName('carry')).toBe('carry');
     expect(categoryDisplayName('strength')).toBe('strength');
+  });
+});
+
+describe('EXERCISE_DISPLAY_NAMES ⇄ EXERCISE_CATALOG', () => {
+  it('has a localized display name for every catalog exercise', () => {
+    // A catalog id without an entry silently renders its raw id
+    // (e.g. "abs.situps") in the stats table and history filter.
+    for (const def of EXERCISE_CATALOG) {
+      expect(EXERCISE_DISPLAY_NAMES[def.id]).toBeTruthy();
+    }
+  });
+
+  it('carries no display name for ids the catalog does not ship', () => {
+    // Orphan entries (e.g. the old forward-compat carry/strength labels)
+    // drift from the catalog and emit dead `$localize` units. The catalog
+    // is the single source of which exercises exist.
+    const catalogIds = new Set(EXERCISE_CATALOG.map((d) => d.id));
+    const orphans = Object.keys(EXERCISE_DISPLAY_NAMES).filter(
+      (id) => !catalogIds.has(id)
+    );
+    expect(orphans).toEqual([]);
   });
 });

--- a/web/src/app/stats/i18n/exercise-display-names.spec.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.spec.ts
@@ -88,7 +88,7 @@ describe('categoryDisplayName', () => {
 });
 
 describe('EXERCISE_DISPLAY_NAMES ⇄ EXERCISE_CATALOG', () => {
-  it('has a localized display name for every catalog exercise', () => {
+  it('Given a catalog exercise, When looked up in EXERCISE_DISPLAY_NAMES, Then it has a localized name', () => {
     // A catalog id without an entry silently renders its raw id
     // (e.g. "abs.situps") in the stats table and history filter.
     for (const def of EXERCISE_CATALOG) {
@@ -96,7 +96,7 @@ describe('EXERCISE_DISPLAY_NAMES ⇄ EXERCISE_CATALOG', () => {
     }
   });
 
-  it('carries no display name for ids the catalog does not ship', () => {
+  it('Given an EXERCISE_DISPLAY_NAMES key, When checked against the catalog, Then no orphan ids remain', () => {
     // Orphan entries (e.g. the old forward-compat carry/strength labels)
     // drift from the catalog and emit dead `$localize` units. The catalog
     // is the single source of which exercises exist.

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -10,8 +10,14 @@ import {
  * `$localize` calls live in this module so the angular build extractor
  * picks them up; consumers (stats table, history page filter) call
  * {@link exerciseDisplayName} to avoid duplicating the lookup table.
+ *
+ * Keys must mirror `EXERCISE_CATALOG` ids exactly. The `$localize`
+ * extraction constraint forces a literal-per-exercise registry that can't
+ * be derived from the catalog at runtime, so a spec guards this map
+ * against the catalog instead (every catalog id present; no orphan ids
+ * for exercises the catalog doesn't ship). Exported only for that guard.
  */
-const EXERCISE_DISPLAY_NAMES: Record<string, string> = {
+export const EXERCISE_DISPLAY_NAMES: Record<string, string> = {
   // core (legacy `abs.*` ids kept for data stability)
   'abs.situps': $localize`:@@exercise.abs.situps.name:Sit-ups`,
   'abs.crunches': $localize`:@@exercise.abs.crunches.name:Crunches`,
@@ -46,11 +52,6 @@ const EXERCISE_DISPLAY_NAMES: Record<string, string> = {
   'pull.deadhang': $localize`:@@exercise.pull.deadhang.name:Dead Hang`,
   'pull.facepull': $localize`:@@exercise.pull.facepull.name:Face Pull`,
 
-  // carry
-  'carry.farmer': $localize`:@@exercise.carry.farmer.name:Farmer's Walk`,
-  'carry.suitcase': $localize`:@@exercise.carry.suitcase.name:Suitcase Carry`,
-  'carry.overhead': $localize`:@@exercise.carry.overhead.name:Overhead Carry`,
-
   // cardio
   'cardio.running': $localize`:@@exercise.cardio.running.name:Laufen`,
   'cardio.walking': $localize`:@@exercise.cardio.walking.name:Gehen`,
@@ -69,14 +70,6 @@ const EXERCISE_DISPLAY_NAMES: Record<string, string> = {
   'mobility.dynamicwarmup': $localize`:@@exercise.mobility.dynamicwarmup.name:Dynamisches Aufwärmen`,
   'mobility.catcow': $localize`:@@exercise.mobility.catcow.name:Katze-Kuh`,
   'mobility.hipopener': $localize`:@@exercise.mobility.hipopener.name:Hüftöffner`,
-
-  // strength
-  'strength.benchpress': $localize`:@@exercise.strength.benchpress.name:Bankdrücken`,
-  'strength.overheadpress': $localize`:@@exercise.strength.overheadpress.name:Schulterdrücken`,
-  'strength.deadlift': $localize`:@@exercise.strength.deadlift.name:Kreuzheben`,
-  'strength.barbellsquat': $localize`:@@exercise.strength.barbellsquat.name:Langhantel-Kniebeuge`,
-  'strength.barbellrow': $localize`:@@exercise.strength.barbellrow.name:Langhantelrudern`,
-  'strength.kettlebellswing': $localize`:@@exercise.strength.kettlebellswing.name:Kettlebell Swing`,
 };
 
 export function exerciseDisplayName(id: string): string {

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -17,7 +17,7 @@ import {
  * against the catalog instead (every catalog id present; no orphan ids
  * for exercises the catalog doesn't ship). Exported only for that guard.
  */
-export const EXERCISE_DISPLAY_NAMES: Record<string, string> = {
+export const EXERCISE_DISPLAY_NAMES: Readonly<Record<string, string>> = {
   // core (legacy `abs.*` ids kept for data stability)
   'abs.situps': $localize`:@@exercise.abs.situps.name:Sit-ups`,
   'abs.crunches': $localize`:@@exercise.abs.crunches.name:Crunches`,

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -377,13 +377,10 @@ export const TrainingPlanStore = signalStore(
       if (!a || !c || a.status !== 'active') return 'noop';
       const day = planDayByIndex(c, dayIndex);
       if (!day || day.kind === 'rest' || day.targetReps <= 0) return 'noop';
-      // Only pushup plan days can be logged idempotently today: the
-      // already-logged check below and the auto-mark effect read
-      // LiveDataStore, which streams the pushup-only `pushups` collection.
-      // A non-pushup day would route reps to the wrong place, so fail
-      // closed. The plan catalog ships none yet (guarded by the plan spec);
-      // wiring per-exercise writes belongs to the multi-exercise history
-      // track.
+      // LiveDataStore streams only the legacy pushup `pushups` collection,
+      // so the already-logged check below and the auto-mark effect can
+      // reason only about pushup reps. Fail closed on any other exercise
+      // rather than logging its reps as pushups.
       if (trainingPlanDayExerciseId(day) !== 'pushup') return 'noop';
 
       const currentIdx = store.currentDayIndex();

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -29,6 +29,7 @@ import {
   startDateForTargetDay,
   TrainingPlan,
   TrainingPlanDay,
+  trainingPlanDayExerciseId,
   TRAINING_PLANS,
   UserTrainingPlan,
 } from '@pu-stats/models';
@@ -376,6 +377,14 @@ export const TrainingPlanStore = signalStore(
       if (!a || !c || a.status !== 'active') return 'noop';
       const day = planDayByIndex(c, dayIndex);
       if (!day || day.kind === 'rest' || day.targetReps <= 0) return 'noop';
+      // Only pushup plan days can be logged idempotently today: the
+      // already-logged check below and the auto-mark effect read
+      // LiveDataStore, which streams the pushup-only `pushups` collection.
+      // A non-pushup day would route reps to the wrong place, so fail
+      // closed. The plan catalog ships none yet (guarded by the plan spec);
+      // wiring per-exercise writes belongs to the multi-exercise history
+      // track.
+      if (trainingPlanDayExerciseId(day) !== 'pushup') return 'noop';
 
       const currentIdx = store.currentDayIndex();
       if (currentIdx === null || dayIndex > currentIdx) return 'noop';
@@ -561,6 +570,9 @@ export const TrainingPlanStore = signalStore(
         // status-based banner state in the UI).
         if (a.status !== 'active') return;
         if (day.kind === 'rest' || day.targetReps <= 0) return;
+        // Pushup-only, matching logPlanDay: don't auto-mark a non-pushup
+        // day off pushup reps streamed from LiveDataStore.
+        if (trainingPlanDayExerciseId(day) !== 'pushup') return;
         if (a.completedDays.includes(idx)) return;
         // Same readiness guard as `logPlanDay` — without this, a
         // pre-sync `_live.entries()` could appear to satisfy the


### PR DESCRIPTION
## Ziel

Sicherstellen, dass `EXERCISE_CATALOG` / `EXERCISE_CATEGORIES` in `@pu-stats/models` die **einzige** Quelle für verfügbare Übungen und Kategorien sind — konsistent über Tagesziele, User-Einträge, Analyse/Statistik **und** Trainingspläne. Die Quelle existierte bereits und war von Zielen/Einträgen/Analyse genutzt; sie hatte aber un-synchronisierte Schatten-Kopien (Drift-Gefahr) und die Trainingspläne hingen gar nicht dran.

Kein Big-Bang-Umbau, keine Datenmigration — die Pushup-Vereinheitlichung (Phase 7) bleibt bewusst außen vor.

## Was sich ändert (6 Commits)

**Härten — die Schatten-Kopien drift-sicher an den Katalog binden:**

1. **`firestore.rules` ⇄ Katalog** — ein Guard-Test (`exercise-rules-sync.spec.ts`) erzwingt, dass die `isRepsExerciseId` / `isTimeExerciseId` / `isDistanceTimeExerciseId`-Allowlists exakt den Katalog-Ids je Measurement entsprechen. Vorher nur ein „keep in sync"-Kommentar → eine neue Übung hätte still zu `permission-denied` beim Speichern geführt.
2. **Leaderboard-Aggregation** — die Measurement→Feld-Routing-Helfer (`supportsLeaderboard` / `valueFieldForMeasurement`) lagen inline im nebenwirkungsbehafteten `index.ts` (in Tests nicht importierbar). Nach `exercise-leaderboard/logic.ts` verschoben (`supportsExerciseLeaderboard` / `exerciseValueFieldFor`), den falschen „CF kann nicht von models abhängen"-Kommentar korrigiert (tut es längst), Guard-Test ergänzt.
3. **i18n-Display-Namen** — `EXERCISE_DISPLAY_NAMES` an den Katalog gebunden (Spec: jede Katalog-Id hat einen Namen, keine Orphans). 9 tote `carry.*` / `strength.*`-Einträge entfernt, die es im Katalog nicht gibt.
4. **Auto-Count / Hold-Timer** — `autoCountProfileId` / `holdTimerProfileId` als Capability-Felder am `ExerciseDefinition` eingeführt; die 4 hardcodierten Web-Maps leiten sich jetzt daraus ab (keine doppelten Katalog-Ids mehr im Feature-Layer). Bestehende Orchestration-Tests (squat→legs.squats, plank→plank.standard, …) belegen Verhaltensgleichheit.

**Anbinden:**

5. **Trainingspläne** — `TrainingPlanDay` bekommt optionales `exerciseId` / `variantId` + `trainingPlanDayExerciseId()` (Default `'pushup'`). Eine Spec erzwingt referenzielle Integrität gegen den Katalog. `logPlanDay` + Auto-Mark konsultieren den Helfer; Pushup-Pfad ist byte-identisch, Nicht-Pushup-Tage failen sicher (LiveDataStore ist heute pushup-only — per-Übung-Logging ist der „Historie für alle Übungen"-Track).

6. **Docs** — `architecture.md` Abschnitt „Single source of truth" + Drift-Guard-Tabelle.

## Bewusst nicht enthalten

- **Pushup-Vereinheitlichung** (`'pushup'` als echter Katalog-Eintrag) + Firestore-Migration — Roadmap Phase 7, eigenes Risiko/PR.
- **Per-Übung-Trainingspläne loggen** — braucht erst, dass `LiveDataStore` Nicht-Pushup-Einträge führt (per-exercise history track). Das Modell ist jetzt katalog-bereit dafür.
- Die entfernten `$localize`-Units bleiben in den generierten `messages.*.xlf`, bis die nächste extract-i18n/Translations-Routine sie beim Merge nach `main` aufräumt (nichts referenziert sie → Build unberührt).

## Tests / Checks

- `nx affected -t lint,test --base=main`: ✅ 15 Projekte
- `nx build cloud-functions`: ✅
- `nx build web -c production`: ✅ (2840 Routen prerendered; nur vorbestehende Bundle-Budget/grpc-Warnungen)

Neue Guard-Specs: `exercise-rules-sync`, `catalog-coupling`, erweiterte `exercise.catalog`, `exercise-display-names`, `training-plan.models`.

https://claude.ai/code/session_01XnSg9hn1foYu8wqn5qnmma

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnSg9hn1foYu8wqn5qnmma)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auto-count and hold-timer support for situps, squats, pullups, planks and related exercises; enhanced exercise leaderboard measurement handling; added exercise-specific training plan options.

* **Behavior Changes**
  * Quick-add/confirm flows now validate catalog mappings and surface an error if unmapped; training-plan logging/auto-marking restricted to pushup-designated days; some display-name keys now fall through to catalog lookup.

* **Documentation**
  * Added architecture guidance on single-source exercise catalog and tooling gotchas.

* **Tests**
  * New guard tests to keep catalog, rules, display names, and leaderboard mappings synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->