### PR TITLE
feat(admin): registry-driven data-migrations panel (#442)

### DIFF
--- a/web/src/app/admin/admin-page.component.ts
+++ b/web/src/app/admin/admin-page.component.ts
@@ -27,6 +27,8 @@ import { DeleteUserDialogComponent } from './delete-user-dialog.component';
 import { DeleteFeedbackDialogComponent } from './delete-feedback-dialog.component';
 import { UserDetailsDialogComponent } from './user-details-dialog.component';
 import { PageHeaderComponent } from '../core/page-header/page-header.component';
+import { MigrationCardComponent } from './migrations/migration-card.component';
+import { DATA_MIGRATIONS } from './migrations/migration-descriptors';
 
 export interface AdminUser {
   uid: string;
@@ -70,6 +72,7 @@ interface AdminFeedback {
     MatTooltipModule,
     MatSlideToggleModule,
     PageHeaderComponent,
+    MigrationCardComponent,
   ],
   template: `
     <div class="admin-page">
@@ -79,6 +82,14 @@ interface AdminFeedback {
           Nutzerverwaltung, Feedback und Bereinigungen.
         </p>
       </app-page-header>
+
+      <!-- Data migrations -->
+      <section class="migrations-section">
+        <h2 i18n="@@admin.migrations.title">Daten-Migrationen</h2>
+        @for (migration of dataMigrations; track migration.id) {
+          <app-migration-card [migration]="migration" />
+        }
+      </section>
 
       <!-- Bulk action card -->
       <mat-card class="bulk-card">
@@ -549,6 +560,7 @@ export class AdminPageComponent {
   readonly createIssueTooltip = $localize`:@@admin.feedback.createIssue:GitHub-Issue erstellen`;
   readonly openIssueTooltip = $localize`:@@admin.feedback.openIssue:GitHub-Issue öffnen`;
   readonly deleteFeedbackTooltip = $localize`:@@admin.feedback.delete:Feedback löschen`;
+  readonly dataMigrations = DATA_MIGRATIONS;
   readonly loading = signal(false);
   readonly error = signal<string | null>(null);
   readonly users = signal<AdminUser[]>([]);

--- a/web/src/app/admin/migrations/migration-card.component.spec.ts
+++ b/web/src/app/admin/migrations/migration-card.component.spec.ts
@@ -96,7 +96,8 @@ describe('MigrationCardComponent', () => {
     // then the callable is invoked with dryRun:true and counters render
     expect(httpsCallable).toHaveBeenCalledWith(
       expect.anything(),
-      'migratePushupsToExerciseEntries'
+      'migratePushupsToExerciseEntries',
+      expect.objectContaining({ timeout: expect.any(Number) })
     );
     const text = fixture.nativeElement.textContent ?? '';
     expect(text).toContain('wouldCopy');
@@ -171,7 +172,8 @@ describe('MigrationCardComponent', () => {
     // then the rollback callable is invoked and its counter renders
     expect(httpsCallable).toHaveBeenCalledWith(
       expect.anything(),
-      'rollbackPushupUnification'
+      'rollbackPushupUnification',
+      expect.objectContaining({ timeout: expect.any(Number) })
     );
     expect(fixture.nativeElement.textContent).toContain('wouldDelete');
   });

--- a/web/src/app/admin/migrations/migration-card.component.spec.ts
+++ b/web/src/app/admin/migrations/migration-card.component.spec.ts
@@ -1,0 +1,201 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Functions, httpsCallable } from '@angular/fire/functions';
+import { MigrationCardComponent } from './migration-card.component';
+import { MigrationDescriptor } from './migration-descriptors';
+
+vi.mock('@angular/fire/functions', () => ({
+  Functions: class {},
+  httpsCallable: vi.fn(),
+}));
+
+interface CallableRecord {
+  name: string;
+  impl: (data: unknown) => Promise<{ data: unknown }>;
+}
+
+function setupCallables(records: CallableRecord[]): void {
+  vi.mocked(httpsCallable).mockImplementation(
+    (_functions: Functions, name: string) => {
+      const match = records.find((r) => r.name === name);
+      if (!match) {
+        return (async () => {
+          throw new Error(`Unexpected callable: ${name}`);
+        }) as unknown as ReturnType<typeof httpsCallable>;
+      }
+      return match.impl as unknown as ReturnType<typeof httpsCallable>;
+    }
+  );
+}
+
+const WITH_ROLLBACK: MigrationDescriptor = {
+  id: 'pushup-unification',
+  title: 'Liegestütze vereinheitlichen',
+  description: 'Kopiert pushups nach exerciseEntries.',
+  migrate: { callable: 'migratePushupsToExerciseEntries' },
+  rollback: { callable: 'rollbackPushupUnification' },
+};
+
+describe('MigrationCardComponent', () => {
+  let fixture: ComponentFixture<MigrationCardComponent>;
+  let component: MigrationCardComponent;
+
+  async function createComponent(
+    migration: MigrationDescriptor,
+    callables: CallableRecord[]
+  ): Promise<void> {
+    setupCallables(callables);
+    await TestBed.configureTestingModule({
+      imports: [MigrationCardComponent],
+      providers: [{ provide: Functions, useValue: {} }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MigrationCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('migration', migration);
+    fixture.detectChanges();
+  }
+
+  /** Click the button whose visible label matches `label`. */
+  async function clickButton(label: string): Promise<void> {
+    const button = fixture.debugElement
+      .queryAll(By.css('button'))
+      .find((b) => (b.nativeElement.textContent ?? '').includes(label));
+    if (!button) throw new Error(`Button not found: ${label}`);
+    button.nativeElement.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  function buttonByLabel(label: string): HTMLButtonElement {
+    const button = fixture.debugElement
+      .queryAll(By.css('button'))
+      .find((b) => (b.nativeElement.textContent ?? '').includes(label));
+    if (!button) throw new Error(`Button not found: ${label}`);
+    return button.nativeElement as HTMLButtonElement;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should run a dry-run migrate and render the returned counters', async () => {
+    // given a migration whose dry-run reports what it would copy
+    await createComponent(WITH_ROLLBACK, [
+      {
+        name: 'migratePushupsToExerciseEntries',
+        impl: async () => ({
+          data: { dryRun: true, wouldCopy: 12, wouldSkipExisting: 0 },
+        }),
+      },
+    ]);
+
+    // when the operator clicks the migrate "Probelauf"
+    await clickButton('Probelauf');
+
+    // then the callable is invoked with dryRun:true and counters render
+    expect(httpsCallable).toHaveBeenCalledWith(
+      expect.anything(),
+      'migratePushupsToExerciseEntries'
+    );
+    const text = fixture.nativeElement.textContent ?? '';
+    expect(text).toContain('wouldCopy');
+    expect(text).toContain('12');
+  });
+
+  it('should keep the live migrate run disabled until a dry-run completes', async () => {
+    // given a migration whose callable records the dryRun flag it received
+    const calls: boolean[] = [];
+    await createComponent(WITH_ROLLBACK, [
+      {
+        name: 'migratePushupsToExerciseEntries',
+        impl: async (data) => {
+          calls.push((data as { dryRun: boolean }).dryRun);
+          return { data: { copied: 12 } };
+        },
+      },
+    ]);
+
+    // then the live "Ausführen" button starts disabled
+    expect(buttonByLabel('Ausführen').disabled).toBe(true);
+
+    // when a dry-run completes
+    await clickButton('Probelauf');
+
+    // then the live run is unlocked
+    expect(buttonByLabel('Ausführen').disabled).toBe(false);
+
+    // when the operator runs it for real
+    await clickButton('Ausführen');
+
+    // then the callable was called dry first, then live
+    expect(calls).toEqual([true, false]);
+  });
+
+  it('should surface a callable error', async () => {
+    // given a callable that rejects
+    await createComponent(WITH_ROLLBACK, [
+      {
+        name: 'migratePushupsToExerciseEntries',
+        impl: async () => {
+          throw new Error('permission-denied');
+        },
+      },
+    ]);
+
+    // when the dry-run is attempted
+    await clickButton('Probelauf');
+
+    // then the error message is shown
+    expect(fixture.nativeElement.textContent).toContain('permission-denied');
+  });
+
+  it('should render a rollback action when the descriptor declares one', async () => {
+    // given a descriptor with a rollback callable
+    await createComponent(WITH_ROLLBACK, [
+      {
+        name: 'rollbackPushupUnification',
+        impl: async () => ({ data: { dryRun: true, wouldDelete: 5 } }),
+      },
+    ]);
+
+    // when the rollback dry-run runs (second "Probelauf" group)
+    const dryRunButtons = fixture.debugElement
+      .queryAll(By.css('button'))
+      .filter((b) => (b.nativeElement.textContent ?? '').includes('Probelauf'));
+    expect(dryRunButtons.length).toBe(2);
+    dryRunButtons[1].nativeElement.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // then the rollback callable is invoked and its counter renders
+    expect(httpsCallable).toHaveBeenCalledWith(
+      expect.anything(),
+      'rollbackPushupUnification'
+    );
+    expect(fixture.nativeElement.textContent).toContain('wouldDelete');
+  });
+
+  it('should not render a rollback action when the descriptor omits one', async () => {
+    // given a migration without a rollback callable
+    const noRollback: MigrationDescriptor = {
+      id: 'one-way',
+      title: 'Einbahn-Migration',
+      description: 'Keine Umkehr.',
+      migrate: { callable: 'migratePushupsToExerciseEntries' },
+    };
+    await createComponent(noRollback, [
+      {
+        name: 'migratePushupsToExerciseEntries',
+        impl: async () => ({ data: { copied: 1 } }),
+      },
+    ]);
+
+    // then only the single (migrate) dry-run button exists
+    const dryRunButtons = fixture.debugElement
+      .queryAll(By.css('button'))
+      .filter((b) => (b.nativeElement.textContent ?? '').includes('Probelauf'));
+    expect(dryRunButtons.length).toBe(1);
+    expect(component.migration().rollback).toBeUndefined();
+  });
+});

--- a/web/src/app/admin/migrations/migration-card.component.ts
+++ b/web/src/app/admin/migrations/migration-card.component.ts
@@ -13,7 +13,15 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import {
   MigrationActionKind,
   MigrationDescriptor,
+  MigrationResult,
 } from './migration-descriptors';
+
+/**
+ * Migration callables can read the whole source collection and write in
+ * batches; the server functions allow up to 540s. The Functions SDK default
+ * (70s) would abort a real run client-side, so match the server budget.
+ */
+const MIGRATION_CALLABLE_TIMEOUT_MS = 540_000;
 
 interface ActionState {
   busy: boolean;
@@ -23,7 +31,7 @@ interface ActionState {
    * the UI enforces it rather than relying on the operator to remember.
    */
   dryRunDone: boolean;
-  result: Record<string, unknown> | null;
+  result: MigrationResult | null;
   error: string | null;
 }
 
@@ -184,7 +192,9 @@ export class MigrationCardComponent {
     return this.state()[kind];
   }
 
-  resultEntries(kind: MigrationActionKind): { key: string; value: unknown }[] {
+  resultEntries(
+    kind: MigrationActionKind
+  ): { key: string; value: number | boolean }[] {
     const result = this.state()[kind].result;
     if (!result) return [];
     return Object.entries(result).map(([key, value]) => ({ key, value }));
@@ -197,9 +207,10 @@ export class MigrationCardComponent {
 
     this.patch(kind, { busy: true, error: null, result: null });
     try {
-      const fn = httpsCallable<{ dryRun: boolean }, Record<string, unknown>>(
+      const fn = httpsCallable<{ dryRun: boolean }, MigrationResult>(
         this.functions,
-        action.callable
+        action.callable,
+        { timeout: MIGRATION_CALLABLE_TIMEOUT_MS }
       );
       const response = await fn({ dryRun });
       this.patch(kind, {

--- a/web/src/app/admin/migrations/migration-card.component.ts
+++ b/web/src/app/admin/migrations/migration-card.component.ts
@@ -1,0 +1,228 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { Functions, httpsCallable } from '@angular/fire/functions';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import {
+  MigrationActionKind,
+  MigrationDescriptor,
+} from './migration-descriptors';
+
+interface ActionState {
+  busy: boolean;
+  /**
+   * A live (non-dry) run stays disabled until a dry-run for the same action
+   * has completed in this session — the runbook mandates "dry-run first", so
+   * the UI enforces it rather than relying on the operator to remember.
+   */
+  dryRunDone: boolean;
+  result: Record<string, unknown> | null;
+  error: string | null;
+}
+
+const IDLE: ActionState = {
+  busy: false,
+  dryRunDone: false,
+  result: null,
+  error: null,
+};
+
+@Component({
+  selector: 'app-migration-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatButtonModule,
+    MatCardModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+  ],
+  template: `
+    <mat-card class="migration-card">
+      <mat-card-header>
+        <mat-card-title>{{ migration().title }}</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <p class="migration-description">{{ migration().description }}</p>
+
+        <div class="migration-action">
+          <h4 i18n="@@admin.migrations.action.migrate">Migrieren</h4>
+          @let migrateState = actionState('migrate');
+          <div class="migration-buttons">
+            <button
+              mat-stroked-button
+              [disabled]="migrateState.busy"
+              (click)="run('migrate', true)"
+            >
+              <mat-icon>science</mat-icon>
+              <span i18n="@@admin.migrations.dryRun">Probelauf</span>
+            </button>
+            <button
+              mat-flat-button
+              color="warn"
+              [disabled]="migrateState.busy || !migrateState.dryRunDone"
+              (click)="run('migrate', false)"
+            >
+              <mat-icon>play_arrow</mat-icon>
+              <span i18n="@@admin.migrations.run">Ausführen</span>
+            </button>
+            @if (migrateState.busy) {
+              <mat-spinner diameter="20" />
+            }
+          </div>
+          @if (resultEntries('migrate'); as entries) {
+            @if (entries.length) {
+              <ul class="migration-result">
+                @for (entry of entries; track entry.key) {
+                  <li>
+                    <code>{{ entry.key }}</code
+                    >: {{ entry.value }}
+                  </li>
+                }
+              </ul>
+            }
+          }
+          @if (migrateState.error) {
+            <p class="error-text">{{ migrateState.error }}</p>
+          }
+        </div>
+
+        @if (migration().rollback) {
+          <div class="migration-action">
+            <h4 i18n="@@admin.migrations.action.rollback">Rückgängig</h4>
+            @let rollbackState = actionState('rollback');
+            <div class="migration-buttons">
+              <button
+                mat-stroked-button
+                [disabled]="rollbackState.busy"
+                (click)="run('rollback', true)"
+              >
+                <mat-icon>science</mat-icon>
+                <span i18n="@@admin.migrations.dryRun">Probelauf</span>
+              </button>
+              <button
+                mat-flat-button
+                color="warn"
+                [disabled]="rollbackState.busy || !rollbackState.dryRunDone"
+                (click)="run('rollback', false)"
+              >
+                <mat-icon>undo</mat-icon>
+                <span i18n="@@admin.migrations.run">Ausführen</span>
+              </button>
+              @if (rollbackState.busy) {
+                <mat-spinner diameter="20" />
+              }
+            </div>
+            @if (resultEntries('rollback'); as entries) {
+              @if (entries.length) {
+                <ul class="migration-result">
+                  @for (entry of entries; track entry.key) {
+                    <li>
+                      <code>{{ entry.key }}</code
+                      >: {{ entry.value }}
+                    </li>
+                  }
+                </ul>
+              }
+            }
+            @if (rollbackState.error) {
+              <p class="error-text">{{ rollbackState.error }}</p>
+            }
+          </div>
+        }
+      </mat-card-content>
+    </mat-card>
+  `,
+  styles: [
+    `
+      .migration-card {
+        margin-bottom: 1rem;
+      }
+      .migration-description {
+        color: var(--mat-sys-on-surface-variant);
+      }
+      .migration-action {
+        margin-top: 1rem;
+      }
+      .migration-action h4 {
+        margin: 0 0 0.5rem;
+      }
+      .migration-buttons {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+      .migration-result {
+        margin: 0.5rem 0 0;
+        padding-left: 1.25rem;
+      }
+      .error-text {
+        color: var(--mat-sys-error);
+      }
+    `,
+  ],
+})
+export class MigrationCardComponent {
+  private readonly functions = inject(Functions);
+
+  readonly migration = input.required<MigrationDescriptor>();
+
+  private readonly state = signal<Record<MigrationActionKind, ActionState>>({
+    migrate: { ...IDLE },
+    rollback: { ...IDLE },
+  });
+
+  /** Reactive per-action state; reads the signal so the template stays live. */
+  actionState(kind: MigrationActionKind): ActionState {
+    return this.state()[kind];
+  }
+
+  resultEntries(kind: MigrationActionKind): { key: string; value: unknown }[] {
+    const result = this.state()[kind].result;
+    if (!result) return [];
+    return Object.entries(result).map(([key, value]) => ({ key, value }));
+  }
+
+  async run(kind: MigrationActionKind, dryRun: boolean): Promise<void> {
+    const action =
+      kind === 'migrate' ? this.migration().migrate : this.migration().rollback;
+    if (!action) return;
+
+    this.patch(kind, { busy: true, error: null, result: null });
+    try {
+      const fn = httpsCallable<{ dryRun: boolean }, Record<string, unknown>>(
+        this.functions,
+        action.callable
+      );
+      const response = await fn({ dryRun });
+      this.patch(kind, {
+        busy: false,
+        result: response.data,
+        // Unlock the live run only after a successful dry-run.
+        ...(dryRun ? { dryRunDone: true } : {}),
+      });
+    } catch (err) {
+      this.patch(kind, {
+        busy: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private patch(
+    kind: MigrationActionKind,
+    partial: Partial<ActionState>
+  ): void {
+    this.state.update((current) => ({
+      ...current,
+      [kind]: { ...current[kind], ...partial },
+    }));
+  }
+}

--- a/web/src/app/admin/migrations/migration-descriptors.ts
+++ b/web/src/app/admin/migrations/migration-descriptors.ts
@@ -1,0 +1,49 @@
+/**
+ * Registry of admin-triggerable data migrations rendered by the admin page's
+ * "Daten-Migrationen" section (one {@link MigrationCardComponent} per entry).
+ *
+ * Each entry binds a human title/description to the deployed `onCall` Cloud
+ * Function(s) that perform the migration. The migration runner contract is
+ * deliberately uniform — every callable takes `{ dryRun: boolean }` and
+ * returns a flat object of numeric counters — so the card can drive any
+ * future migration without bespoke UI. Adding a migration is a descriptor
+ * entry here plus its callable; no component changes required.
+ */
+
+export type MigrationActionKind = 'migrate' | 'rollback';
+
+export interface MigrationAction {
+  /**
+   * Name of the deployed `onCall` Cloud Function. Invoked as
+   * `httpsCallable(functions, callable)({ dryRun })` and expected to return a
+   * flat record of numeric counters (rendered generically by the card).
+   */
+  callable: string;
+}
+
+export interface MigrationDescriptor {
+  /** Stable identifier; used as the list `track` key. */
+  id: string;
+  /** Card heading (German source — admin-only internal tooling). */
+  title: string;
+  /** One-line summary of what the forward migration does. */
+  description: string;
+  /** Forward migration callable. */
+  migrate: MigrationAction;
+  /** Optional reverse callable that undoes the forward run. */
+  rollback?: MigrationAction;
+}
+
+export const DATA_MIGRATIONS: readonly MigrationDescriptor[] = [
+  {
+    id: 'pushup-unification',
+    title: 'Liegestütze vereinheitlichen (pushups → exerciseEntries)',
+    description:
+      'Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ ' +
+      '(exerciseId:"pushup", migratedFrom:"pushups"). Idempotent, lässt die ' +
+      'Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst ' +
+      'den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.',
+    migrate: { callable: 'migratePushupsToExerciseEntries' },
+    rollback: { callable: 'rollbackPushupUnification' },
+  },
+];

--- a/web/src/app/admin/migrations/migration-descriptors.ts
+++ b/web/src/app/admin/migrations/migration-descriptors.ts
@@ -5,18 +5,27 @@
  * Each entry binds a human title/description to the deployed `onCall` Cloud
  * Function(s) that perform the migration. The migration runner contract is
  * deliberately uniform — every callable takes `{ dryRun: boolean }` and
- * returns a flat object of numeric counters — so the card can drive any
- * future migration without bespoke UI. Adding a migration is a descriptor
- * entry here plus its callable; no component changes required.
+ * returns a flat {@link MigrationResult} of primitive counters/flags — so the
+ * card can drive any future migration without bespoke UI. Adding a migration
+ * is a descriptor entry here plus its callable; no component changes required.
  */
 
 export type MigrationActionKind = 'migrate' | 'rollback';
+
+/**
+ * Uniform return shape of a migration callable: a flat record of primitives —
+ * numeric counters (e.g. `wouldCopy`/`copied`/`deleted`) plus the echoed
+ * `dryRun` flag. Open over keys so any future migration's counters render
+ * generically, but pinned to primitives so the card never renders a nested
+ * object.
+ */
+export type MigrationResult = Record<string, number | boolean>;
 
 export interface MigrationAction {
   /**
    * Name of the deployed `onCall` Cloud Function. Invoked as
    * `httpsCallable(functions, callable)({ dryRun })` and expected to return a
-   * flat record of numeric counters (rendered generically by the card).
+   * flat {@link MigrationResult} (rendered generically by the card).
    */
   callable: string;
 }
@@ -24,7 +33,7 @@ export interface MigrationAction {
 export interface MigrationDescriptor {
   /** Stable identifier; used as the list `track` key. */
   id: string;
-  /** Card heading (German source — admin-only internal tooling). */
+  /** Card heading. */
   title: string;
   /** One-line summary of what the forward migration does. */
   description: string;
@@ -37,12 +46,8 @@ export interface MigrationDescriptor {
 export const DATA_MIGRATIONS: readonly MigrationDescriptor[] = [
   {
     id: 'pushup-unification',
-    title: 'Liegestütze vereinheitlichen (pushups → exerciseEntries)',
-    description:
-      'Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ ' +
-      '(exerciseId:"pushup", migratedFrom:"pushups"). Idempotent, lässt die ' +
-      'Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst ' +
-      'den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.',
+    title: $localize`:@@admin.migrations.pushupUnification.title:Liegestütze vereinheitlichen (pushups → exerciseEntries)`,
+    description: $localize`:@@admin.migrations.pushupUnification.description:Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:"pushup", migratedFrom:"pushups"). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.`,
     migrate: { callable: 'migratePushupsToExerciseEntries' },
     rollback: { callable: 'rollbackPushupUnification' },
   },

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9955,5 +9955,35 @@
         <target>Εμφάνιση λεπτομερειών ημερήσιου στόχου</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.title">
+      <segment state="initial">
+        <source>Daten-Migrationen</source>
+        <target>Daten-Migrationen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.migrate">
+      <segment state="initial">
+        <source>Migrieren</source>
+        <target>Migrieren</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.dryRun">
+      <segment state="initial">
+        <source>Probelauf</source>
+        <target>Probelauf</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.run">
+      <segment state="initial">
+        <source>Ausführen</source>
+        <target>Ausführen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.rollback">
+      <segment state="initial">
+        <source>Rückgängig</source>
+        <target>Rückgängig</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9985,5 +9985,17 @@
         <target>Rückgängig</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.pushupUnification.title">
+      <segment state="initial">
+        <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
+        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupUnification.description">
+      <segment state="initial">
+        <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
+        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10121,5 +10121,35 @@ Deine Position: # ·  Reps        </source>
         <target>Show daily goal details</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.title">
+      <segment state="initial">
+        <source>Daten-Migrationen</source>
+        <target>Daten-Migrationen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.migrate">
+      <segment state="initial">
+        <source>Migrieren</source>
+        <target>Migrieren</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.dryRun">
+      <segment state="initial">
+        <source>Probelauf</source>
+        <target>Probelauf</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.run">
+      <segment state="initial">
+        <source>Ausführen</source>
+        <target>Ausführen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.rollback">
+      <segment state="initial">
+        <source>Rückgängig</source>
+        <target>Rückgängig</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10151,5 +10151,17 @@ Deine Position: # ·  Reps        </source>
         <target>Rückgängig</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.pushupUnification.title">
+      <segment state="initial">
+        <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
+        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupUnification.description">
+      <segment state="initial">
+        <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
+        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9981,5 +9981,17 @@
         <target>Rückgängig</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.pushupUnification.title">
+      <segment state="initial">
+        <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
+        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupUnification.description">
+      <segment state="initial">
+        <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
+        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9951,5 +9951,35 @@
         <target>Ver detalles del objetivo diario</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.title">
+      <segment state="initial">
+        <source>Daten-Migrationen</source>
+        <target>Daten-Migrationen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.migrate">
+      <segment state="initial">
+        <source>Migrieren</source>
+        <target>Migrieren</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.dryRun">
+      <segment state="initial">
+        <source>Probelauf</source>
+        <target>Probelauf</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.run">
+      <segment state="initial">
+        <source>Ausführen</source>
+        <target>Ausführen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.rollback">
+      <segment state="initial">
+        <source>Rückgängig</source>
+        <target>Rückgängig</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9827,5 +9827,35 @@
         <target>Afficher les détails de l'objectif quotidien</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.title">
+      <segment state="initial">
+        <source>Daten-Migrationen</source>
+        <target>Daten-Migrationen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.migrate">
+      <segment state="initial">
+        <source>Migrieren</source>
+        <target>Migrieren</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.dryRun">
+      <segment state="initial">
+        <source>Probelauf</source>
+        <target>Probelauf</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.run">
+      <segment state="initial">
+        <source>Ausführen</source>
+        <target>Ausführen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.rollback">
+      <segment state="initial">
+        <source>Rückgängig</source>
+        <target>Rückgängig</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9857,5 +9857,17 @@
         <target>Rückgängig</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.pushupUnification.title">
+      <segment state="initial">
+        <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
+        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupUnification.description">
+      <segment state="initial">
+        <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
+        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9955,5 +9955,35 @@
         <target>Mostra i dettagli dell'obiettivo giornaliero</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.title">
+      <segment state="initial">
+        <source>Daten-Migrationen</source>
+        <target>Daten-Migrationen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.migrate">
+      <segment state="initial">
+        <source>Migrieren</source>
+        <target>Migrieren</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.dryRun">
+      <segment state="initial">
+        <source>Probelauf</source>
+        <target>Probelauf</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.run">
+      <segment state="initial">
+        <source>Ausführen</source>
+        <target>Ausführen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.rollback">
+      <segment state="initial">
+        <source>Rückgängig</source>
+        <target>Rückgängig</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9985,5 +9985,17 @@
         <target>Rückgängig</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.pushupUnification.title">
+      <segment state="initial">
+        <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
+        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupUnification.description">
+      <segment state="initial">
+        <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
+        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9955,5 +9955,35 @@
         <target>Singulas partes propositi diurni ostendere</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.title">
+      <segment state="initial">
+        <source>Daten-Migrationen</source>
+        <target>Daten-Migrationen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.migrate">
+      <segment state="initial">
+        <source>Migrieren</source>
+        <target>Migrieren</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.dryRun">
+      <segment state="initial">
+        <source>Probelauf</source>
+        <target>Probelauf</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.run">
+      <segment state="initial">
+        <source>Ausführen</source>
+        <target>Ausführen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.rollback">
+      <segment state="initial">
+        <source>Rückgängig</source>
+        <target>Rückgängig</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9985,5 +9985,17 @@
         <target>Rückgängig</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.pushupUnification.title">
+      <segment state="initial">
+        <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
+        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupUnification.description">
+      <segment state="initial">
+        <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
+        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9985,5 +9985,17 @@
         <target>Rückgängig</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.pushupUnification.title">
+      <segment state="initial">
+        <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
+        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupUnification.description">
+      <segment state="initial">
+        <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
+        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9955,5 +9955,35 @@
         <target>Dagelijkse doeldetails weergeven</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.title">
+      <segment state="initial">
+        <source>Daten-Migrationen</source>
+        <target>Daten-Migrationen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.migrate">
+      <segment state="initial">
+        <source>Migrieren</source>
+        <target>Migrieren</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.dryRun">
+      <segment state="initial">
+        <source>Probelauf</source>
+        <target>Probelauf</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.run">
+      <segment state="initial">
+        <source>Ausführen</source>
+        <target>Ausführen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.rollback">
+      <segment state="initial">
+        <source>Rückgängig</source>
+        <target>Rückgängig</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9215,5 +9215,35 @@ Deine Position: # ·  Reps        </source>
         <target>Vis detaljer for daglig mål</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.title">
+      <segment state="initial">
+        <source>Daten-Migrationen</source>
+        <target>Daten-Migrationen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.migrate">
+      <segment state="initial">
+        <source>Migrieren</source>
+        <target>Migrieren</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.dryRun">
+      <segment state="initial">
+        <source>Probelauf</source>
+        <target>Probelauf</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.run">
+      <segment state="initial">
+        <source>Ausführen</source>
+        <target>Ausführen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.rollback">
+      <segment state="initial">
+        <source>Rückgängig</source>
+        <target>Rückgängig</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9245,5 +9245,17 @@ Deine Position: # ·  Reps        </source>
         <target>Rückgängig</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.pushupUnification.title">
+      <segment state="initial">
+        <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
+        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupUnification.description">
+      <segment state="initial">
+        <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
+        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2678,7 +2678,7 @@
     </unit>
     <unit id="adminHeaderTitle">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:77,78</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:80,81</note>
       </notes>
       <segment>
         <source>Admin-Bereich</source>
@@ -2686,15 +2686,23 @@
     </unit>
     <unit id="adminHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:79,81</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:82,84</note>
       </notes>
       <segment>
         <source> Nutzerverwaltung, Feedback und Bereinigungen. </source>
       </segment>
     </unit>
+    <unit id="admin.migrations.title">
+      <notes>
+        <note category="location">web/src/app/admin/admin-page.component.ts:88,89</note>
+      </notes>
+      <segment>
+        <source>Daten-Migrationen</source>
+      </segment>
+    </unit>
     <unit id="admin.bulk.title">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:87,89</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:98,100</note>
       </notes>
       <segment>
         <source>Anonyme Benutzer aufräumen</source>
@@ -2702,7 +2710,7 @@
     </unit>
     <unit id="admin.bulk.daysLabel">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:93,95</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:104,106</note>
       </notes>
       <segment>
         <source>Inaktiv seit (Tage)</source>
@@ -2710,7 +2718,7 @@
     </unit>
     <unit id="admin.bulk.hint">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:104,107</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:115,118</note>
       </notes>
       <segment>
         <source> Löscht anonyme Benutzer ohne Pushups in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}"/> Tagen. </source>
@@ -2718,7 +2726,7 @@
     </unit>
     <unit id="admin.bulk.button">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:120,121</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:131,132</note>
       </notes>
       <segment>
         <source>Inaktive löschen</source>
@@ -2726,7 +2734,7 @@
     </unit>
     <unit id="admin.bulk.deleted">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:128,129</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:139,140</note>
       </notes>
       <segment>
         <source>Gelöscht:</source>
@@ -2734,7 +2742,7 @@
     </unit>
     <unit id="admin.bulk.skipped">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:130,131</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:141,142</note>
       </notes>
       <segment>
         <source>Übersprungen:</source>
@@ -2742,7 +2750,7 @@
     </unit>
     <unit id="admin.filter.anonymous">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:149,150</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:160,161</note>
       </notes>
       <segment>
         <source> Nur anonyme Benutzer </source>
@@ -2750,7 +2758,7 @@
     </unit>
     <unit id="admin.col.uid">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:176,177</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:187,188</note>
       </notes>
       <segment>
         <source>UID</source>
@@ -2758,7 +2766,7 @@
     </unit>
     <unit id="admin.col.name">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:191,192</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:202,203</note>
       </notes>
       <segment>
         <source>Name</source>
@@ -2766,7 +2774,7 @@
     </unit>
     <unit id="admin.col.email">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:204,205</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:215,216</note>
       </notes>
       <segment>
         <source>E-Mail</source>
@@ -2774,7 +2782,7 @@
     </unit>
     <unit id="admin.col.anon">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:215,216</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:226,227</note>
       </notes>
       <segment>
         <source>Anon</source>
@@ -2782,7 +2790,7 @@
     </unit>
     <unit id="admin.col.pushups">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:232,233</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:243,244</note>
       </notes>
       <segment>
         <source>Pushups</source>
@@ -2790,7 +2798,7 @@
     </unit>
     <unit id="admin.col.lastEntry">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:243,245</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:254,256</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -2798,7 +2806,7 @@
     </unit>
     <unit id="admin.col.createdAt">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:256,258</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:267,269</note>
       </notes>
       <segment>
         <source>Erstellt</source>
@@ -2806,7 +2814,7 @@
     </unit>
     <unit id="admin.feedback.title">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:294,296</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:305,307</note>
       </notes>
       <segment>
         <source>Feedback</source>
@@ -2814,7 +2822,7 @@
     </unit>
     <unit id="admin.feedback.empty">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:313,315</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:324,326</note>
       </notes>
       <segment>
         <source>Noch kein Feedback vorhanden.</source>
@@ -2822,7 +2830,7 @@
     </unit>
     <unit id="admin.feedback.col.date">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:329,331</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:340,342</note>
       </notes>
       <segment>
         <source>Datum</source>
@@ -2830,7 +2838,7 @@
     </unit>
     <unit id="admin.feedback.col.name">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:341,343</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:352,354</note>
       </notes>
       <segment>
         <source>Name</source>
@@ -2838,7 +2846,7 @@
     </unit>
     <unit id="admin.feedback.col.email">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:351,353</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:362,364</note>
       </notes>
       <segment>
         <source>E-Mail</source>
@@ -2846,7 +2854,7 @@
     </unit>
     <unit id="admin.feedback.col.message">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:360,362</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:371,373</note>
       </notes>
       <segment>
         <source>Nachricht</source>
@@ -2854,7 +2862,7 @@
     </unit>
     <unit id="admin.feedback.col.userId">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:371,373</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:382,384</note>
       </notes>
       <segment>
         <source>User</source>
@@ -2862,7 +2870,7 @@
     </unit>
     <unit id="admin.refresh">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:545</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:556</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -2870,7 +2878,7 @@
     </unit>
     <unit id="admin.feedback.anon">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:546</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:557</note>
       </notes>
       <segment>
         <source>Anonym</source>
@@ -2878,7 +2886,7 @@
     </unit>
     <unit id="admin.feedback.markRead">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:547</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:558</note>
       </notes>
       <segment>
         <source>Als gelesen markieren</source>
@@ -2886,7 +2894,7 @@
     </unit>
     <unit id="admin.feedback.markUnread">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:548</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:559</note>
       </notes>
       <segment>
         <source>Als ungelesen markieren</source>
@@ -2894,7 +2902,7 @@
     </unit>
     <unit id="admin.feedback.createIssue">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:549</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:560</note>
       </notes>
       <segment>
         <source>GitHub-Issue erstellen</source>
@@ -2902,7 +2910,7 @@
     </unit>
     <unit id="admin.feedback.openIssue">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:550</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:561</note>
       </notes>
       <segment>
         <source>GitHub-Issue öffnen</source>
@@ -2910,7 +2918,7 @@
     </unit>
     <unit id="admin.feedback.delete">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:551</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:562</note>
       </notes>
       <segment>
         <source>Feedback löschen</source>
@@ -2918,7 +2926,7 @@
     </unit>
     <unit id="admin.row.detailsAria">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:777</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:789</note>
       </notes>
       <segment>
         <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier"/></source>
@@ -2994,6 +3002,40 @@
       </notes>
       <segment>
         <source> Löschen </source>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.migrate">
+      <notes>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:55,56</note>
+      </notes>
+      <segment>
+        <source>Migrieren</source>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.dryRun">
+      <notes>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:64,66</note>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:104,106</note>
+      </notes>
+      <segment>
+        <source>Probelauf</source>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.run">
+      <notes>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:73,75</note>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:113,115</note>
+      </notes>
+      <segment>
+        <source>Ausführen</source>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.rollback">
+      <notes>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:95,96</note>
+      </notes>
+      <segment>
+        <source>Rückgängig</source>
       </segment>
     </unit>
     <unit id="admin.details.title">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -3006,7 +3006,7 @@
     </unit>
     <unit id="admin.migrations.action.migrate">
       <notes>
-        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:55,56</note>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:63,64</note>
       </notes>
       <segment>
         <source>Migrieren</source>
@@ -3014,8 +3014,8 @@
     </unit>
     <unit id="admin.migrations.dryRun">
       <notes>
-        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:64,66</note>
-        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:104,106</note>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:72,74</note>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:115,117</note>
       </notes>
       <segment>
         <source>Probelauf</source>
@@ -3023,8 +3023,8 @@
     </unit>
     <unit id="admin.migrations.run">
       <notes>
-        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:73,75</note>
-        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:113,115</note>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:81,83</note>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:124,126</note>
       </notes>
       <segment>
         <source>Ausführen</source>
@@ -3032,10 +3032,26 @@
     </unit>
     <unit id="admin.migrations.action.rollback">
       <notes>
-        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:95,96</note>
+        <note category="location">web/src/app/admin/migrations/migration-card.component.ts:106,107</note>
       </notes>
       <segment>
         <source>Rückgängig</source>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupUnification.title">
+      <notes>
+        <note category="location">web/src/app/admin/migrations/migration-descriptors.ts:49</note>
+      </notes>
+      <segment>
+        <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupUnification.description">
+      <notes>
+        <note category="location">web/src/app/admin/migrations/migration-descriptors.ts:50</note>
+      </notes>
+      <segment>
+        <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
       </segment>
     </unit>
     <unit id="admin.details.title">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9449,5 +9449,35 @@
         <target>显示每日目标详情</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.title">
+      <segment state="initial">
+        <source>Daten-Migrationen</source>
+        <target>Daten-Migrationen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.migrate">
+      <segment state="initial">
+        <source>Migrieren</source>
+        <target>Migrieren</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.dryRun">
+      <segment state="initial">
+        <source>Probelauf</source>
+        <target>Probelauf</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.run">
+      <segment state="initial">
+        <source>Ausführen</source>
+        <target>Ausführen</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.action.rollback">
+      <segment state="initial">
+        <source>Rückgängig</source>
+        <target>Rückgängig</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9479,5 +9479,17 @@
         <target>Rückgängig</target>
       </segment>
     </unit>
+    <unit id="admin.migrations.pushupUnification.title">
+      <segment state="initial">
+        <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
+        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupUnification.description">
+      <segment state="initial">
+        <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
+        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>


### PR DESCRIPTION
## What

Adds a **"Daten-Migrationen"** section to the admin page (`/admin`), driven by a declarative registry (`DATA_MIGRATIONS`). Each `MigrationCardComponent` binds a title/description to deployed `onCall` callables with a uniform `{ dryRun }` contract and renders the returned counters generically.

This is **PR #1 of the Phase-7 cutover** ([#442](https://github.com/WolfSoko/pushup-stats-service/issues/442)). It wires the existing `migratePushupsToExerciseEntries` + `rollbackPushupUnification` callables (shipped in #440) into the UI so the **operator can run step 1** (the staged migration) per `docs/migrations/pushup-unification.md` — dry-run → verify → run — without hand-rolled console snippets.

## Why a registry (future-proof)

The multi-exercise roadmap will add more data migrations. Adding one is now a descriptor entry + its callable — **no component changes**. The card renders any flat counter object the callable returns.

## Safety

- Both callables already default to `dryRun: true` server-side.
- The live **"Ausführen"** button stays **disabled until a dry-run completes** for that action, enforcing the runbook's "dry-run first" rule in the UI.
- Read-only to prod until the operator explicitly clicks a live run.

## Scope / sequencing

- This PR does **not** touch the pushup runtime read/write path, guards, or special-casing — that's **PR #2** (the actual cutover), which must be held until the operator has run + verified the migration in prod (trunk auto-deploys).
- Does **not** close #442 on its own.

## Test plan

- [x] `nx test web --filter=MigrationCardComponent` — 5 specs (dry-run renders counters, live-run gated on dry-run, error surfaced, rollback rendered only when declared)
- [x] `nx test web --filter=AdminPageComponent` — unaffected
- [x] `nx lint web`
- [x] i18n extracted + locale fallbacks seeded (5 new `@@admin.migrations.*` units)
- [x] prod build compiles (font-inlining network flake only)

Refs #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Data Migrations section to the admin interface. Administrators can now preview changes with dry-run, execute migrations, and rollback if needed.

* **Tests**
  * Added comprehensive test coverage for migration operations.

* **Localization**
  * Translations added across 9 languages: English, Greek, Spanish, French, Italian, Latin, Dutch, Norwegian, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->