### PR TITLE
chore(i18n): fill missing translations (63 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9956,45 +9956,45 @@
       </segment>
     </unit>
     <unit id="admin.migrations.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Daten-Migrationen</source>
-        <target>Daten-Migrationen</target>
+        <target>Μεταναστεύσεις δεδομένων</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.migrate">
-      <segment state="initial">
+      <segment state="translated">
         <source>Migrieren</source>
-        <target>Migrieren</target>
+        <target>Μετανάστευση</target>
       </segment>
     </unit>
     <unit id="admin.migrations.dryRun">
-      <segment state="initial">
+      <segment state="translated">
         <source>Probelauf</source>
-        <target>Probelauf</target>
+        <target>Δοκιμαστική εκτέλεση</target>
       </segment>
     </unit>
     <unit id="admin.migrations.run">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausführen</source>
-        <target>Ausführen</target>
+        <target>Εκτέλεση</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.rollback">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückgängig</source>
-        <target>Rückgängig</target>
+        <target>Αναίρεση</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
-        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+        <target>Ενοποίηση push-up (pushups → exerciseEntries)</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
-        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+        <target>Αντιγράφει την παλιά συλλογή «pushups» στη «exerciseEntries» (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Ιδεμποτέντ, αφήνει την πηγή ανέπαφη και είναι αναστρέψιμο μέσω «Αναίρεσης». Να εκτελείτε πάντα πρώτα τη δοκιμαστική εκτέλεση και να ελέγχετε τους αριθμούς με το runbook.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10122,45 +10122,45 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.migrations.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Daten-Migrationen</source>
-        <target>Daten-Migrationen</target>
+        <target>Data Migrations</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.migrate">
-      <segment state="initial">
+      <segment state="translated">
         <source>Migrieren</source>
-        <target>Migrieren</target>
+        <target>Migrate</target>
       </segment>
     </unit>
     <unit id="admin.migrations.dryRun">
-      <segment state="initial">
+      <segment state="translated">
         <source>Probelauf</source>
-        <target>Probelauf</target>
+        <target>Dry Run</target>
       </segment>
     </unit>
     <unit id="admin.migrations.run">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausführen</source>
-        <target>Ausführen</target>
+        <target>Run</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.rollback">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückgängig</source>
-        <target>Rückgängig</target>
+        <target>Rollback</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
-        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+        <target>Unify push-ups (pushups → exerciseEntries)</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
-        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+        <target>Copies the legacy “pushups” collection to “exerciseEntries” (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, leaves the source untouched and is reversible via “Rollback”. Always run the dry run first and check the numbers against the runbook.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9952,45 +9952,45 @@
       </segment>
     </unit>
     <unit id="admin.migrations.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Daten-Migrationen</source>
-        <target>Daten-Migrationen</target>
+        <target>Migraciones de datos</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.migrate">
-      <segment state="initial">
+      <segment state="translated">
         <source>Migrieren</source>
-        <target>Migrieren</target>
+        <target>Migrar</target>
       </segment>
     </unit>
     <unit id="admin.migrations.dryRun">
-      <segment state="initial">
+      <segment state="translated">
         <source>Probelauf</source>
-        <target>Probelauf</target>
+        <target>Simulacro</target>
       </segment>
     </unit>
     <unit id="admin.migrations.run">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausführen</source>
-        <target>Ausführen</target>
+        <target>Ejecutar</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.rollback">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückgängig</source>
-        <target>Rückgängig</target>
+        <target>Deshacer</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
-        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+        <target>Unificar flexiones (pushups → exerciseEntries)</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
-        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+        <target>Copia la colección heredada «pushups» en «exerciseEntries» (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotente, deja la fuente intacta y es reversible mediante «Deshacer». Ejecutar siempre primero la simulación y verificar los números con el runbook.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9828,45 +9828,45 @@
       </segment>
     </unit>
     <unit id="admin.migrations.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Daten-Migrationen</source>
-        <target>Daten-Migrationen</target>
+        <target>Migrations de données</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.migrate">
-      <segment state="initial">
+      <segment state="translated">
         <source>Migrieren</source>
-        <target>Migrieren</target>
+        <target>Migrer</target>
       </segment>
     </unit>
     <unit id="admin.migrations.dryRun">
-      <segment state="initial">
+      <segment state="translated">
         <source>Probelauf</source>
-        <target>Probelauf</target>
+        <target>Simulation</target>
       </segment>
     </unit>
     <unit id="admin.migrations.run">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausführen</source>
-        <target>Ausführen</target>
+        <target>Exécuter</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.rollback">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückgängig</source>
-        <target>Rückgängig</target>
+        <target>Annuler</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
-        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+        <target>Unifier les pompes (pushups → exerciseEntries)</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
-        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+        <target>Copie la collection « pushups » héritée vers « exerciseEntries » (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, laisse la source intacte et est réversible via « Annuler ». Toujours effectuer la simulation en premier et vérifier les chiffres par rapport au runbook.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9956,45 +9956,45 @@
       </segment>
     </unit>
     <unit id="admin.migrations.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Daten-Migrationen</source>
-        <target>Daten-Migrationen</target>
+        <target>Migrazioni dati</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.migrate">
-      <segment state="initial">
+      <segment state="translated">
         <source>Migrieren</source>
-        <target>Migrieren</target>
+        <target>Migrare</target>
       </segment>
     </unit>
     <unit id="admin.migrations.dryRun">
-      <segment state="initial">
+      <segment state="translated">
         <source>Probelauf</source>
-        <target>Probelauf</target>
+        <target>Simulazione</target>
       </segment>
     </unit>
     <unit id="admin.migrations.run">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausführen</source>
-        <target>Ausführen</target>
+        <target>Esegui</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.rollback">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückgängig</source>
-        <target>Rückgängig</target>
+        <target>Annulla</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
-        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+        <target>Unifica i push-up (pushups → exerciseEntries)</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
-        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+        <target>Copia la raccolta legacy «pushups» in «exerciseEntries» (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotente, lascia la fonte invariata ed è reversibile tramite «Annulla». Eseguire sempre prima la simulazione e verificare i numeri rispetto al runbook.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9956,45 +9956,45 @@
       </segment>
     </unit>
     <unit id="admin.migrations.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Daten-Migrationen</source>
-        <target>Daten-Migrationen</target>
+        <target>Migrationes Datorum</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.migrate">
-      <segment state="initial">
+      <segment state="translated">
         <source>Migrieren</source>
-        <target>Migrieren</target>
+        <target>Migrare</target>
       </segment>
     </unit>
     <unit id="admin.migrations.dryRun">
-      <segment state="initial">
+      <segment state="translated">
         <source>Probelauf</source>
-        <target>Probelauf</target>
+        <target>Cursus Probatorius</target>
       </segment>
     </unit>
     <unit id="admin.migrations.run">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausführen</source>
-        <target>Ausführen</target>
+        <target>Exsequi</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.rollback">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückgängig</source>
-        <target>Rückgängig</target>
+        <target>Revocare</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
-        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+        <target>Flexiones bracchiorum unificare (pushups → exerciseEntries)</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
-        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+        <target>Copiat collectionem “pushups” antiquam in “exerciseEntries” (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotens, fontem intactum relinquit et per “Revocare” reversibile est. Semper primum cursum probatorium exsequere et numeros cum commentario comparare.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9956,45 +9956,45 @@
       </segment>
     </unit>
     <unit id="admin.migrations.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Daten-Migrationen</source>
-        <target>Daten-Migrationen</target>
+        <target>Datamigraties</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.migrate">
-      <segment state="initial">
+      <segment state="translated">
         <source>Migrieren</source>
-        <target>Migrieren</target>
+        <target>Migreren</target>
       </segment>
     </unit>
     <unit id="admin.migrations.dryRun">
-      <segment state="initial">
+      <segment state="translated">
         <source>Probelauf</source>
-        <target>Probelauf</target>
+        <target>Droogloop</target>
       </segment>
     </unit>
     <unit id="admin.migrations.run">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausführen</source>
-        <target>Ausführen</target>
+        <target>Uitvoeren</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.rollback">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückgängig</source>
-        <target>Rückgängig</target>
+        <target>Ongedaan maken</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
-        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+        <target>Push-ups samenvoegen (pushups → exerciseEntries)</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
-        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+        <target>Kopieert de verouderde «pushups»-collectie naar «exerciseEntries» (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, laat de bron onaangeroerd en is omkeerbaar via «Ongedaan maken». Voer altijd eerst de droogloop uit en controleer de getallen aan de hand van het runbook.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9216,45 +9216,45 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.migrations.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Daten-Migrationen</source>
-        <target>Daten-Migrationen</target>
+        <target>Datamigrasjoner</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.migrate">
-      <segment state="initial">
+      <segment state="translated">
         <source>Migrieren</source>
-        <target>Migrieren</target>
+        <target>Migrér</target>
       </segment>
     </unit>
     <unit id="admin.migrations.dryRun">
-      <segment state="initial">
+      <segment state="translated">
         <source>Probelauf</source>
-        <target>Probelauf</target>
+        <target>Prøvekjøring</target>
       </segment>
     </unit>
     <unit id="admin.migrations.run">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausführen</source>
-        <target>Ausführen</target>
+        <target>Kjør</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.rollback">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückgängig</source>
-        <target>Rückgängig</target>
+        <target>Angre</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
-        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+        <target>Samle push-ups (pushups → exerciseEntries)</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
-        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+        <target>Kopierer den eldre «pushups»-samlingen til «exerciseEntries» (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lar kilden være uberørt og er reversibel via «Angre». Kjør alltid prøvekjøringen først og kontroller tallene mot kjøreboken.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9450,45 +9450,45 @@
       </segment>
     </unit>
     <unit id="admin.migrations.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Daten-Migrationen</source>
-        <target>Daten-Migrationen</target>
+        <target>数据迁移</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.migrate">
-      <segment state="initial">
+      <segment state="translated">
         <source>Migrieren</source>
-        <target>Migrieren</target>
+        <target>迁移</target>
       </segment>
     </unit>
     <unit id="admin.migrations.dryRun">
-      <segment state="initial">
+      <segment state="translated">
         <source>Probelauf</source>
-        <target>Probelauf</target>
+        <target>试运行</target>
       </segment>
     </unit>
     <unit id="admin.migrations.run">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausführen</source>
-        <target>Ausführen</target>
+        <target>执行</target>
       </segment>
     </unit>
     <unit id="admin.migrations.action.rollback">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rückgängig</source>
-        <target>Rückgängig</target>
+        <target>撤销</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Liegestütze vereinheitlichen (pushups → exerciseEntries)</source>
-        <target>Liegestütze vereinheitlichen (pushups → exerciseEntries)</target>
+        <target>统一俯卧撑数据 (pushups → exerciseEntries)</target>
       </segment>
     </unit>
     <unit id="admin.migrations.pushupUnification.description">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
-        <target>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</target>
+        <target>将旧版“pushups”集合复制到“exerciseEntries”（exerciseId:&quot;pushup&quot;，migratedFrom:&quot;pushups&quot;）。幂等操作，不会更改源数据，可通过“撤销”回滚。始终先执行试运行，并对照运行手册检查数字。</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
## Summary

Translates 7 new `admin.migrations.*` XLIFF units (introduced by the migrations admin panel feature in #442) into all 9 target locales.

### Touched locales

- `en`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `fr`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `es`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `it`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `nl`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `el`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `la`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `no`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `zh`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries

### Units translated per locale

| Unit id | Description |
|---|---|
| `admin.migrations.title` | Panel heading |
| `admin.migrations.action.migrate` | Button label |
| `admin.migrations.dryRun` | Toggle/label |
| `admin.migrations.run` | Button label |
| `admin.migrations.action.rollback` | Button label |
| `admin.migrations.pushupUnification.title` | Migration name |
| `admin.migrations.pushupUnification.description` | Migration description (long text) |

## Skipped

None — all 63 items translated successfully.

## Detector summary

```
Detected 0 gap(s) — xliff:0 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, la, no, zh
```
(after applying this PR's changes)


---
_Generated by [Claude Code](https://claude.ai/code/session_013t4mH7Gn9ZwqMB2EjM6hmq)_