### PR TITLE
fix: drop Sentry build steps from staging App Hosting config

### DIFF
--- a/apphosting.staging.yaml
+++ b/apphosting.staging.yaml
@@ -18,14 +18,6 @@ env:
     availability:
       - RUNTIME
 
-  # Optional: tag staging events with the same commit-based release as prod so
-  # both share source maps. Falls through harmlessly if the staging project
-  # doesn't have the secret bound (script no-ops without the token).
-  - variable: SENTRY_AUTH_TOKEN
-    secret: SENTRY_AUTH_TOKEN
-    availability:
-      - BUILD
-
   # Match prod's heap bump — staging builds the same web bundle and
   # OOMs at the same point without it.
   - variable: NODE_OPTIONS
@@ -34,5 +26,9 @@ env:
       - BUILD
 
 scripts:
-  buildCommand: pnpm nx run web:build -c staging && pnpm sentry:sourcemaps
+  # No Sentry source-map upload here (unlike apphosting.yaml): the staging GCP
+  # project has no SENTRY_AUTH_TOKEN secret, and a `secret:` reference to a
+  # missing secret fails the rollout at bind time — before the build even runs —
+  # so it can't be guarded by the upload script's no-op-when-unset check.
+  buildCommand: pnpm nx run web:build -c staging
   runCommand: node dist/web/server/server.mjs

--- a/docs/observability/sentry.md
+++ b/docs/observability/sentry.md
@@ -5,7 +5,7 @@ End-to-end reference for how Sentry is wired up in this project — SDKs, releas
 Read this **before** touching any of:
 
 - `scripts/upload-sentry-sourcemaps.sh`
-- `apphosting.yaml` / `apphosting.staging.yaml` (`SENTRY_AUTH_TOKEN` references, `scripts.buildCommand`)
+- `apphosting.yaml` (`SENTRY_AUTH_TOKEN` reference, `scripts.buildCommand`) — `apphosting.staging.yaml` deliberately omits both (see [Staging](#staging-skips-the-app-hosting-source-map-upload))
 - `.github/workflows/firebase-hosting-merge.yml` (`Upload source maps to Sentry` step)
 - `Sentry.init(...)` calls in `web/src/main.ts`, `web/src/server.ts`, `data-store/functions/src/index.ts`
 
@@ -64,7 +64,7 @@ This is the gotcha that originally caused production stack traces to stay minifi
 
 ### 2. Firebase App Hosting (Cloud Run SSR build that serves `pushup-stats.com`)
 
-- Source: Cloud Secret Manager secret named `SENTRY_AUTH_TOKEN` in the GCP project (`pushup-stats` for prod, `pushup-stats-staging-867b7` for staging).
+- Source: Cloud Secret Manager secret named `SENTRY_AUTH_TOKEN` in the **production** GCP project (`pushup-stats`). Staging (`pushup-stats-staging-867b7`) deliberately omits it — see [Staging skips the App Hosting source-map upload](#staging-skips-the-app-hosting-source-map-upload).
 - Consumed by: `apphosting.yaml` `env` block with `availability: BUILD`. The override in `scripts.buildCommand` runs `pnpm sentry:sourcemaps` after the Angular build inside Cloud Build.
 - Covers: the SSR + browser bundles actually served at `pushup-stats.com`.
 
@@ -81,14 +81,18 @@ echo -n "<token>" | gcloud secrets versions add SENTRY_AUTH_TOKEN \
   --data-file=- --project pushup-stats
 firebase apphosting:secrets:grantaccess SENTRY_AUTH_TOKEN \
   --backend pushup-stats-service --project pushup-stats
-
-# Staging — only needed if apphosting.staging.yaml keeps the SENTRY_AUTH_TOKEN
-# secret reference. Otherwise PR-preview rollouts will fail with "secret not found".
-gcloud secrets create SENTRY_AUTH_TOKEN \
-  --replication-policy=automatic \
-  --project pushup-stats-staging-867b7
-# ... same pattern as above with --project pushup-stats-staging-867b7
 ```
+
+### Staging skips the App Hosting source-map upload
+
+`apphosting.staging.yaml` intentionally has **no** `SENTRY_AUTH_TOKEN` secret reference and **no** `pnpm sentry:sourcemaps` in its `buildCommand`. Staging is an ephemeral preview surface, so minified stack traces there are an acceptable trade-off for a simpler, dependency-free rollout.
+
+This is not just a convenience — it is **load-bearing**. An App Hosting `env` entry with `secret: SENTRY_AUTH_TOKEN` pointing at a secret that doesn't exist in the staging GCP project fails the rollout **at bind time, before the build runs**. The upload script's "no-op when `SENTRY_AUTH_TOKEN` is unset" guard cannot catch this — the failure is in App Hosting's secret resolution, not in the script. The original assumption that the reference would "fall through harmlessly" was wrong and broke every staging rollout.
+
+If you ever need real source maps in staging, you must do **both** together, or the rollout breaks again:
+
+1. Create + grant the secret in the staging project (same `gcloud` / `firebase apphosting:secrets:grantaccess` pattern as production, with `--project pushup-stats-staging-867b7`).
+2. Re-add the `SENTRY_AUTH_TOKEN` `env` block **and** the `&& pnpm sentry:sourcemaps` build step to `apphosting.staging.yaml`.
 
 ### Auth token scopes
 

--- a/tools/src/apphosting-sentry-guard.spec.js
+++ b/tools/src/apphosting-sentry-guard.spec.js
@@ -10,10 +10,18 @@ function load(path) {
   return parse(readFileSync(path, 'utf-8'));
 }
 
+function isMapping(value) {
+  return typeof value === 'object' && value !== null;
+}
+
 function secretVariables(config) {
   return (config.env ?? [])
-    .filter((entry) => entry && 'secret' in entry)
+    .filter((entry) => isMapping(entry) && 'secret' in entry)
     .map((entry) => entry.variable);
+}
+
+function buildCommand(config) {
+  return config.scripts?.buildCommand ?? '';
 }
 
 /**
@@ -43,7 +51,7 @@ describe('App Hosting Sentry configuration', () => {
       // given staging is an ephemeral preview surface with no Sentry token
       // when App Hosting runs scripts.buildCommand
       // then it must build the web bundle without invoking sentry:sourcemaps
-      expect(staging.scripts.buildCommand).not.toMatch(/sentry:sourcemaps/);
+      expect(buildCommand(staging)).not.toMatch(/sentry:sourcemaps/);
     });
   });
 
@@ -67,7 +75,7 @@ describe('App Hosting Sentry configuration', () => {
       // given uploaded source maps are what make prod stack traces readable
       // when App Hosting runs scripts.buildCommand
       // then it must invoke sentry:sourcemaps after the web build
-      expect(prod.scripts.buildCommand).toMatch(/sentry:sourcemaps/);
+      expect(buildCommand(prod)).toMatch(/sentry:sourcemaps/);
     });
   });
 });

--- a/tools/src/apphosting-sentry-guard.spec.js
+++ b/tools/src/apphosting-sentry-guard.spec.js
@@ -1,0 +1,73 @@
+const { readFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+const { parse } = require('yaml');
+
+const ROOT = resolve(__dirname, '../..');
+const PROD_CONFIG = resolve(ROOT, 'apphosting.yaml');
+const STAGING_CONFIG = resolve(ROOT, 'apphosting.staging.yaml');
+
+function load(path) {
+  return parse(readFileSync(path, 'utf-8'));
+}
+
+function secretVariables(config) {
+  return (config.env ?? [])
+    .filter((entry) => entry && 'secret' in entry)
+    .map((entry) => entry.variable);
+}
+
+/**
+ * Locks in the deliberate prod/staging asymmetry around Sentry source-map
+ * upload in the Firebase App Hosting configs. See docs/observability/sentry.md.
+ *
+ * Production binds the SENTRY_AUTH_TOKEN secret and runs `pnpm sentry:sourcemaps`
+ * so the bundles served at pushup-stats.com carry matching debug IDs — without
+ * it every production stack trace stays minified (the weeks-long bug that
+ * originally motivated the upload). Staging must NOT: the staging GCP project
+ * (pushup-stats-staging-867b7) has no such secret, and an App Hosting `secret:`
+ * reference to a missing secret fails the rollout at bind time — before the
+ * build runs — which the upload script's no-op-when-unset guard cannot catch.
+ */
+describe('App Hosting Sentry configuration', () => {
+  describe('staging (apphosting.staging.yaml)', () => {
+    const staging = load(STAGING_CONFIG);
+
+    it('should not reference the SENTRY_AUTH_TOKEN secret', () => {
+      // given the staging GCP project has no SENTRY_AUTH_TOKEN secret bound
+      // when App Hosting resolves env secrets at rollout time
+      // then no secret binding may exist that would fail before the build runs
+      expect(secretVariables(staging)).not.toContain('SENTRY_AUTH_TOKEN');
+    });
+
+    it('should not run the Sentry source-map upload in its build command', () => {
+      // given staging is an ephemeral preview surface with no Sentry token
+      // when App Hosting runs scripts.buildCommand
+      // then it must build the web bundle without invoking sentry:sourcemaps
+      expect(staging.scripts.buildCommand).not.toMatch(/sentry:sourcemaps/);
+    });
+  });
+
+  describe('production (apphosting.yaml)', () => {
+    const prod = load(PROD_CONFIG);
+
+    it('should bind the SENTRY_AUTH_TOKEN secret at BUILD time', () => {
+      // given prod stack traces must de-minify against uploaded source maps
+      // when App Hosting builds the bundle served at pushup-stats.com
+      // then the SENTRY_AUTH_TOKEN secret must be available at BUILD time
+      const tokenEntry = (prod.env ?? []).find(
+        (entry) => entry && entry.variable === 'SENTRY_AUTH_TOKEN'
+      );
+      expect(tokenEntry).toMatchObject({
+        secret: 'SENTRY_AUTH_TOKEN',
+        availability: ['BUILD'],
+      });
+    });
+
+    it('should run the Sentry source-map upload in its build command', () => {
+      // given uploaded source maps are what make prod stack traces readable
+      // when App Hosting runs scripts.buildCommand
+      // then it must invoke sentry:sourcemaps after the web build
+      expect(prod.scripts.buildCommand).toMatch(/sentry:sourcemaps/);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The Firebase **App Hosting staging** deployment of `main` was failing. `apphosting.staging.yaml` declared a `SENTRY_AUTH_TOKEN` secret binding and ran `pnpm sentry:sourcemaps` in its `buildCommand`, but the staging GCP project (`pushup-stats-staging-867b7`) has no such secret in Secret Manager.

An App Hosting `env` entry with `secret: SENTRY_AUTH_TOKEN` pointing at a missing secret fails the rollout **at bind time — before the build runs**. The upload script's "no-op when `SENTRY_AUTH_TOKEN` is unset" guard never gets a chance to skip, so the build process tried to create a Sentry release with no valid token and the staging rollout broke. (The old config comment claimed it would "fall through harmlessly" — that assumption was wrong.)

## Fix

- **`apphosting.staging.yaml`**: removed the `SENTRY_AUTH_TOKEN` `env` secret binding and the `&& pnpm sentry:sourcemaps` build step. Staging now builds with `pnpm nx run web:build -c staging` only.
- **Production (`apphosting.yaml`) is untouched** — its secret *is* bound, and prod still needs source maps so stack traces de-minify. Staging is an ephemeral preview surface, so minified traces there are an acceptable trade-off.

## Regression guard (TDD red-green)

Added `tools/src/apphosting-sentry-guard.spec.js` — a guard test that locks in the deliberate prod/staging asymmetry:

- Staging must **not** reference `SENTRY_AUTH_TOKEN` or run `sentry:sourcemaps` (re-introducing the bug fails CI).
- Production must **keep** both (guards against the original weeks-long minified-traces bug if someone "consistency"-strips it).

Verified non-vacuous: reintroducing the Sentry steps fails exactly the two staging assertions; the fixed config passes all 4.

## Docs

Updated `docs/observability/sentry.md` with a new "Staging skips the App Hosting source-map upload" section explaining the bind-time failure mode and how to safely re-enable Sentry in staging if ever needed.

## Verification

- `pnpm nx test tools` → 6 suites / 99 tests green (incl. the new guard).
- Red-green confirmed: bug reintroduced → 2 failures; restored → all green.
- Prettier + ESLint clean on changed files.

https://claude.ai/code/session_01148oAytJ8gQ2dqxpv3Lw47

---
_Generated by [Claude Code](https://claude.ai/code/session_01148oAytJ8gQ2dqxpv3Lw47)_