### PR TITLE
chore(i18n): fill missing translations (54 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -9998,39 +9998,39 @@
       </segment>
     </unit>
     <unit id="admin.migrations.status.completed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Abgeschlossen</source>
-        <target>Abgeschlossen</target>
+        <target>Ολοκληρωμένο</target>
       </segment>
     </unit>
         <unit id="admin.migrations.status.reopen">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wieder öffnen</source>
-        <target>Wieder öffnen</target>
+        <target>Επαναφορά</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.open">
-      <segment state="initial">
+      <segment state="translated">
         <source>Offen</source>
-        <target>Offen</target>
+        <target>Ανοιχτό</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.markComplete">
-      <segment state="initial">
+      <segment state="translated">
         <source>Als abgeschlossen markieren</source>
-        <target>Als abgeschlossen markieren</target>
+        <target>Επισήμανση ως ολοκληρωμένο</target>
       </segment>
     </unit>
         <unit id="admin.migrations.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <target>Εκτελέστε, ελέγξτε και επισημάνετε εφάπαξ μεταναστεύσεις δεδομένων ως ολοκληρωμένες.</target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Επιστροφή στη διαχείριση</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10164,39 +10164,39 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.migrations.status.completed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Abgeschlossen</source>
-        <target>Abgeschlossen</target>
+        <target>Completed</target>
       </segment>
     </unit>
         <unit id="admin.migrations.status.reopen">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wieder öffnen</source>
-        <target>Wieder öffnen</target>
+        <target>Reopen</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.open">
-      <segment state="initial">
+      <segment state="translated">
         <source>Offen</source>
-        <target>Offen</target>
+        <target>Open</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.markComplete">
-      <segment state="initial">
+      <segment state="translated">
         <source>Als abgeschlossen markieren</source>
-        <target>Als abgeschlossen markieren</target>
+        <target>Mark as completed</target>
       </segment>
     </unit>
         <unit id="admin.migrations.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <target>Run, review, and mark one-time data migrations as complete.</target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Back to admin area</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -9994,39 +9994,39 @@
       </segment>
     </unit>
     <unit id="admin.migrations.status.completed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Abgeschlossen</source>
-        <target>Abgeschlossen</target>
+        <target>Completado</target>
       </segment>
     </unit>
         <unit id="admin.migrations.status.reopen">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wieder öffnen</source>
-        <target>Wieder öffnen</target>
+        <target>Reabrir</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.open">
-      <segment state="initial">
+      <segment state="translated">
         <source>Offen</source>
-        <target>Offen</target>
+        <target>Abierto</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.markComplete">
-      <segment state="initial">
+      <segment state="translated">
         <source>Als abgeschlossen markieren</source>
-        <target>Als abgeschlossen markieren</target>
+        <target>Marcar como completado</target>
       </segment>
     </unit>
         <unit id="admin.migrations.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <target>Ejecutar, revisar y marcar las migraciones de datos únicas como completadas.</target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Volver al área de administración</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9870,39 +9870,39 @@
       </segment>
     </unit>
     <unit id="admin.migrations.status.completed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Abgeschlossen</source>
-        <target>Abgeschlossen</target>
+        <target>Terminé</target>
       </segment>
     </unit>
         <unit id="admin.migrations.status.reopen">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wieder öffnen</source>
-        <target>Wieder öffnen</target>
+        <target>Rouvrir</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.open">
-      <segment state="initial">
+      <segment state="translated">
         <source>Offen</source>
-        <target>Offen</target>
+        <target>Ouvert</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.markComplete">
-      <segment state="initial">
+      <segment state="translated">
         <source>Als abgeschlossen markieren</source>
-        <target>Als abgeschlossen markieren</target>
+        <target>Marquer comme terminé</target>
       </segment>
     </unit>
         <unit id="admin.migrations.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <target>Exécuter, vérifier et marquer les migrations de données ponctuelles comme terminées.</target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Retour à l'espace admin</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -9998,39 +9998,39 @@
       </segment>
     </unit>
     <unit id="admin.migrations.status.completed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Abgeschlossen</source>
-        <target>Abgeschlossen</target>
+        <target>Completato</target>
       </segment>
     </unit>
         <unit id="admin.migrations.status.reopen">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wieder öffnen</source>
-        <target>Wieder öffnen</target>
+        <target>Riapri</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.open">
-      <segment state="initial">
+      <segment state="translated">
         <source>Offen</source>
-        <target>Offen</target>
+        <target>Aperto</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.markComplete">
-      <segment state="initial">
+      <segment state="translated">
         <source>Als abgeschlossen markieren</source>
-        <target>Als abgeschlossen markieren</target>
+        <target>Segna come completato</target>
       </segment>
     </unit>
         <unit id="admin.migrations.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <target>Esegui, verifica e contrassegna le migrazioni dati una tantum come completate.</target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Torna all'area amministrativa</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -9998,39 +9998,39 @@
       </segment>
     </unit>
     <unit id="admin.migrations.status.completed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Abgeschlossen</source>
-        <target>Abgeschlossen</target>
+        <target>Completum</target>
       </segment>
     </unit>
         <unit id="admin.migrations.status.reopen">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wieder öffnen</source>
-        <target>Wieder öffnen</target>
+        <target>Iterum aperire</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.open">
-      <segment state="initial">
+      <segment state="translated">
         <source>Offen</source>
-        <target>Offen</target>
+        <target>Apertum</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.markComplete">
-      <segment state="initial">
+      <segment state="translated">
         <source>Als abgeschlossen markieren</source>
-        <target>Als abgeschlossen markieren</target>
+        <target>Ut completum notare</target>
       </segment>
     </unit>
         <unit id="admin.migrations.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <target>Migrationes datae semel exsequere, probare et ut completas notare.</target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Ad administrationem reverti</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -9998,39 +9998,39 @@
       </segment>
     </unit>
     <unit id="admin.migrations.status.completed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Abgeschlossen</source>
-        <target>Abgeschlossen</target>
+        <target>Voltooid</target>
       </segment>
     </unit>
         <unit id="admin.migrations.status.reopen">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wieder öffnen</source>
-        <target>Wieder öffnen</target>
+        <target>Opnieuw openen</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.open">
-      <segment state="initial">
+      <segment state="translated">
         <source>Offen</source>
-        <target>Offen</target>
+        <target>Open</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.markComplete">
-      <segment state="initial">
+      <segment state="translated">
         <source>Als abgeschlossen markieren</source>
-        <target>Als abgeschlossen markieren</target>
+        <target>Markeer als voltooid</target>
       </segment>
     </unit>
         <unit id="admin.migrations.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <target>Voer eenmalige datamigraties uit, controleer ze en markeer ze als voltooid.</target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Terug naar beheergebied</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9258,39 +9258,39 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.migrations.status.completed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Abgeschlossen</source>
-        <target>Abgeschlossen</target>
+        <target>Fullført</target>
       </segment>
     </unit>
         <unit id="admin.migrations.status.reopen">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wieder öffnen</source>
-        <target>Wieder öffnen</target>
+        <target>Gjenåpne</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.open">
-      <segment state="initial">
+      <segment state="translated">
         <source>Offen</source>
-        <target>Offen</target>
+        <target>Åpen</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.markComplete">
-      <segment state="initial">
+      <segment state="translated">
         <source>Als abgeschlossen markieren</source>
-        <target>Als abgeschlossen markieren</target>
+        <target>Merk som fullført</target>
       </segment>
     </unit>
         <unit id="admin.migrations.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <target>Kjør, gjennomgå og merk engangs-datamigrasjoner som fullførte.</target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Tilbake til administrasjonsområdet</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9492,39 +9492,39 @@
       </segment>
     </unit>
     <unit id="admin.migrations.status.completed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Abgeschlossen</source>
-        <target>Abgeschlossen</target>
+        <target>已完成</target>
       </segment>
     </unit>
         <unit id="admin.migrations.status.reopen">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wieder öffnen</source>
-        <target>Wieder öffnen</target>
+        <target>重新打开</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.open">
-      <segment state="initial">
+      <segment state="translated">
         <source>Offen</source>
-        <target>Offen</target>
+        <target>开放</target>
       </segment>
     </unit>
     <unit id="admin.migrations.status.markComplete">
-      <segment state="initial">
+      <segment state="translated">
         <source>Als abgeschlossen markieren</source>
-        <target>Als abgeschlossen markieren</target>
+        <target>标记为已完成</target>
       </segment>
     </unit>
         <unit id="admin.migrations.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <target>执行、检查并将一次性数据迁移标记为已完成。</target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>返回管理区域</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
## Summary

Fills 54 XLIFF gaps detected by `detect-translation-gaps.mjs` on 2026-06-04. The squash merge of #446 already translated 7 of the 13 new `admin.migrations.*` units; this PR covers the remaining 6 per locale across 9 locales.

- **en**: 6 units (`status.completed`, `status.reopen`, `status.open`, `status.markComplete`, `subtitle`, `backToAdmin`)
- **fr**: 6 units
- **es**: 6 units
- **it**: 6 units
- **nl**: 6 units
- **el**: 6 units
- **la**: 6 units
- **no**: 6 units
- **zh**: 6 units

**Detector summary:** `Detected 0 gap(s) — xliff:0 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, la, no, zh` (after applying translations)

## Skipped

None — all 54 remaining items were translated successfully.

## Test plan

- [x] `node tools/src/detect-translation-gaps.mjs` reports 0 gaps after changes
- [x] `pnpm nx run-many --target=lint` — all 14 projects pass
- [x] `pnpm nx build web --configuration=production` — build succeeds
- [x] `pnpm nx test web` — 979–981 tests pass (2 pre-existing flaky failures in migration specs from #446, unrelated to this PR)

https://claude.ai/code/session_01H5kytBSaMJh5KCH17Lsbuv