### PR TITLE
feat: Phase-7 pushup → exerciseEntries cutover (core) [HOLD — do not merge until migration verified]

### DIFF
--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -14,6 +14,8 @@ service cloud.firestore {
     function isRepsExerciseId(id) {
       return [
         // BEGIN GENERATED isRepsExerciseId (source: EXERCISE_CATALOG; run: pnpm nx run cloud-functions:generate-exercise-rules)
+        // pushup
+        'pushup',
         // push
         'push.benchdips', 'push.dips',
         // pull

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -56,7 +56,6 @@ import {
   planMigration,
   type PushupSourceDoc,
   rollbackTargets,
-  shouldAggregateExerciseEntry,
 } from './pushup-unification';
 import {
   buildPublicProfile,
@@ -939,15 +938,8 @@ export const refreshExerciseLeaderboardsOnEntryWrite = onDocumentWritten(
     retry: false,
   },
   async (event) => {
-    // Staged-migration guard: the pushup→exerciseEntries copies carry
-    // `exerciseId:'pushup'` and must NOT refresh a pushup leaderboard
-    // row before the Phase-7 cutover (the Pushup leaderboard is still
-    // driven by `rebuildLeaderboardsCore` off the legacy `pushups`
-    // collection). Derive the id from after-or-before so create, update
-    // and delete are all covered.
-    const exerciseId = (event.data?.after?.data()?.exerciseId ??
-      event.data?.before?.data()?.exerciseId) as string | undefined;
-    if (!shouldAggregateExerciseEntry(exerciseId)) return;
+    // Post-cutover pushups (`exerciseId:'pushup'`) aggregate + rank like
+    // every other exercise, so there is no exercise-id guard here.
 
     // Carry the previous snapshot's allTime forward and let the
     // scheduled rebuild refresh it. See `rebuildExerciseLeaderboardsCore`
@@ -2048,14 +2040,8 @@ export const updateExerciseStatsOnEntryWrite = onDocumentWritten(
       return;
     }
 
-    // Staged-migration guard: the pushup→exerciseEntries copies carry
-    // `exerciseId:'pushup'` and must NOT create a `perExercise/pushup`
-    // aggregate before the Phase-7 cutover (the Pushup dashboard is still
-    // served by `userStats/{userId}` off the legacy `pushups` collection).
-    // `exerciseId` is already resolved from after-or-before above, so this
-    // covers create, update and delete. Removing this guard at cutover
-    // re-enables aggregation.
-    if (!shouldAggregateExerciseEntry(exerciseId)) return;
+    // Post-cutover pushups (`exerciseId:'pushup'`) aggregate into
+    // `perExercise/pushup` like every other exercise — no guard.
 
     // The aggregation slot stays named `reps` for backwards
     // compatibility with the existing UserStats schema, but for
@@ -2371,5 +2357,78 @@ export const rollbackPushupUnification = onCall(
     });
 
     return { deleted: ids.length };
+  }
+);
+
+// Backfills `userStats/{userId}/perExercise/pushup` for every user with
+// pushup `exerciseEntries`. The write-path flip + guard removal make new
+// pushups aggregate going forward, but the per-exercise aggregate doesn't
+// exist for a user until their first post-cutover write — so the dashboard
+// (re-pointed to `perExercise/pushup`) would read empty until then. This
+// one-shot rebuild (same `rebuildFromEntries` the live trigger uses) seeds
+// the aggregate from the migrated history. Idempotent: re-running recomputes
+// the same doc.
+export const backfillPushupPerExerciseStats = onCall(
+  { region: 'europe-west3', timeoutSeconds: 540 },
+  async (request) => {
+    assertAdmin(request);
+
+    const dryRun = Boolean(request.data?.dryRun ?? true);
+
+    const snap = await db
+      .collection('exerciseEntries')
+      .where('exerciseId', '==', 'pushup')
+      .get();
+
+    const byUser = new Map<
+      string,
+      { timestamp: string; reps: number; sets?: number[] }[]
+    >();
+    for (const doc of snap.docs) {
+      const data = doc.data();
+      const userId = data.userId as string | undefined;
+      const timestamp = data.timestamp as string | undefined;
+      if (!userId || !timestamp) continue;
+      const list = byUser.get(userId) ?? [];
+      list.push({
+        timestamp,
+        reps: Number(data.reps ?? 0),
+        ...(Array.isArray(data.sets) ? { sets: data.sets as number[] } : {}),
+      });
+      byUser.set(userId, list);
+    }
+
+    if (dryRun) {
+      return {
+        dryRun: true,
+        wouldRebuildUsers: byUser.size,
+        entries: snap.size,
+      };
+    }
+
+    const nowIso = new Date().toISOString();
+    let rebuiltUsers = 0;
+    for (const chunk of batchArray([...byUser.entries()], MIGRATION_BATCH_SIZE)) {
+      const batch = db.batch();
+      for (const [userId, entries] of chunk) {
+        const stats = rebuildFromEntries(userId, entries, nowIso);
+        const ref = db
+          .collection('userStats')
+          .doc(userId)
+          .collection('perExercise')
+          .doc('pushup');
+        batch.set(ref, stats);
+        rebuiltUsers += 1;
+      }
+      await batch.commit();
+    }
+
+    logger.info('backfillPushupPerExerciseStats', {
+      rebuiltUsers,
+      entries: snap.size,
+      by: request.auth?.uid,
+    });
+
+    return { rebuiltUsers, entries: snap.size };
   }
 );

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -937,7 +937,7 @@ export const refreshExerciseLeaderboardsOnEntryWrite = onDocumentWritten(
     region: 'europe-west3',
     retry: false,
   },
-  async (event) => {
+  async () => {
     // Post-cutover pushups (`exerciseId:'pushup'`) aggregate + rank like
     // every other exercise, so there is no exercise-id guard here.
 

--- a/data-store/functions/src/pushup-unification/logic.spec.ts
+++ b/data-store/functions/src/pushup-unification/logic.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
 import {
-  shouldAggregateExerciseEntry,
   pushupToExerciseEntry,
   planMigration,
   rollbackTargets,
@@ -10,30 +9,6 @@ import {
 const NOW = '2026-06-03T10:00:00.000Z';
 
 describe('pushup-unification/logic', () => {
-  describe('shouldAggregateExerciseEntry', () => {
-    it('should skip aggregation for the pushup sentinel', () => {
-      // given the pushup sentinel exerciseId
-      // when asked whether to aggregate
-      // then aggregation is skipped
-      expect(shouldAggregateExerciseEntry('pushup')).toBe(false);
-    });
-
-    it('should aggregate every other exercise', () => {
-      // given a non-pushup exerciseId
-      // when asked whether to aggregate
-      // then aggregation proceeds
-      expect(shouldAggregateExerciseEntry('situp')).toBe(true);
-    });
-
-    it('should aggregate when exerciseId is undefined or null', () => {
-      // given a missing exerciseId
-      // when asked whether to aggregate
-      // then it is not the pushup sentinel, so aggregation proceeds
-      expect(shouldAggregateExerciseEntry(undefined)).toBe(true);
-      expect(shouldAggregateExerciseEntry(null)).toBe(true);
-    });
-  });
-
   describe('pushupToExerciseEntry', () => {
     it('should map a full pushup doc to a pushup exerciseEntries payload', () => {
       // given a complete source pushup doc

--- a/data-store/functions/src/pushup-unification/logic.ts
+++ b/data-store/functions/src/pushup-unification/logic.ts
@@ -11,21 +11,6 @@ const MIGRATED_FROM = 'pushups';
 const MIGRATED_ID_PREFIX = 'pushup__';
 const DEFAULT_SOURCE = 'web';
 
-/**
- * The staged migration copies pushups into `exerciseEntries` with
- * `exerciseId:'pushup'`. Until the Phase-7 write-path flip, the
- * per-exercise stats and leaderboard triggers must ignore those copies
- * so they don't create a `perExercise/pushup` aggregate or a pushup
- * leaderboard row (the Pushup dashboard still reads the legacy `pushups`
- * collection + its own `userStats` doc). Reversible: deleting this guard
- * at cutover re-enables aggregation for `exerciseId:'pushup'`.
- */
-export function shouldAggregateExerciseEntry(
-  exerciseId: string | undefined | null
-): boolean {
-  return exerciseId !== PUSHUP_EXERCISE_ID;
-}
-
 export interface PushupSourceDoc {
   id: string;
   userId?: string;

--- a/libs/data-access-state/src/lib/live/live-data.store.spec.ts
+++ b/libs/data-access-state/src/lib/live/live-data.store.spec.ts
@@ -24,14 +24,11 @@ type SnapshotCallback = (snapshot: {
 }) => void;
 
 /**
- * Captures the success callbacks the store passes to `onSnapshot` so a
- * test can drive each subscription. The store subscribes pushups first,
- * then exerciseEntries (the call order in `onInit`).
+ * Captures the success callback the store passes to `onSnapshot`. Post
+ * Phase-7 cutover there is a single subscription — `exerciseEntries`
+ * (pushups included) — so the first captured callback is that feed.
  */
-function captureSnapshotCallbacks(): {
-  pushups: () => SnapshotCallback;
-  exercises: () => SnapshotCallback;
-} {
+function captureExercisesCallback(): () => SnapshotCallback {
   const onNext: SnapshotCallback[] = [];
   jest
     .mocked(onSnapshot)
@@ -39,10 +36,7 @@ function captureSnapshotCallbacks(): {
       onNext.push(next);
       return jest.fn();
     });
-  return {
-    pushups: () => onNext[0],
-    exercises: () => onNext[1],
-  };
+  return () => onNext[0];
 }
 
 describe('LiveDataStore', () => {
@@ -58,7 +52,7 @@ describe('LiveDataStore', () => {
       const store = TestBed.inject(LiveDataStore);
 
       expect(store.connected()).toBe(false);
-      expect(store.entries()).toEqual([]);
+      expect(store.exerciseEntries()).toEqual([]);
       expect(store.updateTick()).toBe(0);
     });
   });
@@ -74,17 +68,17 @@ describe('LiveDataStore', () => {
       const store = TestBed.inject(LiveDataStore);
 
       expect(store.connected()).toBe(false);
-      expect(store.entries()).toEqual([]);
+      expect(store.exerciseEntries()).toEqual([]);
       expect(store.updateTick()).toBe(0);
     });
   });
 
   describe('exerciseEntries loading', () => {
-    it('should mark exerciseEntries loaded after the first exercise snapshot', () => {
-      // given a browser-platform store wired to a signed-in user, with both
-      // Firestore subscriptions captured but not yet fired
+    it('should connect and mark loaded after the first exercise snapshot', () => {
+      // given a browser-platform store wired to a signed-in user, with the
+      // Firestore subscription captured but not yet fired
       jest.mocked(authState).mockReturnValue(of({ uid: 'u1' }) as never);
-      const callbacks = captureSnapshotCallbacks();
+      const exercises = captureExercisesCallback();
       TestBed.configureTestingModule({
         providers: [
           LiveDataStore,
@@ -96,22 +90,22 @@ describe('LiveDataStore', () => {
       const store = TestBed.inject(LiveDataStore);
       TestBed.tick();
 
-      // then it starts unloaded — no exercise snapshot has arrived
+      // then it starts unloaded — no snapshot has arrived
       expect(store.exerciseEntriesLoaded()).toBe(false);
+      expect(store.connected()).toBe(false);
 
       // when the exerciseEntries subscription delivers its first snapshot
-      callbacks.exercises()({ docs: [] });
+      exercises()({ docs: [] });
 
-      // then the loaded flag flips, independent of the pushup stream
+      // then both the loaded flag and the canonical liveness signal flip
       expect(store.exerciseEntriesLoaded()).toBe(true);
-      expect(store.connected()).toBe(false);
+      expect(store.connected()).toBe(true);
     });
 
-    it('should hide staged pushup-sentinel copies from the live exerciseEntries feed', () => {
-      // given a browser-platform store wired to a signed-in user, with both
-      // Firestore subscriptions captured but not yet fired
+    it('should surface pushups (exerciseId:"pushup") on the live feed post-cutover', () => {
+      // given a browser-platform store wired to a signed-in user
       jest.mocked(authState).mockReturnValue(of({ uid: 'u1' }) as never);
-      const callbacks = captureSnapshotCallbacks();
+      const exercises = captureExercisesCallback();
       TestBed.configureTestingModule({
         providers: [
           LiveDataStore,
@@ -123,9 +117,8 @@ describe('LiveDataStore', () => {
       const store = TestBed.inject(LiveDataStore);
       TestBed.tick();
 
-      // when the exerciseEntries snapshot delivers a native squats entry
-      // alongside a migrated pushup-sentinel copy
-      callbacks.exercises()({
+      // when the snapshot delivers a squats entry alongside a pushup entry
+      exercises()({
         docs: [
           {
             id: 'squats-1',
@@ -148,11 +141,14 @@ describe('LiveDataStore', () => {
         ],
       });
 
-      // then only the non-pushup entry surfaces and the feed is marked loaded
-      expect(store.exerciseEntries().map((e) => e._id)).toEqual(['squats-1']);
+      // then both surface — pushups are no longer filtered out
+      expect(store.exerciseEntries().map((e) => e._id)).toEqual([
+        'squats-1',
+        'pushup-1',
+      ]);
       expect(
         store.exerciseEntries().some((e) => e.exerciseId === 'pushup')
-      ).toBe(false);
+      ).toBe(true);
       expect(store.exerciseEntriesLoaded()).toBe(true);
     });
   });
@@ -165,7 +161,7 @@ describe('LiveDataStore', () => {
         uid: 'u1',
       });
       jest.mocked(authState).mockReturnValue(authSubject as never);
-      const callbacks = captureSnapshotCallbacks();
+      const exercises = captureExercisesCallback();
       TestBed.configureTestingModule({
         providers: [
           LiveDataStore,
@@ -176,7 +172,7 @@ describe('LiveDataStore', () => {
       });
       const store = TestBed.inject(LiveDataStore);
       TestBed.tick();
-      callbacks.exercises()({
+      exercises()({
         docs: [
           {
             id: 'squats-1',
@@ -197,9 +193,9 @@ describe('LiveDataStore', () => {
       TestBed.tick();
 
       // then u1's mirrors are dropped before u2's snapshots arrive
-      expect(store.entries()).toEqual([]);
       expect(store.exerciseEntries()).toEqual([]);
       expect(store.exerciseEntriesLoaded()).toBe(false);
+      expect(store.connected()).toBe(false);
     });
   });
 });

--- a/libs/data-access-state/src/lib/live/live-data.store.ts
+++ b/libs/data-access-state/src/lib/live/live-data.store.ts
@@ -10,11 +10,7 @@ import {
   query,
   where,
 } from '@angular/fire/firestore';
-import {
-  ExerciseDefinition,
-  ExerciseEntry,
-  PushupRecord,
-} from '@pu-stats/models';
+import { ExerciseDefinition, ExerciseEntry } from '@pu-stats/models';
 import {
   patchState,
   signalStore,
@@ -24,13 +20,11 @@ import {
 } from '@ngrx/signals';
 
 type LiveDataState = {
-  entries: PushupRecord[];
   /**
-   * Live mirror of `exerciseEntries` (sit-ups, squats, …) for the
-   * current user. Pushups stay on `entries` for backwards compat with
-   * every existing consumer; new code reads `exerciseEntries`. The staged
-   * pushup→exerciseEntries migration's sentinel copies (`exerciseId:'pushup'`)
-   * are filtered out of this feed until the Phase-7 cutover.
+   * Live mirror of every `exerciseEntries` doc for the current user —
+   * post Phase-7 cutover this includes pushups (`exerciseId:'pushup'`),
+   * which are the sole source for pushup history now that writes land
+   * here and the legacy `pushups` collection is no longer read.
    */
   exerciseEntries: ExerciseEntry[];
   /**
@@ -43,12 +37,16 @@ type LiveDataState = {
   exerciseDefinitions: ExerciseDefinition[];
   /**
    * True once the `exerciseEntries` subscription has delivered its first
-   * snapshot. Distinct from `connected` (pushup-stream only) so consumers
-   * reasoning about non-pushup history — the training-plan store's
-   * idempotent logging — can tell "no exercise entries yet" from "haven't
-   * loaded exercise entries yet" and avoid a duplicate write.
+   * snapshot. Distinct from `connected` (which can flip back to false on a
+   * stream error) so the training-plan store's idempotent logging can tell
+   * "no entries yet" from "haven't loaded entries yet" and avoid a
+   * duplicate write.
    */
   exerciseEntriesLoaded: boolean;
+  /**
+   * Liveness of the `exerciseEntries` subscription — the canonical "live
+   * data is ready" signal for every entry-derived view (pushups included).
+   */
   connected: boolean;
   updateTick: number;
 };
@@ -56,7 +54,6 @@ type LiveDataState = {
 export const LiveDataStore = signalStore(
   { providedIn: 'root' },
   withState<LiveDataState>({
-    entries: [],
     exerciseEntries: [],
     exerciseDefinitions: [],
     exerciseEntriesLoaded: false,
@@ -91,7 +88,6 @@ export const LiveDataStore = signalStore(
         if (!u) {
           patchState(store, {
             connected: false,
-            entries: [],
             exerciseEntries: [],
             exerciseDefinitions: [],
             exerciseEntriesLoaded: false,
@@ -106,7 +102,6 @@ export const LiveDataStore = signalStore(
         if (u.uid !== subscribedUid) {
           patchState(store, {
             connected: false,
-            entries: [],
             exerciseEntries: [],
             exerciseDefinitions: [],
             exerciseEntriesLoaded: false,
@@ -114,59 +109,29 @@ export const LiveDataStore = signalStore(
           });
           subscribedUid = u.uid;
         }
-        const pushupQuery = query(
-          collection(fs, 'pushups'),
-          where('userId', '==', u.uid),
-          orderBy('timestamp', 'asc')
-        );
         const exerciseQuery = query(
           collection(fs, 'exerciseEntries'),
           where('userId', '==', u.uid),
           orderBy('timestamp', 'asc')
         );
-        const unsubPushups = onSnapshot(
-          pushupQuery,
+        const unsubExercises = onSnapshot(
+          exerciseQuery,
           (snapshot) => {
+            // Post-cutover this feed is the single source for all entry
+            // history, pushups included (`exerciseId:'pushup'`). Its first
+            // snapshot is the canonical liveness signal.
             patchState(store, {
               connected: true,
-              entries: snapshot.docs.map(
-                (d) => ({ _id: d.id, ...d.data() }) as PushupRecord
+              exerciseEntries: snapshot.docs.map(
+                (d) => ({ _id: d.id, ...d.data() }) as ExerciseEntry
               ),
+              exerciseEntriesLoaded: true,
               updateTick: store.updateTick() + 1,
             });
           },
           () => patchState(store, { connected: false })
         );
-        const unsubExercises = onSnapshot(
-          exerciseQuery,
-          (snapshot) => {
-            // `connected` is intentionally NOT set here — the pushup
-            // subscription is the canonical liveness indicator. If we
-            // also flipped it to `true` from this handler, an
-            // exercise-only success would mask a concurrent pushup
-            // subscription failure (the error handler on the pushup
-            // stream sets `connected: false`).
-            patchState(store, {
-              // Staged pushup→exerciseEntries migration copies carry
-              // `exerciseId:'pushup'` and must stay invisible to the live
-              // feed until the Phase-7 cutover, so browser consumers that
-              // union `entries()` + `exerciseEntries()` don't double-count
-              // pushups. The server-side trigger guards only cover
-              // aggregates/leaderboards, not browser reads.
-              exerciseEntries: snapshot.docs
-                .map((d) => ({ _id: d.id, ...d.data() }) as ExerciseEntry)
-                .filter((e) => e.exerciseId !== 'pushup'),
-              exerciseEntriesLoaded: true,
-              updateTick: store.updateTick() + 1,
-            });
-          },
-          // A failure on the exerciseEntries subscription must not flip
-          // `connected` to false either — same reason: pushups own the
-          // canonical signal.
-          () => undefined
-        );
         onCleanup(() => {
-          unsubPushups();
           unsubExercises();
         });
       });

--- a/libs/data-access/src/lib/api/pushup-firestore.service.ts
+++ b/libs/data-access/src/lib/api/pushup-firestore.service.ts
@@ -24,6 +24,9 @@ import {
 import { from, map, Observable, throwError } from 'rxjs';
 
 const PUSHUPS_COLLECTION = 'pushups';
+const EXERCISE_ENTRIES_COLLECTION = 'exerciseEntries';
+/** Pushups are stored as `exerciseEntries` with this id post-cutover. */
+const PUSHUP_EXERCISE_ID = 'pushup';
 
 export class PushupValidationError extends Error {
   constructor(
@@ -113,14 +116,24 @@ export class PushupFirestoreService {
     );
   }
 
+  /**
+   * Post Phase-7 cutover a "pushup" is just an `exerciseEntries` doc with
+   * `exerciseId:'pushup'` — the same store, aggregation, leaderboard and
+   * history path as every other exercise. New pushups therefore land in
+   * `exerciseEntries` (auto-id), NOT the legacy `pushups` collection, which
+   * is now read-only until its step-6 deletion. The legacy pushup variant
+   * (`type`) has no field in the unified schema and is intentionally dropped
+   * (matches the staged migration). The return keeps the `PushupRecord`
+   * shape so existing callers stay source-compatible.
+   */
   createPushup(
     userId: string,
     payload: PushupCreate
   ): Observable<PushupRecord> {
     const violation = repsViolationObservable<PushupRecord>(payload.reps);
     if (violation) return violation;
-    const pushupsRef = collection(this.firestore, PUSHUPS_COLLECTION);
-    const newRef = doc(pushupsRef);
+    const entriesRef = collection(this.firestore, EXERCISE_ENTRIES_COLLECTION);
+    const newRef = doc(entriesRef);
     const nowIso = new Date().toISOString();
     const record: PushupRecord & { userId: string } = {
       _id: newRef.id,
@@ -135,10 +148,10 @@ export class PushupFirestoreService {
     };
 
     const firestoreData: Record<string, unknown> = {
+      exerciseId: PUSHUP_EXERCISE_ID,
       timestamp: record.timestamp,
       reps: record.reps,
       source: record.source,
-      type: record.type ?? 'Standard',
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
       userId,

--- a/libs/data-access/src/lib/api/user-stats-api.service.ts
+++ b/libs/data-access/src/lib/api/user-stats-api.service.ts
@@ -21,4 +21,27 @@ export class UserStatsApiService {
       map((data) => (data ? (data as UserStats) : null))
     );
   }
+
+  /**
+   * Subscribe to the per-exercise aggregate at
+   * `userStats/{userId}/perExercise/{exerciseId}`. Same {@link UserStats}
+   * shape as {@link getUserStats}; the `updateExerciseStatsOnEntryWrite`
+   * trigger rewrites it after each matching `exerciseEntries` write. Emits
+   * null while the doc is missing (no entries / backfill not run yet).
+   */
+  getPerExerciseStats(
+    userId: string,
+    exerciseId: string
+  ): Observable<UserStats | null> {
+    const docRef = doc(
+      this.firestore,
+      USER_STATS_COLLECTION,
+      userId,
+      'perExercise',
+      exerciseId
+    );
+    return docData(docRef).pipe(
+      map((data) => (data ? (data as UserStats) : null))
+    );
+  }
 }

--- a/libs/quick-add/src/lib/adaptive-quick-add.service.ts
+++ b/libs/quick-add/src/lib/adaptive-quick-add.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { PushupRecord } from '@pu-stats/models';
 
 @Injectable({ providedIn: 'root' })
 export class AdaptiveQuickAddService {
@@ -7,8 +6,11 @@ export class AdaptiveQuickAddService {
    * Computes 3 adaptive suggestions based on the last 5 entries.
    * Suggestions are rounded to the nearest 5, minimum 1.
    * Falls back to [1, 5, 10] when no history is available.
+   *
+   * Only `reps` is read, so any rep-bearing record works (legacy
+   * `PushupRecord` or a unified pushup `exerciseEntries` row).
    */
-  compute(records: PushupRecord[]): [number, number, number] {
+  compute(records: readonly { reps: number }[]): [number, number, number] {
     const recent = records.slice(-5);
     if (recent.length === 0) {
       return [1, 5, 10];

--- a/libs/stats/src/lib/models/exercise.catalog.spec.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.spec.ts
@@ -6,10 +6,7 @@ import {
   findExerciseCategory,
   findExerciseDefinition,
 } from './exercise.catalog';
-import {
-  AUTO_COUNT_QUICK_ADD_EXERCISE_IDS,
-  PUSHUP_QUICK_ADD_EXERCISE_ID,
-} from './user-config.models';
+import { AUTO_COUNT_QUICK_ADD_EXERCISE_IDS } from './user-config.models';
 import { PUSHUP_REPS_MAX, PUSHUP_REPS_MIN } from './pushup.models';
 
 describe('EXERCISE_CATEGORIES', () => {
@@ -225,7 +222,7 @@ describe('exercisesByCategory', () => {
 });
 
 describe('auto-count / hold-timer catalog capabilities', () => {
-  it('should mark exactly situps, squats and pullups with an autoCountProfileId', () => {
+  it('should mark exactly pushups, situps, squats and pullups with an autoCountProfileId', () => {
     // given / when
     const profiles = EXERCISE_CATALOG.filter((d) => d.autoCountProfileId).map(
       (d) => [d.id, d.autoCountProfileId]
@@ -235,6 +232,7 @@ describe('auto-count / hold-timer catalog capabilities', () => {
       ['abs.situps', 'situp'],
       ['legs.squats', 'squat'],
       ['pull.pullups', 'pullup'],
+      ['pushup', 'pushup'],
     ]);
   });
 
@@ -242,7 +240,7 @@ describe('auto-count / hold-timer catalog capabilities', () => {
     // given — the union is type-only in web/auto-count, so this bounded set
     // is the catalog-side half of the contract; the orchestration spec
     // covers the round-trip through autoCountProfileForCatalogId.
-    const allowed = new Set(['squat', 'pullup', 'situp']);
+    const allowed = new Set(['pushup', 'squat', 'pullup', 'situp']);
     // when / then
     for (const def of EXERCISE_CATALOG) {
       if (def.autoCountProfileId) {
@@ -270,19 +268,18 @@ describe('auto-count / hold-timer catalog capabilities', () => {
 
   it('should keep AUTO_COUNT_QUICK_ADD_EXERCISE_IDS derivable from the catalog flags', () => {
     // given the catalog auto-count flags, when the quick-add subset is
-    // derived, then it equals the pushup sentinel plus every catalog
-    // exercise that declares a camera profile — no hand-maintained drift.
-    const derived = [
-      PUSHUP_QUICK_ADD_EXERCISE_ID,
-      ...EXERCISE_CATALOG.filter((d) => d.autoCountProfileId).map((d) => d.id),
-    ].sort();
+    // derived, then it equals every catalog exercise that declares a camera
+    // profile — pushup is now one of them, so no hand-maintained drift.
+    const derived = EXERCISE_CATALOG.filter((d) => d.autoCountProfileId)
+      .map((d) => d.id)
+      .sort();
     expect([...AUTO_COUNT_QUICK_ADD_EXERCISE_IDS].sort()).toEqual(derived);
   });
 });
 
 describe('PUSHUP_DEFINITION', () => {
-  it('should resolve the pushup sentinel through the catalog lookup', () => {
-    // given the legacy pushup sentinel id
+  it('should resolve the pushup id through the catalog lookup', () => {
+    // given the pushup exercise id
     // when resolved through the shared catalog lookup
     const def = findExerciseDefinition('pushup');
     // then it returns the first-class pushup definition, so consumers can
@@ -296,22 +293,21 @@ describe('PUSHUP_DEFINITION', () => {
     expect(def?.nameKey).toMatch(/^@@/);
   });
 
-  it('should keep the pushup sentinel out of the iterable EXERCISE_CATALOG', () => {
+  it('should list pushup as a first-class member of EXERCISE_CATALOG', () => {
     // given the "available exercises" array iterated by the dashboard, goal
-    // picker, leaderboard rebuild, rules-allowlist guard, and display-name
+    // picker, leaderboard rebuild, rules-allowlist codegen, and display-name
     // registry
-    // when scanning it for the pushup sentinel
-    // then it is absent — pushups live in the legacy collection and must not
-    // double-list, or those surfaces and their guard tests break
-    expect(EXERCISE_CATALOG.some((d) => d.id === 'pushup')).toBe(false);
+    // when scanning it for the pushup exercise
+    // then it is present exactly once — post-cutover pushups live in
+    // exerciseEntries and surface like every other exercise
+    expect(EXERCISE_CATALOG.filter((d) => d.id === 'pushup')).toHaveLength(1);
   });
 
-  it('should not give the pushup sentinel a camera autoCountProfileId', () => {
-    // given the camera 'pushup' profile is a separate concern from the catalog
-    // definition (the auto-count maps stay keyed off the sentinel)
+  it('should give pushup the camera "pushup" autoCountProfileId', () => {
+    // given the camera 'pushup' profile the original app shipped
     // when inspecting the definition
-    // then it carries no autoCountProfileId, so the auto-count derivation guard
-    // keeps treating pushup as a prepended sentinel
-    expect(PUSHUP_DEFINITION.autoCountProfileId).toBeUndefined();
+    // then it carries the matching autoCountProfileId, so the auto-count
+    // derivation treats pushup as a normal catalog auto-count exercise
+    expect(PUSHUP_DEFINITION.autoCountProfileId).toBe('pushup');
   });
 });

--- a/libs/stats/src/lib/models/exercise.catalog.ts
+++ b/libs/stats/src/lib/models/exercise.catalog.ts
@@ -99,7 +99,30 @@ export const EXERCISE_CATEGORIES: ReadonlyArray<ExerciseCategoryInfo> = [
  * Caps mirror the `exerciseEntries` Firestore rule. Any change here MUST
  * be reflected in `data-store/firestore.rules` and vice versa.
  */
+
+/**
+ * Pushups (`id: 'pushup'`) are a first-class catalog exercise: post Phase-7
+ * cutover they live in `exerciseEntries` with `exerciseId:'pushup'` and
+ * aggregate into `perExercise/pushup` like any other exercise. Exported as a
+ * named const (legacy callers reference it directly) and listed in
+ * {@link EXERCISE_CATALOG} below so the dashboard, goal picker,
+ * leaderboard rebuild, `firestore.rules` allowlist codegen, display-name
+ * registry, and camera auto-count all pick it up automatically.
+ */
+export const PUSHUP_DEFINITION: ExerciseDefinition = {
+  id: 'pushup',
+  categoryId: 'pushup',
+  autoCountProfileId: 'pushup',
+  measurement: 'reps',
+  min: PUSHUP_REPS_MIN,
+  max: PUSHUP_REPS_MAX,
+  unit: 'reps',
+  nameKey: '@@exercise.category.pushup',
+  icon: 'fitness_center',
+};
+
 export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
+  PUSHUP_DEFINITION,
   {
     // Legacy id `abs.situps` predates the movement-pattern restructure.
     // Kept as-is so existing Firestore docs continue to resolve; only
@@ -808,34 +831,8 @@ export const EXERCISE_CATALOG: ReadonlyArray<ExerciseDefinition> = [
   // per-exercise stats trigger work to surface PRs in load × reps.
 ];
 
-/**
- * First-class definition for the `'pushup'` sentinel so it resolves through
- * {@link findExerciseDefinition} like any other exercise (goals, entries,
- * analysis, and training plans stop special-casing the literal).
- *
- * Deliberately NOT a member of {@link EXERCISE_CATALOG}: that array is the
- * "available exercises" list iterated by the dashboard, the goal picker, the
- * exercise-leaderboard rebuild, the `firestore.rules` allowlist guard, and the
- * display-name registry. Pushups live in the legacy `pushups` collection with
- * their own dedicated UI and own no camera `autoCountProfileId`, so listing it
- * in the array would double-list it across those surfaces and break their
- * guard tests. Folding it into the by-id lookup only is the
- * resolvable-but-not-listed base the multi-exercise roadmap's Phase-7
- * pushup→exerciseEntries migration builds on.
- */
-export const PUSHUP_DEFINITION: ExerciseDefinition = {
-  id: 'pushup',
-  categoryId: 'pushup',
-  measurement: 'reps',
-  min: PUSHUP_REPS_MIN,
-  max: PUSHUP_REPS_MAX,
-  unit: 'reps',
-  nameKey: '@@exercise.category.pushup',
-  icon: 'fitness_center',
-};
-
 const CATALOG_BY_ID: ReadonlyMap<string, ExerciseDefinition> = new Map(
-  [...EXERCISE_CATALOG, PUSHUP_DEFINITION].map((d) => [d.id, d])
+  EXERCISE_CATALOG.map((d) => [d.id, d])
 );
 
 const CATEGORIES_BY_ID: ReadonlyMap<string, ExerciseCategoryInfo> = new Map(

--- a/web/src/app/admin/migrations/migration-descriptors.ts
+++ b/web/src/app/admin/migrations/migration-descriptors.ts
@@ -64,4 +64,10 @@ export const DATA_MIGRATIONS: readonly MigrationDescriptor[] = [
     migrate: { callable: 'migratePushupsToExerciseEntries' },
     rollback: { callable: 'rollbackPushupUnification' },
   },
+  {
+    id: 'pushup-perexercise-backfill',
+    title: $localize`:@@admin.migrations.pushupBackfill.title:Pushup-Aggregat backfillen (perExercise/pushup)`,
+    description: $localize`:@@admin.migrations.pushupBackfill.description:Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.`,
+    migrate: { callable: 'backfillPushupPerExerciseStats' },
+  },
 ];

--- a/web/src/app/app.config.ts
+++ b/web/src/app/app.config.ts
@@ -30,7 +30,7 @@ import {
   withI18nSupport,
   withIncrementalHydration,
 } from '@angular/platform-browser';
-import { provideRouter, Router, withInMemoryScrolling } from '@angular/router';
+import { provideRouter, Router, withInMemoryScrolling, withViewTransitions } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
 import {
   provideAuth,
@@ -59,6 +59,7 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(withFetch()),
     provideRouter(
       appRoutes,
+      withViewTransitions(),
       withInMemoryScrolling({
         anchorScrolling: 'enabled',
         scrollPositionRestoration: 'enabled',

--- a/web/src/app/core/app-data.facade.spec.ts
+++ b/web/src/app/core/app-data.facade.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
-import { signal } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import { AppDataFacade } from './app-data.facade';
 import { StatsApiService, UserConfigApiService } from '@pu-stats/data-access';
 import { LiveDataStore } from '@pu-stats/data-access-state';
@@ -102,7 +102,12 @@ describe('AppDataFacade', () => {
           provide: LiveDataStore,
           useValue: {
             connected: liveConnected.asReadonly(),
-            entries: liveEntries.asReadonly(),
+            // Post-cutover pushups live on the exerciseEntries feed
+            // (`exerciseId:'pushup'`); tests still seed `liveEntries`.
+            exerciseEntries: computed(() =>
+              liveEntries().map((r) => ({ ...r, exerciseId: 'pushup' }))
+            ),
+            exerciseEntriesLoaded: liveConnected.asReadonly(),
             updateTick: signal(0).asReadonly(),
           },
         },
@@ -390,7 +395,10 @@ describe('AppDataFacade', () => {
             provide: LiveDataStore,
             useValue: {
               connected: liveConnected.asReadonly(),
-              entries: liveEntries.asReadonly(),
+              exerciseEntries: computed(() =>
+                liveEntries().map((r) => ({ ...r, exerciseId: 'pushup' }))
+              ),
+              exerciseEntriesLoaded: liveConnected.asReadonly(),
               updateTick: signal(0).asReadonly(),
             },
           },

--- a/web/src/app/core/app-data.facade.ts
+++ b/web/src/app/core/app-data.facade.ts
@@ -107,17 +107,22 @@ export class AppDataFacade {
   });
 
   /** Last 7 days of entries — derived live from Firestore in the browser. */
-  private readonly recentEntries = computed(() => {
-    if (this.isBrowser && this.live.connected()) {
-      const sevenDaysAgo = new Date();
-      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-      const cutoff = sevenDaysAgo.toISOString().slice(0, 10);
-      return this.live
-        .entries()
-        .filter((e) => e.timestamp.slice(0, 10) >= cutoff);
+  private readonly recentEntries = computed<{ timestamp: string; reps: number }[]>(
+    () => {
+      if (this.isBrowser && this.live.connected()) {
+        const sevenDaysAgo = new Date();
+        sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+        const cutoff = sevenDaysAgo.toISOString().slice(0, 10);
+        return this.live
+          .exerciseEntries()
+          .filter(
+            (e) => e.exerciseId === 'pushup' && e.timestamp.slice(0, 10) >= cutoff
+          )
+          .map((e) => ({ timestamp: e.timestamp, reps: e.reps ?? 0 }));
+      }
+      return this.recentEntriesResource.value() ?? [];
     }
-    return this.recentEntriesResource.value() ?? [];
-  });
+  );
 
   readonly quickAddSuggestions = computed<QuickAddSuggestion[]>(() => {
     const configured = this.userConfig.quickAdds();
@@ -177,9 +182,13 @@ export class AppDataFacade {
     if (this.isBrowser && this.live.connected()) {
       const berlinToday = toBerlinIsoDate(new Date());
       return this.live
-        .entries()
-        .filter((e) => e.timestamp.slice(0, 10) === berlinToday)
-        .reduce((sum, e) => sum + e.reps, 0);
+        .exerciseEntries()
+        .filter(
+          (e) =>
+            e.exerciseId === 'pushup' &&
+            e.timestamp.slice(0, 10) === berlinToday
+        )
+        .reduce((sum, e) => sum + (e.reps ?? 0), 0);
     }
     return this.dailyProgressResource.value() ?? 0;
   });
@@ -255,9 +264,10 @@ export class AppDataFacade {
       .exerciseEntries()
       .filter((e) => e.timestamp.slice(0, 10) === berlinToday);
     return entries.map((entry) => {
-      if (entry.exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID) {
-        return pushupRepsToday;
-      }
+      // Post-cutover pushups live in `exerciseEntries` (`exerciseId:'pushup'`)
+      // like every other exercise, so the generic matching below handles
+      // them — no pushup short-circuit needed.
+      //
       // When the goal pins a specific variant, count only entries of that
       // variant. Otherwise match every entry for the exercise across all
       // its variants — the goals page deliberately does not expose a

--- a/web/src/app/core/goal-reached-notification.service.spec.ts
+++ b/web/src/app/core/goal-reached-notification.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { signal } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { UserConfigApiService } from '@pu-stats/data-access';
 import { LiveDataStore } from '@pu-stats/data-access-state';
@@ -23,8 +23,12 @@ describe('GoalReachedNotificationService', () => {
   const liveEntries = signal<PushupRecord[]>([]);
   const liveTick = signal(0);
   const liveConnected = signal(true);
+  // Post-cutover pushups live in `exerciseEntries` (`exerciseId:'pushup'`);
+  // tests still seed `liveEntries`, the mock surfaces them on that feed.
   const liveStoreMock = {
-    entries: liveEntries.asReadonly(),
+    exerciseEntries: computed(() =>
+      liveEntries().map((r) => ({ ...r, exerciseId: 'pushup' }))
+    ),
     updateTick: liveTick.asReadonly(),
     connected: liveConnected.asReadonly(),
   };

--- a/web/src/app/core/goal-reached-notification.service.ts
+++ b/web/src/app/core/goal-reached-notification.service.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { LiveDataStore } from '@pu-stats/data-access-state';
-import { PushupRecord, SNAP_QUALITY_PARTICLES } from '@pu-stats/models';
+import { SNAP_QUALITY_PARTICLES } from '@pu-stats/models';
 import { toBerlinIsoDate } from '@pu-stats/date';
 import type { GoalKind } from '../stats/components/goal-reached-dialog/goal-reached-dialog.component';
 import { TrainingPlanStore } from '../training-plans/training-plan.store';
@@ -45,8 +45,14 @@ export class GoalReachedNotificationService {
   private readonly live = inject(LiveDataStore);
   private readonly trainingPlan = inject(TrainingPlanStore);
 
-  private readonly entries = computed<PushupRecord[]>(() =>
-    this.live.entries()
+  // Post-cutover pushups live in `exerciseEntries` (`exerciseId:'pushup'`).
+  // Only the legacy daily/weekly/monthly goals tracked here are pushup-reps.
+  private readonly entries = computed<{ timestamp: string; reps: number }[]>(
+    () =>
+      this.live
+        .exerciseEntries()
+        .filter((e) => e.exerciseId === 'pushup')
+        .map((e) => ({ timestamp: e.timestamp, reps: e.reps ?? 0 }))
   );
 
   /**

--- a/web/src/app/goals/shell/goals-page.component.ts
+++ b/web/src/app/goals/shell/goals-page.component.ts
@@ -29,7 +29,7 @@ import {
   type ExerciseDefinition,
   type GoalScope,
   type MeasurementType,
-  PUSHUP_QUICK_ADD_EXERCISE_ID,
+  PUSHUP_DEFINITION,
 } from '@pu-stats/models';
 import { PageHeaderComponent } from '../../core/page-header/page-header.component';
 import { UserConfigStore } from '../../core/user-config.store';
@@ -49,15 +49,6 @@ interface ExercisePickerEntry {
   max: number;
 }
 
-const PUSHUP_PICKER_ENTRY: ExercisePickerEntry = {
-  id: PUSHUP_QUICK_ADD_EXERCISE_ID,
-  label: $localize`:@@exercise.category.pushup:Liegestütze`,
-  measurement: 'reps',
-  unit: 'reps',
-  min: 1,
-  max: 1000,
-};
-
 function pickerFromDefinition(def: ExerciseDefinition): ExercisePickerEntry {
   return {
     id: def.id,
@@ -70,7 +61,7 @@ function pickerFromDefinition(def: ExerciseDefinition): ExercisePickerEntry {
 }
 
 function buildExerciseOptions(): ExercisePickerEntry[] {
-  return [PUSHUP_PICKER_ENTRY, ...EXERCISE_CATALOG.map(pickerFromDefinition)];
+  return EXERCISE_CATALOG.map(pickerFromDefinition);
 }
 
 function makeEntryId(): string {
@@ -568,10 +559,10 @@ export class GoalsPageComponent {
     if (list.length >= this.maxPerScope) return;
     const next: ComplexGoalEntry = {
       id: makeEntryId(),
-      exerciseId: PUSHUP_PICKER_ENTRY.id,
+      exerciseId: PUSHUP_DEFINITION.id,
       target: 10,
-      measurement: PUSHUP_PICKER_ENTRY.measurement,
-      unit: PUSHUP_PICKER_ENTRY.unit,
+      measurement: PUSHUP_DEFINITION.measurement,
+      unit: PUSHUP_DEFINITION.unit,
     };
     this.entriesFor(scope).set([...list, next]);
   }

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -651,11 +651,12 @@ export const AnalysisStore = signalStore(
     // canonical model — no parallel field list to drift.
     type ChartFeedEntry = Pick<UnifiedEntry, 'timestamp' | 'reps' | 'sets'>;
 
-    // Post-cutover the live feed carries pushups too, so once it has
-    // connected it is the single source (no REST-pushup merge, no
-    // double-count). SSR / cold-start has no live feed, so it falls back to
-    // the pushup REST resource (pushups-only — acceptable for the analysis
-    // surface until the live snapshot mounts).
+    // Pushup rows come from the REST resource (so SSR + variant history keep
+    // working); other exercises come from the live snapshot. Post-cutover the
+    // live feed ALSO carries pushups (`exerciseId:'pushup'`), so those are
+    // filtered out here to avoid double-counting the REST pushups. (New
+    // post-cutover pushups therefore surface on analysis only after the legacy
+    // collection is retired in step 6 — acceptable for this secondary view.)
     const unifiedRows = computed<UnifiedEntry[]>(() => {
       const from = store.from();
       const to = store.to();
@@ -665,15 +666,14 @@ export const AnalysisStore = signalStore(
         if (to && date > to) return false;
         return true;
       };
-      if (store._live.connected()) {
-        return store._live
-          .exerciseEntries()
-          .filter((e) => inRange(e.timestamp))
-          .map(exerciseEntryToUnified);
-      }
-      return rows()
+      const pushups = rows()
         .filter((r) => inRange(r.timestamp))
         .map(pushupRecordToUnified);
+      const exercises = store._live
+        .exerciseEntries()
+        .filter((e) => e.exerciseId !== 'pushup' && inRange(e.timestamp))
+        .map(exerciseEntryToUnified);
+      return [...pushups, ...exercises];
     });
 
     /** Distinct kind keys with at least one entry in the visible range. */
@@ -1011,17 +1011,16 @@ export const AnalysisStore = signalStore(
       window: { from: string; to: string }
     ): UnifiedEntry[] => {
       const inRange = inRangeFn(window.from, window.to);
-      // Live feed (incl. pushups) is the single source once connected; REST
-      // pushups are the SSR/cold-start fallback. Mirrors `unifiedRows`.
-      if (store._live.connected()) {
-        return store._live
-          .exerciseEntries()
-          .filter((e) => inRange(e.timestamp))
-          .map(exerciseEntryToUnified);
-      }
-      return pushupRows
+      // Pushups from REST; other exercises from the live feed (pushup copies
+      // filtered out to avoid double-count). Mirrors `unifiedRows`.
+      const pushups = pushupRows
         .filter((r) => inRange(r.timestamp))
         .map(pushupRecordToUnified);
+      const exercises = store._live
+        .exerciseEntries()
+        .filter((e) => e.exerciseId !== 'pushup' && inRange(e.timestamp))
+        .map(exerciseEntryToUnified);
+      return [...pushups, ...exercises];
     };
 
     const applyViewFilter = (rows: UnifiedEntry[]): UnifiedEntry[] => {

--- a/web/src/app/stats/analysis.store.ts
+++ b/web/src/app/stats/analysis.store.ts
@@ -651,9 +651,11 @@ export const AnalysisStore = signalStore(
     // canonical model — no parallel field list to drift.
     type ChartFeedEntry = Pick<UnifiedEntry, 'timestamp' | 'reps' | 'sets'>;
 
-    // Pushup rows come from the REST resource (works on SSR); exercise
-    // entries come from the live Firestore snapshot, so SSR yields
-    // pushups only.
+    // Post-cutover the live feed carries pushups too, so once it has
+    // connected it is the single source (no REST-pushup merge, no
+    // double-count). SSR / cold-start has no live feed, so it falls back to
+    // the pushup REST resource (pushups-only — acceptable for the analysis
+    // surface until the live snapshot mounts).
     const unifiedRows = computed<UnifiedEntry[]>(() => {
       const from = store.from();
       const to = store.to();
@@ -663,14 +665,15 @@ export const AnalysisStore = signalStore(
         if (to && date > to) return false;
         return true;
       };
-      const pushups = rows()
+      if (store._live.connected()) {
+        return store._live
+          .exerciseEntries()
+          .filter((e) => inRange(e.timestamp))
+          .map(exerciseEntryToUnified);
+      }
+      return rows()
         .filter((r) => inRange(r.timestamp))
         .map(pushupRecordToUnified);
-      const exercises = store._live
-        .exerciseEntries()
-        .filter((e) => inRange(e.timestamp))
-        .map(exerciseEntryToUnified);
-      return [...pushups, ...exercises];
     });
 
     /** Distinct kind keys with at least one entry in the visible range. */
@@ -1008,14 +1011,17 @@ export const AnalysisStore = signalStore(
       window: { from: string; to: string }
     ): UnifiedEntry[] => {
       const inRange = inRangeFn(window.from, window.to);
-      const pushups = pushupRows
+      // Live feed (incl. pushups) is the single source once connected; REST
+      // pushups are the SSR/cold-start fallback. Mirrors `unifiedRows`.
+      if (store._live.connected()) {
+        return store._live
+          .exerciseEntries()
+          .filter((e) => inRange(e.timestamp))
+          .map(exerciseEntryToUnified);
+      }
+      return pushupRows
         .filter((r) => inRange(r.timestamp))
         .map(pushupRecordToUnified);
-      const exercises = store._live
-        .exerciseEntries()
-        .filter((e) => inRange(e.timestamp))
-        .map(exerciseEntryToUnified);
-      return [...pushups, ...exercises];
     };
 
     const applyViewFilter = (rows: UnifiedEntry[]): UnifiedEntry[] => {

--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.spec.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.spec.ts
@@ -32,10 +32,16 @@ function makeLiveStoreMock(
     exerciseEntries?: unknown[];
   } = {}
 ) {
+  // Post-cutover pushups live on the exerciseEntries feed
+  // (`exerciseId:'pushup'`); tests still pass them via `entries`, merged here.
+  const pushups = (overrides.entries ?? []).map((r) => ({
+    ...(r as Record<string, unknown>),
+    exerciseId: 'pushup',
+  }));
   return {
     connected: signal(overrides.connected ?? false),
-    entries: signal(overrides.entries ?? []),
-    exerciseEntries: signal(overrides.exerciseEntries ?? []),
+    exerciseEntries: signal([...pushups, ...(overrides.exerciseEntries ?? [])]),
+    exerciseEntriesLoaded: signal(overrides.connected ?? false),
     updateTick: signal(0),
   };
 }

--- a/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
+++ b/web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts
@@ -185,12 +185,21 @@ export class AnalysisTeaserCardComponent {
       return this.pushupLabel;
     }
 
+    // Post-cutover pushups are `exerciseEntries` too, so split the single
+    // feed on `exerciseId` to keep the "Liegestütze" vs "Alle Übungen"
+    // distinction.
     const hasPushupReps = this.live
-      .entries()
-      .some((e) => inRange(e.timestamp) && e.reps > 0);
+      .exerciseEntries()
+      .some(
+        (e) =>
+          e.exerciseId === 'pushup' && inRange(e.timestamp) && (e.reps ?? 0) > 0
+      );
     const hasOtherReps = this.live
       .exerciseEntries()
-      .some((e) => inRange(e.timestamp) && (e.reps ?? 0) > 0);
+      .some(
+        (e) =>
+          e.exerciseId !== 'pushup' && inRange(e.timestamp) && (e.reps ?? 0) > 0
+      );
 
     if (hasOtherReps) return this.allExercisesLabel;
     if (hasPushupReps) return this.pushupLabel;
@@ -224,11 +233,9 @@ export class AnalysisTeaserCardComponent {
       return day >= from && day <= to;
     };
 
-    for (const entry of this.live.entries()) {
-      if (!inRange(entry.timestamp)) continue;
-      const day = entry.timestamp.slice(0, 10);
-      totals.set(day, (totals.get(day) ?? 0) + entry.reps);
-    }
+    // Post-cutover the live feed carries pushups too, so a single pass over
+    // `exerciseEntries()` sums every exercise (no separate pushup loop, no
+    // double-count).
     for (const entry of this.live.exerciseEntries()) {
       if (!inRange(entry.timestamp)) continue;
       const reps = entry.reps ?? 0;

--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -20,7 +20,6 @@ import {
   findExerciseDefinition,
   isAutoCountQuickAddExerciseId,
   PUSHUP_QUICK_ADD_EXERCISE_ID,
-  PushupRecord,
   pushupRecordToUnified,
   QuickAddConfig,
   QuickAddMode,
@@ -109,7 +108,7 @@ const EMPTY_STATS: StatsResponse = {
   series: [],
 };
 
-function sortedUniqueDates(rows: PushupRecord[]): string[] {
+function sortedUniqueDates(rows: { timestamp: string }[]): string[] {
   return [...new Set(rows.map((x) => x.timestamp.slice(0, 10)))].sort((a, b) =>
     a.localeCompare(b)
   );
@@ -175,14 +174,18 @@ export const DashboardStore = signalStore(
     allTimeResource: resource({
       loader: async () => firstValueFrom(store._api.load({})),
     }),
-    // Real-time listener on `userStats/{userId}`. The Cloud Function
-    // aggregator rewrites this doc after each pushup write — `rxResource`
-    // ensures the dashboard re-renders without polling or manual reload.
+    // Real-time listener on the per-exercise pushup aggregate
+    // `userStats/{userId}/perExercise/pushup`. Post-cutover this is the
+    // source for pushup totals/streak/heatmap (the
+    // `updateExerciseStatsOnEntryWrite` trigger rewrites it after each
+    // pushup `exerciseEntries` write); `rxResource` re-renders without
+    // polling. Same `UserStats` shape as the legacy `userStats/{userId}`
+    // doc, so downstream bindings are unchanged.
     userStatsResource: rxResource({
       params: () => ({ userId: store._user.userIdSafe() }),
       stream: ({ params }) =>
         params.userId
-          ? store._userStatsApi.getUserStats(params.userId)
+          ? store._userStatsApi.getPerExerciseStats(params.userId, 'pushup')
           : of(null),
     }),
   })),
@@ -195,11 +198,17 @@ export const DashboardStore = signalStore(
     // has connected (reactive, real-time). Until then we fall back to the
     // REST resource so SSR and the cold-start hydration window still render
     // data instead of an empty state.
-    const entryRows = computed<PushupRecord[]>(() => {
+    const entryRows = computed<{ timestamp: string; reps: number }[]>(() => {
       if (store._isBrowser && store._live.connected()) {
-        return store._live.entries();
+        return store._live
+          .exerciseEntries()
+          .filter((e) => e.exerciseId === 'pushup')
+          .map((e) => ({ timestamp: e.timestamp, reps: e.reps ?? 0 }));
       }
-      return store.entriesResource.value() ?? [];
+      return (store.entriesResource.value() ?? []).map((r) => ({
+        timestamp: r.timestamp,
+        reps: r.reps,
+      }));
     });
 
     /** Precomputed server-side stats (null if not yet available). */
@@ -319,16 +328,17 @@ export const DashboardStore = signalStore(
       () => configuredDailyGoal() > 0 && todayTotal() >= configuredDailyGoal()
     );
 
-    // SSR only sees pushups (no exerciseEntries REST endpoint). Goal /
-    // streak / total metrics stay on the pushup-only `entryRows()` —
-    // only the history surfaces consume `unifiedRows`.
+    // Browser: the live feed already carries pushups alongside every other
+    // exercise, so the unified history is a single map over
+    // `exerciseEntries()`. SSR has no exerciseEntries REST endpoint, so it
+    // falls back to the pushup REST resource. Goal / streak / total metrics
+    // stay on the pushup-only `entryRows()`; only history surfaces consume
+    // `unifiedRows`.
     const unifiedRows = computed<UnifiedEntry[]>(() => {
-      const pushups = entryRows().map(pushupRecordToUnified);
-      if (!store._isBrowser) return pushups;
-      const exercises = store._live
-        .exerciseEntries()
-        .map(exerciseEntryToUnified);
-      return [...pushups, ...exercises];
+      if (!store._isBrowser) {
+        return (store.entriesResource.value() ?? []).map(pushupRecordToUnified);
+      }
+      return store._live.exerciseEntries().map(exerciseEntryToUnified);
     });
 
     const lastEntry = computed<UnifiedEntry | null>(() => {

--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -328,17 +328,18 @@ export const DashboardStore = signalStore(
       () => configuredDailyGoal() > 0 && todayTotal() >= configuredDailyGoal()
     );
 
-    // Browser: the live feed already carries pushups alongside every other
-    // exercise, so the unified history is a single map over
-    // `exerciseEntries()`. SSR has no exerciseEntries REST endpoint, so it
-    // falls back to the pushup REST resource. Goal / streak / total metrics
-    // stay on the pushup-only `entryRows()`; only history surfaces consume
-    // `unifiedRows`.
+    // Once the live feed has connected it already carries pushups alongside
+    // every other exercise, so the unified history is a single map over
+    // `exerciseEntries()`. SSR and the cold-start browser window (before the
+    // listener connects) fall back to the pushup REST resource (pushup-only —
+    // exerciseEntries have no REST endpoint) so history renders instead of
+    // flickering empty. Goal / streak / total metrics stay on the pushup-only
+    // `entryRows()`; only history surfaces consume `unifiedRows`.
     const unifiedRows = computed<UnifiedEntry[]>(() => {
-      if (!store._isBrowser) {
-        return (store.entriesResource.value() ?? []).map(pushupRecordToUnified);
+      if (store._isBrowser && store._live.connected()) {
+        return store._live.exerciseEntries().map(exerciseEntryToUnified);
       }
-      return store._live.exerciseEntries().map(exerciseEntryToUnified);
+      return (store.entriesResource.value() ?? []).map(pushupRecordToUnified);
     });
 
     const lastEntry = computed<UnifiedEntry | null>(() => {

--- a/web/src/app/stats/entries.store.ts
+++ b/web/src/app/stats/entries.store.ts
@@ -107,13 +107,14 @@ export const EntriesStore = signalStore(
      */
     rows: computed<UnifiedEntry[]>(() => {
       if (store._isBrowser) {
-        const pushups = store._live.entries().map(pushupRecordToUnified);
-        const exercises = store._live
+        // Post-cutover the live feed already carries pushups
+        // (`exerciseId:'pushup'`) alongside every other exercise, so a
+        // single map over `exerciseEntries()` is the whole history — no
+        // separate pushup source to merge (and nothing to double-count).
+        return store._live
           .exerciseEntries()
-          .map(exerciseEntryToUnified);
-        return [...pushups, ...exercises].sort((a, b) =>
-          a.timestamp.localeCompare(b.timestamp)
-        );
+          .map(exerciseEntryToUnified)
+          .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
       }
       const ssrPushups = (store._entriesResource.value() ?? []).map(
         pushupRecordToUnified

--- a/web/src/app/stats/i18n/exercise-display-names.ts
+++ b/web/src/app/stats/i18n/exercise-display-names.ts
@@ -18,6 +18,11 @@ import {
  * for exercises the catalog doesn't ship). Exported only for that guard.
  */
 export const EXERCISE_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  // pushup — first-class catalog exercise post Phase-7 cutover; reuses the
+  // shared `@@exercise.category.pushup` id so the label stays in lockstep
+  // with the category name and the legacy display paths.
+  pushup: $localize`:@@exercise.category.pushup:Liegestütze`,
+
   // core (legacy `abs.*` ids kept for data stability)
   'abs.situps': $localize`:@@exercise.abs.situps.name:Sit-ups`,
   'abs.crunches': $localize`:@@exercise.abs.crunches.name:Crunches`,

--- a/web/src/app/stats/shell/entries-page.component.spec.ts
+++ b/web/src/app/stats/shell/entries-page.component.spec.ts
@@ -59,13 +59,21 @@ describe('EntriesPageComponent', () => {
     updatePushup: vitest.fn().mockReturnValue(of({ _id: '1' })),
   };
 
+  // Post-cutover pushups are `exerciseEntries` (`exerciseId:'pushup'`) with
+  // no variant/`type` — the legacy variant is dropped by the migration. The
+  // history feed therefore surfaces plain Liegestütze rows.
   const liveMock = {
     connected: signal(true),
-    entries: signal(rows),
-    // EntriesStore now reads from both pushups and exerciseEntries via
-    // LiveDataStore. The Phase-0 history flow only exercises pushups
-    // here, so an empty exerciseEntries signal is enough.
-    exerciseEntries: signal([] as never[]),
+    exerciseEntriesLoaded: signal(true),
+    exerciseEntries: signal(
+      rows.map((r) => ({
+        _id: r._id,
+        exerciseId: 'pushup',
+        timestamp: r.timestamp,
+        reps: r.reps,
+        source: r.source,
+      }))
+    ),
     updateTick: signal(0),
   };
 
@@ -105,12 +113,10 @@ describe('EntriesPageComponent', () => {
     expect(store.to()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
-  it('applies source, type and reps filter', () => {
-    // The filter dropdown emits canonical kebab-case ids. Legacy
-    // entryLabel rows ("Wide") still match because the store
-    // canonicalizes both sides before comparing.
+  it('applies source and reps filter', () => {
+    // Post-cutover pushups carry no variant, so only source + reps narrow
+    // the list. source 'wa' → rows 1 & 3; reps ≥ 11 → row 3.
     store.setSource('wa');
-    store.setType('wide');
     store.setRepsMin(11);
 
     expect(store.filteredRows().map((x: { _id: string }) => x._id)).toEqual([
@@ -157,21 +163,11 @@ describe('EntriesPageComponent', () => {
     expect(apiMock.deletePushup).toHaveBeenCalledWith('2');
   });
 
-  it('deduplicates legacy entryLabel and new canonical id in typeOptions', () => {
-    // Rows 2 ("Diamond") and 4 ("diamond") must collapse into a single
-    // filter option keyed by the canonical id.
+  it('exposes no pushup variant type options post-cutover', () => {
+    // Pushups carry no variant after the exerciseEntries cutover, so the
+    // legacy Diamond/Wide "Typ" options no longer appear.
     const options = store.typeOptions();
-    const diamondOptions = options.filter((o) => o.value === 'diamond');
-    expect(diamondOptions).toHaveLength(1);
-    // Filter selection on the canonical id must match both legacy AND
-    // new-form rows in filteredRows.
-    store.setType('diamond');
-    expect(
-      store
-        .filteredRows()
-        .map((x: { _id: string }) => x._id)
-        .sort()
-    ).toEqual(['2', '4']);
+    expect(options.some((o) => o.value === 'diamond')).toBe(false);
   });
 
   describe('kindFilterOptions + kindLabel', () => {

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -14,7 +14,7 @@ import {
 import { LiveDataStore } from '@pu-stats/data-access-state';
 import { AuthStore, UserContextService } from '@pu-auth/auth';
 import { AdsStore } from '@pu-stats/ads';
-import { signal } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import { makeAuthStoreMock } from '@pu-stats/testing';
 import {
   ActivatedRoute,
@@ -111,8 +111,13 @@ describe('StatsDashboardComponent', () => {
   const liveMock = {
     updateTick: liveTick.asReadonly(),
     connected: liveConnected.asReadonly(),
-    entries: liveEntries.asReadonly(),
-    exerciseEntries: liveExerciseEntries.asReadonly(),
+    exerciseEntriesLoaded: liveConnected.asReadonly(),
+    // Post-cutover the live feed carries pushups (`exerciseId:'pushup'`)
+    // alongside other exercises; tests still seed `liveEntries` for pushups.
+    exerciseEntries: computed(() => [
+      ...liveEntries().map((r) => ({ ...r, exerciseId: 'pushup' })),
+      ...liveExerciseEntries(),
+    ]),
   };
 
   const adsConfigMock = {
@@ -196,6 +201,7 @@ describe('StatsDashboardComponent', () => {
           provide: UserStatsApiService,
           useValue: {
             getUserStats: vitest.fn().mockReturnValue(of(null)),
+            getPerExerciseStats: vitest.fn().mockReturnValue(of(null)),
           },
         },
         { provide: LiveDataStore, useValue: liveMock },
@@ -924,7 +930,10 @@ describe('StatsDashboardComponent', () => {
           { provide: StatsApiService, useValue: serviceMock },
           {
             provide: UserStatsApiService,
-            useValue: { getUserStats: vitest.fn().mockReturnValue(of(null)) },
+            useValue: {
+              getUserStats: vitest.fn().mockReturnValue(of(null)),
+              getPerExerciseStats: vitest.fn().mockReturnValue(of(null)),
+            },
           },
           { provide: LiveDataStore, useValue: liveMock },
           { provide: UserContextService, useValue: { userIdSafe: () => 'u1' } },

--- a/web/src/app/training-plans/training-plan.store.spec.ts
+++ b/web/src/app/training-plans/training-plan.store.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { PLATFORM_ID, signal } from '@angular/core';
+import { computed, PLATFORM_ID, signal, type Signal } from '@angular/core';
 import { BehaviorSubject, from, map, of } from 'rxjs';
 import { UserContextService } from '@pu-auth/auth';
 import {
@@ -140,8 +140,7 @@ interface Mocks {
     createEntry: ReturnType<typeof vitest.fn>;
   };
   liveMock: {
-    entries: ReturnType<typeof signal<PushupRecord[]>>;
-    exerciseEntries: ReturnType<typeof signal<ExerciseEntry[]>>;
+    exerciseEntries: Signal<ExerciseEntry[]>;
     connected: ReturnType<typeof signal<boolean>>;
     exerciseEntriesLoaded: ReturnType<typeof signal<boolean>>;
     updateTick: ReturnType<typeof signal<number>>;
@@ -303,8 +302,14 @@ describe('TrainingPlanStore', () => {
         ),
       },
       liveMock: {
-        entries: liveEntries,
-        exerciseEntries: liveExerciseEntries,
+        // Post-cutover pushups are exerciseEntries (`exerciseId:'pushup'`);
+        // tests still seed `initialEntries` as pushups, merged here.
+        exerciseEntries: computed<ExerciseEntry[]>(() => [
+          ...liveEntries().map(
+            (r) => ({ ...r, exerciseId: 'pushup' }) as ExerciseEntry
+          ),
+          ...liveExerciseEntries(),
+        ]),
         connected: signal(true),
         exerciseEntriesLoaded: signal(true),
         updateTick: signal(0),
@@ -644,15 +649,16 @@ describe('TrainingPlanStore', () => {
       };
       const statsApiMock = { createPushup: vitest.fn() };
       const exerciseApiMock = { createEntry: vitest.fn() };
-      // Pre-existing entry that DOES cover the target — but
-      // `connected: false` means we shouldn't trust it.
-      const liveEntries = signal<PushupRecord[]>([
+      // Pre-existing pushup entry that DOES cover the target — but the
+      // exerciseEntries feed hasn't loaded yet, so we shouldn't trust it.
+      const liveExerciseEntries = signal<ExerciseEntry[]>([
         {
           _id: 'existing',
+          exerciseId: 'pushup',
           timestamp: `${today}T08:00:00.000+02:00`,
           reps: target,
           source: 'web',
-        },
+        } as ExerciseEntry,
       ]);
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
@@ -664,10 +670,9 @@ describe('TrainingPlanStore', () => {
           {
             provide: LiveDataStore,
             useValue: {
-              entries: liveEntries,
-              exerciseEntries: signal<ExerciseEntry[]>([]),
-              connected: signal(false),
-              exerciseEntriesLoaded: signal(true),
+              exerciseEntries: liveExerciseEntries,
+              connected: signal(true),
+              exerciseEntriesLoaded: signal(false),
               updateTick: signal(0),
             },
           },
@@ -713,7 +718,6 @@ describe('TrainingPlanStore', () => {
           {
             provide: LiveDataStore,
             useValue: {
-              entries: signal<PushupRecord[]>([]),
               exerciseEntries: signal<ExerciseEntry[]>([]),
               connected: signal(true),
               exerciseEntriesLoaded: signal(false),
@@ -764,7 +768,6 @@ describe('TrainingPlanStore', () => {
         createPushup: vitest.fn(() => from(firstWrite).pipe(map(() => ({})))),
       };
       const exerciseApiMock = { createEntry: vitest.fn() };
-      const liveEntries = signal<PushupRecord[]>([]);
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
         providers: [
@@ -779,7 +782,6 @@ describe('TrainingPlanStore', () => {
           {
             provide: LiveDataStore,
             useValue: {
-              entries: liveEntries,
               exerciseEntries: signal<ExerciseEntry[]>([]),
               connected: signal(true),
               exerciseEntriesLoaded: signal(true),
@@ -1005,8 +1007,12 @@ describe('TrainingPlanStore', () => {
           {
             provide: LiveDataStore,
             useValue: {
-              entries: liveEntries,
-              exerciseEntries: signal<ExerciseEntry[]>([]),
+              // Pushups are surfaced on the exerciseEntries feed post-cutover.
+              exerciseEntries: computed<ExerciseEntry[]>(() =>
+                liveEntries().map(
+                  (r) => ({ ...r, exerciseId: 'pushup' }) as ExerciseEntry
+                )
+              ),
               connected: signal(true),
               exerciseEntriesLoaded: signal(true),
               updateTick: signal(0),

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -276,15 +276,9 @@ export const TrainingPlanStore = signalStore(
     },
 
     /** Sum of reps already logged on a given local date for one exercise.
-     *  Pushup days read the legacy `pushups` mirror (`entries()`); every other
-     *  exercise reads the `exerciseEntries` mirror filtered by id. */
+     *  Reads the `exerciseEntries` mirror filtered by id — post-cutover
+     *  pushups live there too (`exerciseId:'pushup'`), so no special case. */
     _repsLoggedOn(dateIso: string, exerciseId: string): number {
-      if (exerciseId === 'pushup') {
-        return store._live
-          .entries()
-          .filter((e) => e.timestamp.slice(0, 10) === dateIso)
-          .reduce((sum, e) => sum + e.reps, 0);
-      }
       return store._live
         .exerciseEntries()
         .filter(
@@ -437,18 +431,13 @@ export const TrainingPlanStore = signalStore(
       const currentIdx = store.currentDayIndex();
       if (currentIdx === null || dayIndex > currentIdx) return 'noop';
 
-      // `_live` mirrors are empty until the Firestore listeners have
-      // emitted at least once. Don't make a write decision off pre-sync
-      // data — it would top-up a day that's already covered as soon as
-      // the listener catches up. Pushup days gate on `connected` (their
-      // stream); non-pushup days gate on `exerciseEntriesLoaded` —
-      // `connected` is pushup-only, so trusting it for a non-pushup day
-      // could read empty exerciseEntries and duplicate-write.
-      const synced =
-        exerciseId === 'pushup'
-          ? store._live.connected()
-          : store._live.exerciseEntriesLoaded();
-      if (store._isBrowser && !synced) return 'not-ready';
+      // The `exerciseEntries` mirror is empty until its Firestore listener
+      // has emitted at least once. Don't make a write decision off pre-sync
+      // data — it would top-up a day that's already covered as soon as the
+      // listener catches up. Post-cutover pushups live in that same mirror,
+      // so every exercise gates on `exerciseEntriesLoaded`.
+      if (store._isBrowser && !store._live.exerciseEntriesLoaded())
+        return 'not-ready';
 
       if (!store._acquireWriteLock(dayIndex)) return 'in-flight';
 

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -640,19 +640,15 @@ export const TrainingPlanStore = signalStore(
         if (a.completedDays.includes(idx)) return;
         // Same readiness guard as `logPlanDay` — without this, a pre-sync
         // mirror could appear to satisfy the target on stale state and
-        // trigger a false auto-mark. Pushup days gate on `connected`;
-        // non-pushup days gate on `exerciseEntriesLoaded`.
-        const synced =
-          exerciseId === 'pushup'
-            ? store._live.connected()
-            : store._live.exerciseEntriesLoaded();
-        if (!synced) return;
+        // trigger a false auto-mark. Post-cutover pushups live in the
+        // `exerciseEntries` feed too, so every exercise gates on
+        // `exerciseEntriesLoaded`.
+        if (!store._live.exerciseEntriesLoaded()) return;
         // The same in-flight lock guards manual logPlanDay calls,
         // so a fast Quick-Add + auto-mark can't double-write.
         if (store._writingDays().has(idx)) return;
-        // `_live.entries()` is the same source the dashboard uses;
-        // it streams from Firestore in real time so manual logs
-        // propagate here without polling.
+        // Reps come from the `exerciseEntries` mirror (real-time Firestore),
+        // so manual logs propagate here without polling.
         const todayIso = toBerlinIsoDate(new Date());
         // Establish a tick dependency so this re-runs at midnight.
         store._dayTick();

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10021,16 +10021,28 @@
         <target>Als abgeschlossen markieren</target>
       </segment>
     </unit>
-        <unit id="admin.migrations.subtitle">
+            <unit id="admin.migrations.subtitle">
       <segment state="initial">
-        <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <source> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </source>
+        <target> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
       <segment state="initial">
         <source>Zurück zum Admin-Bereich</source>
         <target>Zurück zum Admin-Bereich</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.title">
+      <segment state="initial">
+        <source>Pushup-Aggregat backfillen (perExercise/pushup)</source>
+        <target>Pushup-Aggregat backfillen (perExercise/pushup)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.description">
+      <segment state="initial">
+        <source>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</source>
+        <target>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10187,16 +10187,28 @@ Deine Position: # ·  Reps        </source>
         <target>Als abgeschlossen markieren</target>
       </segment>
     </unit>
-        <unit id="admin.migrations.subtitle">
+            <unit id="admin.migrations.subtitle">
       <segment state="initial">
-        <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <source> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </source>
+        <target> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
       <segment state="initial">
         <source>Zurück zum Admin-Bereich</source>
         <target>Zurück zum Admin-Bereich</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.title">
+      <segment state="initial">
+        <source>Pushup-Aggregat backfillen (perExercise/pushup)</source>
+        <target>Pushup-Aggregat backfillen (perExercise/pushup)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.description">
+      <segment state="initial">
+        <source>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</source>
+        <target>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10017,16 +10017,28 @@
         <target>Als abgeschlossen markieren</target>
       </segment>
     </unit>
-        <unit id="admin.migrations.subtitle">
+            <unit id="admin.migrations.subtitle">
       <segment state="initial">
-        <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <source> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </source>
+        <target> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
       <segment state="initial">
         <source>Zurück zum Admin-Bereich</source>
         <target>Zurück zum Admin-Bereich</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.title">
+      <segment state="initial">
+        <source>Pushup-Aggregat backfillen (perExercise/pushup)</source>
+        <target>Pushup-Aggregat backfillen (perExercise/pushup)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.description">
+      <segment state="initial">
+        <source>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</source>
+        <target>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9893,16 +9893,28 @@
         <target>Als abgeschlossen markieren</target>
       </segment>
     </unit>
-        <unit id="admin.migrations.subtitle">
+            <unit id="admin.migrations.subtitle">
       <segment state="initial">
-        <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <source> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </source>
+        <target> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
       <segment state="initial">
         <source>Zurück zum Admin-Bereich</source>
         <target>Zurück zum Admin-Bereich</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.title">
+      <segment state="initial">
+        <source>Pushup-Aggregat backfillen (perExercise/pushup)</source>
+        <target>Pushup-Aggregat backfillen (perExercise/pushup)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.description">
+      <segment state="initial">
+        <source>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</source>
+        <target>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10021,16 +10021,28 @@
         <target>Als abgeschlossen markieren</target>
       </segment>
     </unit>
-        <unit id="admin.migrations.subtitle">
+            <unit id="admin.migrations.subtitle">
       <segment state="initial">
-        <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <source> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </source>
+        <target> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
       <segment state="initial">
         <source>Zurück zum Admin-Bereich</source>
         <target>Zurück zum Admin-Bereich</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.title">
+      <segment state="initial">
+        <source>Pushup-Aggregat backfillen (perExercise/pushup)</source>
+        <target>Pushup-Aggregat backfillen (perExercise/pushup)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.description">
+      <segment state="initial">
+        <source>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</source>
+        <target>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -10021,16 +10021,28 @@
         <target>Als abgeschlossen markieren</target>
       </segment>
     </unit>
-        <unit id="admin.migrations.subtitle">
+            <unit id="admin.migrations.subtitle">
       <segment state="initial">
-        <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <source> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </source>
+        <target> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
       <segment state="initial">
         <source>Zurück zum Admin-Bereich</source>
         <target>Zurück zum Admin-Bereich</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.title">
+      <segment state="initial">
+        <source>Pushup-Aggregat backfillen (perExercise/pushup)</source>
+        <target>Pushup-Aggregat backfillen (perExercise/pushup)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.description">
+      <segment state="initial">
+        <source>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</source>
+        <target>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10021,16 +10021,28 @@
         <target>Als abgeschlossen markieren</target>
       </segment>
     </unit>
-        <unit id="admin.migrations.subtitle">
+            <unit id="admin.migrations.subtitle">
       <segment state="initial">
-        <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <source> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </source>
+        <target> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
       <segment state="initial">
         <source>Zurück zum Admin-Bereich</source>
         <target>Zurück zum Admin-Bereich</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.title">
+      <segment state="initial">
+        <source>Pushup-Aggregat backfillen (perExercise/pushup)</source>
+        <target>Pushup-Aggregat backfillen (perExercise/pushup)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.description">
+      <segment state="initial">
+        <source>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</source>
+        <target>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9281,16 +9281,28 @@ Deine Position: # ·  Reps        </source>
         <target>Als abgeschlossen markieren</target>
       </segment>
     </unit>
-        <unit id="admin.migrations.subtitle">
+            <unit id="admin.migrations.subtitle">
       <segment state="initial">
-        <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <source> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </source>
+        <target> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
       <segment state="initial">
         <source>Zurück zum Admin-Bereich</source>
         <target>Zurück zum Admin-Bereich</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.title">
+      <segment state="initial">
+        <source>Pushup-Aggregat backfillen (perExercise/pushup)</source>
+        <target>Pushup-Aggregat backfillen (perExercise/pushup)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.description">
+      <segment state="initial">
+        <source>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</source>
+        <target>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4175,15 +4175,15 @@
     <unit id="exercise.category.pushup">
       <notes>
         <note category="location">web/src/app/core/app-data.facade.ts:354</note>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:54</note>
         <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:43</note>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:145</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:385</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:222</note>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1288</note>
         <note category="location">web/src/app/stats/dashboard.store.ts:78</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:190</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:214</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:24</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:195</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:219</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:289</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:393</note>
       </notes>
@@ -4309,7 +4309,7 @@
     </unit>
     <unit id="goals.weekday.short.mon">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:84</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:75</note>
       </notes>
       <segment>
         <source>Mo</source>
@@ -4317,7 +4317,7 @@
     </unit>
     <unit id="goals.weekday.short.tue">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:85</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:76</note>
       </notes>
       <segment>
         <source>Di</source>
@@ -4325,7 +4325,7 @@
     </unit>
     <unit id="goals.weekday.short.wed">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:86</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:77</note>
       </notes>
       <segment>
         <source>Mi</source>
@@ -4333,7 +4333,7 @@
     </unit>
     <unit id="goals.weekday.short.thu">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:87</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:78</note>
       </notes>
       <segment>
         <source>Do</source>
@@ -4341,7 +4341,7 @@
     </unit>
     <unit id="goals.weekday.short.fri">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:88</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:79</note>
       </notes>
       <segment>
         <source>Fr</source>
@@ -4349,7 +4349,7 @@
     </unit>
     <unit id="goals.weekday.short.sat">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:89</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:80</note>
       </notes>
       <segment>
         <source>Sa</source>
@@ -4357,7 +4357,7 @@
     </unit>
     <unit id="goals.weekday.short.sun">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:90</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:81</note>
       </notes>
       <segment>
         <source>So</source>
@@ -4365,7 +4365,7 @@
     </unit>
     <unit id="goalsHeaderTitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:113,114</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:104,105</note>
       </notes>
       <segment>
         <source>Tagesziele</source>
@@ -4373,7 +4373,7 @@
     </unit>
     <unit id="goalsHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:115,117</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:106,108</note>
       </notes>
       <segment>
         <source> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </source>
@@ -4381,7 +4381,7 @@
     </unit>
     <unit id="goals.status.saving">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:131,133</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:122,124</note>
       </notes>
       <segment>
         <source>Speichert…</source>
@@ -4389,7 +4389,7 @@
     </unit>
     <unit id="goals.status.saved">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:135,137</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:126,128</note>
       </notes>
       <segment>
         <source>Gespeichert</source>
@@ -4397,7 +4397,7 @@
     </unit>
     <unit id="goals.status.error">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:139,141</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:130,132</note>
       </notes>
       <segment>
         <source>Fehler beim Speichern</source>
@@ -4405,7 +4405,7 @@
     </unit>
     <unit id="goals.status.retry">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:146,147</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:137,138</note>
       </notes>
       <segment>
         <source> Erneut versuchen </source>
@@ -4413,7 +4413,7 @@
     </unit>
     <unit id="goals.status.pending">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:152,154</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:143,145</note>
       </notes>
       <segment>
         <source>Ungespeicherte Änderungen…</source>
@@ -4421,7 +4421,7 @@
     </unit>
     <unit id="goals.status.synced">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:157,160</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:148,151</note>
       </notes>
       <segment>
         <source>Alle Ziele gespeichert</source>
@@ -4429,7 +4429,7 @@
     </unit>
     <unit id="guest.banner.text">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:167,170</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:158,161</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:137,140</note>
       </notes>
       <segment>
@@ -4438,7 +4438,7 @@
     </unit>
     <unit id="guest.banner.cta">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:171,174</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:162,165</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.ts:141,144</note>
       </notes>
       <segment>
@@ -4447,7 +4447,7 @@
     </unit>
     <unit id="goals.intro">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:177,180</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:168,171</note>
       </notes>
       <segment>
         <source> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </source>
@@ -4455,7 +4455,7 @@
     </unit>
     <unit id="goals.section.empty">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:201,202</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:192,193</note>
       </notes>
       <segment>
         <source> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </source>
@@ -4463,7 +4463,7 @@
     </unit>
     <unit id="goals.field.exercise">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:210,211</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:201,202</note>
       </notes>
       <segment>
         <source>Übung</source>
@@ -4471,7 +4471,7 @@
     </unit>
     <unit id="goals.weekdayLabel">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:253,255</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:244,246</note>
       </notes>
       <segment>
         <source>Aktiv an:</source>
@@ -4479,7 +4479,7 @@
     </unit>
     <unit id="goals.weekdayEveryDayHint">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:274,276</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:265,267</note>
       </notes>
       <segment>
         <source>Keine Auswahl = gilt jeden Tag.</source>
@@ -4487,7 +4487,7 @@
     </unit>
     <unit id="goals.addEntry">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:289,290</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:280,281</note>
       </notes>
       <segment>
         <source>Ziel hinzufügen</source>
@@ -4495,7 +4495,7 @@
     </unit>
     <unit id="goals.limitHint">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:293,294</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:284,285</note>
       </notes>
       <segment>
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
@@ -4503,7 +4503,7 @@
     </unit>
     <unit id="goals.linkBack.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:304,306</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:295,297</note>
       </notes>
       <segment>
         <source>Andere Einstellungen</source>
@@ -4511,7 +4511,7 @@
     </unit>
     <unit id="goals.linkBack.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:307,308</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:298,299</note>
       </notes>
       <segment>
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
@@ -4519,7 +4519,7 @@
     </unit>
     <unit id="goals.linkBack.cta">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:316,318</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:307,309</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
@@ -4527,7 +4527,7 @@
     </unit>
     <unit id="goals.removeAria">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:461</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:452</note>
       </notes>
       <segment>
         <source>Ziel entfernen</source>
@@ -4535,7 +4535,7 @@
     </unit>
     <unit id="goals.weekdayAria">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:462</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:453</note>
       </notes>
       <segment>
         <source>Wochentage</source>
@@ -4543,7 +4543,7 @@
     </unit>
     <unit id="goals.section.daily.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:473</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:464</note>
       </notes>
       <segment>
         <source>Tagesziele</source>
@@ -4551,7 +4551,7 @@
     </unit>
     <unit id="goals.section.daily.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:474</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:465</note>
       </notes>
       <segment>
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
@@ -4559,7 +4559,7 @@
     </unit>
     <unit id="goals.section.weekly.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:479</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:470</note>
       </notes>
       <segment>
         <source>Wochenziele</source>
@@ -4567,7 +4567,7 @@
     </unit>
     <unit id="goals.section.weekly.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:480</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:471</note>
       </notes>
       <segment>
         <source>Summen pro Übung über die ganze Woche.</source>
@@ -4575,7 +4575,7 @@
     </unit>
     <unit id="goals.section.monthly.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:485</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:476</note>
       </notes>
       <segment>
         <source>Monatsziele</source>
@@ -4583,7 +4583,7 @@
     </unit>
     <unit id="goals.section.monthly.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:486</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:477</note>
       </notes>
       <segment>
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
@@ -4591,7 +4591,7 @@
     </unit>
     <unit id="goals.field.target.time">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:650</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:641</note>
       </notes>
       <segment>
         <source>Ziel (Sekunden)</source>
@@ -4599,7 +4599,7 @@
     </unit>
     <unit id="goals.field.target.distance">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:653</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:644</note>
       </notes>
       <segment>
         <source>Ziel (Meter)</source>
@@ -4607,7 +4607,7 @@
     </unit>
     <unit id="goals.field.target.reps">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:657</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:648</note>
       </notes>
       <segment>
         <source>Ziel</source>
@@ -7384,7 +7384,7 @@
     <unit id="exercise.category.push">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1289</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:215</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:220</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:462</note>
       </notes>
       <segment>
@@ -7394,7 +7394,7 @@
     <unit id="exercise.category.pull">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1290</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:216</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:463</note>
       </notes>
       <segment>
@@ -7404,7 +7404,7 @@
     <unit id="exercise.category.squat">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1291</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:217</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:222</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:464</note>
       </notes>
       <segment>
@@ -7414,7 +7414,7 @@
     <unit id="exercise.category.hinge">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1292</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:218</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:223</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:465</note>
       </notes>
       <segment>
@@ -7424,7 +7424,7 @@
     <unit id="exercise.category.lunge">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1293</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:219</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:224</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:466</note>
       </notes>
       <segment>
@@ -7442,7 +7442,7 @@
     <unit id="exercise.category.core">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1295</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:220</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:225</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:467</note>
       </notes>
       <segment>
@@ -7452,7 +7452,7 @@
     <unit id="exercise.category.cardio">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1296</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:226</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:468</note>
       </notes>
       <segment>
@@ -7462,7 +7462,7 @@
     <unit id="exercise.category.mobility">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1297</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:222</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:227</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:469</note>
       </notes>
       <segment>
@@ -7567,7 +7567,7 @@
     </unit>
     <unit id="exercise.abs.situps.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:22</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:27</note>
       </notes>
       <segment>
         <source>Sit-ups</source>
@@ -7575,7 +7575,7 @@
     </unit>
     <unit id="exercise.abs.crunches.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:23</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:28</note>
       </notes>
       <segment>
         <source>Crunches</source>
@@ -7583,7 +7583,7 @@
     </unit>
     <unit id="exercise.abs.legraises.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:24</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:29</note>
       </notes>
       <segment>
         <source>Beinheben</source>
@@ -7591,7 +7591,7 @@
     </unit>
     <unit id="exercise.abs.russiantwist.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:25</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:30</note>
       </notes>
       <segment>
         <source>Russian Twist</source>
@@ -7599,7 +7599,7 @@
     </unit>
     <unit id="exercise.abs.mountainclimbers.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:26</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:31</note>
       </notes>
       <segment>
         <source>Mountain Climbers</source>
@@ -7607,7 +7607,7 @@
     </unit>
     <unit id="exercise.core.deadbug.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:27</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:32</note>
       </notes>
       <segment>
         <source>Dead Bug</source>
@@ -7615,7 +7615,7 @@
     </unit>
     <unit id="exercise.core.hollowhold.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:28</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:33</note>
       </notes>
       <segment>
         <source>Hollow Hold</source>
@@ -7623,7 +7623,7 @@
     </unit>
     <unit id="exercise.plank.standard.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:29</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:34</note>
       </notes>
       <segment>
         <source>Plank</source>
@@ -7631,7 +7631,7 @@
     </unit>
     <unit id="exercise.legs.squats.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:32</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:37</note>
       </notes>
       <segment>
         <source>Kniebeugen</source>
@@ -7639,7 +7639,7 @@
     </unit>
     <unit id="exercise.legs.jumpsquats.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:33</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:38</note>
       </notes>
       <segment>
         <source>Jump Squats</source>
@@ -7647,7 +7647,7 @@
     </unit>
     <unit id="exercise.legs.calfraises.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:34</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:39</note>
       </notes>
       <segment>
         <source>Wadenheben</source>
@@ -7655,7 +7655,7 @@
     </unit>
     <unit id="exercise.squat.wallsit.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:35</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:40</note>
       </notes>
       <segment>
         <source>Wandsitz</source>
@@ -7663,7 +7663,7 @@
     </unit>
     <unit id="exercise.squat.boxjump.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:36</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:41</note>
       </notes>
       <segment>
         <source>Box Jumps</source>
@@ -7671,7 +7671,7 @@
     </unit>
     <unit id="exercise.legs.glutebridge.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:37</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:42</note>
       </notes>
       <segment>
         <source>Hüftheben</source>
@@ -7679,7 +7679,7 @@
     </unit>
     <unit id="exercise.hinge.singlelegRdl.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:38</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:43</note>
       </notes>
       <segment>
         <source>Einbeiniges Kreuzheben</source>
@@ -7687,7 +7687,7 @@
     </unit>
     <unit id="exercise.hinge.goodmorning.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:39</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:44</note>
       </notes>
       <segment>
         <source>Good Morning</source>
@@ -7695,7 +7695,7 @@
     </unit>
     <unit id="exercise.legs.lunges.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:40</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:45</note>
       </notes>
       <segment>
         <source>Ausfallschritte</source>
@@ -7703,7 +7703,7 @@
     </unit>
     <unit id="exercise.lunge.stepup.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:41</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:46</note>
       </notes>
       <segment>
         <source>Step-ups</source>
@@ -7711,7 +7711,7 @@
     </unit>
     <unit id="exercise.push.dips.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:45</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:50</note>
       </notes>
       <segment>
         <source>Dips</source>
@@ -7719,7 +7719,7 @@
     </unit>
     <unit id="exercise.push.benchdips.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:46</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:51</note>
       </notes>
       <segment>
         <source>Bankdips</source>
@@ -7727,7 +7727,7 @@
     </unit>
     <unit id="exercise.push.handstandhold.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:47</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:52</note>
       </notes>
       <segment>
         <source>Handstand-Hold</source>
@@ -7735,7 +7735,7 @@
     </unit>
     <unit id="exercise.pull.pullups.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:50</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:55</note>
       </notes>
       <segment>
         <source>Klimmzüge</source>
@@ -7743,7 +7743,7 @@
     </unit>
     <unit id="exercise.pull.rows.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:51</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:56</note>
       </notes>
       <segment>
         <source>Ruderzug</source>
@@ -7751,7 +7751,7 @@
     </unit>
     <unit id="exercise.pull.deadhang.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:52</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:57</note>
       </notes>
       <segment>
         <source>Dead Hang</source>
@@ -7759,7 +7759,7 @@
     </unit>
     <unit id="exercise.pull.facepull.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:53</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:58</note>
       </notes>
       <segment>
         <source>Face Pull</source>
@@ -7767,7 +7767,7 @@
     </unit>
     <unit id="exercise.cardio.running.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:56</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:61</note>
       </notes>
       <segment>
         <source>Laufen</source>
@@ -7775,7 +7775,7 @@
     </unit>
     <unit id="exercise.cardio.walking.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:57</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:62</note>
       </notes>
       <segment>
         <source>Gehen</source>
@@ -7783,7 +7783,7 @@
     </unit>
     <unit id="exercise.cardio.cycling.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:58</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:63</note>
       </notes>
       <segment>
         <source>Radfahren</source>
@@ -7791,7 +7791,7 @@
     </unit>
     <unit id="exercise.cardio.rowing.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:59</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:64</note>
       </notes>
       <segment>
         <source>Rudern</source>
@@ -7799,7 +7799,7 @@
     </unit>
     <unit id="exercise.cardio.swimming.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:60</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:65</note>
       </notes>
       <segment>
         <source>Schwimmen</source>
@@ -7807,7 +7807,7 @@
     </unit>
     <unit id="exercise.cardio.jumprope.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:61</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:66</note>
       </notes>
       <segment>
         <source>Seilspringen</source>
@@ -7815,7 +7815,7 @@
     </unit>
     <unit id="exercise.cardio.burpees.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:62</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:67</note>
       </notes>
       <segment>
         <source>Burpees</source>
@@ -7823,7 +7823,7 @@
     </unit>
     <unit id="exercise.cardio.jumpingjacks.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:63</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:68</note>
       </notes>
       <segment>
         <source>Hampelmänner</source>
@@ -7831,7 +7831,7 @@
     </unit>
     <unit id="exercise.cardio.highknees.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:64</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:69</note>
       </notes>
       <segment>
         <source>High Knees</source>
@@ -7839,7 +7839,7 @@
     </unit>
     <unit id="exercise.mobility.stretching.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:67</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:72</note>
       </notes>
       <segment>
         <source>Dehnen</source>
@@ -7847,7 +7847,7 @@
     </unit>
     <unit id="exercise.mobility.yoga.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:68</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:73</note>
       </notes>
       <segment>
         <source>Yoga</source>
@@ -7855,7 +7855,7 @@
     </unit>
     <unit id="exercise.mobility.foamrolling.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:69</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:74</note>
       </notes>
       <segment>
         <source>Faszienrolle</source>
@@ -7863,7 +7863,7 @@
     </unit>
     <unit id="exercise.mobility.dynamicwarmup.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:70</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:75</note>
       </notes>
       <segment>
         <source>Dynamisches Aufwärmen</source>
@@ -7871,7 +7871,7 @@
     </unit>
     <unit id="exercise.mobility.catcow.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:71</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:76</note>
       </notes>
       <segment>
         <source>Katze-Kuh</source>
@@ -7879,7 +7879,7 @@
     </unit>
     <unit id="exercise.mobility.hipopener.name">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:72</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:77</note>
       </notes>
       <segment>
         <source>Hüftöffner</source>
@@ -7887,7 +7887,7 @@
     </unit>
     <unit id="exercise.variant.situps.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:92</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:97</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -7895,7 +7895,7 @@
     </unit>
     <unit id="exercise.variant.situps.decline">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:93</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:98</note>
       </notes>
       <segment>
         <source>Decline</source>
@@ -7903,7 +7903,7 @@
     </unit>
     <unit id="exercise.variant.situps.weighted">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:94</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:99</note>
       </notes>
       <segment>
         <source>Mit Zusatzgewicht</source>
@@ -7911,7 +7911,7 @@
     </unit>
     <unit id="exercise.variant.crunches.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:97</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:102</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -7919,7 +7919,7 @@
     </unit>
     <unit id="exercise.variant.crunches.reverse">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:98</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:103</note>
       </notes>
       <segment>
         <source>Reverse Crunches</source>
@@ -7927,7 +7927,7 @@
     </unit>
     <unit id="exercise.variant.crunches.bicycle">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:99</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:104</note>
       </notes>
       <segment>
         <source>Bicycle Crunches</source>
@@ -7935,7 +7935,7 @@
     </unit>
     <unit id="exercise.variant.crunches.oblique">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:100</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:105</note>
       </notes>
       <segment>
         <source>Schräge Crunches</source>
@@ -7943,7 +7943,7 @@
     </unit>
     <unit id="exercise.variant.legraises.lying">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:103</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:108</note>
       </notes>
       <segment>
         <source>Liegend</source>
@@ -7951,7 +7951,7 @@
     </unit>
     <unit id="exercise.variant.legraises.hanging-knee">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:104</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:109</note>
       </notes>
       <segment>
         <source>Hängend (Knie)</source>
@@ -7959,7 +7959,7 @@
     </unit>
     <unit id="exercise.variant.legraises.hanging-straight">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:105</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:110</note>
       </notes>
       <segment>
         <source>Hängend (gestreckt)</source>
@@ -7967,7 +7967,7 @@
     </unit>
     <unit id="exercise.variant.russiantwist.bodyweight">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:108</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:113</note>
       </notes>
       <segment>
         <source>Eigengewicht</source>
@@ -7975,7 +7975,7 @@
     </unit>
     <unit id="exercise.variant.russiantwist.weighted">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:109</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:114</note>
       </notes>
       <segment>
         <source>Mit Zusatzgewicht</source>
@@ -7983,7 +7983,7 @@
     </unit>
     <unit id="exercise.variant.mountainclimbers.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:112</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:117</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -7991,7 +7991,7 @@
     </unit>
     <unit id="exercise.variant.mountainclimbers.cross-body">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:113</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:118</note>
       </notes>
       <segment>
         <source>Cross-Body</source>
@@ -7999,7 +7999,7 @@
     </unit>
     <unit id="exercise.variant.plank.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:116</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:121</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -8007,7 +8007,7 @@
     </unit>
     <unit id="exercise.variant.plank.forearm">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:117</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:122</note>
       </notes>
       <segment>
         <source>Unterarmstütz</source>
@@ -8015,7 +8015,7 @@
     </unit>
     <unit id="exercise.variant.plank.side">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:118</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:123</note>
       </notes>
       <segment>
         <source>Seitlich</source>
@@ -8023,7 +8023,7 @@
     </unit>
     <unit id="exercise.variant.plank.reverse">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:119</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:124</note>
       </notes>
       <segment>
         <source>Umgekehrt</source>
@@ -8031,7 +8031,7 @@
     </unit>
     <unit id="exercise.variant.squats.bodyweight">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:122</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:127</note>
       </notes>
       <segment>
         <source>Eigengewicht</source>
@@ -8039,7 +8039,7 @@
     </unit>
     <unit id="exercise.variant.squats.sumo">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:123</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:128</note>
       </notes>
       <segment>
         <source>Sumo</source>
@@ -8047,7 +8047,7 @@
     </unit>
     <unit id="exercise.variant.squats.goblet">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:124</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:129</note>
       </notes>
       <segment>
         <source>Goblet</source>
@@ -8055,7 +8055,7 @@
     </unit>
     <unit id="exercise.variant.squats.bulgarian-split">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:125</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:130</note>
       </notes>
       <segment>
         <source>Bulgarian Split</source>
@@ -8063,7 +8063,7 @@
     </unit>
     <unit id="exercise.variant.squats.pistol">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:126</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:131</note>
       </notes>
       <segment>
         <source>Pistol</source>
@@ -8071,7 +8071,7 @@
     </unit>
     <unit id="exercise.variant.calfraises.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:129</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:134</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -8079,7 +8079,7 @@
     </unit>
     <unit id="exercise.variant.calfraises.single-leg">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:130</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:135</note>
       </notes>
       <segment>
         <source>Einbeinig</source>
@@ -8087,7 +8087,7 @@
     </unit>
     <unit id="exercise.variant.calfraises.seated">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:131</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:136</note>
       </notes>
       <segment>
         <source>Sitzend</source>
@@ -8095,7 +8095,7 @@
     </unit>
     <unit id="exercise.variant.glutebridge.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:134</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:139</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -8103,7 +8103,7 @@
     </unit>
     <unit id="exercise.variant.glutebridge.single-leg">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:135</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:140</note>
       </notes>
       <segment>
         <source>Einbeinig</source>
@@ -8111,7 +8111,7 @@
     </unit>
     <unit id="exercise.variant.glutebridge.hip-thrust">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:136</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:141</note>
       </notes>
       <segment>
         <source>Hip Thrust</source>
@@ -8119,7 +8119,7 @@
     </unit>
     <unit id="exercise.variant.glutebridge.march">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:137</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:142</note>
       </notes>
       <segment>
         <source>Marching</source>
@@ -8127,7 +8127,7 @@
     </unit>
     <unit id="exercise.variant.lunges.forward">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:140</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:145</note>
       </notes>
       <segment>
         <source>Vorwärts</source>
@@ -8135,7 +8135,7 @@
     </unit>
     <unit id="exercise.variant.lunges.reverse">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:141</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:146</note>
       </notes>
       <segment>
         <source>Rückwärts</source>
@@ -8143,7 +8143,7 @@
     </unit>
     <unit id="exercise.variant.lunges.walking">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:142</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:147</note>
       </notes>
       <segment>
         <source>Walking</source>
@@ -8151,7 +8151,7 @@
     </unit>
     <unit id="exercise.variant.lunges.lateral">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:143</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:148</note>
       </notes>
       <segment>
         <source>Seitlich</source>
@@ -8159,7 +8159,7 @@
     </unit>
     <unit id="exercise.variant.lunges.curtsy">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:144</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:149</note>
       </notes>
       <segment>
         <source>Curtsy</source>
@@ -8167,7 +8167,7 @@
     </unit>
     <unit id="exercise.variant.lunges.jumping">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:145</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:150</note>
       </notes>
       <segment>
         <source>Jumping</source>
@@ -8175,7 +8175,7 @@
     </unit>
     <unit id="exercise.variant.pullups.standard">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:148</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:153</note>
       </notes>
       <segment>
         <source>Standard</source>
@@ -8183,7 +8183,7 @@
     </unit>
     <unit id="exercise.variant.pullups.chin-up">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:149</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:154</note>
       </notes>
       <segment>
         <source>Chin-up</source>
@@ -8191,7 +8191,7 @@
     </unit>
     <unit id="exercise.variant.pullups.wide-grip">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:150</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:155</note>
       </notes>
       <segment>
         <source>Breiter Griff</source>
@@ -8199,7 +8199,7 @@
     </unit>
     <unit id="exercise.variant.pullups.neutral-grip">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:151</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:156</note>
       </notes>
       <segment>
         <source>Neutraler Griff</source>
@@ -8207,7 +8207,7 @@
     </unit>
     <unit id="exercise.variant.pullups.negative">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:152</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:157</note>
       </notes>
       <segment>
         <source>Negativ</source>
@@ -8215,7 +8215,7 @@
     </unit>
     <unit id="exercise.variant.pullups.assisted">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:153</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:158</note>
       </notes>
       <segment>
         <source>Assistiert</source>
@@ -8223,7 +8223,7 @@
     </unit>
     <unit id="exercise.variant.pullups.archer">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:154</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:159</note>
       </notes>
       <segment>
         <source>Archer</source>
@@ -8231,7 +8231,7 @@
     </unit>
     <unit id="exercise.variant.rows.inverted">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:157</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:162</note>
       </notes>
       <segment>
         <source>Inverted Row</source>
@@ -8239,7 +8239,7 @@
     </unit>
     <unit id="exercise.variant.rows.australian">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:158</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:163</note>
       </notes>
       <segment>
         <source>Australian Row</source>
@@ -8247,7 +8247,7 @@
     </unit>
     <unit id="exercise.variant.rows.dumbbell">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:159</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:164</note>
       </notes>
       <segment>
         <source>Kurzhantel</source>
@@ -8255,7 +8255,7 @@
     </unit>
     <unit id="exercise.variant.rows.barbell">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:160</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:165</note>
       </notes>
       <segment>
         <source>Langhantel</source>
@@ -8263,7 +8263,7 @@
     </unit>
     <unit id="exercise.variant.dips.parallel">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:163</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:168</note>
       </notes>
       <segment>
         <source>Barren</source>
@@ -8271,7 +8271,7 @@
     </unit>
     <unit id="exercise.variant.dips.straight-bar">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:164</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:169</note>
       </notes>
       <segment>
         <source>Stange</source>
@@ -8279,7 +8279,7 @@
     </unit>
     <unit id="exercise.variant.dips.ring">
       <notes>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:165</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:170</note>
       </notes>
       <segment>
         <source>Ringe</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -654,7 +654,7 @@
     </unit>
     <unit id="pushup.validation.reps.outOfRange">
       <notes>
-        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:48</note>
+        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:51</note>
       </notes>
       <segment>
         <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
@@ -662,7 +662,7 @@
     </unit>
     <unit id="pushup.validation.reps.notInteger">
       <notes>
-        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:51</note>
+        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:54</note>
       </notes>
       <segment>
         <source>Reps muss eine ganze Zahl sein.</source>
@@ -670,7 +670,7 @@
     </unit>
     <unit id="pushup.validation.generic">
       <notes>
-        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:54</note>
+        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:57</note>
       </notes>
       <segment>
         <source>Eintrag konnte nicht gespeichert werden.</source>
@@ -3087,17 +3087,33 @@
         <source>Kopiert die Legacy-„pushups“-Collection nach „exerciseEntries“ (exerciseId:&quot;pushup&quot;, migratedFrom:&quot;pushups&quot;). Idempotent, lässt die Quelle unangetastet und ist über „Rückgängig“ reversibel. Immer erst den Probelauf ausführen und die Zahlen gegen das Runbook prüfen.</source>
       </segment>
     </unit>
-    <unit id="admin.migrations.subtitle">
+    <unit id="admin.migrations.pushupBackfill.title">
       <notes>
-        <note category="location">web/src/app/admin/migrations/migrations-page.component.ts:29,32</note>
+        <note category="location">web/src/app/admin/migrations/migration-descriptors.ts:69</note>
       </notes>
       <segment>
-        <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
+        <source>Pushup-Aggregat backfillen (perExercise/pushup)</source>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.description">
+      <notes>
+        <note category="location">web/src/app/admin/migrations/migration-descriptors.ts:70</note>
+      </notes>
+      <segment>
+        <source>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</source>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.subtitle">
+      <notes>
+        <note category="location">web/src/app/admin/migrations/migrations-page.component.ts:30,33</note>
+      </notes>
+      <segment>
+        <source> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </source>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
       <notes>
-        <note category="location">web/src/app/admin/migrations/migrations-page.component.ts:35,39</note>
+        <note category="location">web/src/app/admin/migrations/migrations-page.component.ts:38,42</note>
       </notes>
       <segment>
         <source>Zurück zum Admin-Bereich</source>
@@ -4174,13 +4190,13 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:354</note>
+        <note category="location">web/src/app/core/app-data.facade.ts:364</note>
         <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:43</note>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:145</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:385</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:222</note>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1288</note>
-        <note category="location">web/src/app/stats/dashboard.store.ts:78</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:77</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:24</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:195</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:219</note>
@@ -7527,7 +7543,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:539</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:550</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Schau dir mein Profil an:</source>
@@ -7535,7 +7551,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:540</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:551</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
@@ -7543,7 +7559,7 @@
     </unit>
     <unit id="dashboard.share.text.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:544</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:555</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
@@ -7551,7 +7567,7 @@
     </unit>
     <unit id="dashboard.share.text.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:545</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:556</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
@@ -7559,7 +7575,7 @@
     </unit>
     <unit id="dashboard.share.title">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:549</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:560</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9515,16 +9515,28 @@
         <target>Als abgeschlossen markieren</target>
       </segment>
     </unit>
-        <unit id="admin.migrations.subtitle">
+            <unit id="admin.migrations.subtitle">
       <segment state="initial">
-        <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
-        <target>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</target>
+        <source> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </source>
+        <target> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </target>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
       <segment state="initial">
         <source>Zurück zum Admin-Bereich</source>
         <target>Zurück zum Admin-Bereich</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.title">
+      <segment state="initial">
+        <source>Pushup-Aggregat backfillen (perExercise/pushup)</source>
+        <target>Pushup-Aggregat backfillen (perExercise/pushup)</target>
+      </segment>
+    </unit>
+    <unit id="admin.migrations.pushupBackfill.description">
+      <segment state="initial">
+        <source>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</source>
+        <target>Baut „userStats/{uid}/perExercise/pushup“ aus den migrierten Pushup-Einträgen neu auf, damit das Dashboard nach dem Cutover sofort korrekte Pushup-Totals und -Streaks zeigt. Nach der Unification-Migration ausführen. Idempotent.</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
## ⛔ HOLD — do not merge until the prod migration is run + verified

This is the **core** of the Phase-7 cutover ([#442](https://github.com/WolfSoko/pushup-stats-service/issues/442)). The repo auto-deploys `main`, and this PR re-points the pushup dashboard to `perExercise/pushup` — which is **empty until the migration + backfill have run**. Merging early would blank the pushup dashboard.

### Deploy-ordering checklist (operator)
1. ✅ Run `migratePushupsToExerciseEntries` (done — copies `pushups` → `exerciseEntries/pushup__*`). Mark it complete on `/admin/migrations`.
2. **Merge this PR** → CI deploys the write-path flip + guard removal + dashboard re-point.
3. Immediately run **`backfillPushupPerExerciseStats`** (new descriptor on `/admin/migrations`) to seed `perExercise/pushup` for all users from the migrated history.
4. Verify the dashboard / streaks / history against the runbook (`docs/migrations/pushup-unification.md`).

## What's in this PR (core cutover)
- **Catalog:** `PUSHUP_DEFINITION` is now a first-class member of `EXERCISE_CATALOG` (+ `firestore.rules` codegen, display-name, camera auto-count, goal picker); synthetic `PUSHUP_PICKER_ENTRY` removed.
- **Write-path flip:** `createPushup` writes `exerciseEntries` (`exerciseId:'pushup'`); all 3 call sites (quick-add, dashboard, training-plan) flip through it.
- **Live reads unified:** legacy `pushups` listener dropped, `connected` retied to the `exerciseEntries` feed; all browser consumers read pushups from `exerciseEntries` (no double-count). SSR/cold-start keeps the REST pushup fallback.
- **Staging guards removed**; pushups now aggregate into `perExercise/pushup` + rank via the per-exercise rebuild.
- **Dashboard re-pointed** to `perExercise/pushup` (`getPerExerciseStats`); **`backfillPushupPerExerciseStats`** callable added + wired into the migrations panel.
- **Analysis** keeps pushups on REST + filters `exerciseId:'pushup'` out of the live feed (no double-count; variant history preserved until step 6).
- **`/entries`** pushups render as plain Liegestütze (variant/`type` dropped, per the migration design).

## Deferred to the step-6 follow-up (by dependency)
- **Leaderboard** pushup data-source switch (`leaderboards/current` → `leaderboards/exercises`) — coupled to removing the legacy ranker. **Interim:** pushup leaderboard rankings go stale until step 6.
- **Public-profile** Cloud Function re-point (`userStats/{uid}` → `perExercise/pushup`).
- Removing the `kind:'pushup'` union special-casing (SSR/REST still produces those until `listPushups`/the legacy collection are gone).

## Test plan
- [x] `cloud-functions` (383), all libs, `web` (981) — green
- [x] lint (web + cloud-functions + libs) clean
- [x] i18n extracted + locale fallbacks seeded
- [ ] prod build (font-inlining flake locally; passes in CI)

Closes #442 (core). Step 6 (legacy `pushups` deletion + leaderboard/profile switch) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)