### PR TITLE
feat(web): router view transitions + i18n refresh

### DIFF
--- a/web/src/app/app.config.ts
+++ b/web/src/app/app.config.ts
@@ -52,13 +52,13 @@ import { DEMO_USER_ID } from '@pu-stats/data-access';
 import { PushSubscriptionService, VAPID_PUBLIC_KEY } from '@pu-push/push';
 import { SHOULD_SKIP_IN_APP_REMINDER } from '@pu-reminders/reminders';
 import { appRoutes } from './app.routes';
-import { appRouterFeatures } from './app.router-features';
+import { createAppRouterFeatures } from './app.router-features';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideHttpClient(withFetch()),
-    provideRouter(appRoutes, ...appRouterFeatures),
+    provideRouter(appRoutes, ...createAppRouterFeatures()),
     // Sentry error monitoring – production only (not in dev mode or emulator)
     ...(!firebaseRuntime.useEmulators && !isDevMode()
       ? [

--- a/web/src/app/app.config.ts
+++ b/web/src/app/app.config.ts
@@ -30,7 +30,7 @@ import {
   withI18nSupport,
   withIncrementalHydration,
 } from '@angular/platform-browser';
-import { provideRouter, Router, withInMemoryScrolling } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
 import {
   provideAuth,
@@ -52,18 +52,13 @@ import { DEMO_USER_ID } from '@pu-stats/data-access';
 import { PushSubscriptionService, VAPID_PUBLIC_KEY } from '@pu-push/push';
 import { SHOULD_SKIP_IN_APP_REMINDER } from '@pu-reminders/reminders';
 import { appRoutes } from './app.routes';
+import { appRouterFeatures } from './app.router-features';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideHttpClient(withFetch()),
-    provideRouter(
-      appRoutes,
-      withInMemoryScrolling({
-        anchorScrolling: 'enabled',
-        scrollPositionRestoration: 'enabled',
-      })
-    ),
+    provideRouter(appRoutes, ...appRouterFeatures),
     // Sentry error monitoring – production only (not in dev mode or emulator)
     ...(!firebaseRuntime.useEmulators && !isDevMode()
       ? [

--- a/web/src/app/app.router-features.spec.ts
+++ b/web/src/app/app.router-features.spec.ts
@@ -4,20 +4,38 @@ import { provideRouter } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { appRouterFeatures } from './app.router-features';
+import { createAppRouterFeatures } from './app.router-features';
 
-@Component({ template: 'a' })
+@Component({ template: 'a', standalone: true })
 class RouteAComponent {}
 
-@Component({ template: 'b' })
+@Component({ template: 'b', standalone: true })
 class RouteBComponent {}
 
-describe('appRouterFeatures', () => {
+describe('createAppRouterFeatures', () => {
   let originalStartViewTransition: Document['startViewTransition'] | undefined;
+  let originalMatchMedia: typeof globalThis.matchMedia | undefined;
+  let startViewTransition: ReturnType<typeof vi.fn>;
+  let skipTransition: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     originalStartViewTransition = (document as Partial<Document>)
       .startViewTransition;
+    originalMatchMedia = (globalThis as Partial<typeof globalThis>).matchMedia;
+
+    // jsdom omits the View Transitions API; stub it so the router feature runs.
+    skipTransition = vi.fn();
+    startViewTransition = vi.fn((callback?: () => void | Promise<void>) => {
+      void callback?.();
+      return {
+        finished: Promise.resolve(),
+        ready: Promise.resolve(),
+        updateCallbackDone: Promise.resolve(),
+        skipTransition,
+      } as unknown as ViewTransition;
+    });
+    document.startViewTransition =
+      startViewTransition as Document['startViewTransition'];
   });
 
   afterEach(() => {
@@ -26,25 +44,22 @@ describe('appRouterFeatures', () => {
     } else {
       delete (document as Partial<Document>).startViewTransition;
     }
+    if (originalMatchMedia) {
+      globalThis.matchMedia = originalMatchMedia;
+    } else {
+      delete (globalThis as Partial<typeof globalThis>).matchMedia;
+    }
   });
 
-  it('should drive cross-route navigation through the View Transitions API while skipping the initial one', async () => {
-    // given the View Transitions API stubbed (jsdom omits it) and the app's
-    // router features applied to two routes
-    const startViewTransition = vi.fn(
-      (callback?: () => void | Promise<void>) => {
-        void callback?.();
-        return {
-          finished: Promise.resolve(),
-          ready: Promise.resolve(),
-          updateCallbackDone: Promise.resolve(),
-          skipTransition: () => undefined,
-        } as unknown as ViewTransition;
-      }
-    );
-    document.startViewTransition =
-      startViewTransition as Document['startViewTransition'];
+  const stubReducedMotion = (matches: boolean): void => {
+    globalThis.matchMedia = ((query: string) =>
+      ({
+        matches,
+        media: query,
+      }) as unknown as MediaQueryList) as typeof globalThis.matchMedia;
+  };
 
+  const createHarness = async (): Promise<RouterTestingHarness> => {
     TestBed.configureTestingModule({
       providers: [
         provideRouter(
@@ -52,23 +67,43 @@ describe('appRouterFeatures', () => {
             { path: 'a', component: RouteAComponent },
             { path: 'b', component: RouteBComponent },
           ],
-          ...appRouterFeatures
+          ...createAppRouterFeatures()
         ),
       ],
     });
-    const harness = await RouterTestingHarness.create();
+    return RouterTestingHarness.create();
+  };
+
+  it('should drive cross-route navigation through the View Transitions API while skipping the initial one', async () => {
+    // given motion is allowed and the app's router features on two routes
+    stubReducedMotion(false);
+    const harness = await createHarness();
 
     // when the router performs its first navigation
     await harness.navigateByUrl('/a');
 
-    // then the initial transition is skipped (withViewTransitions
-    // skipInitialTransition)
+    // then the initial transition is skipped (skipInitialTransition)
     expect(startViewTransition).not.toHaveBeenCalled();
 
     // when navigating to a different route
     await harness.navigateByUrl('/b');
 
-    // then the View Transitions API drives the change
+    // then the View Transitions API drives the change and the animation runs
     expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(skipTransition).not.toHaveBeenCalled();
+  });
+
+  it('should skip the transition animation when the user prefers reduced motion', async () => {
+    // given the user prefers reduced motion
+    stubReducedMotion(true);
+    const harness = await createHarness();
+
+    // when navigating across routes (the first navigation is the skipped one)
+    await harness.navigateByUrl('/a');
+    await harness.navigateByUrl('/b');
+
+    // then the created transition still starts but its animation is skipped
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(skipTransition).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/app/app.router-features.spec.ts
+++ b/web/src/app/app.router-features.spec.ts
@@ -1,0 +1,74 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appRouterFeatures } from './app.router-features';
+
+@Component({ template: 'a' })
+class RouteAComponent {}
+
+@Component({ template: 'b' })
+class RouteBComponent {}
+
+describe('appRouterFeatures', () => {
+  let originalStartViewTransition: Document['startViewTransition'] | undefined;
+
+  beforeEach(() => {
+    originalStartViewTransition = (document as Partial<Document>)
+      .startViewTransition;
+  });
+
+  afterEach(() => {
+    if (originalStartViewTransition) {
+      document.startViewTransition = originalStartViewTransition;
+    } else {
+      delete (document as Partial<Document>).startViewTransition;
+    }
+  });
+
+  it('should drive cross-route navigation through the View Transitions API while skipping the initial one', async () => {
+    // given the View Transitions API stubbed (jsdom omits it) and the app's
+    // router features applied to two routes
+    const startViewTransition = vi.fn(
+      (callback?: () => void | Promise<void>) => {
+        void callback?.();
+        return {
+          finished: Promise.resolve(),
+          ready: Promise.resolve(),
+          updateCallbackDone: Promise.resolve(),
+          skipTransition: () => undefined,
+        } as unknown as ViewTransition;
+      }
+    );
+    document.startViewTransition =
+      startViewTransition as Document['startViewTransition'];
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(
+          [
+            { path: 'a', component: RouteAComponent },
+            { path: 'b', component: RouteBComponent },
+          ],
+          ...appRouterFeatures
+        ),
+      ],
+    });
+    const harness = await RouterTestingHarness.create();
+
+    // when the router performs its first navigation
+    await harness.navigateByUrl('/a');
+
+    // then the initial transition is skipped (withViewTransitions
+    // skipInitialTransition)
+    expect(startViewTransition).not.toHaveBeenCalled();
+
+    // when navigating to a different route
+    await harness.navigateByUrl('/b');
+
+    // then the View Transitions API drives the change
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/app/app.router-features.ts
+++ b/web/src/app/app.router-features.ts
@@ -4,12 +4,26 @@ import {
   type RouterFeatures,
 } from '@angular/router';
 
-export const appRouterFeatures: RouterFeatures[] = [
-  withInMemoryScrolling({
-    anchorScrolling: 'enabled',
-    scrollPositionRestoration: 'enabled',
-  }),
-  // The first navigation only re-renders the already SSR-painted route, so a
-  // transition there is a no-op flicker — skip it.
-  withViewTransitions({ skipInitialTransition: true }),
-];
+export function createAppRouterFeatures(): RouterFeatures[] {
+  return [
+    withInMemoryScrolling({
+      anchorScrolling: 'enabled',
+      scrollPositionRestoration: 'enabled',
+    }),
+    // The first navigation only re-renders the already SSR-painted route, so a
+    // transition there is a no-op flicker — skip it.
+    withViewTransitions({
+      skipInitialTransition: true,
+      onViewTransitionCreated: ({ transition }) => {
+        // Honour the OS-level reduced-motion preference: finish the DOM swap
+        // instantly instead of cross-fading.
+        if (
+          typeof globalThis.matchMedia === 'function' &&
+          globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches
+        ) {
+          transition.skipTransition();
+        }
+      },
+    }),
+  ];
+}

--- a/web/src/app/app.router-features.ts
+++ b/web/src/app/app.router-features.ts
@@ -1,0 +1,15 @@
+import {
+  withInMemoryScrolling,
+  withViewTransitions,
+  type RouterFeatures,
+} from '@angular/router';
+
+export const appRouterFeatures: RouterFeatures[] = [
+  withInMemoryScrolling({
+    anchorScrolling: 'enabled',
+    scrollPositionRestoration: 'enabled',
+  }),
+  // The first navigation only re-renders the already SSR-painted route, so a
+  // transition there is a no-op flicker — skip it.
+  withViewTransitions({ skipInitialTransition: true }),
+];

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -3089,15 +3089,15 @@
     </unit>
     <unit id="admin.migrations.subtitle">
       <notes>
-        <note category="location">web/src/app/admin/migrations/migrations-page.component.ts:29,32</note>
+        <note category="location">web/src/app/admin/migrations/migrations-page.component.ts:30,33</note>
       </notes>
       <segment>
-        <source>Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren.</source>
+        <source> Einmalige Datenmigrationen ausführen, prüfen und als abgeschlossen markieren. </source>
       </segment>
     </unit>
     <unit id="admin.migrations.backToAdmin">
       <notes>
-        <note category="location">web/src/app/admin/migrations/migrations-page.component.ts:35,39</note>
+        <note category="location">web/src/app/admin/migrations/migrations-page.component.ts:38,42</note>
       </notes>
       <segment>
         <source>Zurück zum Admin-Bereich</source>


### PR DESCRIPTION
## Summary

This PR bundles work from the `claude/nifty-davinci-WNAXw` branch:

- **feat(web): enable router view transitions** — adds `withViewTransitions` to the Angular router via a new `createAppRouterFeatures()` helper, consolidating `withInMemoryScrolling` + view-transition setup in one place.
- **fix(web): honour reduced-motion for router view transitions** — skips the view transition animation when the user has `prefers-reduced-motion: reduce` set, with unit tests to validate both branches.
- **chore(i18n): fill missing translations (54 items)** — filled XLIFF gaps across supported locales.
- **chore(i18n): refresh messages.xlf from extract-i18n** — re-ran `pnpm nx run web:extract-i18n`; location note line numbers and source whitespace updated to match current template markup.

## Changed files

| File | Change |
|------|--------|
| `web/src/app/app.router-features.ts` | New helper encapsulating router features |
| `web/src/app/app.router-features.spec.ts` | Vitest coverage for view transitions + reduced-motion |
| `web/src/app/app.config.ts` | Switches to `createAppRouterFeatures()` |
| `web/src/locale/messages.xlf` | Regenerated i18n source |
| `web/src/locale/messages.*.xlf` | Filled translation gaps |

## Test plan

- [ ] `lint-test-build` CI passes
- [ ] `e2e` CI passes
- [ ] Staging build green (already ✅)

https://claude.ai/code/session_01VGVGYin8TtNPo6Q9q873nL