### PR TITLE
feat: step 6a — pushup leaderboard + public-profile read perExercise (#452)

### DIFF
--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -959,7 +959,16 @@ async function fetchPublicProfileProjection(uid: string) {
   const db = admin.firestore();
   const [cfgSnap, statsSnap] = await Promise.all([
     db.collection('userConfigs').doc(uid).get(),
-    db.collection('userStats').doc(uid).get(),
+    // Post Phase-7 cutover the public pushup stats live in the per-exercise
+    // aggregate (`updateExerciseStatsOnEntryWrite` keeps it fresh); the
+    // top-level `userStats/{uid}` doc is frozen for pushups. Same UserStats
+    // shape, so `buildPublicProfile` is unchanged.
+    db
+      .collection('userStats')
+      .doc(uid)
+      .collection('perExercise')
+      .doc('pushup')
+      .get(),
   ]);
   const config = cfgSnap.exists
     ? (cfgSnap.data() as UserConfigForPublicProfile)
@@ -2408,7 +2417,10 @@ export const backfillPushupPerExerciseStats = onCall(
 
     const nowIso = new Date().toISOString();
     let rebuiltUsers = 0;
-    for (const chunk of batchArray([...byUser.entries()], MIGRATION_BATCH_SIZE)) {
+    for (const chunk of batchArray(
+      [...byUser.entries()],
+      MIGRATION_BATCH_SIZE
+    )) {
       const batch = db.batch();
       for (const [userId, entries] of chunk) {
         const stats = rebuildFromEntries(userId, entries, nowIso);

--- a/libs/data-access-state/src/lib/leaderboard/leaderboard.store.spec.ts
+++ b/libs/data-access-state/src/lib/leaderboard/leaderboard.store.spec.ts
@@ -188,7 +188,7 @@ describe('LeaderboardStore — live snapshot reload', () => {
 });
 
 describe('LeaderboardStore — exercise snapshot reload', () => {
-  it('Force-reloads every cached non-pushup exerciseId when the exercise snapshot doc emits', async () => {
+  it('Force-reloads every cached exerciseId (incl pushup) when the exercise snapshot doc emits', async () => {
     // Given — the store has the pushup bucket and two exercise buckets
     // already cached from earlier user navigation.
     const api = makeApiMock();
@@ -209,16 +209,16 @@ describe('LeaderboardStore — exercise snapshot reload', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    // Then — the pushup bucket is untouched by the exercise sub
-    // (its own sub on `leaderboards/current` owns invalidation), and
-    // both cached exercise buckets get refetched so the user sees the
-    // newly rebuilt rankings without manually re-selecting.
+    // Then — every cached bucket gets refetched so the user sees the
+    // newly rebuilt rankings without manually re-selecting. Post Phase-7
+    // cutover pushups are ranked in `leaderboards/exercises` too, so the
+    // pushup bucket is refreshed by this sub like any other exercise.
     expect(api.load).toHaveBeenCalledWith('legs.squats');
     expect(api.load).toHaveBeenCalledWith('plank.standard');
     const pushupForceReloads = api.load.mock.calls.filter(
       ([id]) => id === LEADERBOARD_PUSHUP_ID
     ).length;
-    expect(pushupForceReloads).toBe(1); // only the initial load
+    expect(pushupForceReloads).toBe(2); // initial load + exercise-snapshot refresh
   });
 
   it('Tears down both subscriptions on injector destroy', () => {

--- a/libs/data-access-state/src/lib/leaderboard/leaderboard.store.ts
+++ b/libs/data-access-state/src/lib/leaderboard/leaderboard.store.ts
@@ -183,10 +183,8 @@ export const LeaderboardStore = signalStore(
       // an empty bucket and never see it refill, because
       // `load(exerciseId)` short-circuits on cache hits. Force-reload
       // every already-cached exerciseId on each emission so the visible
-      // leaderboard stays fresh. Post Phase-7 cutover pushups are ranked
-      // here too, so they're refreshed by this sub like any other exercise
-      // (the legacy `pushupSub` above is now redundant and goes away with
-      // the legacy ranker in step 6 — see #452).
+      // leaderboard stays fresh. Pushups are ranked here too, so they're
+      // refreshed by this sub like any other exercise.
       const exerciseSub = store._api.observeExerciseSnapshot().subscribe({
         next: () => {
           const cachedExerciseIds = Object.keys(store.data());

--- a/libs/data-access-state/src/lib/leaderboard/leaderboard.store.ts
+++ b/libs/data-access-state/src/lib/leaderboard/leaderboard.store.ts
@@ -182,14 +182,14 @@ export const LeaderboardStore = signalStore(
       // page before the first post-deploy snapshot exists would cache
       // an empty bucket and never see it refill, because
       // `load(exerciseId)` short-circuits on cache hits. Force-reload
-      // every already-cached non-pushup exerciseId on each emission so
-      // the visible leaderboard stays fresh; the pushup sub above
-      // owns the pushup bucket's invalidation.
+      // every already-cached exerciseId on each emission so the visible
+      // leaderboard stays fresh. Post Phase-7 cutover pushups are ranked
+      // here too, so they're refreshed by this sub like any other exercise
+      // (the legacy `pushupSub` above is now redundant and goes away with
+      // the legacy ranker in step 6 — see #452).
       const exerciseSub = store._api.observeExerciseSnapshot().subscribe({
         next: () => {
-          const cachedExerciseIds = Object.keys(store.data()).filter(
-            (id) => id !== LEADERBOARD_PUSHUP_ID
-          );
+          const cachedExerciseIds = Object.keys(store.data());
           for (const exerciseId of cachedExerciseIds) {
             void store.load(exerciseId, { force: true });
           }

--- a/libs/data-access/src/lib/api/leaderboard.service.spec.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.spec.ts
@@ -31,7 +31,6 @@ import {
 
 const getDoc = firestoreFns.getDoc as unknown as jest.Mock;
 const getDocs = firestoreFns.getDocs as unknown as jest.Mock;
-const where = firestoreFns.where as unknown as jest.Mock;
 
 function makeSnapshot(
   periods: Record<string, unknown> | null,
@@ -62,167 +61,6 @@ describe('LeaderboardService — load() merging', () => {
 
     // Default: no rows from Firestore
     getDocs.mockResolvedValue({ docs: [] });
-  });
-
-  describe('Given the snapshot still has the legacy weekly/monthly shape', () => {
-    it('Then last7/last30 fall back to the client-computed top instead of empty arrays', async () => {
-      // Given — legacy snapshot has only `daily` of the new keys; weekly/monthly
-      // are what the old Cloud Function wrote.
-      getDoc.mockResolvedValueOnce(
-        makeSnapshot({
-          daily: [{ alias: 'D...Y', reps: 5 }],
-          weekly: [{ alias: 'W...Y', reps: 50 }],
-          monthly: [{ alias: 'M...Y', reps: 500 }],
-        })
-      );
-
-      // And — the client fetches some recent rows it can aggregate locally.
-      const today = new Date();
-      const isoToday = today.toISOString();
-      getDocs.mockResolvedValueOnce({
-        docs: [
-          { data: () => ({ userId: 'alice', reps: 12, timestamp: isoToday }) },
-        ],
-      });
-
-      // When
-      const result = await service.load();
-
-      // Then — daily comes from the cached snapshot (server is authoritative).
-      expect(result.daily.top).toEqual([
-        expect.objectContaining({ alias: 'D...Y', reps: 5 }),
-      ]);
-
-      // And — last7/last30 use the client fallback because the snapshot
-      // doesn't carry those fields yet.
-      expect(result.last7.top).toEqual([
-        expect.objectContaining({ alias: 'A...E', reps: 12 }),
-      ]);
-      expect(result.last30.top).toEqual([
-        expect.objectContaining({ alias: 'A...E', reps: 12 }),
-      ]);
-    });
-  });
-
-  describe('Given the snapshot carries an allTime bucket', () => {
-    it('Surfaces the cumulative ranking from the snapshot (no client fallback)', async () => {
-      // Given — snapshot has a cumulative top from `userStats.total`.
-      getDoc.mockResolvedValueOnce(
-        makeSnapshot({
-          daily: [],
-          last7: [],
-          last30: [],
-          allTime: [{ alias: 'A...M', reps: 99999, uid: 'allTimer' }],
-        })
-      );
-
-      // When
-      const result = await service.load();
-
-      // Then — allTime mirrors the snapshot row (rank backfilled,
-      // current-user flag false because no auth).
-      expect(result.allTime.top).toEqual([
-        expect.objectContaining({
-          alias: 'A...M',
-          reps: 99999,
-          rank: 1,
-          uid: 'allTimer',
-        }),
-      ]);
-    });
-
-    it('Falls back to an empty bucket when the snapshot lacks allTime (pre-deploy rollout)', async () => {
-      // Given — legacy snapshot without allTime. The client can't
-      // synthesise lifetime totals from the 30-day pushups query, so the
-      // expected behaviour is "empty" until the next rebuild rather than
-      // a misleading last30 stand-in.
-      getDoc.mockResolvedValueOnce(
-        makeSnapshot({ daily: [], last7: [], last30: [] })
-      );
-
-      // When
-      const result = await service.load();
-
-      // Then
-      expect(result.allTime.top).toEqual([]);
-      expect(result.allTime.current).toBeNull();
-    });
-  });
-
-  describe('Given the snapshot has the new last7/last30 shape', () => {
-    it('Then top entries come from the snapshot, not the client fallback', async () => {
-      // Given
-      getDoc.mockResolvedValueOnce(
-        makeSnapshot({
-          daily: [],
-          last7: [{ alias: 'S...R', reps: 100 }],
-          last30: [{ alias: 'S...R', reps: 100 }],
-        })
-      );
-
-      const isoToday = new Date().toISOString();
-      getDocs.mockResolvedValueOnce({
-        docs: [
-          { data: () => ({ userId: 'alice', reps: 1, timestamp: isoToday }) },
-        ],
-      });
-
-      // When
-      const result = await service.load();
-
-      // Then — server values win, even though client could compute its own.
-      expect(result.last7.top).toEqual([
-        expect.objectContaining({ alias: 'S...R', reps: 100 }),
-      ]);
-      expect(result.last30.top).toEqual([
-        expect.objectContaining({ alias: 'S...R', reps: 100 }),
-      ]);
-    });
-
-    it('Then an explicit empty array is preserved (not replaced by fallback)', async () => {
-      // Given — server says "no entries" for last7 (e.g. nobody trained).
-      getDoc.mockResolvedValueOnce(
-        makeSnapshot({
-          daily: [],
-          last7: [],
-          last30: [],
-        })
-      );
-
-      const isoToday = new Date().toISOString();
-      getDocs.mockResolvedValueOnce({
-        docs: [
-          { data: () => ({ userId: 'alice', reps: 99, timestamp: isoToday }) },
-        ],
-      });
-
-      // When
-      const result = await service.load();
-
-      // Then — we trust the server's empty list; we don't override with stale
-      // client computation.
-      expect(result.last7.top).toEqual([]);
-      expect(result.last30.top).toEqual([]);
-    });
-  });
-
-  describe('Firestore query bound', () => {
-    it('Uses a date-only YYYY-MM-DD lower bound for the timestamp filter', async () => {
-      // Given — no snapshot, so `load()` triggers `fetchRows`.
-      getDoc.mockResolvedValueOnce(makeSnapshot(null));
-
-      // When
-      await service.load();
-
-      // Then — the `where` clause is called with a YYYY-MM-DD string, NOT a
-      // full ISO datetime. This makes the query robust to whatever timestamp
-      // format the entries carry (Z-suffix, +01:00 offset, ms or no ms).
-      const lowerBoundCall = where.mock.calls.find(
-        ([field, op]) => field === 'timestamp' && op === '>='
-      );
-      expect(lowerBoundCall).toBeDefined();
-      expect(lowerBoundCall?.[2]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    });
   });
 
   describe('Given an exerciseId other than the legacy pushup sentinel', () => {
@@ -520,24 +358,10 @@ describe('LeaderboardService — load() merging', () => {
       expect(result.updatedAt).toBeNull();
     });
 
-    it('Uses the client clock only when no snapshot doc exists at all (purely client-side buckets)', async () => {
-      // Given — `loadSnapshot` returns null (no doc). The displayed
-      // buckets are entirely the client-aggregated fallback, so "now"
-      // truly describes when they were computed.
-      const before = Date.now();
-      getDoc.mockResolvedValueOnce({ exists: () => false, data: () => ({}) });
-
-      // When
-      const result = await service.load();
-
-      // Then
-      const { updatedAt } = result;
-      expect(updatedAt).not.toBeNull();
-      if (!updatedAt) return;
-      const after = Date.now();
-      expect(updatedAt.getTime()).toBeGreaterThanOrEqual(before);
-      expect(updatedAt.getTime()).toBeLessThanOrEqual(after);
-    });
+    // (Removed) The legacy client-clock fallback when no snapshot doc exists
+    // was specific to the retired `loadPushup` client-aggregation path. Post
+    // Phase-7 cutover pushups read the precomputed `leaderboards/exercises`
+    // snapshot like every other exercise (no client-side compute).
   });
 
   describe('Given a per-exercise leaderboard', () => {

--- a/libs/data-access/src/lib/api/leaderboard.service.spec.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.spec.ts
@@ -357,11 +357,6 @@ describe('LeaderboardService — load() merging', () => {
       // rather than lying.
       expect(result.updatedAt).toBeNull();
     });
-
-    // (Removed) The legacy client-clock fallback when no snapshot doc exists
-    // was specific to the retired `loadPushup` client-aggregation path. Post
-    // Phase-7 cutover pushups read the precomputed `leaderboards/exercises`
-    // snapshot like every other exercise (no client-side compute).
   });
 
   describe('Given a per-exercise leaderboard', () => {

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -141,12 +141,8 @@ export class LeaderboardService {
   /**
    * Loads ranked buckets (daily / last7 / last30 / allTime) for the
    * requested exercise from the precomputed `leaderboards/exercises`
-   * snapshot. Post Phase-7 cutover pushups (`LEADERBOARD_PUSHUP_ID`) are a
-   * first-class catalog exercise ranked there like every other exercise.
-   *
-   * The legacy `loadPushup`/`leaderboards/current` path is now unreachable;
-   * it (and the `pushups`-collection reads it depends on) is deleted in
-   * step 6 alongside the legacy ranker — see #452.
+   * snapshot. Pushups (`LEADERBOARD_PUSHUP_ID`) are a first-class catalog
+   * exercise ranked there like every other exercise.
    */
   async load(
     exerciseId: string = LEADERBOARD_PUSHUP_ID

--- a/libs/data-access/src/lib/api/leaderboard.service.ts
+++ b/libs/data-access/src/lib/api/leaderboard.service.ts
@@ -139,17 +139,18 @@ export class LeaderboardService {
   }
 
   /**
-   * Loads ranked buckets (daily / last7 / last30) for the requested
-   * exercise. The default — and the `LEADERBOARD_PUSHUP_ID` sentinel —
-   * routes through the legacy `pushups` collection and merges in the
-   * precomputed snapshot at `leaderboards/current`. Every other
-   * exerciseId queries `exerciseEntries` and aggregates client-side;
-   * the snapshot doesn't carry per-exercise rankings yet.
+   * Loads ranked buckets (daily / last7 / last30 / allTime) for the
+   * requested exercise from the precomputed `leaderboards/exercises`
+   * snapshot. Post Phase-7 cutover pushups (`LEADERBOARD_PUSHUP_ID`) are a
+   * first-class catalog exercise ranked there like every other exercise.
+   *
+   * The legacy `loadPushup`/`leaderboards/current` path is now unreachable;
+   * it (and the `pushups`-collection reads it depends on) is deleted in
+   * step 6 alongside the legacy ranker — see #452.
    */
   async load(
     exerciseId: string = LEADERBOARD_PUSHUP_ID
   ): Promise<LeaderboardData> {
-    if (exerciseId === LEADERBOARD_PUSHUP_ID) return this.loadPushup();
     return this.loadExercise(exerciseId);
   }
 


### PR DESCRIPTION
## What

First (reversible) slice of [#452](https://github.com/WolfSoko/pushup-stats-service/issues/452). Post Phase-7 cutover (#449), pushups are ranked in the per-exercise `leaderboards/exercises` snapshot and aggregated in `perExercise/pushup` — but two surfaces still read the now-frozen legacy docs:

- **Leaderboard** (`LeaderboardService.load`) → routed `LEADERBOARD_PUSHUP_ID` through `loadExercise` (reads `leaderboards/exercises`). Fixes the interim **stale pushup-ranking** degradation flagged in #449. The store's `leaderboards/exercises` subscription now refreshes the pushup bucket too.
- **Public profile** (`fetchPublicProfileProjection`) → reads pushup stats from `userStats/{uid}/perExercise/pushup` (kept fresh by `updateExerciseStatsOnEntryWrite`) instead of the frozen `userStats/{uid}`. Same `UserStats` shape, so `buildPublicProfile` is unchanged.

## Notes
- The legacy `loadPushup` / `leaderboards/current` / `pushups`-collection read path is now **unreachable**; it's deleted in **step 6c** alongside the legacy ranker + collection (kept here to preserve the #449 rollback path). The retired pushup-path service specs were removed (the per-exercise path is already covered).
- Independently deployable + reversible (no irreversible deletion).

## Test plan
- [x] `stats-data-access` (108), `stats-data-access-state` (17), `cloud-functions` (383), `web` (983) — all green
- [x] lint clean (data-access, data-access-state, cloud-functions)

Refs #452. Step 6b (kind:'pushup' cleanup) + 6c (legacy collection/trigger deletion) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Push-up statistics now sourced from dedicated per-exercise data for improved accuracy.
  * Leaderboard exercise snapshots now refresh consistently across all exercises.

* **Refactor**
  * Consolidated legacy push-up leaderboard handling with standard exercise processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->