### PR TITLE
fix(stats-chart): destroy chart on teardown (analysis resize crash)

### DIFF
--- a/web/src/app/stats/components/stats-chart/stats-chart.component.ts
+++ b/web/src/app/stats/components/stats-chart/stats-chart.component.ts
@@ -3,6 +3,7 @@ import {
   AfterViewInit,
   Component,
   computed,
+  DestroyRef,
   effect,
   ElementRef,
   inject,
@@ -258,6 +259,15 @@ export class StatsChartComponent implements AfterViewInit {
       this.measurement();
       this.paceSeries();
       queueMicrotask(() => this.renderChart(currentSeries, currentEntries));
+    });
+    // Destroy the chart when the component is torn down (e.g. the analysis
+    // page toggles it out via `@if`). Without this, Chart.js's responsive
+    // ResizeObserver outlives the element and a queued resize fires on the
+    // detached chart — crashing in a plugin hook
+    // (`Cannot set properties of undefined (setting '_listened')`).
+    inject(DestroyRef).onDestroy(() => {
+      this.chart?.destroy();
+      this.chart = undefined;
     });
   }
 


### PR DESCRIPTION
## Bug
Runtime crash on the **Analysis page** (reported for pushups):
`TypeError: Cannot set properties of undefined (setting '_listened')` — thrown from chartjs-plugin-datalabels' `beforeUpdate` during a Chart.js `_doResize`.

## Cause
`StatsChartComponent` destroyed its `Chart` instance only **before re-render** (in `renderChart`), never on **component destroy**. The analysis page mounts/unmounts the chart via `@if (isEmptyRange())`. When it unmounts, Chart.js's `responsive: true` ResizeObserver outlived the removed `<canvas>`, and a queued resize RAF fired on the detached chart → crash in the plugin hook.

Pre-existing latent race, **surfaced by the pushup cutover**: analysis pushup data now loads live (empty→populated as the Firestore listener connects), so `isEmptyRange()` flips and toggles the chart in/out far more often.

## Fix
Destroy the chart via `DestroyRef.onDestroy` so the ResizeObserver is torn down with the component.

## Test plan
- [x] `StatsChartComponent` spec (13) + lint green
- Note: browser-only lifecycle race — jsdom short-circuits chart creation (`renderChart` early-returns), so it isn't exercised by unit tests; verified by reasoning about the Chart.js responsive-resize lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak in statistics chart components where Chart.js instances were not properly destroyed when components were removed from view. The component now properly cleans up all chart resources during destruction, improving application performance, preventing resource waste, and enhancing overall stability when navigating between different sections and views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->