### PR TITLE
chore(i18n): refresh messages.xlf after extract-i18n

### DIFF
--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -654,7 +654,7 @@
     </unit>
     <unit id="pushup.validation.reps.outOfRange">
       <notes>
-        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:51</note>
+        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:21</note>
       </notes>
       <segment>
         <source>Reps müssen zwischen <ph id="0" equiv="min" disp="PUSHUP_REPS_MIN"/> und <ph id="1" equiv="max" disp="PUSHUP_REPS_MAX"/> liegen.</source>
@@ -662,7 +662,7 @@
     </unit>
     <unit id="pushup.validation.reps.notInteger">
       <notes>
-        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:54</note>
+        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:24</note>
       </notes>
       <segment>
         <source>Reps muss eine ganze Zahl sein.</source>
@@ -670,24 +670,17 @@
     </unit>
     <unit id="pushup.validation.generic">
       <notes>
-        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:57</note>
+        <note category="location">libs/data-access/src/lib/api/pushup-firestore.service.ts:27</note>
       </notes>
       <segment>
         <source>Eintrag konnte nicht gespeichert werden.</source>
       </segment>
     </unit>
-    <unit id="reminder.quickLog.success">
-      <notes>
-        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:66</note>
-      </notes>
-      <segment>
-        <source><ph id="0" equiv="reps" disp="reps"/> Push-ups eingetragen ✓</source>
-      </segment>
-    </unit>
     <unit id="snackbar.close">
       <notes>
-        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:67</note>
-        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:73</note>
+        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:63</note>
+        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:80</note>
+        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:86</note>
         <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:484</note>
         <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:512</note>
         <note category="location">web/src/app/reminders/shell/reminders-page.component.ts:528</note>
@@ -698,6 +691,14 @@
       </notes>
       <segment>
         <source>Schließen</source>
+      </segment>
+    </unit>
+    <unit id="reminder.quickLog.success">
+      <notes>
+        <note category="location">libs/push/src/lib/quick-log-listener.service.ts:79</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="reps" disp="reps"/> Push-ups eingetragen ✓</source>
       </segment>
     </unit>
     <unit id="quickAdd.fab.feedbackAria">
@@ -4166,7 +4167,7 @@
     </unit>
     <unit id="quickAdd.fab.pushupRepsLabel">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:52</note>
+        <note category="location">web/src/app/core/app-data.facade.ts:44</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
@@ -4174,7 +4175,7 @@
     </unit>
     <unit id="quickAdd.fab.repAria">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:53</note>
+        <note category="location">web/src/app/core/app-data.facade.ts:45</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
@@ -4182,7 +4183,7 @@
     </unit>
     <unit id="quickAdd.fab.exerciseRepAria">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:74</note>
+        <note category="location">web/src/app/core/app-data.facade.ts:66</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="REPS" disp="cfg.reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
@@ -4190,16 +4191,15 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:364</note>
+        <note category="location">web/src/app/core/app-data.facade.ts:332</note>
         <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:43</note>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:145</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:123</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:385</note>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:222</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:205</note>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1288</note>
-        <note category="location">web/src/app/stats/dashboard.store.ts:77</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:69</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:24</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:195</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:219</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:211</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:289</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:393</note>
       </notes>
@@ -4266,9 +4266,9 @@
     </unit>
     <unit id="quickAdd.success.create">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:166</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:190</note>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:431</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:160</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:191</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:439</note>
       </notes>
       <segment>
         <source>Eintrag gespeichert.</source>
@@ -4276,7 +4276,7 @@
     </unit>
     <unit id="quickAdd.success.goalReached">
       <notes>
-        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:219</note>
+        <note category="location">web/src/app/core/quick-add-orchestration.service.ts:227</note>
       </notes>
       <segment>
         <source>Tagesziel erreicht 🎉</source>
@@ -6128,7 +6128,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:42,43</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:27,28</note>
       </notes>
       <segment>
         <source>Analyse öffnen</source>
@@ -6136,7 +6136,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserTitle">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:47,49</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:32,34</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -6144,7 +6144,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserStreak">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:51,52</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:36,37</note>
       </notes>
       <segment>
         <source>Streak: <ph id="0" equiv="INTERPOLATION" disp="{{ streak() }}"/> Tage</source>
@@ -6152,23 +6152,15 @@
     </unit>
     <unit id="dashboard.analysisTeaserWeekReps">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:55,57</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:40,42</note>
       </notes>
       <segment>
         <source>Diese Woche: <ph id="0" equiv="INTERPOLATION" disp="{{ weekReps() }}"/> / <ph id="1" equiv="INTERPOLATION_1" disp="{{ weeklyGoal() }}"/> Reps</source>
       </segment>
     </unit>
-    <unit id="dashboard.analysisTeaserError">
-      <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:63,65</note>
-      </notes>
-      <segment>
-        <source> Daten konnten nicht geladen werden. </source>
-      </segment>
-    </unit>
     <unit id="dashboard.analysisTeaserCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:81,82</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:60,61</note>
       </notes>
       <segment>
         <source>Zur Analyse navigieren</source>
@@ -6176,7 +6168,7 @@
     </unit>
     <unit id="dashboard.analysisTeaserCta">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:85,87</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:64,66</note>
       </notes>
       <segment>
         <source>Zur Analyse</source>
@@ -6184,7 +6176,7 @@
     </unit>
     <unit id="chart.kindLabel.all">
       <notes>
-        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:139</note>
+        <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:117</note>
       </notes>
       <segment>
         <source>Alle Übungen</source>
@@ -6841,7 +6833,7 @@
     </unit>
     <unit id="chart.modeToggleAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:81,82</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:82,83</note>
       </notes>
       <segment>
         <source>Zeitraum der Stundenansicht</source>
@@ -6849,7 +6841,7 @@
     </unit>
     <unit id="chart.mode14h">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:85,86</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:86,87</note>
       </notes>
       <segment>
         <source>14h</source>
@@ -6857,7 +6849,7 @@
     </unit>
     <unit id="chart.mode24h">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:88,89</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:89,90</note>
       </notes>
       <segment>
         <source>24h</source>
@@ -6865,7 +6857,7 @@
     </unit>
     <unit id="chart.legendAria">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:102</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:103</note>
       </notes>
       <segment>
         <source>Legende</source>
@@ -6873,8 +6865,8 @@
     </unit>
     <unit id="chart.withSets">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:112,113</note>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:271</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:113,114</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:281</note>
       </notes>
       <segment>
         <source>Mit Sets</source>
@@ -6882,7 +6874,7 @@
     </unit>
     <unit id="chart.titleHourly">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:162</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:163</note>
       </notes>
       <segment>
         <source>Verlauf (Stundenwerte)</source>
@@ -6890,7 +6882,7 @@
     </unit>
     <unit id="chart.titleDaily">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:163</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:164</note>
       </notes>
       <segment>
         <source>Verlauf (Tageswerte)</source>
@@ -6898,7 +6890,7 @@
     </unit>
     <unit id="chart.subtitle.reps">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:175</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:176</note>
       </notes>
       <segment>
         <source>Balken zeigen deine Wiederholungen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
@@ -6906,7 +6898,7 @@
     </unit>
     <unit id="chart.subtitle.time">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:176</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:177</note>
       </notes>
       <segment>
         <source>Balken zeigen deine Übungsdauer (s) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
@@ -6914,7 +6906,7 @@
     </unit>
     <unit id="chart.subtitle.distance">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:177</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:178</note>
       </notes>
       <segment>
         <source>Balken zeigen deine Strecke (km) pro Zeitabschnitt. Die orange Linie zeigt dein Tempo (min/km), die grüne deinen Strecken-Trend.</source>
@@ -6922,7 +6914,7 @@
     </unit>
     <unit id="chart.subtitle.weight">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:178</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:179</note>
       </notes>
       <segment>
         <source>Balken zeigen dein Trainingsgewicht (kg) pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
@@ -6930,7 +6922,7 @@
     </unit>
     <unit id="chart.subtitle.mixed">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:179</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:180</note>
       </notes>
       <segment>
         <source>Balken zeigen dein Trainingsvolumen pro Zeitabschnitt. Die orange Linie summiert den Tag, die grüne zeigt deinen Trend.</source>
@@ -6938,7 +6930,7 @@
     </unit>
     <unit id="chart.interval">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:199</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:200</note>
       </notes>
       <segment>
         <source>Intervallwert</source>
@@ -6946,7 +6938,7 @@
     </unit>
     <unit id="chart.dayIntegral">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:200</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:201</note>
       </notes>
       <segment>
         <source>Tages-Integral</source>
@@ -6954,7 +6946,7 @@
     </unit>
     <unit id="chart.kmPace">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:201</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:202</note>
       </notes>
       <segment>
         <source>km Tempo</source>
@@ -6962,7 +6954,7 @@
     </unit>
     <unit id="chart.movingAvg">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:202</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:203</note>
       </notes>
       <segment>
         <source>Gleitender Durchschnitt</source>
@@ -6970,7 +6962,7 @@
     </unit>
     <unit id="chart.setsTooltip">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:270</note>
+        <note category="location">web/src/app/stats/components/stats-chart/stats-chart.component.ts:280</note>
       </notes>
       <segment>
         <source>Sets</source>
@@ -7101,7 +7093,7 @@
     </unit>
     <unit id="colExercise">
       <notes>
-        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:218</note>
+        <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:201</note>
       </notes>
       <segment>
         <source>Übung</source>
@@ -7400,7 +7392,7 @@
     <unit id="exercise.category.push">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1289</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:220</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:212</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:462</note>
       </notes>
       <segment>
@@ -7410,7 +7402,7 @@
     <unit id="exercise.category.pull">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1290</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:221</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:213</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:463</note>
       </notes>
       <segment>
@@ -7420,7 +7412,7 @@
     <unit id="exercise.category.squat">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1291</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:222</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:214</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:464</note>
       </notes>
       <segment>
@@ -7430,7 +7422,7 @@
     <unit id="exercise.category.hinge">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1292</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:223</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:215</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:465</note>
       </notes>
       <segment>
@@ -7440,7 +7432,7 @@
     <unit id="exercise.category.lunge">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1293</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:224</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:216</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:466</note>
       </notes>
       <segment>
@@ -7458,7 +7450,7 @@
     <unit id="exercise.category.core">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1295</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:225</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:217</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:467</note>
       </notes>
       <segment>
@@ -7468,7 +7460,7 @@
     <unit id="exercise.category.cardio">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1296</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:226</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:218</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:468</note>
       </notes>
       <segment>
@@ -7478,7 +7470,7 @@
     <unit id="exercise.category.mobility">
       <notes>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1297</note>
-        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:227</note>
+        <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:219</note>
         <note category="location">web/src/app/wiki/exercises-page.component.ts:469</note>
       </notes>
       <segment>
@@ -7543,7 +7535,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:550</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:479</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Schau dir mein Profil an:</source>
@@ -7551,7 +7543,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:551</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:480</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
@@ -7559,7 +7551,7 @@
     </unit>
     <unit id="dashboard.share.text.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:555</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:484</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
@@ -7567,7 +7559,7 @@
     </unit>
     <unit id="dashboard.share.text.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:556</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:485</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
@@ -7575,7 +7567,7 @@
     </unit>
     <unit id="dashboard.share.title">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:560</note>
+        <note category="location">web/src/app/stats/dashboard.store.ts:489</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -9432,19 +9424,10 @@
         <source>Letzter Eintrag</source>
       </segment>
     </unit>
-    <unit id="latEntryReps">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:346,348</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:410,411</note>
-      </notes>
-      <segment>
-        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ latest.reps }}"/> Reps · <ph id="1" equiv="INTERPOLATION_1" disp="{{ pushupTypeLabel(latest) }}"/> </source>
-      </segment>
-    </unit>
     <unit id="dashboard.noEntryYet">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:356,358</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:433,436</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:350,352</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:416,419</note>
       </notes>
       <segment>
         <source>Noch kein Eintrag.</source>
@@ -9452,7 +9435,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:377,381</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:371,375</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -9460,24 +9443,15 @@
     </unit>
     <unit id="dashboard.latestExercises">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:382,383</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:376,377</note>
       </notes>
       <segment>
         <source>Letzte Übungen</source>
       </segment>
     </unit>
-    <unit id="dashboard.tile.pushupTitle">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:407,409</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:115</note>
-      </notes>
-      <segment>
-        <source>Liegestütze</source>
-      </segment>
-    </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:440,441</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:423,424</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -9485,7 +9459,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:445,448</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:428,431</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -9493,7 +9467,7 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:451</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:434</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -9501,7 +9475,7 @@
     </unit>
     <unit id="dashboard.tile.openInHistoryAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:117</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:101</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="label" disp="label"/> in der Historie öffnen</source>
@@ -9509,7 +9483,7 @@
     </unit>
     <unit id="dashboard.share.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:120</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:104</note>
       </notes>
       <segment>
         <source>Tagesleistung teilen</source>
@@ -9517,7 +9491,7 @@
     </unit>
     <unit id="dashboard.share">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:121</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:105</note>
       </notes>
       <segment>
         <source>Teilen</source>


### PR DESCRIPTION
## Summary

- Ran `pnpm nx run web:extract-i18n` during the translation routine (zero gaps detected across all locales)
- Auto-generated `messages.xlf` updated: source line number annotations refreshed throughout; `reminder.quickLog.success` unit moved to a new position (it still exists and is referenced in `quick-log-listener.service.ts`); obsolete units `dashboard.analysisTeaserError`, `latEntryReps`, and `dashboard.tile.pushupTitle` removed
- No target locale files changed — all translations remain complete

## Translation routine result

`has_gaps=false` — 0 XLIFF units, 0 blog posts, 0 wiki entries missing across locales: en, fr, es, it, nl, el, la, no, zh. No translation PR was needed.

_Note: branch rebased onto main after #459 merged so only the messages.xlf regeneration is in scope._