### PR TITLE
chore(i18n): fill missing translations (45 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10046,33 +10046,33 @@
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schnellerfassung</source>
-        <target>Schnellerfassung</target>
+        <target>Γρήγορη καταχώρηση</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</source>
-        <target>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</target>
+        <target>Με αυτό το κουμπί + καταγράφεις επαναλήψεις αστραπιαία – από οποιαδήποτε σελίδα.</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.dismiss">
-      <segment state="initial">
+      <segment state="translated">
         <source>Verstanden</source>
-        <target>Verstanden</target>
+        <target>Κατάλαβα</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.closeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tutorial schließen</source>
-        <target>Tutorial schließen</target>
+        <target>Κλείσιμο οδηγού</target>
       </segment>
     </unit>
     <unit id="dashboard.quickActions.speedDialHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
-        <target>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</target>
+        <target>Συμβουλή: Χρησιμοποίησε το πλωτό κουμπί + κάτω δεξιά για γρήγορη καταγραφή από οποιαδήποτε σελίδα.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10212,33 +10212,33 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schnellerfassung</source>
-        <target>Schnellerfassung</target>
+        <target>Quick Add</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</source>
-        <target>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</target>
+        <target>Use this + button to record reps lightning fast – from any page.</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.dismiss">
-      <segment state="initial">
+      <segment state="translated">
         <source>Verstanden</source>
-        <target>Verstanden</target>
+        <target>Got it</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.closeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tutorial schließen</source>
-        <target>Tutorial schließen</target>
+        <target>Close tutorial</target>
       </segment>
     </unit>
     <unit id="dashboard.quickActions.speedDialHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
-        <target>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</target>
+        <target>Tip: Use the floating + button at the bottom right to quickly log from any page.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10042,33 +10042,33 @@
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schnellerfassung</source>
-        <target>Schnellerfassung</target>
+        <target>Registro rápido</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</source>
-        <target>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</target>
+        <target>Con este botón + puedes registrar repeticiones al instante – desde cualquier página.</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.dismiss">
-      <segment state="initial">
+      <segment state="translated">
         <source>Verstanden</source>
-        <target>Verstanden</target>
+        <target>Entendido</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.closeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tutorial schließen</source>
-        <target>Tutorial schließen</target>
+        <target>Cerrar tutorial</target>
       </segment>
     </unit>
     <unit id="dashboard.quickActions.speedDialHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
-        <target>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</target>
+        <target>Consejo: Usa el botón + flotante en la esquina inferior derecha para registrar desde cualquier página al instante.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9918,33 +9918,33 @@
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schnellerfassung</source>
-        <target>Schnellerfassung</target>
+        <target>Saisie rapide</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</source>
-        <target>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</target>
+        <target>Ce bouton + te permet d'enregistrer des répétitions en un éclair – depuis n'importe quelle page.</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.dismiss">
-      <segment state="initial">
+      <segment state="translated">
         <source>Verstanden</source>
-        <target>Verstanden</target>
+        <target>Compris</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.closeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tutorial schließen</source>
-        <target>Tutorial schließen</target>
+        <target>Fermer le tutoriel</target>
       </segment>
     </unit>
     <unit id="dashboard.quickActions.speedDialHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
-        <target>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</target>
+        <target>Astuce : Utilise le bouton + flottant en bas à droite pour saisir rapidement depuis n'importe quelle page.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10046,33 +10046,33 @@
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schnellerfassung</source>
-        <target>Schnellerfassung</target>
+        <target>Inserimento rapido</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</source>
-        <target>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</target>
+        <target>Con questo pulsante + puoi registrare le ripetizioni in un lampo – da qualsiasi pagina.</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.dismiss">
-      <segment state="initial">
+      <segment state="translated">
         <source>Verstanden</source>
-        <target>Verstanden</target>
+        <target>Capito</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.closeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tutorial schließen</source>
-        <target>Tutorial schließen</target>
+        <target>Chiudi il tutorial</target>
       </segment>
     </unit>
     <unit id="dashboard.quickActions.speedDialHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
-        <target>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</target>
+        <target>Suggerimento: Usa il pulsante + flottante in basso a destra per registrare rapidamente da qualsiasi pagina.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -10046,33 +10046,33 @@
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schnellerfassung</source>
-        <target>Schnellerfassung</target>
+        <target>Additio celeris</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</source>
-        <target>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</target>
+        <target>Hoc botone + repetitiones velocissime addes – ex quavis pagina.</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.dismiss">
-      <segment state="initial">
+      <segment state="translated">
         <source>Verstanden</source>
-        <target>Verstanden</target>
+        <target>Intellexi</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.closeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tutorial schließen</source>
-        <target>Tutorial schließen</target>
+        <target>Tutorialem claudere</target>
       </segment>
     </unit>
     <unit id="dashboard.quickActions.speedDialHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
-        <target>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</target>
+        <target>Consilium: Hoc botone + fluctuante dextra infra repetitiones ex quavis pagina velocissime addes.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10054,7 +10054,7 @@
     <unit id="quickAdd.coachmark.body">
       <segment state="translated">
         <source>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</source>
-        <target>Met deze +-knop registreer je herhalingen razendsnel – van elke pagina.</target>
+        <target>Met deze +‑knop registreer je herhalingen razendsnel – van elke pagina.</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.dismiss">
@@ -10072,7 +10072,7 @@
     <unit id="dashboard.quickActions.speedDialHint">
       <segment state="translated">
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
-        <target>Tip: Met de zwevende +-knop rechtsonder registreer je razendsnel van elke pagina.</target>
+        <target>Tip: Met de zwevende +‑knop rechtsonder registreer je razendsnel van elke pagina.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10046,33 +10046,33 @@
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schnellerfassung</source>
-        <target>Schnellerfassung</target>
+        <target>Snel invoeren</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</source>
-        <target>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</target>
+        <target>Met deze +-knop registreer je herhalingen razendsnel – van elke pagina.</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.dismiss">
-      <segment state="initial">
+      <segment state="translated">
         <source>Verstanden</source>
-        <target>Verstanden</target>
+        <target>Begrepen</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.closeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tutorial schließen</source>
-        <target>Tutorial schließen</target>
+        <target>Tutorial sluiten</target>
       </segment>
     </unit>
     <unit id="dashboard.quickActions.speedDialHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
-        <target>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</target>
+        <target>Tip: Met de zwevende +-knop rechtsonder registreer je razendsnel van elke pagina.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9306,33 +9306,33 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schnellerfassung</source>
-        <target>Schnellerfassung</target>
+        <target>Hurtigregistrering</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</source>
-        <target>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</target>
+        <target>Med denne +-knappen registrerer du repetisjoner lynraskt – fra hvilken som helst side.</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.dismiss">
-      <segment state="initial">
+      <segment state="translated">
         <source>Verstanden</source>
-        <target>Verstanden</target>
+        <target>Forstått</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.closeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tutorial schließen</source>
-        <target>Tutorial schließen</target>
+        <target>Lukk veiledning</target>
       </segment>
     </unit>
     <unit id="dashboard.quickActions.speedDialHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
-        <target>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</target>
+        <target>Tips: Bruk den flytende +-knappen nede til høyre for å registrere lynraskt fra hvilken som helst side.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9314,7 +9314,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="quickAdd.coachmark.body">
       <segment state="translated">
         <source>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</source>
-        <target>Med denne +-knappen registrerer du repetisjoner lynraskt – fra hvilken som helst side.</target>
+        <target>Med denne +‑knappen registrerer du repetisjoner lynraskt – fra hvilken som helst side.</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.dismiss">
@@ -9332,7 +9332,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="dashboard.quickActions.speedDialHint">
       <segment state="translated">
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
-        <target>Tips: Bruk den flytende +-knappen nede til høyre for å registrere lynraskt fra hvilken som helst side.</target>
+        <target>Tips: Bruk den flytende +‑knappen nede til høyre for å registrere lynraskt fra hvilken som helst side.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -247,7 +247,7 @@
     </unit>
     <unit id="auth.onboarding.google.error.noUser">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login-ui.store.ts:95</note>
+        <note category="location">libs/auth/src/lib/ui/login/login-ui.store.ts:96</note>
       </notes>
       <segment>
         <source>Kein eingeloggter Nutzer gefunden.</source>
@@ -255,7 +255,7 @@
     </unit>
     <unit id="auth.onboarding.google.error.consentRequired">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login-ui.store.ts:101</note>
+        <note category="location">libs/auth/src/lib/ui/login/login-ui.store.ts:102</note>
       </notes>
       <segment>
         <source>Bitte stimme der Datenverarbeitung zu.</source>
@@ -348,7 +348,7 @@
     </unit>
     <unit id="validate.email.required">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:61</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:59</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.ts:123</note>
       </notes>
       <segment>
@@ -357,7 +357,7 @@
     </unit>
     <unit id="validate.email.email">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:64</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:62</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.ts:126</note>
       </notes>
       <segment>
@@ -366,7 +366,7 @@
     </unit>
     <unit id="validate.password.required">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:67</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:65</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.ts:129</note>
       </notes>
       <segment>
@@ -375,7 +375,7 @@
     </unit>
     <unit id="validate.password.minLength">
       <notes>
-        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:70</note>
+        <note category="location">libs/auth/src/lib/ui/login/login.component.ts:68</note>
         <note category="location">libs/auth/src/lib/ui/register/register.component.ts:132</note>
       </notes>
       <segment>
@@ -3725,7 +3725,7 @@
     </unit>
     <unit id="earlyAccess.text">
       <notes>
-        <note category="location">web/src/app/app.ts:187</note>
+        <note category="location">web/src/app/app.ts:191</note>
       </notes>
       <segment>
         <source>Early Access – pushup-stats.com befindet sich noch im Aufbau. Funktionen und Design können sich jederzeit ändern.</source>
@@ -3733,7 +3733,7 @@
     </unit>
     <unit id="earlyAccess.feedback">
       <notes>
-        <note category="location">web/src/app/app.ts:188</note>
+        <note category="location">web/src/app/app.ts:192</note>
       </notes>
       <segment>
         <source>Feedback</source>
@@ -3741,7 +3741,7 @@
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
       <notes>
-        <note category="location">web/src/app/app.ts:304</note>
+        <note category="location">web/src/app/app.ts:308</note>
       </notes>
       <segment>
         <source>Tagesziel-Einzelpositionen anzeigen</source>
@@ -3749,7 +3749,7 @@
     </unit>
     <unit id="seo.default.title">
       <notes>
-        <note category="location">web/src/app/app.ts:415</note>
+        <note category="location">web/src/app/app.ts:419</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -3757,7 +3757,7 @@
     </unit>
     <unit id="seo.default.description">
       <notes>
-        <note category="location">web/src/app/app.ts:418</note>
+        <note category="location">web/src/app/app.ts:422</note>
       </notes>
       <segment>
         <source>Tracke Reps, Trends und Streaks mit Pushup Tracker.</source>
@@ -3765,7 +3765,7 @@
     </unit>
     <unit id="sw.update.available">
       <notes>
-        <note category="location">web/src/app/app.ts:439</note>
+        <note category="location">web/src/app/app.ts:443</note>
       </notes>
       <segment>
         <source>Neue Version verfügbar</source>
@@ -3773,7 +3773,7 @@
     </unit>
     <unit id="sw.update.reload">
       <notes>
-        <note category="location">web/src/app/app.ts:440</note>
+        <note category="location">web/src/app/app.ts:444</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -3781,7 +3781,7 @@
     </unit>
     <unit id="toolbarDailyGoal.replayAria">
       <notes>
-        <note category="location">web/src/app/app.ts:516</note>
+        <note category="location">web/src/app/app.ts:520</note>
       </notes>
       <segment>
         <source>Tagesziel-Animation erneut abspielen</source>
@@ -3789,7 +3789,7 @@
     </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:545</note>
+        <note category="location">web/src/app/app.ts:549</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -3797,7 +3797,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:552</note>
+        <note category="location">web/src/app/app.ts:556</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9540,33 +9540,33 @@
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Schnellerfassung</source>
-        <target>Schnellerfassung</target>
+        <target>快速记录</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.body">
-      <segment state="initial">
+      <segment state="translated">
         <source>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</source>
-        <target>Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus.</target>
+        <target>使用此 + 按钮，可从任意页面闪速记录训练次数。</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.dismiss">
-      <segment state="initial">
+      <segment state="translated">
         <source>Verstanden</source>
-        <target>Verstanden</target>
+        <target>知道了</target>
       </segment>
     </unit>
     <unit id="quickAdd.coachmark.closeAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tutorial schließen</source>
-        <target>Tutorial schließen</target>
+        <target>关闭教程</target>
       </segment>
     </unit>
     <unit id="dashboard.quickActions.speedDialHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
-        <target>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</target>
+        <target>提示：使用右下角的悬浮 + 按钮，可从任意页面快速记录。</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
## Summary

Fills 45 missing XLIFF translation units across 9 target locales, all belonging to the new `quickAdd` coachmark feature and the speed-dial hint.

### Touched locales

- `en`: 5 unit(s), 0 blog post(s), 0 wiki entry/entries
- `fr`: 5 unit(s), 0 blog post(s), 0 wiki entry/entries
- `es`: 5 unit(s), 0 blog post(s), 0 wiki entry/entries
- `it`: 5 unit(s), 0 blog post(s), 0 wiki entry/entries
- `nl`: 5 unit(s), 0 blog post(s), 0 wiki entry/entries
- `el`: 5 unit(s), 0 blog post(s), 0 wiki entry/entries
- `la`: 5 unit(s), 0 blog post(s), 0 wiki entry/entries
- `no`: 5 unit(s), 0 blog post(s), 0 wiki entry/entries
- `zh`: 5 unit(s), 0 blog post(s), 0 wiki entry/entries

### Translated units (all locales)

| Unit id | German source |
|---|---|
| `quickAdd.coachmark.title` | Schnellerfassung |
| `quickAdd.coachmark.body` | Über diesen +‑Button erfasst du Wiederholungen blitzschnell – von jeder Seite aus. |
| `quickAdd.coachmark.dismiss` | Verstanden |
| `quickAdd.coachmark.closeAria` | Tutorial schließen |
| `dashboard.quickActions.speedDialHint` | Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell. |

### Detector summary

`Detected 45 gap(s) — xliff:45 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, la, no, zh`
(Post-fill re-run: `Detected 0 gap(s)`)

## Skipped

None — all 45 units translated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8znSd2S3wJFvUJGDw2gQH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced localization for the Quick Add feature and floating action button across eight languages (Greek, English, Spanish, French, Italian, Latin, Dutch, Norwegian, and Chinese) by replacing placeholder translations with complete, properly localized text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->