### PR TITLE
fix(web): 14h chart night-bucket bugs + i18n location refresh

### DIFF
--- a/web/src/app/stats/analysis/chart-series.spec.ts
+++ b/web/src/app/stats/analysis/chart-series.spec.ts
@@ -94,6 +94,17 @@ describe('bucketKeyForTimestamp', () => {
     // then
     expect(key).toBe('2026-06-15T03:00:00');
   });
+
+  it('should fall back to timestamp-derived hour when from is null', () => {
+    // given / when — from is nullable in the type; guard prevents nullT…:00:00
+    const key = bucketKeyForTimestamp('2026-06-15T09:00:00', {
+      isDayRange: true,
+      dayChartMode: '14h',
+      from: null,
+    });
+    // then
+    expect(key).toBe('2026-06-15T09:00:00');
+  });
 });
 
 describe('buildViewChartSeries', () => {

--- a/web/src/app/stats/analysis/chart-series.ts
+++ b/web/src/app/stats/analysis/chart-series.ts
@@ -55,6 +55,7 @@ export function bucketKeyForTimestamp(
   }
 ): string {
   if (!opts.isDayRange) return timestamp.slice(0, 10);
+  if (!opts.from) return timestamp.slice(0, 13) + ':00:00';
   const hour = new Date(timestamp).getHours();
   if (opts.dayChartMode === '14h' && (hour < 8 || hour >= 22)) {
     return `${opts.from}T00:00:00`;

--- a/web/src/app/stats/components/stats-chart/stats-chart.component.ts
+++ b/web/src/app/stats/components/stats-chart/stats-chart.component.ts
@@ -352,8 +352,8 @@ export class StatsChartComponent implements AfterViewInit {
       let bucketTs: number;
       if (isHourly) {
         const hour = date.getHours();
-        // In 14h mode, hours 0-7 merge into the 00:00 bucket
-        const mappedHour = is14h && hour < 8 ? 0 : hour;
+        // In 14h mode, hours 0-7 and 22-23 merge into the 00:00 bucket
+        const mappedHour = is14h && (hour < 8 || hour >= 22) ? 0 : hour;
         bucketTs = new Date(
           date.getFullYear(),
           date.getMonth(),

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -8530,7 +8530,7 @@
     </unit>
     <unit id="analysisHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:58,59</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:59,60</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -8538,7 +8538,7 @@
     </unit>
     <unit id="analysisHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:60,62</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:61,63</note>
       </notes>
       <segment>
         <source> Trends, Verteilungen und Streaks deines Trainings auf einen Blick. </source>
@@ -8546,7 +8546,7 @@
     </unit>
     <unit id="analysis.empty.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:79,81</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:80,82</note>
       </notes>
       <segment>
         <source>Noch keine Daten zum Analysieren.</source>
@@ -8554,7 +8554,7 @@
     </unit>
     <unit id="analysis.empty.body">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:82,84</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:83,85</note>
       </notes>
       <segment>
         <source> Starte einen Trainingsplan oder trage deinen ersten Satz ein — dann zeigen wir dir hier Trends und Streaks. </source>
@@ -8562,7 +8562,7 @@
     </unit>
     <unit id="analysis.empty.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:93,95</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:94,96</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Trainingsplan wählen </source>
@@ -8570,7 +8570,7 @@
     </unit>
     <unit id="analysis.tabs.overview">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:109,111</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:110,112</note>
       </notes>
       <segment>
         <source>Übersicht</source>


### PR DESCRIPTION
## Summary

- **i18n**: Refreshed `web/src/locale/messages.xlf` source-location `<note>` line numbers after the file-length refactor (PR #472) shifted lines in `analysis-page.component.ts`. Auto-generated by `pnpm nx run web:extract-i18n`.
- **Bug fix — sets stacking (Codex)**: In 14h chart mode, `stats-chart.component.ts` was only mapping hours `< 8` to the night bucket when building `setsByBucket`, but `chart-series.ts` also folds hours 22–23 into the `00:00` bucket. Late-evening sets entries were orphaned, causing the "Mit Sets" stacked segment to disappear. Fixed by aligning the hour mapping: `hour < 8 || hour >= 22`.
- **Bug fix — nullable `from` guard (CodeRabbit)**: `bucketKeyForTimestamp` in `chart-series.ts` interpolated `opts.from` (`string | null`) directly, yielding invalid keys like `nullT09:00:00` when called without a date boundary. Added a guard that falls back to the timestamp-derived hour string when `from` is null. Covered by a new regression test.

## Translation routine result

Ran the scheduled translations routine — **0 gaps** detected across all target locales (en, fr, es, it, nl, el, la, no, zh). No missing XLIFF units, blog posts, or wiki entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M49FaDgrV5QKPupuMwnzC8