### PR TITLE
refactor(web): extract dashboard helpers, centralise date utils, refresh i18n locations

### DIFF
--- a/libs/stats-date/src/index.ts
+++ b/libs/stats-date/src/index.ts
@@ -6,3 +6,5 @@ export * from './lib/now-local-iso-timestamp';
 export * from './lib/create-week-range';
 export * from './lib/infer-range-mode';
 export * from './lib/range-modes.type';
+export * from './lib/days-between';
+export * from './lib/sorted-unique-dates';

--- a/libs/stats-date/src/lib/days-between.spec.ts
+++ b/libs/stats-date/src/lib/days-between.spec.ts
@@ -1,0 +1,19 @@
+import { daysBetween } from './days-between';
+
+describe('daysBetween', () => {
+  it('counts whole calendar days forward', () => {
+    expect(daysBetween('2026-06-01', '2026-06-02')).toBe(1);
+    expect(daysBetween('2026-06-01', '2026-06-08')).toBe(7);
+  });
+
+  it('returns 0 for the same day and negative when b is before a', () => {
+    expect(daysBetween('2026-06-01', '2026-06-01')).toBe(0);
+    expect(daysBetween('2026-06-02', '2026-06-01')).toBe(-1);
+  });
+
+  it('rounds across a DST transition to a whole day', () => {
+    // Europe/Berlin springs forward on 2026-03-29 (a 23h day); the count
+    // must still be exactly 1.
+    expect(daysBetween('2026-03-29', '2026-03-30')).toBe(1);
+  });
+});

--- a/libs/stats-date/src/lib/days-between.ts
+++ b/libs/stats-date/src/lib/days-between.ts
@@ -1,0 +1,13 @@
+/**
+ * Whole calendar days from `a` to `b` (both `YYYY-MM-DD`), in local time.
+ * Positive when `b` is after `a`, negative when before, `0` for the same
+ * day. Each bound is anchored to local midnight, so DST transitions
+ * (23h/25h days) still round to a whole-day count.
+ */
+export function daysBetween(a: string, b: string): number {
+  const ad = new Date(`${a}T00:00:00`);
+  const bd = new Date(`${b}T00:00:00`);
+  ad.setHours(0, 0, 0, 0);
+  bd.setHours(0, 0, 0, 0);
+  return Math.round((bd.getTime() - ad.getTime()) / 86_400_000);
+}

--- a/libs/stats-date/src/lib/sorted-unique-dates.spec.ts
+++ b/libs/stats-date/src/lib/sorted-unique-dates.spec.ts
@@ -1,0 +1,16 @@
+import { sortedUniqueDates } from './sorted-unique-dates';
+
+describe('sortedUniqueDates', () => {
+  it('dedupes to day granularity and sorts ascending', () => {
+    const rows = [
+      { timestamp: '2026-06-03T10:00:00' },
+      { timestamp: '2026-06-01T08:00:00' },
+      { timestamp: '2026-06-01T20:00:00' },
+    ];
+    expect(sortedUniqueDates(rows)).toEqual(['2026-06-01', '2026-06-03']);
+  });
+
+  it('returns an empty array for no rows', () => {
+    expect(sortedUniqueDates([])).toEqual([]);
+  });
+});

--- a/libs/stats-date/src/lib/sorted-unique-dates.ts
+++ b/libs/stats-date/src/lib/sorted-unique-dates.ts
@@ -1,0 +1,12 @@
+/**
+ * Distinct `YYYY-MM-DD` day keys from a set of timestamped rows, sorted
+ * ascending. Timestamps are sliced to their date portion, so multiple
+ * entries on the same day collapse to one key.
+ */
+export function sortedUniqueDates(
+  rows: ReadonlyArray<{ timestamp: string }>
+): string[] {
+  return [...new Set(rows.map((x) => x.timestamp.slice(0, 10)))].sort((a, b) =>
+    a.localeCompare(b)
+  );
+}

--- a/web/src/app/stats/analysis/trend-math.spec.ts
+++ b/web/src/app/stats/analysis/trend-math.spec.ts
@@ -4,10 +4,8 @@ import {
   buildWeekTrend,
   computeCurrentStreak,
   computeLongestStreak,
-  daysBetween,
   isoWeek,
   isoWeekYear,
-  sortedUniqueDates,
   startOfIsoWeek,
   startOfMonth,
   TREND_MONTHS,
@@ -29,30 +27,6 @@ function repEntry(
     ...(sets ? { sets } : {}),
   };
 }
-
-describe('daysBetween', () => {
-  it('should count whole calendar days between two ISO dates', () => {
-    // given / when / then
-    expect(daysBetween('2026-01-01', '2026-01-02')).toBe(1);
-    expect(daysBetween('2026-01-01', '2026-01-01')).toBe(0);
-    expect(daysBetween('2026-03-01', '2026-02-28')).toBe(-1);
-  });
-});
-
-describe('sortedUniqueDates', () => {
-  it('should dedupe to day granularity and sort ascending', () => {
-    // given
-    const rows = [
-      { timestamp: '2026-01-03T10:00:00' },
-      { timestamp: '2026-01-01T08:00:00' },
-      { timestamp: '2026-01-01T20:00:00' },
-    ];
-    // when
-    const dates = sortedUniqueDates(rows);
-    // then
-    expect(dates).toEqual(['2026-01-01', '2026-01-03']);
-  });
-});
 
 describe('isoWeek / isoWeekYear', () => {
   it('should place the 2026-01-01 Thursday in ISO week 1 of 2026', () => {

--- a/web/src/app/stats/analysis/trend-math.ts
+++ b/web/src/app/stats/analysis/trend-math.ts
@@ -1,4 +1,5 @@
 import { type UnifiedEntry, unifiedEntryPrimaryValue } from '@pu-stats/models';
+import { daysBetween, sortedUniqueDates } from '@pu-stats/date';
 import type { TrendPoint } from './analysis.types';
 
 export const TREND_WEEKS = 8;
@@ -21,20 +22,6 @@ export function isoWeekYear(date: Date): number {
   const day = d.getUTCDay() || 7;
   d.setUTCDate(d.getUTCDate() + 4 - day);
   return d.getUTCFullYear();
-}
-
-export function daysBetween(a: string, b: string): number {
-  const ad = new Date(`${a}T00:00:00`).getTime();
-  const bd = new Date(`${b}T00:00:00`).getTime();
-  return Math.round((bd - ad) / 86_400_000);
-}
-
-export function sortedUniqueDates(
-  rows: ReadonlyArray<{ timestamp: string }>
-): string[] {
-  return [...new Set(rows.map((x) => x.timestamp.slice(0, 10)))].sort((a, b) =>
-    a.localeCompare(b)
-  );
 }
 
 /** Monday of the ISO week containing the given date (local time, midnight). */

--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -14,7 +14,7 @@ import {
   type UnifiedEntry,
   type UserStats,
 } from '@pu-stats/models';
-import { toBerlinIsoDate } from '@pu-stats/date';
+import { daysBetween, toBerlinIsoDate } from '@pu-stats/date';
 import { AdsStore } from '@pu-stats/ads';
 import { UserContextService } from '@pu-auth/auth';
 import { MotivationStore } from '@pu-stats/motivation';
@@ -30,7 +30,6 @@ import {
   computeStreakFromEntries,
   currentIsoWeekKey,
   currentMonthKey,
-  daysBetween,
   goalPercent,
   type RepEntry,
   sumRepsInMonth,

--- a/web/src/app/stats/dashboard.store.ts
+++ b/web/src/app/stats/dashboard.store.ts
@@ -11,123 +11,32 @@ import { UserStatsApiService } from '@pu-stats/data-access';
 import { LiveDataStore } from '@pu-stats/data-access-state';
 import {
   exerciseEntryToUnified,
-  findExerciseDefinition,
-  isAutoCountQuickAddExerciseId,
-  PUSHUP_QUICK_ADD_EXERCISE_ID,
-  type QuickAddConfig,
-  type QuickAddMode,
   type UnifiedEntry,
   type UserStats,
 } from '@pu-stats/models';
-import { toBerlinIsoDate, toLocalIsoDate } from '@pu-stats/date';
+import { toBerlinIsoDate } from '@pu-stats/date';
 import { AdsStore } from '@pu-stats/ads';
 import { UserContextService } from '@pu-auth/auth';
 import { MotivationStore } from '@pu-stats/motivation';
 import { of } from 'rxjs';
 import { UserConfigStore } from '../core/user-config.store';
 import { ShareResult, ShareService } from '../core/share.service';
-import { buildProfileShareUrl } from '../core/profile-share-url';
 import { TrainingPlanStore } from '../training-plans/training-plan.store';
-import { exerciseDisplayName } from './i18n/exercise-display-names';
-
-export interface QuickAddButtonViewModel {
-  /**
-   * Stable per-slot tracking key for `@for`. Derived from the slot index
-   * (not from `reps`/`mode`/`exerciseId`) so editing an existing button
-   * reuses its DOM node and duplicate buttons (same reps/exercise/mode)
-   * don't collide.
-   */
-  readonly key: string;
-  readonly mode: QuickAddMode;
-  /** `'pushup'` sentinel or a rep-based catalog exerciseId. */
-  readonly exerciseId: string;
-  /** Rep count for `mode === 'reps'`; ignored for `'auto-count'`. */
-  readonly reps: number;
-  /** Material icon name — exercise's catalog icon, with mode-aware fallbacks. */
-  readonly icon: string;
-  /** Translated exercise display label (e.g. `"Liegestütze"`). */
-  readonly exerciseLabel: string;
-  /** Fully composed button label, e.g. `"+10 Liegestütze"` / `"Auto: Sit-ups"`. */
-  readonly label: string;
-}
-
-function toQuickAddViewModel(
-  config: QuickAddConfig,
-  slotIndex: number
-): QuickAddButtonViewModel {
-  const exerciseId = config.exerciseId ?? PUSHUP_QUICK_ADD_EXERCISE_ID;
-  const mode: QuickAddMode = config.mode ?? 'reps';
-  // Resolve the display label for the legacy pushup sentinel separately —
-  // it isn't in EXERCISE_CATALOG (lives in the pushups collection) but the
-  // template needs a localised label all the same.
-  const def =
-    exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID
-      ? null
-      : findExerciseDefinition(exerciseId);
-  const exerciseLabel =
-    exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID
-      ? $localize`:@@exercise.category.pushup:Liegestütze`
-      : exerciseDisplayName(exerciseId);
-  // The catalog `icon` is the natural per-exercise glyph. Pushup falls
-  // back to `fitness_center`; auto-count rows override to a camera icon
-  // to make the mode visually obvious.
-  const icon =
-    mode === 'auto-count' && isAutoCountQuickAddExerciseId(exerciseId)
-      ? 'videocam'
-      : (def?.icon ?? 'fitness_center');
-  const repsLabel = mode === 'auto-count' ? '' : `+${config.reps} `;
-  const label = `${repsLabel}${exerciseLabel}`;
-  return {
-    key: `slot:${slotIndex}`,
-    mode,
-    exerciseId,
-    reps: config.reps,
-    icon,
-    exerciseLabel,
-    label,
-  };
-}
-
-function sortedUniqueDates(rows: { timestamp: string }[]): string[] {
-  return [...new Set(rows.map((x) => x.timestamp.slice(0, 10)))].sort((a, b) =>
-    a.localeCompare(b)
-  );
-}
-
-function daysBetween(a: string, b: string): number {
-  const ad = new Date(`${a}T00:00:00`);
-  const bd = new Date(`${b}T00:00:00`);
-  ad.setHours(0, 0, 0, 0);
-  bd.setHours(0, 0, 0, 0);
-  return Math.round((bd.getTime() - ad.getTime()) / 86_400_000);
-}
-
-function currentIsoWeekKey(): string {
-  // Use Berlin date to match server-side period key calculation
-  const berlinDate = toBerlinIsoDate(new Date());
-  const [y, m, day] = berlinDate.split('-').map(Number);
-  const d = new Date(y, m - 1, day);
-  d.setHours(0, 0, 0, 0);
-  const weekday = (d.getDay() + 6) % 7;
-  d.setDate(d.getDate() + 3 - weekday);
-  const isoYear = d.getFullYear();
-  const firstThursday = new Date(isoYear, 0, 4);
-  firstThursday.setHours(0, 0, 0, 0);
-  const ftDay = (firstThursday.getDay() + 6) % 7;
-  firstThursday.setDate(firstThursday.getDate() + 3 - ftDay);
-  const week =
-    1 +
-    Math.round(
-      (d.getTime() - firstThursday.getTime()) / (7 * 24 * 60 * 60 * 1000)
-    );
-  return `${isoYear}-W${String(week).padStart(2, '0')}`;
-}
-
-function currentMonthKey(): string {
-  // Use Berlin date to match server-side period key calculation
-  const berlinDate = toBerlinIsoDate(new Date());
-  return berlinDate.slice(0, 7);
-}
+import {
+  type QuickAddButtonViewModel,
+  buildQuickAddButtons,
+} from './dashboard/quick-add-view-model';
+import {
+  computeStreakFromEntries,
+  currentIsoWeekKey,
+  currentMonthKey,
+  daysBetween,
+  goalPercent,
+  type RepEntry,
+  sumRepsInMonth,
+  sumRepsInWeek,
+} from './dashboard/dashboard-math';
+import { buildShareDayPayload } from './dashboard/dashboard-share';
 
 export const DashboardStore = signalStore(
   withProps(() => ({
@@ -159,7 +68,7 @@ export const DashboardStore = signalStore(
     }),
   })),
   withComputed((store) => {
-    const entryRows = computed<{ timestamp: string; reps: number }[]>(() =>
+    const entryRows = computed<RepEntry[]>(() =>
       store._live
         .exerciseEntries()
         .filter((e) => e.exerciseId === 'pushup')
@@ -233,32 +142,12 @@ export const DashboardStore = signalStore(
     const weeklyGoal = computed(() => store._userConfig.weeklyGoal() || 50);
     const monthlyGoal = computed(() => store._userConfig.monthlyGoal() || 200);
 
-    /** View-model for the Schnellaktionen card. When the user configured
-     *  any custom buttons those override the defaults (three pushup-reps
-     *  buttons 10/20/30). Each VM carries everything the template needs:
-     *  display label, icon, mode, and the click-handler payload. */
-    const quickAddButtons = computed<QuickAddButtonViewModel[]>(() => {
-      const configured = store._userConfig.quickAdds();
-      if (configured.length > 0) {
-        return configured.map((cfg, i) => toQuickAddViewModel(cfg, i));
-      }
-      return [10, 20, 30].map((reps, i) =>
-        toQuickAddViewModel(
-          {
-            reps,
-            inSpeedDial: false,
-            exerciseId: PUSHUP_QUICK_ADD_EXERCISE_ID,
-            mode: 'reps',
-          },
-          i
-        )
-      );
-    });
+    const quickAddButtons = computed<QuickAddButtonViewModel[]>(() =>
+      buildQuickAddButtons(store._userConfig.quickAdds())
+    );
 
     const goalProgressPercent = computed(() =>
-      dailyGoal()
-        ? Math.min(100, Math.round((todayTotal() / dailyGoal()) * 100))
-        : 0
+      goalPercent(todayTotal(), dailyGoal())
     );
 
     /** Effective daily goal = plan target if active, else configured. */
@@ -308,83 +197,35 @@ export const DashboardStore = signalStore(
         const diff = daysBetween(us.lastEntryDate, toBerlinIsoDate(new Date()));
         return diff >= 0 && diff <= 1 ? us.currentStreak : 0;
       }
-
       // Fallback: client-side computation
-      const dates = sortedUniqueDates(entryRows());
-      if (!dates.length) return 0;
-
-      const today = toBerlinIsoDate(new Date());
-      const lastDate = dates[dates.length - 1];
-
-      const diff = daysBetween(lastDate, today);
-      if (diff > 1 || diff < 0) return 0;
-
-      let streak = 1;
-      for (let i = dates.length - 1; i > 0; i--) {
-        if (daysBetween(dates[i - 1], dates[i]) === 1) {
-          streak += 1;
-        } else {
-          break;
-        }
-      }
-      return streak;
-    });
-
-    // Live computation from entries — used as the primary source in the
-    // browser (always fresh) and as the fallback elsewhere.
-    const weekRepsFromEntries = computed(() => {
-      const berlinToday = toBerlinIsoDate(new Date());
-      const [by, bm, bd] = berlinToday.split('-').map(Number);
-      const todayDate = new Date(by, bm - 1, bd);
-      const dayOfWeek = (todayDate.getDay() + 6) % 7; // Monday = 0
-      const monday = new Date(todayDate);
-      monday.setDate(todayDate.getDate() - dayOfWeek);
-      const mondayStr = toLocalIsoDate(monday);
-      const sunday = new Date(monday);
-      sunday.setDate(monday.getDate() + 6);
-      const sundayStr = toLocalIsoDate(sunday);
-
-      return entryRows()
-        .filter((entry) => {
-          const day = entry.timestamp.slice(0, 10);
-          return day >= mondayStr && day <= sundayStr;
-        })
-        .reduce((sum, entry) => sum + entry.reps, 0);
+      return computeStreakFromEntries(entryRows(), toBerlinIsoDate(new Date()));
     });
 
     const weekReps = computed(() => {
+      // In the browser live entries are always fresher than the
+      // server-precomputed period totals (the aggregator runs after the
+      // write), so prefer the live sum when connected.
       if (store._isBrowser && store._live.connected())
-        return weekRepsFromEntries();
+        return sumRepsInWeek(entryRows(), toBerlinIsoDate(new Date()));
       const us = userStats();
       if (us && us.weeklyKey === currentIsoWeekKey()) return us.weeklyReps;
-      return weekRepsFromEntries();
-    });
-
-    const monthRepsFromEntries = computed(() => {
-      const prefix = toBerlinIsoDate(new Date()).slice(0, 7);
-      return entryRows()
-        .filter((entry) => entry.timestamp.startsWith(prefix))
-        .reduce((sum, entry) => sum + entry.reps, 0);
+      return sumRepsInWeek(entryRows(), toBerlinIsoDate(new Date()));
     });
 
     const monthReps = computed(() => {
       if (store._isBrowser && store._live.connected())
-        return monthRepsFromEntries();
+        return sumRepsInMonth(entryRows(), toBerlinIsoDate(new Date()));
       const us = userStats();
       if (us && us.monthlyKey === currentMonthKey()) return us.monthlyReps;
-      return monthRepsFromEntries();
+      return sumRepsInMonth(entryRows(), toBerlinIsoDate(new Date()));
     });
 
     const weeklyGoalProgressPercent = computed(() =>
-      weeklyGoal()
-        ? Math.min(100, Math.round((weekReps() / weeklyGoal()) * 100))
-        : 0
+      goalPercent(weekReps(), weeklyGoal())
     );
 
     const monthlyGoalProgressPercent = computed(() =>
-      monthlyGoal()
-        ? Math.min(100, Math.round((monthReps() / monthlyGoal()) * 100))
-        : 0
+      goalPercent(monthReps(), monthlyGoal())
     );
 
     const weeklyGoalReached = computed(
@@ -459,37 +300,15 @@ export const DashboardStore = signalStore(
       await store._motivation.loadQuotes(store._user.userIdSafe());
     },
     shareDay(): Promise<ShareResult> {
-      const total = store.todayTotal();
-      const streak = store.currentStreak();
-      // Prefer the user's public-profile URL when they opted in — it carries
-      // the dynamic OG card (per-user stats + CTA) so the shared link
-      // produces a much richer social-card preview than the generic
-      // homepage. When the user hasn't opted in, fall back to the homepage
-      // and a plain CTA text — same as before.
-      const uid = store._user.userIdSafe();
-      const publicProfile =
-        store._userConfig.config()?.ui?.publicProfile === true;
-      const profileUrl =
-        publicProfile && uid ? buildProfileShareUrl(uid, store._localeId) : '';
-
-      let text: string;
-      if (profileUrl) {
-        text =
-          streak > 1
-            ? $localize`:@@dashboard.share.text.profile.streak:Heute schon ${total}:total: Liegestütze geschafft – Streak: ${streak}:streak: Tage 🔥 Schau dir mein Profil an:`
-            : $localize`:@@dashboard.share.text.profile.simple:Heute schon ${total}:total: Liegestütze geschafft! 💪 Schau dir mein Profil an:`;
-      } else {
-        text =
-          streak > 1
-            ? $localize`:@@dashboard.share.text.streak:Heute schon ${total}:total: Liegestütze geschafft – Streak: ${streak}:streak: Tage 🔥 Tracke deine Stats kostenlos:`
-            : $localize`:@@dashboard.share.text.simple:Heute schon ${total}:total: Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:`;
-      }
-
-      return store._share.share({
-        title: $localize`:@@dashboard.share.title:Pushup Tracker`,
-        text,
-        url: profileUrl || 'https://pushup-stats.com',
-      });
+      return store._share.share(
+        buildShareDayPayload({
+          total: store.todayTotal(),
+          streak: store.currentStreak(),
+          uid: store._user.userIdSafe(),
+          publicProfile: store._userConfig.config()?.ui?.publicProfile === true,
+          localeId: store._localeId,
+        })
+      );
     },
   }))
 );

--- a/web/src/app/stats/dashboard/dashboard-math.spec.ts
+++ b/web/src/app/stats/dashboard/dashboard-math.spec.ts
@@ -2,10 +2,8 @@ import {
   computeStreakFromEntries,
   currentIsoWeekKey,
   currentMonthKey,
-  daysBetween,
   goalPercent,
   type RepEntry,
-  sortedUniqueDates,
   sumRepsInMonth,
   sumRepsInWeek,
 } from './dashboard-math';
@@ -13,28 +11,6 @@ import {
 function row(timestamp: string, reps: number): RepEntry {
   return { timestamp, reps };
 }
-
-describe('sortedUniqueDates', () => {
-  it('should dedupe to day granularity and sort ascending', () => {
-    // given
-    const rows = [
-      row('2026-06-03T10:00:00', 5),
-      row('2026-06-01T08:00:00', 5),
-      row('2026-06-01T20:00:00', 5),
-    ];
-    // when / then
-    expect(sortedUniqueDates(rows)).toEqual(['2026-06-01', '2026-06-03']);
-  });
-});
-
-describe('daysBetween', () => {
-  it('should count whole calendar days, ignoring time of day', () => {
-    // given / when / then
-    expect(daysBetween('2026-06-01', '2026-06-02')).toBe(1);
-    expect(daysBetween('2026-06-01', '2026-06-01')).toBe(0);
-    expect(daysBetween('2026-06-02', '2026-06-01')).toBe(-1);
-  });
-});
 
 describe('computeStreakFromEntries', () => {
   it('should return 0 for no rows', () => {

--- a/web/src/app/stats/dashboard/dashboard-math.spec.ts
+++ b/web/src/app/stats/dashboard/dashboard-math.spec.ts
@@ -1,0 +1,117 @@
+import {
+  computeStreakFromEntries,
+  currentIsoWeekKey,
+  currentMonthKey,
+  daysBetween,
+  goalPercent,
+  type RepEntry,
+  sortedUniqueDates,
+  sumRepsInMonth,
+  sumRepsInWeek,
+} from './dashboard-math';
+
+function row(timestamp: string, reps: number): RepEntry {
+  return { timestamp, reps };
+}
+
+describe('sortedUniqueDates', () => {
+  it('should dedupe to day granularity and sort ascending', () => {
+    // given
+    const rows = [
+      row('2026-06-03T10:00:00', 5),
+      row('2026-06-01T08:00:00', 5),
+      row('2026-06-01T20:00:00', 5),
+    ];
+    // when / then
+    expect(sortedUniqueDates(rows)).toEqual(['2026-06-01', '2026-06-03']);
+  });
+});
+
+describe('daysBetween', () => {
+  it('should count whole calendar days, ignoring time of day', () => {
+    // given / when / then
+    expect(daysBetween('2026-06-01', '2026-06-02')).toBe(1);
+    expect(daysBetween('2026-06-01', '2026-06-01')).toBe(0);
+    expect(daysBetween('2026-06-02', '2026-06-01')).toBe(-1);
+  });
+});
+
+describe('computeStreakFromEntries', () => {
+  it('should return 0 for no rows', () => {
+    expect(computeStreakFromEntries([], '2026-06-15')).toBe(0);
+  });
+
+  it('should count consecutive days ending today', () => {
+    // given three consecutive days ending on "today"
+    const rows = [
+      row('2026-06-13T10:00:00', 10),
+      row('2026-06-14T10:00:00', 10),
+      row('2026-06-15T10:00:00', 10),
+    ];
+    // when / then
+    expect(computeStreakFromEntries(rows, '2026-06-15')).toBe(3);
+  });
+
+  it('should still count when the last entry was yesterday', () => {
+    // given last entry one day before today
+    const rows = [
+      row('2026-06-13T10:00:00', 10),
+      row('2026-06-14T10:00:00', 10),
+    ];
+    // when / then
+    expect(computeStreakFromEntries(rows, '2026-06-15')).toBe(2);
+  });
+
+  it('should return 0 when the last entry is older than yesterday', () => {
+    // given a stale last entry (>1 day gap to today)
+    const rows = [row('2026-06-10T10:00:00', 10)];
+    // when / then
+    expect(computeStreakFromEntries(rows, '2026-06-15')).toBe(0);
+  });
+});
+
+describe('sumRepsInWeek', () => {
+  it('should sum only entries within the ISO week (Mon–Sun) of today', () => {
+    // given 2026-06-15 is a Monday; its week is 2026-06-15..06-21
+    const rows = [
+      row('2026-06-14T10:00:00', 100), // previous Sunday — excluded
+      row('2026-06-15T10:00:00', 10),
+      row('2026-06-21T10:00:00', 20), // Sunday — included
+      row('2026-06-22T10:00:00', 100), // next Monday — excluded
+    ];
+    // when / then
+    expect(sumRepsInWeek(rows, '2026-06-15')).toBe(30);
+  });
+});
+
+describe('sumRepsInMonth', () => {
+  it('should sum only entries in the same calendar month as today', () => {
+    // given
+    const rows = [
+      row('2026-05-31T10:00:00', 100),
+      row('2026-06-01T10:00:00', 10),
+      row('2026-06-30T10:00:00', 20),
+      row('2026-07-01T10:00:00', 100),
+    ];
+    // when / then
+    expect(sumRepsInMonth(rows, '2026-06-15')).toBe(30);
+  });
+});
+
+describe('goalPercent', () => {
+  it('should return a capped 0–100 integer and 0 for a falsy goal', () => {
+    // given / when / then
+    expect(goalPercent(5, 10)).toBe(50);
+    expect(goalPercent(15, 10)).toBe(100);
+    expect(goalPercent(1, 3)).toBe(33);
+    expect(goalPercent(5, 0)).toBe(0);
+  });
+});
+
+describe('currentIsoWeekKey / currentMonthKey', () => {
+  it('should produce well-formed period keys for the current date', () => {
+    // given / when / then
+    expect(currentIsoWeekKey()).toMatch(/^\d{4}-W\d{2}$/);
+    expect(currentMonthKey()).toMatch(/^\d{4}-\d{2}$/);
+  });
+});

--- a/web/src/app/stats/dashboard/dashboard-math.ts
+++ b/web/src/app/stats/dashboard/dashboard-math.ts
@@ -1,0 +1,110 @@
+import { toBerlinIsoDate, toLocalIsoDate } from '@pu-stats/date';
+
+export interface RepEntry {
+  timestamp: string;
+  reps: number;
+}
+
+export function sortedUniqueDates(
+  rows: ReadonlyArray<{ timestamp: string }>
+): string[] {
+  return [...new Set(rows.map((x) => x.timestamp.slice(0, 10)))].sort((a, b) =>
+    a.localeCompare(b)
+  );
+}
+
+export function daysBetween(a: string, b: string): number {
+  const ad = new Date(`${a}T00:00:00`);
+  const bd = new Date(`${b}T00:00:00`);
+  ad.setHours(0, 0, 0, 0);
+  bd.setHours(0, 0, 0, 0);
+  return Math.round((bd.getTime() - ad.getTime()) / 86_400_000);
+}
+
+/** ISO-week key (`YYYY-Www`) for today, in the Berlin timezone used by
+ *  the server-side period-key aggregation. */
+export function currentIsoWeekKey(): string {
+  const berlinDate = toBerlinIsoDate(new Date());
+  const [y, m, day] = berlinDate.split('-').map(Number);
+  const d = new Date(y, m - 1, day);
+  d.setHours(0, 0, 0, 0);
+  const weekday = (d.getDay() + 6) % 7;
+  d.setDate(d.getDate() + 3 - weekday);
+  const isoYear = d.getFullYear();
+  const firstThursday = new Date(isoYear, 0, 4);
+  firstThursday.setHours(0, 0, 0, 0);
+  const ftDay = (firstThursday.getDay() + 6) % 7;
+  firstThursday.setDate(firstThursday.getDate() + 3 - ftDay);
+  const week =
+    1 +
+    Math.round(
+      (d.getTime() - firstThursday.getTime()) / (7 * 24 * 60 * 60 * 1000)
+    );
+  return `${isoYear}-W${String(week).padStart(2, '0')}`;
+}
+
+/** `YYYY-MM` month key for today, in the Berlin timezone. */
+export function currentMonthKey(): string {
+  return toBerlinIsoDate(new Date()).slice(0, 7);
+}
+
+/**
+ * Client-side fallback streak: consecutive logged days ending at the most
+ * recent entry, but only when that entry is today or yesterday (`diff`
+ * 0/1). Used when the precomputed server stats aren't available yet.
+ */
+export function computeStreakFromEntries(
+  rows: ReadonlyArray<RepEntry>,
+  today: string
+): number {
+  const dates = sortedUniqueDates(rows);
+  if (!dates.length) return 0;
+  const lastDate = dates[dates.length - 1];
+  const diff = daysBetween(lastDate, today);
+  if (diff > 1 || diff < 0) return 0;
+  let streak = 1;
+  for (let i = dates.length - 1; i > 0; i--) {
+    if (daysBetween(dates[i - 1], dates[i]) === 1) streak += 1;
+    else break;
+  }
+  return streak;
+}
+
+/** Sum of reps logged in the ISO week (Mon–Sun) containing `today`. */
+export function sumRepsInWeek(
+  rows: ReadonlyArray<RepEntry>,
+  today: string
+): number {
+  const [by, bm, bd] = today.split('-').map(Number);
+  const todayDate = new Date(by, bm - 1, bd);
+  const dayOfWeek = (todayDate.getDay() + 6) % 7; // Monday = 0
+  const monday = new Date(todayDate);
+  monday.setDate(todayDate.getDate() - dayOfWeek);
+  const mondayStr = toLocalIsoDate(monday);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  const sundayStr = toLocalIsoDate(sunday);
+
+  return rows
+    .filter((entry) => {
+      const day = entry.timestamp.slice(0, 10);
+      return day >= mondayStr && day <= sundayStr;
+    })
+    .reduce((sum, entry) => sum + entry.reps, 0);
+}
+
+/** Sum of reps logged in the calendar month containing `today`. */
+export function sumRepsInMonth(
+  rows: ReadonlyArray<RepEntry>,
+  today: string
+): number {
+  const prefix = today.slice(0, 7);
+  return rows
+    .filter((entry) => entry.timestamp.startsWith(prefix))
+    .reduce((sum, entry) => sum + entry.reps, 0);
+}
+
+/** Capped 0–100 integer progress percentage; 0 when the goal is falsy. */
+export function goalPercent(value: number, goal: number): number {
+  return goal ? Math.min(100, Math.round((value / goal) * 100)) : 0;
+}

--- a/web/src/app/stats/dashboard/dashboard-math.ts
+++ b/web/src/app/stats/dashboard/dashboard-math.ts
@@ -1,24 +1,13 @@
-import { toBerlinIsoDate, toLocalIsoDate } from '@pu-stats/date';
+import {
+  daysBetween,
+  sortedUniqueDates,
+  toBerlinIsoDate,
+  toLocalIsoDate,
+} from '@pu-stats/date';
 
 export interface RepEntry {
   timestamp: string;
   reps: number;
-}
-
-export function sortedUniqueDates(
-  rows: ReadonlyArray<{ timestamp: string }>
-): string[] {
-  return [...new Set(rows.map((x) => x.timestamp.slice(0, 10)))].sort((a, b) =>
-    a.localeCompare(b)
-  );
-}
-
-export function daysBetween(a: string, b: string): number {
-  const ad = new Date(`${a}T00:00:00`);
-  const bd = new Date(`${b}T00:00:00`);
-  ad.setHours(0, 0, 0, 0);
-  bd.setHours(0, 0, 0, 0);
-  return Math.round((bd.getTime() - ad.getTime()) / 86_400_000);
 }
 
 /** ISO-week key (`YYYY-Www`) for today, in the Berlin timezone used by

--- a/web/src/app/stats/dashboard/dashboard-share.spec.ts
+++ b/web/src/app/stats/dashboard/dashboard-share.spec.ts
@@ -1,0 +1,46 @@
+import { buildShareDayPayload } from './dashboard-share';
+
+describe('buildShareDayPayload', () => {
+  it('should share the generic homepage when the user has no public profile', () => {
+    // given a signed-in user who did not opt into a public profile
+    const payload = buildShareDayPayload({
+      total: 42,
+      streak: 1,
+      uid: 'user-1',
+      publicProfile: false,
+      localeId: 'de',
+    });
+    // then
+    expect(payload.url).toBe('https://pushup-stats.com');
+    expect(payload.title.length).toBeGreaterThan(0);
+    expect(payload.text).toContain('42');
+  });
+
+  it('should share the profile URL when the user opted into a public profile', () => {
+    // given a public-profile user
+    const payload = buildShareDayPayload({
+      total: 42,
+      streak: 5,
+      uid: 'user-1',
+      publicProfile: true,
+      localeId: 'de',
+    });
+    // then — a non-homepage profile URL referencing the user
+    expect(payload.url).not.toBe('https://pushup-stats.com');
+    expect(payload.url).toContain('user-1');
+    expect(payload.text).toContain('5');
+  });
+
+  it('should fall back to the homepage when public profile is on but uid is missing', () => {
+    // given opted-in but signed out (no uid)
+    const payload = buildShareDayPayload({
+      total: 10,
+      streak: 1,
+      uid: '',
+      publicProfile: true,
+      localeId: 'de',
+    });
+    // then
+    expect(payload.url).toBe('https://pushup-stats.com');
+  });
+});

--- a/web/src/app/stats/dashboard/dashboard-share.ts
+++ b/web/src/app/stats/dashboard/dashboard-share.ts
@@ -1,0 +1,48 @@
+import { buildProfileShareUrl } from '../../core/profile-share-url';
+
+export interface ShareDayInput {
+  total: number;
+  streak: number;
+  /** Current user id, or empty when signed out. */
+  uid: string;
+  /** Whether the user opted into a public profile (richer OG card). */
+  publicProfile: boolean;
+  localeId: string;
+}
+
+export interface SharePayload {
+  title: string;
+  text: string;
+  url: string;
+}
+
+/**
+ * Builds the share-sheet payload for "share today's progress". When the
+ * user opted into a public profile we share their profile URL (dynamic
+ * OG card with per-user stats) instead of the generic homepage, and the
+ * copy nudges the reader to view the profile.
+ */
+export function buildShareDayPayload(input: ShareDayInput): SharePayload {
+  const { total, streak, uid, publicProfile, localeId } = input;
+  const profileUrl =
+    publicProfile && uid ? buildProfileShareUrl(uid, localeId) : '';
+
+  let text: string;
+  if (profileUrl) {
+    text =
+      streak > 1
+        ? $localize`:@@dashboard.share.text.profile.streak:Heute schon ${total}:total: Liegestütze geschafft – Streak: ${streak}:streak: Tage 🔥 Schau dir mein Profil an:`
+        : $localize`:@@dashboard.share.text.profile.simple:Heute schon ${total}:total: Liegestütze geschafft! 💪 Schau dir mein Profil an:`;
+  } else {
+    text =
+      streak > 1
+        ? $localize`:@@dashboard.share.text.streak:Heute schon ${total}:total: Liegestütze geschafft – Streak: ${streak}:streak: Tage 🔥 Tracke deine Stats kostenlos:`
+        : $localize`:@@dashboard.share.text.simple:Heute schon ${total}:total: Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:`;
+  }
+
+  return {
+    title: $localize`:@@dashboard.share.title:Pushup Tracker`,
+    text,
+    url: profileUrl || 'https://pushup-stats.com',
+  };
+}

--- a/web/src/app/stats/dashboard/quick-add-view-model.spec.ts
+++ b/web/src/app/stats/dashboard/quick-add-view-model.spec.ts
@@ -1,0 +1,82 @@
+import { PUSHUP_QUICK_ADD_EXERCISE_ID } from '@pu-stats/models';
+import {
+  buildQuickAddButtons,
+  toQuickAddViewModel,
+} from './quick-add-view-model';
+
+describe('toQuickAddViewModel', () => {
+  it('should label the pushup sentinel with the fitness fallback icon', () => {
+    // given the legacy pushup sentinel in reps mode
+    const vm = toQuickAddViewModel(
+      {
+        reps: 10,
+        inSpeedDial: false,
+        exerciseId: PUSHUP_QUICK_ADD_EXERCISE_ID,
+        mode: 'reps',
+      },
+      0
+    );
+    // then
+    expect(vm.key).toBe('slot:0');
+    expect(vm.exerciseId).toBe('pushup');
+    expect(vm.reps).toBe(10);
+    expect(vm.icon).toBe('fitness_center');
+    expect(vm.label).toBe(`+10 ${vm.exerciseLabel}`);
+    expect(vm.exerciseLabel.length).toBeGreaterThan(0);
+  });
+
+  it('should resolve a catalog exercise icon and reps label', () => {
+    // given a rep-based catalog exercise
+    const vm = toQuickAddViewModel(
+      { reps: 15, inSpeedDial: false, exerciseId: 'legs.squats', mode: 'reps' },
+      2
+    );
+    // then
+    expect(vm.key).toBe('slot:2');
+    expect(vm.exerciseId).toBe('legs.squats');
+    expect(vm.icon.length).toBeGreaterThan(0);
+    expect(vm.label).toBe(`+15 ${vm.exerciseLabel}`);
+  });
+
+  it('should use the camera icon and drop the reps prefix for auto-count mode', () => {
+    // given an auto-count-capable exercise in auto-count mode
+    const vm = toQuickAddViewModel(
+      {
+        reps: 0,
+        inSpeedDial: false,
+        exerciseId: 'legs.squats',
+        mode: 'auto-count',
+      },
+      1
+    );
+    // then
+    expect(vm.mode).toBe('auto-count');
+    expect(vm.icon).toBe('videocam');
+    expect(vm.label).toBe(vm.exerciseLabel);
+  });
+});
+
+describe('buildQuickAddButtons', () => {
+  it('should fall back to three default pushup buttons (10/20/30) when none configured', () => {
+    // given no configured quick-adds
+    const buttons = buildQuickAddButtons([]);
+    // then
+    expect(buttons).toHaveLength(3);
+    expect(buttons.map((b) => b.reps)).toEqual([10, 20, 30]);
+    expect(buttons.map((b) => b.key)).toEqual(['slot:0', 'slot:1', 'slot:2']);
+    expect(buttons.every((b) => b.exerciseId === 'pushup')).toBe(true);
+  });
+
+  it('should map configured quick-adds preserving slot order', () => {
+    // given
+    const buttons = buildQuickAddButtons([
+      { reps: 5, inSpeedDial: false, exerciseId: 'pushup', mode: 'reps' },
+      { reps: 25, inSpeedDial: false, exerciseId: 'legs.squats', mode: 'reps' },
+    ]);
+    // then
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].reps).toBe(5);
+    expect(buttons[1].exerciseId).toBe('legs.squats');
+    expect(buttons[1].key).toBe('slot:1');
+  });
+});

--- a/web/src/app/stats/dashboard/quick-add-view-model.ts
+++ b/web/src/app/stats/dashboard/quick-add-view-model.ts
@@ -1,0 +1,89 @@
+import {
+  findExerciseDefinition,
+  isAutoCountQuickAddExerciseId,
+  PUSHUP_QUICK_ADD_EXERCISE_ID,
+  type QuickAddConfig,
+  type QuickAddMode,
+} from '@pu-stats/models';
+import { exerciseDisplayName } from '../i18n/exercise-display-names';
+
+export interface QuickAddButtonViewModel {
+  /**
+   * Stable per-slot tracking key for `@for`. Derived from the slot index
+   * (not from `reps`/`mode`/`exerciseId`) so editing an existing button
+   * reuses its DOM node and duplicate buttons (same reps/exercise/mode)
+   * don't collide.
+   */
+  readonly key: string;
+  readonly mode: QuickAddMode;
+  /** `'pushup'` sentinel or a rep-based catalog exerciseId. */
+  readonly exerciseId: string;
+  /** Rep count for `mode === 'reps'`; ignored for `'auto-count'`. */
+  readonly reps: number;
+  /** Material icon name — exercise's catalog icon, with mode-aware fallbacks. */
+  readonly icon: string;
+  /** Translated exercise display label (e.g. `"Liegestütze"`). */
+  readonly exerciseLabel: string;
+  /** Fully composed button label, e.g. `"+10 Liegestütze"` / `"Auto: Sit-ups"`. */
+  readonly label: string;
+}
+
+export function toQuickAddViewModel(
+  config: QuickAddConfig,
+  slotIndex: number
+): QuickAddButtonViewModel {
+  const exerciseId = config.exerciseId ?? PUSHUP_QUICK_ADD_EXERCISE_ID;
+  const mode: QuickAddMode = config.mode ?? 'reps';
+  // Resolve the display label for the legacy pushup sentinel separately —
+  // it isn't in EXERCISE_CATALOG (lives in the pushups collection) but the
+  // template needs a localised label all the same.
+  const def =
+    exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID
+      ? null
+      : findExerciseDefinition(exerciseId);
+  const exerciseLabel =
+    exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID
+      ? $localize`:@@exercise.category.pushup:Liegestütze`
+      : exerciseDisplayName(exerciseId);
+  // The catalog `icon` is the natural per-exercise glyph. Pushup falls
+  // back to `fitness_center`; auto-count rows override to a camera icon
+  // to make the mode visually obvious.
+  const icon =
+    mode === 'auto-count' && isAutoCountQuickAddExerciseId(exerciseId)
+      ? 'videocam'
+      : (def?.icon ?? 'fitness_center');
+  const repsLabel = mode === 'auto-count' ? '' : `+${config.reps} `;
+  const label = `${repsLabel}${exerciseLabel}`;
+  return {
+    key: `slot:${slotIndex}`,
+    mode,
+    exerciseId,
+    reps: config.reps,
+    icon,
+    exerciseLabel,
+    label,
+  };
+}
+
+/**
+ * View-models for the Schnellaktionen card. User-configured buttons
+ * override the defaults (three pushup-reps buttons 10/20/30).
+ */
+export function buildQuickAddButtons(
+  configured: ReadonlyArray<QuickAddConfig>
+): QuickAddButtonViewModel[] {
+  if (configured.length > 0) {
+    return configured.map((cfg, i) => toQuickAddViewModel(cfg, i));
+  }
+  return [10, 20, 30].map((reps, i) =>
+    toQuickAddViewModel(
+      {
+        reps,
+        inSpeedDial: false,
+        exerciseId: PUSHUP_QUICK_ADD_EXERCISE_ID,
+        mode: 'reps',
+      },
+      i
+    )
+  );
+}

--- a/web/src/app/stats/dashboard/quick-add-view-model.ts
+++ b/web/src/app/stats/dashboard/quick-add-view-model.ts
@@ -24,7 +24,8 @@ export interface QuickAddButtonViewModel {
   readonly icon: string;
   /** Translated exercise display label (e.g. `"Liegestütze"`). */
   readonly exerciseLabel: string;
-  /** Fully composed button label, e.g. `"+10 Liegestütze"` / `"Auto: Sit-ups"`. */
+  /** Fully composed button label: `"+10 Liegestütze"` in reps mode, or
+   *  just the exercise label (e.g. `"Sit-ups"`) in auto-count mode. */
   readonly label: string;
 }
 
@@ -34,20 +35,11 @@ export function toQuickAddViewModel(
 ): QuickAddButtonViewModel {
   const exerciseId = config.exerciseId ?? PUSHUP_QUICK_ADD_EXERCISE_ID;
   const mode: QuickAddMode = config.mode ?? 'reps';
-  // Resolve the display label for the legacy pushup sentinel separately —
-  // it isn't in EXERCISE_CATALOG (lives in the pushups collection) but the
-  // template needs a localised label all the same.
-  const def =
-    exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID
-      ? null
-      : findExerciseDefinition(exerciseId);
-  const exerciseLabel =
-    exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID
-      ? $localize`:@@exercise.category.pushup:Liegestütze`
-      : exerciseDisplayName(exerciseId);
-  // The catalog `icon` is the natural per-exercise glyph. Pushup falls
-  // back to `fitness_center`; auto-count rows override to a camera icon
-  // to make the mode visually obvious.
+  const def = findExerciseDefinition(exerciseId);
+  const exerciseLabel = exerciseDisplayName(exerciseId);
+  // The catalog `icon` is the natural per-exercise glyph, with a
+  // `fitness_center` fallback for unknown ids; auto-count rows override
+  // to a camera icon to make the mode visually obvious.
   const icon =
     mode === 'auto-count' && isAutoCountQuickAddExerciseId(exerciseId)
       ? 'videocam'

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -47,10 +47,8 @@ import {
   TrainingEntryDialogResult,
 } from '../components/training-entry-dialog/training-entry-dialog.component';
 import { QuickAddConfigDialogComponent } from '../components/quick-add-config-dialog/quick-add-config-dialog.component';
-import {
-  DashboardStore,
-  type QuickAddButtonViewModel,
-} from '../dashboard.store';
+import { DashboardStore } from '../dashboard.store';
+import type { QuickAddButtonViewModel } from '../dashboard/quick-add-view-model';
 
 @Component({
   selector: 'app-stats-dashboard',

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4213,7 +4213,6 @@
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:385</note>
         <note category="location">web/src/app/stats/components/stats-table/stats-table.component.ts:205</note>
         <note category="location">web/src/app/stats/components/training-entry-dialog/training-entry-dialog.component.ts:1288</note>
-        <note category="location">web/src/app/stats/dashboard.store.ts:69</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:24</note>
         <note category="location">web/src/app/stats/i18n/exercise-display-names.ts:211</note>
         <note category="location">web/src/app/stats/shell/entries-page.component.ts:289</note>
@@ -7543,7 +7542,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:479</note>
+        <note category="location">web/src/app/stats/dashboard/dashboard-share.ts:34</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Schau dir mein Profil an:</source>
@@ -7551,7 +7550,7 @@
     </unit>
     <unit id="dashboard.share.text.profile.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:480</note>
+        <note category="location">web/src/app/stats/dashboard/dashboard-share.ts:35</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Schau dir mein Profil an:</source>
@@ -7559,7 +7558,7 @@
     </unit>
     <unit id="dashboard.share.text.streak">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:484</note>
+        <note category="location">web/src/app/stats/dashboard/dashboard-share.ts:39</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft – Streak: <ph id="1" equiv="streak" disp="streak"/> Tage 🔥 Tracke deine Stats kostenlos:</source>
@@ -7567,7 +7566,7 @@
     </unit>
     <unit id="dashboard.share.text.simple">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:485</note>
+        <note category="location">web/src/app/stats/dashboard/dashboard-share.ts:40</note>
       </notes>
       <segment>
         <source>Heute schon <ph id="0" equiv="total" disp="total"/> Liegestütze geschafft! 💪 Tracke deine Stats kostenlos:</source>
@@ -7575,7 +7574,7 @@
     </unit>
     <unit id="dashboard.share.title">
       <notes>
-        <note category="location">web/src/app/stats/dashboard.store.ts:489</note>
+        <note category="location">web/src/app/stats/dashboard/dashboard-share.ts:44</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -8530,7 +8529,7 @@
     </unit>
     <unit id="analysisHeaderTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:58,59</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:59,60</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -8538,7 +8537,7 @@
     </unit>
     <unit id="analysisHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:60,62</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:61,63</note>
       </notes>
       <segment>
         <source> Trends, Verteilungen und Streaks deines Trainings auf einen Blick. </source>
@@ -8546,7 +8545,7 @@
     </unit>
     <unit id="analysis.empty.title">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:79,81</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:80,82</note>
       </notes>
       <segment>
         <source>Noch keine Daten zum Analysieren.</source>
@@ -8554,7 +8553,7 @@
     </unit>
     <unit id="analysis.empty.body">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:82,84</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:83,85</note>
       </notes>
       <segment>
         <source> Starte einen Trainingsplan oder trage deinen ersten Satz ein — dann zeigen wir dir hier Trends und Streaks. </source>
@@ -8562,7 +8561,7 @@
     </unit>
     <unit id="analysis.empty.cta">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:93,95</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:94,96</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon aria-hidden=&quot;true&quot;&gt;" dispEnd="&lt;/mat-icon&gt;">fitness_center</pc> Trainingsplan wählen </source>
@@ -8570,7 +8569,7 @@
     </unit>
     <unit id="analysis.tabs.overview">
       <notes>
-        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:109,111</note>
+        <note category="location">web/src/app/stats/shell/analysis-page.component.ts:110,112</note>
       </notes>
       <segment>
         <source>Übersicht</source>
@@ -9491,7 +9490,7 @@
     </unit>
     <unit id="dashboard.tile.openInHistoryAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:101</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:99</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="label" disp="label"/> in der Historie öffnen</source>
@@ -9499,7 +9498,7 @@
     </unit>
     <unit id="dashboard.share.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:104</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:102</note>
       </notes>
       <segment>
         <source>Tagesleistung teilen</source>
@@ -9507,7 +9506,7 @@
     </unit>
     <unit id="dashboard.share">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:105</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:103</note>
       </notes>
       <segment>
         <source>Teilen</source>


### PR DESCRIPTION
## Summary

- **Dashboard helper extraction:** Pure logic from `dashboard.store.ts` split into focused modules — `dashboard-share.ts`, `dashboard-math.ts`, and `quick-add-view-model.ts` — each with dedicated unit tests.
- **Shared date utilities:** `daysBetween` and `sortedUniqueDates` centralised into `@pu-stats/date`; `analysis/trend-math.ts` now consumes them instead of local copies.
- **i18n refresh:** `messages.xlf` regenerated via `extract-i18n` to update `<note category="location">` entries after the refactor (auto-generated, no translatable content changed). Zero translation gaps detected across all locales.

## Files changed

| Area | Files |
|------|-------|
| Dashboard helpers | `dashboard/dashboard-share.ts/.spec.ts`, `dashboard/dashboard-math.ts/.spec.ts`, `dashboard/quick-add-view-model.ts/.spec.ts` |
| Dashboard store | `dashboard.store.ts`, `shell/stats-dashboard.component.ts` |
| Shared date lib | `libs/stats-date/src/lib/days-between.ts/.spec.ts`, `sorted-unique-dates.ts/.spec.ts`, `index.ts` |
| Analysis | `analysis/trend-math.ts/.spec.ts` |
| i18n (generated) | `web/src/locale/messages.xlf` |

## Test plan

- [x] `pnpm nx run web:build -c staging` — passed (Nx Cloud)
- [ ] `pnpm nx affected -t=lint,test,build -c=production` — CI in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jeeg2v1iG1Lcg2wbxVUhX