### PR TITLE
fix(i18n): localize delete confirmation phrase and fix stale hint translations

### DIFF
--- a/web/src/app/stats/shell/settings-page.component.spec.ts
+++ b/web/src/app/stats/shell/settings-page.component.spec.ts
@@ -271,6 +271,78 @@ describe('SettingsPageComponent — auto-save', () => {
     ).toBeNull();
   });
 
+  describe('account deletion', () => {
+    it('should set deleteDialogError when wrong phrase is entered', async () => {
+      // given
+      setup();
+      await flushMicrotasks();
+      component.deletePhraseInput.set('wrong');
+
+      // when
+      await component.confirmDeleteFromDialog();
+
+      // then
+      expect(component.deleteDialogError()).not.toBe('');
+      expect(component.deletingAccount()).toBe(false);
+    });
+
+    it('should clear deleteDialogError and start deletion when correct phrase is entered', async () => {
+      // given
+      const deleteAccountSpy = vitest.fn().mockResolvedValue(undefined);
+      TestBed.resetTestingModule();
+      const configSignalLocal = signal<UserConfig>({
+        userId: 'u1',
+        displayName: 'Wolf',
+      });
+      TestBed.configureTestingModule({
+        imports: [SettingsPageComponent],
+        providers: [
+          {
+            provide: UserConfigStore,
+            useValue: {
+              config: configSignalLocal.asReadonly(),
+              save: vitest
+                .fn()
+                .mockResolvedValue({ userId: 'u1', displayName: 'Wolf' }),
+              reload: vitest.fn(),
+            },
+          },
+          {
+            provide: UserContextService,
+            useValue: { isGuest: signal(false), userIdSafe: signal('u1') },
+          },
+          {
+            provide: AuthStore,
+            useValue: {
+              ...makeAuthStoreMock(),
+              deleteAccount: deleteAccountSpy,
+            },
+          },
+          provideRouter([]),
+          { provide: Analytics, useValue: null },
+          {
+            provide: PushSubscriptionService,
+            useValue: { unsubscribe: vitest.fn().mockResolvedValue(undefined) },
+          },
+          { provide: ShareService, useValue: { share: vitest.fn() } },
+        ],
+      });
+      const localFixture = TestBed.createComponent(SettingsPageComponent);
+      const localComponent = localFixture.componentInstance;
+      localFixture.detectChanges();
+      await flushMicrotasks();
+      localComponent.deletePhraseInput.set('löschen');
+
+      // when
+      await localComponent.confirmDeleteFromDialog();
+      await flushMicrotasks();
+
+      // then
+      expect(localComponent.deleteDialogError()).toBe('');
+      expect(deleteAccountSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('displayName validation', () => {
     it('Given an invalid displayName, When the debounce elapses, Then no save fires and the error message is rendered', async () => {
       setup({ userId: 'u1', displayName: 'Alex' });

--- a/web/src/app/stats/shell/settings-page.component.spec.ts
+++ b/web/src/app/stats/shell/settings-page.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { Analytics } from '@angular/fire/analytics';
+import { clearTranslations, loadTranslations } from '@angular/localize';
 import { AuthStore, UserContextService } from '@pu-auth/auth';
 import { PushSubscriptionService } from '@pu-push/push';
 import { UserConfig, UserConfigUpdate } from '@pu-stats/models';
@@ -286,8 +287,11 @@ describe('SettingsPageComponent — auto-save', () => {
       expect(component.deletingAccount()).toBe(false);
     });
 
-    it('should clear deleteDialogError and start deletion when correct phrase is entered', async () => {
-      // given
+    it('should accept the locale-translated phrase, not the German fallback', async () => {
+      // given — inject a non-German translation so $localize returns 'delete'.
+      // This test would have FAILED before the fix: the old hardcoded 'löschen'
+      // would not match 'delete', blocking deletion on every non-German locale.
+      loadTranslations({ 'settings.delete.confirmPlaceholder': 'delete' });
       const deleteAccountSpy = vitest.fn().mockResolvedValue(undefined);
       TestBed.resetTestingModule();
       const configSignalLocal = signal<UserConfig>({
@@ -331,7 +335,7 @@ describe('SettingsPageComponent — auto-save', () => {
       const localComponent = localFixture.componentInstance;
       localFixture.detectChanges();
       await flushMicrotasks();
-      localComponent.deletePhraseInput.set('löschen');
+      localComponent.deletePhraseInput.set('delete');
 
       // when
       await localComponent.confirmDeleteFromDialog();
@@ -340,6 +344,8 @@ describe('SettingsPageComponent — auto-save', () => {
       // then
       expect(localComponent.deleteDialogError()).toBe('');
       expect(deleteAccountSpy).toHaveBeenCalledTimes(1);
+
+      clearTranslations();
     });
   });
 

--- a/web/src/app/stats/shell/settings-page.component.spec.ts
+++ b/web/src/app/stats/shell/settings-page.component.spec.ts
@@ -273,6 +273,10 @@ describe('SettingsPageComponent — auto-save', () => {
   });
 
   describe('account deletion', () => {
+    afterEach(() => {
+      clearTranslations();
+    });
+
     it('should set deleteDialogError when wrong phrase is entered', async () => {
       // given
       setup();
@@ -344,8 +348,6 @@ describe('SettingsPageComponent — auto-save', () => {
       // then
       expect(localComponent.deleteDialogError()).toBe('');
       expect(deleteAccountSpy).toHaveBeenCalledTimes(1);
-
-      clearTranslations();
     });
   });
 

--- a/web/src/app/stats/shell/settings-page.component.ts
+++ b/web/src/app/stats/shell/settings-page.component.ts
@@ -100,7 +100,7 @@ export class SettingsPageComponent implements OnDestroy {
   readonly deletePhraseInput = signal('');
   readonly deleteDialogError = signal('');
 
-  private readonly deleteConfirmationPhrase = 'löschen';
+  private readonly deleteConfirmationPhrase = $localize`:@@settings.delete.confirmPlaceholder:löschen`;
 
   readonly config = computed<ResolvedConfig>(() =>
     resolveConfig(this.userConfigStore.config())

--- a/web/src/app/stats/shell/settings-page.component.ts
+++ b/web/src/app/stats/shell/settings-page.component.ts
@@ -100,7 +100,10 @@ export class SettingsPageComponent implements OnDestroy {
   readonly deletePhraseInput = signal('');
   readonly deleteDialogError = signal('');
 
-  private readonly deleteConfirmationPhrase = $localize`:@@settings.delete.confirmPlaceholder:löschen`;
+  private readonly deleteConfirmationPhrase =
+    $localize`:@@settings.delete.confirmPlaceholder:löschen`
+      .trim()
+      .toLowerCase();
 
   readonly config = computed<ResolvedConfig>(() =>
     resolveConfig(this.userConfigStore.config())

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10049,31 +10049,31 @@
       </segment>
     </unit>
     <unit id="analysis.repsUnitLong">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reps</source>
         <target>Reps</target>
       </segment>
     </unit>
     <unit id="settings.delete.confirmPlaceholder">
-      <segment state="initial">
+      <segment state="translated">
         <source>löschen</source>
-        <target>löschen</target>
+        <target>διαγραφή</target>
       </segment>
     </unit>
     <unit id="settings.delete.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bitte exakt „löschen“ eingeben.</source>
-        <target>Bitte exakt „löschen“ eingeben.</target>
+        <target>Παρακαλώ εισάγετε ακριβώς «διαγραφή».</target>
       </segment>
     </unit>
     <unit id="settings.anonymizedName">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gelöschter Benutzer</source>
-        <target>Gelöschter Benutzer</target>
+        <target>Διαγραμμένος χρήστης</target>
       </segment>
     </unit>
     <unit id="trainingPlans.photoCredit.unsplash">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unsplash</source>
         <target>Unsplash</target>
       </segment>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -4070,7 +4070,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="settings.deleteDialogPhraseHint">
       <segment state="translated">
         <source />
-        <target>Please enter exactly "löschen".</target>
+        <target>Please enter exactly "delete".</target>
       </segment>
     </unit>
     <unit id="settings.deleteDialogPhraseLabel">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10224,31 +10224,31 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="analysis.repsUnitLong">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reps</source>
         <target>Reps</target>
       </segment>
     </unit>
     <unit id="settings.delete.confirmPlaceholder">
-      <segment state="initial">
+      <segment state="translated">
         <source>löschen</source>
-        <target>löschen</target>
+        <target>delete</target>
       </segment>
     </unit>
     <unit id="settings.delete.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bitte exakt „löschen“ eingeben.</source>
-        <target>Bitte exakt „löschen“ eingeben.</target>
+        <target>Please enter exactly “delete”.</target>
       </segment>
     </unit>
     <unit id="settings.anonymizedName">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gelöschter Benutzer</source>
-        <target>Gelöschter Benutzer</target>
+        <target>Deleted User</target>
       </segment>
     </unit>
     <unit id="trainingPlans.photoCredit.unsplash">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unsplash</source>
         <target>Unsplash</target>
       </segment>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10045,31 +10045,31 @@
       </segment>
     </unit>
     <unit id="analysis.repsUnitLong">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reps</source>
         <target>Reps</target>
       </segment>
     </unit>
     <unit id="settings.delete.confirmPlaceholder">
-      <segment state="initial">
+      <segment state="translated">
         <source>löschen</source>
-        <target>löschen</target>
+        <target>eliminar</target>
       </segment>
     </unit>
     <unit id="settings.delete.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bitte exakt „löschen“ eingeben.</source>
-        <target>Bitte exakt „löschen“ eingeben.</target>
+        <target>Introduce exactamente “eliminar”.</target>
       </segment>
     </unit>
     <unit id="settings.anonymizedName">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gelöschter Benutzer</source>
-        <target>Gelöschter Benutzer</target>
+        <target>Usuario eliminado</target>
       </segment>
     </unit>
     <unit id="trainingPlans.photoCredit.unsplash">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unsplash</source>
         <target>Unsplash</target>
       </segment>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9921,31 +9921,31 @@
       </segment>
     </unit>
     <unit id="analysis.repsUnitLong">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reps</source>
         <target>Reps</target>
       </segment>
     </unit>
     <unit id="settings.delete.confirmPlaceholder">
-      <segment state="initial">
+      <segment state="translated">
         <source>löschen</source>
-        <target>löschen</target>
+        <target>supprimer</target>
       </segment>
     </unit>
     <unit id="settings.delete.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bitte exakt „löschen“ eingeben.</source>
-        <target>Bitte exakt „löschen“ eingeben.</target>
+        <target>Veuillez saisir exactement « supprimer ».</target>
       </segment>
     </unit>
     <unit id="settings.anonymizedName">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gelöschter Benutzer</source>
-        <target>Gelöschter Benutzer</target>
+        <target>Utilisateur supprimé</target>
       </segment>
     </unit>
     <unit id="trainingPlans.photoCredit.unsplash">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unsplash</source>
         <target>Unsplash</target>
       </segment>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -5838,7 +5838,7 @@
       </notes>
       <segment state="translated">
         <source>Bitte exakt „löscchen“ eingeben.</source>
-        <target>Inserisci esattamente "cancella".</target>
+        <target>Inserisci esattamente "elimina".</target>
       </segment>
     </unit>
     <unit id="settings.deleteConfirmFinal">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10049,31 +10049,31 @@
       </segment>
     </unit>
     <unit id="analysis.repsUnitLong">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reps</source>
         <target>Reps</target>
       </segment>
     </unit>
     <unit id="settings.delete.confirmPlaceholder">
-      <segment state="initial">
+      <segment state="translated">
         <source>löschen</source>
-        <target>löschen</target>
+        <target>elimina</target>
       </segment>
     </unit>
     <unit id="settings.delete.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bitte exakt „löschen“ eingeben.</source>
-        <target>Bitte exakt „löschen“ eingeben.</target>
+        <target>Inserisci esattamente “elimina”.</target>
       </segment>
     </unit>
     <unit id="settings.anonymizedName">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gelöschter Benutzer</source>
-        <target>Gelöschter Benutzer</target>
+        <target>Utente eliminato</target>
       </segment>
     </unit>
     <unit id="trainingPlans.photoCredit.unsplash">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unsplash</source>
         <target>Unsplash</target>
       </segment>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -10049,31 +10049,31 @@
       </segment>
     </unit>
     <unit id="analysis.repsUnitLong">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reps</source>
         <target>Reps</target>
       </segment>
     </unit>
     <unit id="settings.delete.confirmPlaceholder">
-      <segment state="initial">
+      <segment state="translated">
         <source>löschen</source>
-        <target>löschen</target>
+        <target>delere</target>
       </segment>
     </unit>
     <unit id="settings.delete.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bitte exakt „löschen“ eingeben.</source>
-        <target>Bitte exakt „löschen“ eingeben.</target>
+        <target>Scribe exacte “delere”.</target>
       </segment>
     </unit>
     <unit id="settings.anonymizedName">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gelöschter Benutzer</source>
-        <target>Gelöschter Benutzer</target>
+        <target>Usor deletus</target>
       </segment>
     </unit>
     <unit id="trainingPlans.photoCredit.unsplash">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unsplash</source>
         <target>Unsplash</target>
       </segment>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -5838,7 +5838,7 @@
       </notes>
       <segment state="translated">
         <source>Bitte exakt „löscchen“ eingeben.</source>
-        <target>Please enter “delete” prorsus.</target>
+        <target>Scribe exacte “delere”.</target>
       </segment>
     </unit>
     <unit id="settings.deleteConfirmFinal">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10049,31 +10049,31 @@
       </segment>
     </unit>
     <unit id="analysis.repsUnitLong">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reps</source>
         <target>Reps</target>
       </segment>
     </unit>
     <unit id="settings.delete.confirmPlaceholder">
-      <segment state="initial">
+      <segment state="translated">
         <source>löschen</source>
-        <target>löschen</target>
+        <target>verwijderen</target>
       </segment>
     </unit>
     <unit id="settings.delete.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bitte exakt „löschen“ eingeben.</source>
-        <target>Bitte exakt „löschen“ eingeben.</target>
+        <target>Voer precies “verwijderen” in.</target>
       </segment>
     </unit>
     <unit id="settings.anonymizedName">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gelöschter Benutzer</source>
-        <target>Gelöschter Benutzer</target>
+        <target>Verwijderde gebruiker</target>
       </segment>
     </unit>
     <unit id="trainingPlans.photoCredit.unsplash">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unsplash</source>
         <target>Unsplash</target>
       </segment>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9318,31 +9318,31 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="analysis.repsUnitLong">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reps</source>
         <target>Reps</target>
       </segment>
     </unit>
     <unit id="settings.delete.confirmPlaceholder">
-      <segment state="initial">
+      <segment state="translated">
         <source>löschen</source>
-        <target>löschen</target>
+        <target>slett</target>
       </segment>
     </unit>
     <unit id="settings.delete.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bitte exakt „löschen“ eingeben.</source>
-        <target>Bitte exakt „löschen“ eingeben.</target>
+        <target>Skriv inn nøyaktig «slett».</target>
       </segment>
     </unit>
     <unit id="settings.anonymizedName">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gelöschter Benutzer</source>
-        <target>Gelöschter Benutzer</target>
+        <target>Slettet bruker</target>
       </segment>
     </unit>
     <unit id="trainingPlans.photoCredit.unsplash">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unsplash</source>
         <target>Unsplash</target>
       </segment>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -5859,7 +5859,7 @@
     </unit>
     <unit id="reminder.quietHours.label">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-quiet-hours.component.ts:32,33</note>
+        <note category="location">web/src/app/reminders/shell/reminder-quiet-hours.component.ts:27,28</note>
       </notes>
       <segment>
         <source>Ruhezeiten</source>
@@ -5867,7 +5867,7 @@
     </unit>
     <unit id="reminder.quietHours.from">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-quiet-hours.component.ts:36,38</note>
+        <note category="location">web/src/app/reminders/shell/reminder-quiet-hours.component.ts:31,33</note>
       </notes>
       <segment>
         <source>Von</source>
@@ -5875,7 +5875,7 @@
     </unit>
     <unit id="reminder.quietHours.to">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-quiet-hours.component.ts:52,54</note>
+        <note category="location">web/src/app/reminders/shell/reminder-quiet-hours.component.ts:47,49</note>
       </notes>
       <segment>
         <source>Bis</source>
@@ -5883,7 +5883,7 @@
     </unit>
     <unit id="reminder.quietHours.remove.aria">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-quiet-hours.component.ts:72,73</note>
+        <note category="location">web/src/app/reminders/shell/reminder-quiet-hours.component.ts:67,68</note>
       </notes>
       <segment>
         <source>Ruhezeit entfernen</source>
@@ -5891,7 +5891,7 @@
     </unit>
     <unit id="reminder.quietHours.add">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-quiet-hours.component.ts:86,88</note>
+        <note category="location">web/src/app/reminders/shell/reminder-quiet-hours.component.ts:81,83</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">add</pc> Ruhezeit hinzufügen </source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -9114,6 +9114,7 @@
     <unit id="settings.delete.confirmPlaceholder">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.html:422,423</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:103</note>
       </notes>
       <segment>
         <source>löschen</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -6423,7 +6423,7 @@
       </notes>
       <segment state="translated">
         <source>Bitte exakt „löscchen“ eingeben.</source>
-      <target>请准确输入"löscchen"。</target></segment>
+      <target>请准确输入"删除"。</target></segment>
     </unit>
     <unit id="settings.deleteConfirmFinal">
       <notes>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9546,31 +9546,31 @@
       </segment>
     </unit>
     <unit id="analysis.repsUnitLong">
-      <segment state="initial">
+      <segment state="translated">
         <source>Reps</source>
         <target>Reps</target>
       </segment>
     </unit>
     <unit id="settings.delete.confirmPlaceholder">
-      <segment state="initial">
+      <segment state="translated">
         <source>löschen</source>
-        <target>löschen</target>
+        <target>删除</target>
       </segment>
     </unit>
     <unit id="settings.delete.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Bitte exakt „löschen“ eingeben.</source>
-        <target>Bitte exakt „löschen“ eingeben.</target>
+        <target>请准确输入“删除”。</target>
       </segment>
     </unit>
     <unit id="settings.anonymizedName">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gelöschter Benutzer</source>
-        <target>Gelöschter Benutzer</target>
+        <target>已删除用户</target>
       </segment>
     </unit>
     <unit id="trainingPlans.photoCredit.unsplash">
-      <segment state="initial">
+      <segment state="translated">
         <source>Unsplash</source>
         <target>Unsplash</target>
       </segment>


### PR DESCRIPTION
## Summary

- **`settings-page.component.ts`**: Use `$localize` for the account-deletion confirmation phrase (`settings.delete.confirmPlaceholder`) so non-German locales get the locale-appropriate word instead of the hardcoded German "löschen". Normalize the phrase with `.trim().toLowerCase()` so translations with different casing never silently block deletion.
- **`settings-page.component.spec.ts`**: Add tests for locale-specific deletion confirmation; move `clearTranslations()` into `afterEach` to prevent i18n state leaking on test failure.
- **Locale XLIFF files**: Mark `settings.delete.confirmPlaceholder`, `settings.delete.error`, and `settings.anonymizedName` as `translated` across all 9 target locales with correct locale-specific words.
- **`messages.xlf`**: Refresh location notes from `extract-i18n` run (quiet-hours line shifts, new TS reference for `settings.delete.confirmPlaceholder`).
- **Fix stale `settings.deleteDialogPhraseHint` targets** in 4 locales where the hint text still showed "löschen" instead of the locale word: `en` (→ "delete"), `it` (→ "elimina"), `la` (→ "delere"), `zh` (→ "删除").

## Test plan

- [x] All 1374 web unit tests pass locally
- [ ] CI lint-test-build green
- [ ] CI e2e green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCibwYhEPGxP6xiUazdaJR