### PR TITLE
refactor(goals) + chore(i18n): split goals-page into modules & refresh messages.xlf

### DIFF
--- a/web/src/app/goals/shell/goals-autosave.controller.spec.ts
+++ b/web/src/app/goals/shell/goals-autosave.controller.spec.ts
@@ -1,0 +1,229 @@
+import type { ComplexGoals } from '@pu-stats/models';
+import {
+  GoalsAutoSaveController,
+  type GoalsAutoSaveDeps,
+} from './goals-autosave.controller';
+
+const PERSISTED: ComplexGoals = {
+  daily: [
+    {
+      id: 'a',
+      exerciseId: 'pushup',
+      target: 10,
+      measurement: 'reps',
+      unit: 'reps',
+    },
+  ],
+  weekly: [],
+  monthly: [],
+};
+
+const DIRTY: ComplexGoals = {
+  ...PERSISTED,
+  daily: [
+    {
+      id: 'a',
+      exerciseId: 'pushup',
+      target: 25,
+      measurement: 'reps',
+      unit: 'reps',
+    },
+  ],
+};
+
+const DEBOUNCE_MS = 600;
+
+function makeDeps(overrides: Partial<GoalsAutoSaveDeps> = {}): {
+  deps: GoalsAutoSaveDeps;
+  save: ReturnType<typeof vitest.fn>;
+  applyDraft: ReturnType<typeof vitest.fn>;
+  draftRef: { current: ComplexGoals };
+} {
+  const draftRef = { current: PERSISTED };
+  const save = vitest.fn().mockResolvedValue({});
+  const applyDraft = vitest.fn();
+  const deps: GoalsAutoSaveDeps = {
+    readDraft: () => draftRef.current,
+    applyDraft,
+    save,
+    isBrowser: true,
+    ...overrides,
+  };
+  return { deps, save, applyDraft, draftRef };
+}
+
+describe('GoalsAutoSaveController', () => {
+  afterEach(() => {
+    vitest.useRealTimers();
+  });
+
+  describe('hydrate', () => {
+    it('should apply goals and seed the baseline when none exists yet', () => {
+      // given
+      const { deps, applyDraft } = makeDeps();
+      const ctrl = new GoalsAutoSaveController(deps);
+
+      // when
+      ctrl.hydrate(PERSISTED);
+
+      // then
+      expect(applyDraft).toHaveBeenCalledWith(PERSISTED);
+      expect(ctrl.saveStatus()).toBe('idle');
+    });
+
+    it('should not clobber dirty drafts when a store emission arrives', () => {
+      // given
+      const { deps, applyDraft, draftRef } = makeDeps();
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      applyDraft.mockClear();
+      draftRef.current = DIRTY;
+      ctrl.onDraftChange(DIRTY);
+
+      // when
+      ctrl.hydrate(PERSISTED);
+
+      // then
+      expect(applyDraft).not.toHaveBeenCalled();
+      ctrl.destroy();
+    });
+
+    it('should re-apply goals when an emission arrives over pristine drafts', () => {
+      // given
+      const { deps, applyDraft } = makeDeps();
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      applyDraft.mockClear();
+
+      // when
+      ctrl.hydrate(PERSISTED);
+
+      // then
+      expect(applyDraft).toHaveBeenCalledWith(PERSISTED);
+    });
+  });
+
+  describe('onDraftChange', () => {
+    it('should not schedule a save without a baseline', () => {
+      // given
+      vitest.useFakeTimers();
+      const { deps, save } = makeDeps();
+      const ctrl = new GoalsAutoSaveController(deps);
+
+      // when
+      ctrl.onDraftChange(DIRTY);
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+
+      // then
+      expect(save).not.toHaveBeenCalled();
+      expect(ctrl.saveStatus()).toBe('idle');
+    });
+
+    it('should run save once when the debounce elapses on a dirty draft', async () => {
+      // given
+      vitest.useFakeTimers({ shouldAdvanceTime: true });
+      const { deps, save, draftRef } = makeDeps();
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      draftRef.current = DIRTY;
+
+      // when
+      ctrl.onDraftChange(DIRTY);
+      expect(ctrl.saveStatus()).toBe('pending');
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // then
+      expect(save).toHaveBeenCalledTimes(1);
+      expect(ctrl.saveStatus()).toBe('saved');
+    });
+
+    it('should return a pending status to idle when a draft reverts to the baseline', () => {
+      // given
+      vitest.useFakeTimers();
+      const { deps, save } = makeDeps();
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      ctrl.onDraftChange(DIRTY);
+      expect(ctrl.saveStatus()).toBe('pending');
+
+      // when
+      ctrl.onDraftChange(PERSISTED);
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+
+      // then
+      expect(save).not.toHaveBeenCalled();
+      expect(ctrl.saveStatus()).toBe('idle');
+    });
+  });
+
+  describe('save failure', () => {
+    it('should set status to error when save rejects after the debounce elapses', async () => {
+      // given
+      vitest.useFakeTimers({ shouldAdvanceTime: true });
+      const { deps, draftRef } = makeDeps({
+        save: vitest.fn().mockRejectedValue(new Error('down')),
+      });
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      draftRef.current = DIRTY;
+
+      // when
+      ctrl.onDraftChange(DIRTY);
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // then
+      expect(ctrl.saveStatus()).toBe('error');
+    });
+
+    it('should re-run the save when retry is called after a failure', async () => {
+      // given
+      vitest.useFakeTimers({ shouldAdvanceTime: true });
+      const save = vitest
+        .fn()
+        .mockRejectedValueOnce(new Error('down'))
+        .mockResolvedValue({});
+      const { deps, draftRef } = makeDeps({ save });
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      draftRef.current = DIRTY;
+      ctrl.onDraftChange(DIRTY);
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(ctrl.saveStatus()).toBe('error');
+
+      // when
+      ctrl.retry();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // then
+      expect(save).toHaveBeenCalledTimes(2);
+      expect(ctrl.saveStatus()).toBe('saved');
+      ctrl.destroy();
+    });
+  });
+
+  describe('SSR', () => {
+    it('should not fire a timer-driven save on a non-browser platform', () => {
+      // given
+      vitest.useFakeTimers();
+      const { deps, save, draftRef } = makeDeps({ isBrowser: false });
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      draftRef.current = DIRTY;
+
+      // when
+      ctrl.onDraftChange(DIRTY);
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+
+      // then
+      expect(save).not.toHaveBeenCalled();
+      expect(ctrl.saveStatus()).toBe('pending');
+    });
+  });
+});

--- a/web/src/app/goals/shell/goals-autosave.controller.spec.ts
+++ b/web/src/app/goals/shell/goals-autosave.controller.spec.ts
@@ -32,6 +32,20 @@ const DIRTY: ComplexGoals = {
 };
 
 const DEBOUNCE_MS = 600;
+const SAVED_INDICATOR_MS = 1800;
+
+const DIRTIER: ComplexGoals = {
+  ...PERSISTED,
+  daily: [
+    {
+      id: 'a',
+      exerciseId: 'pushup',
+      target: 99,
+      measurement: 'reps',
+      unit: 'reps',
+    },
+  ],
+};
 
 function makeDeps(overrides: Partial<GoalsAutoSaveDeps> = {}): {
   deps: GoalsAutoSaveDeps;
@@ -203,6 +217,86 @@ describe('GoalsAutoSaveController', () => {
 
       // then
       expect(save).toHaveBeenCalledTimes(2);
+      expect(ctrl.saveStatus()).toBe('saved');
+      ctrl.destroy();
+    });
+
+    it('should reset a stale error status to idle when the draft reverts to clean', async () => {
+      // given
+      vitest.useFakeTimers({ shouldAdvanceTime: true });
+      const { deps, draftRef } = makeDeps({
+        save: vitest.fn().mockRejectedValue(new Error('down')),
+      });
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      draftRef.current = DIRTY;
+      ctrl.onDraftChange(DIRTY);
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(ctrl.saveStatus()).toBe('error');
+
+      // when
+      draftRef.current = PERSISTED;
+      ctrl.onDraftChange(PERSISTED);
+
+      // then
+      expect(ctrl.saveStatus()).toBe('idle');
+      ctrl.destroy();
+    });
+  });
+
+  describe('saved indicator', () => {
+    it('should return the saved status to idle after the indicator window elapses', async () => {
+      // given
+      vitest.useFakeTimers({ shouldAdvanceTime: true });
+      const { deps, draftRef } = makeDeps();
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      draftRef.current = DIRTY;
+      ctrl.onDraftChange(DIRTY);
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(ctrl.saveStatus()).toBe('saved');
+
+      // when
+      vitest.advanceTimersByTime(SAVED_INDICATOR_MS);
+
+      // then
+      expect(ctrl.saveStatus()).toBe('idle');
+      ctrl.destroy();
+    });
+  });
+
+  describe('coalescing', () => {
+    it('should run a second save for the newest draft when it changes mid-flight', async () => {
+      // given a save whose first call we hold open
+      vitest.useFakeTimers({ shouldAdvanceTime: true });
+      let resolveFirst!: () => void;
+      const first = new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const save = vitest.fn().mockReturnValueOnce(first).mockResolvedValue({});
+      const { deps, draftRef } = makeDeps({ save });
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      draftRef.current = DIRTY;
+      ctrl.onDraftChange(DIRTY);
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+      await Promise.resolve();
+      expect(ctrl.saveStatus()).toBe('saving');
+
+      // when a newer draft arrives before the first save resolves
+      draftRef.current = DIRTIER;
+      ctrl.onDraftChange(DIRTIER);
+      vitest.advanceTimersByTime(DEBOUNCE_MS);
+      resolveFirst();
+      for (let i = 0; i < 6; i++) await Promise.resolve();
+
+      // then the held save and a coalesced follow-up both run, latest last
+      expect(save).toHaveBeenCalledTimes(2);
+      expect(save.mock.calls[1][0].daily?.[0].target).toBe(99);
       expect(ctrl.saveStatus()).toBe('saved');
       ctrl.destroy();
     });

--- a/web/src/app/goals/shell/goals-autosave.controller.spec.ts
+++ b/web/src/app/goals/shell/goals-autosave.controller.spec.ts
@@ -322,6 +322,25 @@ describe('GoalsAutoSaveController', () => {
       expect(save).toHaveBeenCalledTimes(1);
       expect(save).toHaveBeenCalledWith(DIRTY);
     });
+
+    it('should not schedule a savedTimer after teardown', async () => {
+      // given
+      vitest.useFakeTimers({ shouldAdvanceTime: true });
+      const { deps, draftRef } = makeDeps();
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      draftRef.current = DIRTY;
+      ctrl.onDraftChange(DIRTY);
+
+      // when
+      ctrl.destroy();
+      await Promise.resolve();
+      await Promise.resolve();
+      vitest.advanceTimersByTime(SAVED_INDICATOR_MS);
+
+      // then – status stays at whatever it was after save; no timer fires to mutate it
+      expect(ctrl.saveStatus()).not.toBe('idle');
+    });
   });
 
   describe('SSR', () => {

--- a/web/src/app/goals/shell/goals-autosave.controller.spec.ts
+++ b/web/src/app/goals/shell/goals-autosave.controller.spec.ts
@@ -302,6 +302,28 @@ describe('GoalsAutoSaveController', () => {
     });
   });
 
+  describe('destroy', () => {
+    it('should flush a pending dirty draft instead of silently dropping it on teardown', async () => {
+      // given
+      vitest.useFakeTimers({ shouldAdvanceTime: true });
+      const { deps, save, draftRef } = makeDeps();
+      const ctrl = new GoalsAutoSaveController(deps);
+      ctrl.hydrate(PERSISTED);
+      draftRef.current = DIRTY;
+      ctrl.onDraftChange(DIRTY);
+      expect(ctrl.saveStatus()).toBe('pending');
+
+      // when – destroy is called before the debounce timer fires
+      ctrl.destroy();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // then
+      expect(save).toHaveBeenCalledTimes(1);
+      expect(save).toHaveBeenCalledWith(DIRTY);
+    });
+  });
+
   describe('SSR', () => {
     it('should not fire a timer-driven save on a non-browser platform', () => {
       // given

--- a/web/src/app/goals/shell/goals-autosave.controller.ts
+++ b/web/src/app/goals/shell/goals-autosave.controller.ts
@@ -33,6 +33,7 @@ export class GoalsAutoSaveController {
   private autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
   private savedTimer: ReturnType<typeof setTimeout> | null = null;
   private inFlightSave: Promise<void> | null = null;
+  private destroyed = false;
 
   constructor(private readonly deps: GoalsAutoSaveDeps) {}
 
@@ -76,6 +77,7 @@ export class GoalsAutoSaveController {
   }
 
   destroy(): void {
+    this.destroyed = true;
     if (this.autoSaveTimer !== null) {
       clearTimeout(this.autoSaveTimer);
       this.autoSaveTimer = null;
@@ -132,6 +134,7 @@ export class GoalsAutoSaveController {
     try {
       await this.deps.save(draft);
       this.lastPersisted.set(cloneGoals(draft));
+      if (this.destroyed) return;
       this.saveStatus.set('saved');
       if (this.savedTimer !== null) clearTimeout(this.savedTimer);
       this.savedTimer = setTimeout(() => {

--- a/web/src/app/goals/shell/goals-autosave.controller.ts
+++ b/web/src/app/goals/shell/goals-autosave.controller.ts
@@ -76,7 +76,13 @@ export class GoalsAutoSaveController {
   }
 
   destroy(): void {
-    this.cancelTimer();
+    if (this.autoSaveTimer !== null) {
+      clearTimeout(this.autoSaveTimer);
+      this.autoSaveTimer = null;
+      // Flush the pending dirty draft before teardown — cancelling the timer
+      // would otherwise silently drop edits made within the debounce window.
+      void this.flush();
+    }
     if (this.savedTimer !== null) {
       clearTimeout(this.savedTimer);
       this.savedTimer = null;

--- a/web/src/app/goals/shell/goals-autosave.controller.ts
+++ b/web/src/app/goals/shell/goals-autosave.controller.ts
@@ -1,0 +1,137 @@
+import { signal } from '@angular/core';
+import type { ComplexGoals } from '@pu-stats/models';
+import {
+  AUTO_SAVE_DEBOUNCE_MS,
+  SAVED_INDICATOR_MS,
+  type SaveStatus,
+} from './goals-page.models';
+import { cloneGoals, scopesEqual } from './goals-page.helpers';
+
+export interface GoalsAutoSaveDeps {
+  readDraft: () => ComplexGoals;
+  applyDraft: (goals: ComplexGoals) => void;
+  save: (goals: ComplexGoals) => Promise<unknown>;
+  isBrowser: boolean;
+}
+
+/**
+ * Owns the debounced auto-save state machine for the goals page: dirty
+ * detection against the last persisted snapshot, the debounce + saved-indicator
+ * timers, and coalescing of overlapping save round trips. The component drives
+ * it from its hydration and draft-change effects and binds `saveStatus` in the
+ * template; all timer and in-flight bookkeeping lives here.
+ */
+export class GoalsAutoSaveController {
+  readonly saveStatus = signal<SaveStatus>('idle');
+
+  /**
+   * Last successfully persisted snapshot. Drafts are compared against this to
+   * decide whether a save is needed. `null` until the first hydration, which is
+   * why save is suppressed before the baseline exists.
+   */
+  private readonly lastPersisted = signal<ComplexGoals | null>(null);
+  private autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
+  private savedTimer: ReturnType<typeof setTimeout> | null = null;
+  private inFlightSave: Promise<void> | null = null;
+
+  constructor(private readonly deps: GoalsAutoSaveDeps) {}
+
+  /**
+   * Hydrate drafts from the store, unless the user has dirty edits or a save is
+   * mid-flight — otherwise the realtime listener clobbers input the user is
+   * mid-editing. Dirty is measured against the OLD baseline, never the incoming
+   * goals (else every store emission would look dirty).
+   */
+  hydrate(goals: ComplexGoals): void {
+    const status = this.saveStatus();
+    const baseline = this.lastPersisted();
+    const dirty =
+      baseline !== null && !scopesEqual(this.deps.readDraft(), baseline);
+    if (
+      baseline !== null &&
+      (status === 'pending' || status === 'saving' || dirty)
+    ) {
+      return;
+    }
+    this.deps.applyDraft(cloneGoals(goals));
+    this.lastPersisted.set(cloneGoals(goals));
+    if (this.saveStatus() === 'pending') this.saveStatus.set('idle');
+  }
+
+  onDraftChange(draft: ComplexGoals): void {
+    const baseline = this.lastPersisted();
+    if (baseline === null) return;
+    if (scopesEqual(draft, baseline)) {
+      this.cancelTimer();
+      if (this.saveStatus() === 'pending') this.saveStatus.set('idle');
+      return;
+    }
+    this.schedule();
+  }
+
+  retry(): void {
+    void this.flush();
+  }
+
+  destroy(): void {
+    this.cancelTimer();
+    if (this.savedTimer !== null) {
+      clearTimeout(this.savedTimer);
+      this.savedTimer = null;
+    }
+  }
+
+  private schedule(): void {
+    this.saveStatus.set('pending');
+    this.cancelTimer();
+    if (!this.deps.isBrowser) {
+      // SSR: never schedule timers; the user can't interact anyway.
+      return;
+    }
+    this.autoSaveTimer = setTimeout(() => {
+      this.autoSaveTimer = null;
+      void this.flush();
+    }, AUTO_SAVE_DEBOUNCE_MS);
+  }
+
+  cancelTimer(): void {
+    if (this.autoSaveTimer !== null) {
+      clearTimeout(this.autoSaveTimer);
+      this.autoSaveTimer = null;
+    }
+  }
+
+  private async flush(): Promise<void> {
+    if (this.inFlightSave) {
+      // Coalesce: wait for the running save, then re-check for newer drafts.
+      await this.inFlightSave;
+      const baseline = this.lastPersisted();
+      if (baseline && scopesEqual(this.deps.readDraft(), baseline)) return;
+    }
+    const run = this.performSave();
+    this.inFlightSave = run;
+    try {
+      await run;
+    } finally {
+      if (this.inFlightSave === run) this.inFlightSave = null;
+    }
+  }
+
+  private async performSave(): Promise<void> {
+    this.cancelTimer();
+    const draft = this.deps.readDraft();
+    this.saveStatus.set('saving');
+    try {
+      await this.deps.save(draft);
+      this.lastPersisted.set(cloneGoals(draft));
+      this.saveStatus.set('saved');
+      if (this.savedTimer !== null) clearTimeout(this.savedTimer);
+      this.savedTimer = setTimeout(() => {
+        this.savedTimer = null;
+        if (this.saveStatus() === 'saved') this.saveStatus.set('idle');
+      }, SAVED_INDICATOR_MS);
+    } catch {
+      this.saveStatus.set('error');
+    }
+  }
+}

--- a/web/src/app/goals/shell/goals-autosave.controller.ts
+++ b/web/src/app/goals/shell/goals-autosave.controller.ts
@@ -63,7 +63,9 @@ export class GoalsAutoSaveController {
     if (baseline === null) return;
     if (scopesEqual(draft, baseline)) {
       this.cancelTimer();
-      if (this.saveStatus() === 'pending') this.saveStatus.set('idle');
+      // Clean draft: clear any leftover 'pending' or stale 'error' pill. Never
+      // stomp a 'saving' status mid-round-trip.
+      if (this.saveStatus() !== 'saving') this.saveStatus.set('idle');
       return;
     }
     this.schedule();

--- a/web/src/app/goals/shell/goals-page.component.html
+++ b/web/src/app/goals/shell/goals-page.component.html
@@ -1,0 +1,201 @@
+<main class="page-wrap">
+  <app-page-header icon="flag" variant="default">
+    <h1 page-title i18n="@@goalsHeaderTitle">Tagesziele</h1>
+    <p page-subtitle i18n="@@goalsHeaderSubtitle">
+      Verschiedene Übungen pro Tag, pro Woche, pro Monat.
+    </p>
+    <div
+      page-actions
+      class="save-status"
+      role="status"
+      aria-live="polite"
+      [attr.data-status]="saveStatus()"
+      data-testid="goals-save-status"
+    >
+      @switch (saveStatus()) {
+        @case ('saving') {
+          <mat-progress-spinner
+            diameter="16"
+            mode="indeterminate"
+          ></mat-progress-spinner>
+          <span i18n="@@goals.status.saving">Speichert…</span>
+        }
+        @case ('saved') {
+          <mat-icon class="status-icon ok">check_circle</mat-icon>
+          <span i18n="@@goals.status.saved">Gespeichert</span>
+        }
+        @case ('error') {
+          <mat-icon class="status-icon err">error</mat-icon>
+          <span i18n="@@goals.status.error">Fehler beim Speichern</span>
+          <button
+            type="button"
+            mat-stroked-button
+            (click)="retrySave()"
+            i18n="@@goals.status.retry"
+          >
+            Erneut versuchen
+          </button>
+        }
+        @case ('pending') {
+          <mat-icon class="status-icon">edit</mat-icon>
+          <span i18n="@@goals.status.pending">Ungespeicherte Änderungen…</span>
+        }
+        @default {
+          <mat-icon class="status-icon ok">cloud_done</mat-icon>
+          <span i18n="@@goals.status.synced">Alle Ziele gespeichert</span>
+        }
+      }
+    </div>
+  </app-page-header>
+
+  @if (isGuest()) {
+    <div class="guest-banner">
+      <mat-icon>info</mat-icon>
+      <span i18n="@@guest.banner.text"
+        >Du nutzt die App als Gast. Erstelle ein Konto um alle Funktionen zu
+        nutzen.</span
+      >
+      <a mat-stroked-button routerLink="/register" i18n="@@guest.banner.cta"
+        >Konto erstellen</a
+      >
+    </div>
+  }
+
+  <p class="intro" i18n="@@goals.intro">
+    Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei
+    Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das
+    jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan.
+  </p>
+
+  @for (scope of scopes; track scope.id) {
+    <mat-card
+      [id]="'goals-' + scope.id"
+      class="section-card"
+      [attr.data-testid]="'goals-section-' + scope.id"
+    >
+      <mat-card-header>
+        <mat-icon mat-card-avatar>{{ scope.icon }}</mat-icon>
+        <mat-card-title>{{ scope.title }}</mat-card-title>
+        <mat-card-subtitle>{{ scope.subtitle }}</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content class="stack">
+        @let list = entriesFor(scope.id)();
+        @if (list.length === 0) {
+          <p
+            class="muted empty"
+            [attr.data-testid]="'goals-empty-' + scope.id"
+            i18n="@@goals.section.empty"
+          >
+            Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu.
+          </p>
+        }
+        @for (entry of list; track entry.id) {
+          <div
+            class="goal-row"
+            [attr.data-testid]="'goal-row-' + scope.id + '-' + $index"
+          >
+            <mat-form-field appearance="outline" class="exercise-field">
+              <mat-label i18n="@@goals.field.exercise">Übung</mat-label>
+              <mat-select
+                [value]="entry.exerciseId"
+                (selectionChange)="
+                  updateExercise(scope.id, entry.id, $event.value)
+                "
+              >
+                @for (opt of exerciseOptions; track opt.id) {
+                  <mat-option [value]="opt.id">{{ opt.label }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="target-field">
+              <mat-label>{{ targetLabel(entry) }}</mat-label>
+              <input
+                matInput
+                type="number"
+                [min]="targetMin(entry)"
+                [max]="targetMax(entry)"
+                [value]="entry.target"
+                [attr.aria-label]="targetLabel(entry)"
+                (input)="updateTarget(scope.id, entry.id, asNumber($event, 1))"
+              />
+              <span matTextSuffix>{{ entry.unit }}</span>
+            </mat-form-field>
+
+            <button
+              type="button"
+              mat-icon-button
+              color="warn"
+              (click)="removeEntry(scope.id, entry.id)"
+              [attr.aria-label]="removeAriaLabel"
+              [attr.data-testid]="'goal-remove-' + scope.id + '-' + $index"
+            >
+              <mat-icon>delete</mat-icon>
+            </button>
+
+            @if (scope.id === 'daily') {
+              <div class="weekday-row">
+                <span class="weekday-label" i18n="@@goals.weekdayLabel"
+                  >Aktiv an:</span
+                >
+                <mat-button-toggle-group
+                  multiple
+                  hideMultipleSelectionIndicator
+                  [value]="weekdayValue(entry)"
+                  (change)="updateWeekdays(scope.id, entry.id, $event.value)"
+                  [attr.aria-label]="weekdayAria"
+                >
+                  @for (day of weekdays; track day.value) {
+                    <mat-button-toggle [value]="day.value">{{
+                      day.label
+                    }}</mat-button-toggle>
+                  }
+                </mat-button-toggle-group>
+                @if (weekdayValue(entry).length === 0) {
+                  <span
+                    class="muted weekday-hint"
+                    i18n="@@goals.weekdayEveryDayHint"
+                    >Keine Auswahl = gilt jeden Tag.</span
+                  >
+                }
+              </div>
+            }
+          </div>
+        }
+        <button
+          type="button"
+          mat-stroked-button
+          [disabled]="list.length >= maxPerScope"
+          (click)="addEntry(scope.id)"
+          [attr.data-testid]="'goal-add-' + scope.id"
+        >
+          <mat-icon>add</mat-icon>
+          <span i18n="@@goals.addEntry">Ziel hinzufügen</span>
+        </button>
+        @if (list.length >= maxPerScope) {
+          <p class="muted limit-hint" i18n="@@goals.limitHint">
+            Maximal {{ maxPerScope }} Ziele pro Bereich.
+          </p>
+        }
+      </mat-card-content>
+    </mat-card>
+  }
+
+  <mat-card class="section-card hint-card">
+    <mat-card-header>
+      <mat-icon mat-card-avatar>tips_and_updates</mat-icon>
+      <mat-card-title i18n="@@goals.linkBack.title"
+        >Andere Einstellungen</mat-card-title
+      >
+      <mat-card-subtitle i18n="@@goals.linkBack.subtitle">
+        Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten.
+      </mat-card-subtitle>
+    </mat-card-header>
+    <mat-card-actions>
+      <a mat-stroked-button routerLink="/settings" i18n="@@goals.linkBack.cta">
+        <mat-icon>tune</mat-icon>
+        Einstellungen öffnen
+      </a>
+    </mat-card-actions>
+  </mat-card>
+</main>

--- a/web/src/app/goals/shell/goals-page.component.scss
+++ b/web/src/app/goals/shell/goals-page.component.scss
@@ -1,0 +1,125 @@
+.page-wrap {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 16px;
+  display: grid;
+  gap: 16px;
+}
+.intro {
+  margin: 0;
+  padding: 12px 16px;
+  border-radius: 10px;
+  background: rgba(123, 159, 255, 0.08);
+  border: 1px solid rgba(123, 159, 255, 0.2);
+  line-height: 1.5;
+}
+.save-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  transition:
+    background 200ms ease,
+    border-color 200ms ease;
+}
+.save-status[data-status='saving'] {
+  background: rgba(123, 159, 255, 0.16);
+  border-color: rgba(123, 159, 255, 0.4);
+}
+.save-status[data-status='saved'] {
+  background: rgba(120, 220, 140, 0.14);
+  border-color: rgba(120, 220, 140, 0.36);
+}
+.save-status[data-status='error'] {
+  background: rgba(255, 120, 120, 0.16);
+  border-color: rgba(255, 120, 120, 0.45);
+}
+.save-status[data-status='pending'] {
+  background: rgba(255, 200, 100, 0.14);
+  border-color: rgba(255, 200, 100, 0.36);
+}
+.save-status .status-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+.save-status .status-icon.ok {
+  color: #7fd99a;
+}
+.save-status .status-icon.err {
+  color: #ff8b8b;
+}
+.section-card {
+  padding: 4px 4px 8px;
+}
+.section-card mat-card-header {
+  padding-bottom: 8px;
+}
+.stack {
+  display: grid;
+  gap: 12px;
+}
+.goal-row {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(120px, 180px) auto;
+  gap: 8px;
+  align-items: center;
+  padding: 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+.weekday-row {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+.weekday-label {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.weekday-hint {
+  flex-basis: 100%;
+  margin-top: 0;
+}
+.exercise-field,
+.target-field {
+  width: 100%;
+}
+.muted {
+  opacity: 0.8;
+  font-size: 0.9rem;
+  margin: 0;
+}
+.empty {
+  padding: 12px 4px;
+  font-style: italic;
+}
+.limit-hint {
+  margin-top: 4px;
+}
+.guest-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 6px;
+  background: rgba(100, 160, 255, 0.1);
+  border: 1px solid rgba(100, 160, 255, 0.3);
+  flex-wrap: wrap;
+}
+@media (max-width: 640px) {
+  .goal-row {
+    grid-template-columns: 1fr auto;
+  }
+  .target-field {
+    grid-column: 1 / 2;
+  }
+}

--- a/web/src/app/goals/shell/goals-page.component.ts
+++ b/web/src/app/goals/shell/goals-page.component.ts
@@ -5,6 +5,7 @@ import {
   computed,
   effect,
   inject,
+  OnDestroy,
   PLATFORM_ID,
   signal,
   untracked,
@@ -30,35 +31,18 @@ import {
 } from '@pu-stats/models';
 import { PageHeaderComponent } from '../../core/page-header/page-header.component';
 import { UserConfigStore } from '../../core/user-config.store';
+import { GoalsAutoSaveController } from './goals-autosave.controller';
+import { GOAL_SCOPES, WEEKDAYS } from './goals-page.content';
 import {
   buildExerciseOptions,
   clampTargetForEntry,
   clampTargetToOption,
-  cloneGoals,
   findOption,
   makeEntryId,
   normaliseWeekdays,
-  scopesEqual,
   targetFromInput,
   targetLabel,
 } from './goals-page.helpers';
-import {
-  AUTO_SAVE_DEBOUNCE_MS,
-  type GoalScopeDescriptor,
-  SAVED_INDICATOR_MS,
-  type SaveStatus,
-  type WeekdayOption,
-} from './goals-page.models';
-
-const WEEKDAYS: readonly WeekdayOption[] = [
-  { value: 1, label: $localize`:@@goals.weekday.short.mon:Mo` },
-  { value: 2, label: $localize`:@@goals.weekday.short.tue:Di` },
-  { value: 3, label: $localize`:@@goals.weekday.short.wed:Mi` },
-  { value: 4, label: $localize`:@@goals.weekday.short.thu:Do` },
-  { value: 5, label: $localize`:@@goals.weekday.short.fri:Fr` },
-  { value: 6, label: $localize`:@@goals.weekday.short.sat:Sa` },
-  { value: 0, label: $localize`:@@goals.weekday.short.sun:So` },
-];
 
 @Component({
   selector: 'app-goals-page',
@@ -77,348 +61,10 @@ const WEEKDAYS: readonly WeekdayOption[] = [
     PageHeaderComponent,
     RouterLink,
   ],
-  template: `
-    <main class="page-wrap">
-      <app-page-header icon="flag" variant="default">
-        <h1 page-title i18n="@@goalsHeaderTitle">Tagesziele</h1>
-        <p page-subtitle i18n="@@goalsHeaderSubtitle">
-          Verschiedene Übungen pro Tag, pro Woche, pro Monat.
-        </p>
-        <div
-          page-actions
-          class="save-status"
-          role="status"
-          aria-live="polite"
-          [attr.data-status]="saveStatus()"
-          data-testid="goals-save-status"
-        >
-          @switch (saveStatus()) {
-            @case ('saving') {
-              <mat-progress-spinner
-                diameter="16"
-                mode="indeterminate"
-              ></mat-progress-spinner>
-              <span i18n="@@goals.status.saving">Speichert…</span>
-            }
-            @case ('saved') {
-              <mat-icon class="status-icon ok">check_circle</mat-icon>
-              <span i18n="@@goals.status.saved">Gespeichert</span>
-            }
-            @case ('error') {
-              <mat-icon class="status-icon err">error</mat-icon>
-              <span i18n="@@goals.status.error">Fehler beim Speichern</span>
-              <button
-                type="button"
-                mat-stroked-button
-                (click)="retrySave()"
-                i18n="@@goals.status.retry"
-              >
-                Erneut versuchen
-              </button>
-            }
-            @case ('pending') {
-              <mat-icon class="status-icon">edit</mat-icon>
-              <span i18n="@@goals.status.pending"
-                >Ungespeicherte Änderungen…</span
-              >
-            }
-            @default {
-              <mat-icon class="status-icon ok">cloud_done</mat-icon>
-              <span i18n="@@goals.status.synced">Alle Ziele gespeichert</span>
-            }
-          }
-        </div>
-      </app-page-header>
-
-      @if (isGuest()) {
-        <div class="guest-banner">
-          <mat-icon>info</mat-icon>
-          <span i18n="@@guest.banner.text"
-            >Du nutzt die App als Gast. Erstelle ein Konto um alle Funktionen zu
-            nutzen.</span
-          >
-          <a mat-stroked-button routerLink="/register" i18n="@@guest.banner.cta"
-            >Konto erstellen</a
-          >
-        </div>
-      }
-
-      <p class="intro" i18n="@@goals.intro">
-        Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an.
-        Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das
-        jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan.
-      </p>
-
-      @for (scope of scopes; track scope.id) {
-        <mat-card
-          [id]="'goals-' + scope.id"
-          class="section-card"
-          [attr.data-testid]="'goals-section-' + scope.id"
-        >
-          <mat-card-header>
-            <mat-icon mat-card-avatar>{{ scope.icon }}</mat-icon>
-            <mat-card-title>{{ scope.title }}</mat-card-title>
-            <mat-card-subtitle>{{ scope.subtitle }}</mat-card-subtitle>
-          </mat-card-header>
-          <mat-card-content class="stack">
-            @let list = entriesFor(scope.id)();
-            @if (list.length === 0) {
-              <p
-                class="muted empty"
-                [attr.data-testid]="'goals-empty-' + scope.id"
-                i18n="@@goals.section.empty"
-              >
-                Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu.
-              </p>
-            }
-            @for (entry of list; track entry.id) {
-              <div
-                class="goal-row"
-                [attr.data-testid]="'goal-row-' + scope.id + '-' + $index"
-              >
-                <mat-form-field appearance="outline" class="exercise-field">
-                  <mat-label i18n="@@goals.field.exercise">Übung</mat-label>
-                  <mat-select
-                    [value]="entry.exerciseId"
-                    (selectionChange)="
-                      updateExercise(scope.id, entry.id, $event.value)
-                    "
-                  >
-                    @for (opt of exerciseOptions; track opt.id) {
-                      <mat-option [value]="opt.id">{{ opt.label }}</mat-option>
-                    }
-                  </mat-select>
-                </mat-form-field>
-
-                <mat-form-field appearance="outline" class="target-field">
-                  <mat-label>{{ targetLabel(entry) }}</mat-label>
-                  <input
-                    matInput
-                    type="number"
-                    [min]="targetMin(entry)"
-                    [max]="targetMax(entry)"
-                    [value]="entry.target"
-                    [attr.aria-label]="targetLabel(entry)"
-                    (input)="
-                      updateTarget(scope.id, entry.id, asNumber($event, 1))
-                    "
-                  />
-                  <span matTextSuffix>{{ entry.unit }}</span>
-                </mat-form-field>
-
-                <button
-                  type="button"
-                  mat-icon-button
-                  color="warn"
-                  (click)="removeEntry(scope.id, entry.id)"
-                  [attr.aria-label]="removeAriaLabel"
-                  [attr.data-testid]="'goal-remove-' + scope.id + '-' + $index"
-                >
-                  <mat-icon>delete</mat-icon>
-                </button>
-
-                @if (scope.id === 'daily') {
-                  <div class="weekday-row">
-                    <span class="weekday-label" i18n="@@goals.weekdayLabel"
-                      >Aktiv an:</span
-                    >
-                    <mat-button-toggle-group
-                      multiple
-                      hideMultipleSelectionIndicator
-                      [value]="weekdayValue(entry)"
-                      (change)="
-                        updateWeekdays(scope.id, entry.id, $event.value)
-                      "
-                      [attr.aria-label]="weekdayAria"
-                    >
-                      @for (day of weekdays; track day.value) {
-                        <mat-button-toggle [value]="day.value">{{
-                          day.label
-                        }}</mat-button-toggle>
-                      }
-                    </mat-button-toggle-group>
-                    @if (weekdayValue(entry).length === 0) {
-                      <span
-                        class="muted weekday-hint"
-                        i18n="@@goals.weekdayEveryDayHint"
-                        >Keine Auswahl = gilt jeden Tag.</span
-                      >
-                    }
-                  </div>
-                }
-              </div>
-            }
-            <button
-              type="button"
-              mat-stroked-button
-              [disabled]="list.length >= maxPerScope"
-              (click)="addEntry(scope.id)"
-              [attr.data-testid]="'goal-add-' + scope.id"
-            >
-              <mat-icon>add</mat-icon>
-              <span i18n="@@goals.addEntry">Ziel hinzufügen</span>
-            </button>
-            @if (list.length >= maxPerScope) {
-              <p class="muted limit-hint" i18n="@@goals.limitHint">
-                Maximal {{ maxPerScope }} Ziele pro Bereich.
-              </p>
-            }
-          </mat-card-content>
-        </mat-card>
-      }
-
-      <mat-card class="section-card hint-card">
-        <mat-card-header>
-          <mat-icon mat-card-avatar>tips_and_updates</mat-icon>
-          <mat-card-title i18n="@@goals.linkBack.title"
-            >Andere Einstellungen</mat-card-title
-          >
-          <mat-card-subtitle i18n="@@goals.linkBack.subtitle">
-            Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten.
-          </mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-actions>
-          <a
-            mat-stroked-button
-            routerLink="/settings"
-            i18n="@@goals.linkBack.cta"
-          >
-            <mat-icon>tune</mat-icon>
-            Einstellungen öffnen
-          </a>
-        </mat-card-actions>
-      </mat-card>
-    </main>
-  `,
-  styles: `
-    .page-wrap {
-      max-width: 900px;
-      margin: 0 auto;
-      padding: 16px;
-      display: grid;
-      gap: 16px;
-    }
-    .intro {
-      margin: 0;
-      padding: 12px 16px;
-      border-radius: 10px;
-      background: rgba(123, 159, 255, 0.08);
-      border: 1px solid rgba(123, 159, 255, 0.2);
-      line-height: 1.5;
-    }
-    .save-status {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 6px 12px;
-      border-radius: 999px;
-      font-size: 0.85rem;
-      background: rgba(255, 255, 255, 0.06);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      transition:
-        background 200ms ease,
-        border-color 200ms ease;
-    }
-    .save-status[data-status='saving'] {
-      background: rgba(123, 159, 255, 0.16);
-      border-color: rgba(123, 159, 255, 0.4);
-    }
-    .save-status[data-status='saved'] {
-      background: rgba(120, 220, 140, 0.14);
-      border-color: rgba(120, 220, 140, 0.36);
-    }
-    .save-status[data-status='error'] {
-      background: rgba(255, 120, 120, 0.16);
-      border-color: rgba(255, 120, 120, 0.45);
-    }
-    .save-status[data-status='pending'] {
-      background: rgba(255, 200, 100, 0.14);
-      border-color: rgba(255, 200, 100, 0.36);
-    }
-    .save-status .status-icon {
-      font-size: 18px;
-      width: 18px;
-      height: 18px;
-    }
-    .save-status .status-icon.ok {
-      color: #7fd99a;
-    }
-    .save-status .status-icon.err {
-      color: #ff8b8b;
-    }
-    .section-card {
-      padding: 4px 4px 8px;
-    }
-    .section-card mat-card-header {
-      padding-bottom: 8px;
-    }
-    .stack {
-      display: grid;
-      gap: 12px;
-    }
-    .goal-row {
-      display: grid;
-      grid-template-columns: minmax(160px, 1fr) minmax(120px, 180px) auto;
-      gap: 8px;
-      align-items: center;
-      padding: 12px;
-      border-radius: 10px;
-      background: rgba(255, 255, 255, 0.03);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-    }
-    .weekday-row {
-      grid-column: 1 / -1;
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: 8px;
-      margin-top: 4px;
-    }
-    .weekday-label {
-      font-size: 0.85rem;
-      opacity: 0.85;
-    }
-    .weekday-hint {
-      flex-basis: 100%;
-      margin-top: 0;
-    }
-    .exercise-field,
-    .target-field {
-      width: 100%;
-    }
-    .muted {
-      opacity: 0.8;
-      font-size: 0.9rem;
-      margin: 0;
-    }
-    .empty {
-      padding: 12px 4px;
-      font-style: italic;
-    }
-    .limit-hint {
-      margin-top: 4px;
-    }
-    .guest-banner {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      padding: 10px 14px;
-      border-radius: 6px;
-      background: rgba(100, 160, 255, 0.1);
-      border: 1px solid rgba(100, 160, 255, 0.3);
-      flex-wrap: wrap;
-    }
-    @media (max-width: 640px) {
-      .goal-row {
-        grid-template-columns: 1fr auto;
-      }
-      .target-field {
-        grid-column: 1 / 2;
-      }
-    }
-  `,
+  templateUrl: './goals-page.component.html',
+  styleUrl: './goals-page.component.scss',
 })
-export class GoalsPageComponent {
+export class GoalsPageComponent implements OnDestroy {
   private readonly userConfigStore = inject(UserConfigStore);
   private readonly user = inject(UserContextService);
   private readonly platformId = inject(PLATFORM_ID);
@@ -426,48 +72,15 @@ export class GoalsPageComponent {
   readonly isGuest = this.user.isGuest;
   readonly exerciseOptions = buildExerciseOptions();
   readonly weekdays = WEEKDAYS;
+  readonly scopes = GOAL_SCOPES;
   readonly maxPerScope = COMPLEX_GOALS_MAX_PER_SCOPE;
 
   readonly removeAriaLabel = $localize`:@@goals.removeAria:Ziel entfernen`;
   readonly weekdayAria = $localize`:@@goals.weekdayAria:Wochentage`;
 
-  readonly scopes: readonly GoalScopeDescriptor[] = [
-    {
-      id: 'daily',
-      icon: 'today',
-      title: $localize`:@@goals.section.daily.title:Tagesziele`,
-      subtitle: $localize`:@@goals.section.daily.subtitle:Was du an einzelnen Wochentagen schaffen willst.`,
-    },
-    {
-      id: 'weekly',
-      icon: 'date_range',
-      title: $localize`:@@goals.section.weekly.title:Wochenziele`,
-      subtitle: $localize`:@@goals.section.weekly.subtitle:Summen pro Übung über die ganze Woche.`,
-    },
-    {
-      id: 'monthly',
-      icon: 'calendar_month',
-      title: $localize`:@@goals.section.monthly.title:Monatsziele`,
-      subtitle: $localize`:@@goals.section.monthly.subtitle:Größere Ziele über den ganzen Monat verteilt.`,
-    },
-  ];
-
-  readonly saveStatus = signal<SaveStatus>('idle');
-
   private readonly draftDaily = signal<ComplexGoalEntry[]>([]);
   private readonly draftWeekly = signal<ComplexGoalEntry[]>([]);
   private readonly draftMonthly = signal<ComplexGoalEntry[]>([]);
-
-  /**
-   * Last persisted snapshot per scope. While drafts diverge from this we
-   * consider the user to have unsaved edits and skip rehydration from the
-   * Firestore listener so live emissions don't clobber the input.
-   */
-  private readonly lastPersisted = signal<ComplexGoals | null>(null);
-
-  private autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
-  private savedTimer: ReturnType<typeof setTimeout> | null = null;
-  private inFlightSave: Promise<void> | null = null;
 
   private readonly draftSnapshot = computed<ComplexGoals>(() => ({
     daily: this.draftDaily(),
@@ -475,41 +88,32 @@ export class GoalsPageComponent {
     monthly: this.draftMonthly(),
   }));
 
+  private readonly autoSave = new GoalsAutoSaveController({
+    readDraft: () => this.draftSnapshot(),
+    applyDraft: (goals) => this.applyGoalsToDrafts(goals),
+    save: (goals) => this.userConfigStore.saveGoals(goals),
+    isBrowser: isPlatformBrowser(this.platformId),
+  });
+
+  readonly saveStatus = this.autoSave.saveStatus;
+
   constructor() {
-    // Hydrate drafts from store. Skip while dirty or saving so the live
-    // Firestore listener doesn't clobber input mid-edit. Mirrors the
-    // pattern used in SettingsPageComponent.
+    // The realtime listener and the debounce timer both mutate `saveStatus`;
+    // running the side-effect blocks in `untracked` keeps those writes from
+    // looping the effects back on themselves.
     effect(() => {
-      const storeGoals = this.userConfigStore.goals();
-      untracked(() => {
-        const status = this.saveStatus();
-        const baseline = this.lastPersisted();
-        const dirty =
-          baseline !== null && !scopesEqual(this.draftSnapshot(), baseline);
-        if (
-          baseline !== null &&
-          (status === 'pending' || status === 'saving' || dirty)
-        ) {
-          return;
-        }
-        this.applyGoalsToDrafts(storeGoals);
-      });
+      const goals = this.userConfigStore.goals();
+      untracked(() => this.autoSave.hydrate(goals));
     });
 
-    // Auto-save: every draft change schedules a debounced flush.
     effect(() => {
       const draft = this.draftSnapshot();
-      const baseline = this.lastPersisted();
-      untracked(() => {
-        if (baseline === null) return;
-        if (scopesEqual(draft, baseline)) {
-          this.cancelAutoSaveTimer();
-          if (this.saveStatus() === 'pending') this.saveStatus.set('idle');
-          return;
-        }
-        this.scheduleAutoSave();
-      });
+      untracked(() => this.autoSave.onDraftChange(draft));
     });
+  }
+
+  ngOnDestroy(): void {
+    this.autoSave.destroy();
   }
 
   entriesFor(scope: GoalScope) {
@@ -524,7 +128,7 @@ export class GoalsPageComponent {
   }
 
   retrySave(): void {
-    void this.flushSave();
+    this.autoSave.retry();
   }
 
   addEntry(scope: GoalScope): void {
@@ -614,64 +218,8 @@ export class GoalsPageComponent {
   }
 
   private applyGoalsToDrafts(goals: ComplexGoals): void {
-    const snapshot = cloneGoals(goals);
-    this.draftDaily.set(snapshot.daily ?? []);
-    this.draftWeekly.set(snapshot.weekly ?? []);
-    this.draftMonthly.set(snapshot.monthly ?? []);
-    this.lastPersisted.set(cloneGoals(goals));
-    if (this.saveStatus() === 'pending') this.saveStatus.set('idle');
-  }
-
-  private scheduleAutoSave(): void {
-    this.saveStatus.set('pending');
-    this.cancelAutoSaveTimer();
-    if (!isPlatformBrowser(this.platformId)) {
-      return;
-    }
-    this.autoSaveTimer = setTimeout(() => {
-      this.autoSaveTimer = null;
-      void this.flushSave();
-    }, AUTO_SAVE_DEBOUNCE_MS);
-  }
-
-  private cancelAutoSaveTimer(): void {
-    if (this.autoSaveTimer !== null) {
-      clearTimeout(this.autoSaveTimer);
-      this.autoSaveTimer = null;
-    }
-  }
-
-  private async flushSave(): Promise<void> {
-    if (this.inFlightSave) {
-      await this.inFlightSave;
-      const draft = this.draftSnapshot();
-      const baseline = this.lastPersisted();
-      if (baseline && scopesEqual(draft, baseline)) return;
-    }
-    const run = this.performSave();
-    this.inFlightSave = run;
-    try {
-      await run;
-    } finally {
-      if (this.inFlightSave === run) this.inFlightSave = null;
-    }
-  }
-
-  private async performSave(): Promise<void> {
-    this.cancelAutoSaveTimer();
-    const draft = this.draftSnapshot();
-    this.saveStatus.set('saving');
-    try {
-      await this.userConfigStore.saveGoals(draft);
-      this.lastPersisted.set(cloneGoals(draft));
-      this.saveStatus.set('saved');
-      if (this.savedTimer !== null) clearTimeout(this.savedTimer);
-      this.savedTimer = setTimeout(() => {
-        this.savedTimer = null;
-        if (this.saveStatus() === 'saved') this.saveStatus.set('idle');
-      }, SAVED_INDICATOR_MS);
-    } catch {
-      this.saveStatus.set('error');
-    }
+    this.draftDaily.set(goals.daily ?? []);
+    this.draftWeekly.set(goals.weekly ?? []);
+    this.draftMonthly.set(goals.monthly ?? []);
   }
 }

--- a/web/src/app/goals/shell/goals-page.content.ts
+++ b/web/src/app/goals/shell/goals-page.content.ts
@@ -1,0 +1,32 @@
+import type { GoalScopeDescriptor, WeekdayOption } from './goals-page.models';
+
+export const WEEKDAYS: readonly WeekdayOption[] = [
+  { value: 1, label: $localize`:@@goals.weekday.short.mon:Mo` },
+  { value: 2, label: $localize`:@@goals.weekday.short.tue:Di` },
+  { value: 3, label: $localize`:@@goals.weekday.short.wed:Mi` },
+  { value: 4, label: $localize`:@@goals.weekday.short.thu:Do` },
+  { value: 5, label: $localize`:@@goals.weekday.short.fri:Fr` },
+  { value: 6, label: $localize`:@@goals.weekday.short.sat:Sa` },
+  { value: 0, label: $localize`:@@goals.weekday.short.sun:So` },
+];
+
+export const GOAL_SCOPES: readonly GoalScopeDescriptor[] = [
+  {
+    id: 'daily',
+    icon: 'today',
+    title: $localize`:@@goals.section.daily.title:Tagesziele`,
+    subtitle: $localize`:@@goals.section.daily.subtitle:Was du an einzelnen Wochentagen schaffen willst.`,
+  },
+  {
+    id: 'weekly',
+    icon: 'date_range',
+    title: $localize`:@@goals.section.weekly.title:Wochenziele`,
+    subtitle: $localize`:@@goals.section.weekly.subtitle:Summen pro Übung über die ganze Woche.`,
+  },
+  {
+    id: 'monthly',
+    icon: 'calendar_month',
+    title: $localize`:@@goals.section.monthly.title:Monatsziele`,
+    subtitle: $localize`:@@goals.section.monthly.subtitle:Größere Ziele über den ganzen Monat verteilt.`,
+  },
+];

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4336,65 +4336,9 @@
         <source>Dunkles Design aktiv. Klicken zum Wechseln</source>
       </segment>
     </unit>
-    <unit id="goals.weekday.short.mon">
-      <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:54</note>
-      </notes>
-      <segment>
-        <source>Mo</source>
-      </segment>
-    </unit>
-    <unit id="goals.weekday.short.tue">
-      <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:55</note>
-      </notes>
-      <segment>
-        <source>Di</source>
-      </segment>
-    </unit>
-    <unit id="goals.weekday.short.wed">
-      <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:56</note>
-      </notes>
-      <segment>
-        <source>Mi</source>
-      </segment>
-    </unit>
-    <unit id="goals.weekday.short.thu">
-      <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:57</note>
-      </notes>
-      <segment>
-        <source>Do</source>
-      </segment>
-    </unit>
-    <unit id="goals.weekday.short.fri">
-      <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:58</note>
-      </notes>
-      <segment>
-        <source>Fr</source>
-      </segment>
-    </unit>
-    <unit id="goals.weekday.short.sat">
-      <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:59</note>
-      </notes>
-      <segment>
-        <source>Sa</source>
-      </segment>
-    </unit>
-    <unit id="goals.weekday.short.sun">
-      <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:60</note>
-      </notes>
-      <segment>
-        <source>So</source>
-      </segment>
-    </unit>
     <unit id="goalsHeaderTitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:83,84</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:3,4</note>
       </notes>
       <segment>
         <source>Tagesziele</source>
@@ -4402,7 +4346,7 @@
     </unit>
     <unit id="goalsHeaderSubtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:85,87</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:5,8</note>
       </notes>
       <segment>
         <source> Verschiedene Übungen pro Tag, pro Woche, pro Monat. </source>
@@ -4410,7 +4354,7 @@
     </unit>
     <unit id="goals.status.saving">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:101,103</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:21,23</note>
       </notes>
       <segment>
         <source>Speichert…</source>
@@ -4418,7 +4362,7 @@
     </unit>
     <unit id="goals.status.saved">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:105,107</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:25,27</note>
       </notes>
       <segment>
         <source>Gespeichert</source>
@@ -4426,7 +4370,7 @@
     </unit>
     <unit id="goals.status.error">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:109,111</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:29,31</note>
       </notes>
       <segment>
         <source>Fehler beim Speichern</source>
@@ -4434,7 +4378,7 @@
     </unit>
     <unit id="goals.status.retry">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:116,117</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:36,38</note>
       </notes>
       <segment>
         <source> Erneut versuchen </source>
@@ -4442,7 +4386,7 @@
     </unit>
     <unit id="goals.status.pending">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:122,124</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:41,43</note>
       </notes>
       <segment>
         <source>Ungespeicherte Änderungen…</source>
@@ -4450,7 +4394,7 @@
     </unit>
     <unit id="goals.status.synced">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:127,130</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:45,48</note>
       </notes>
       <segment>
         <source>Alle Ziele gespeichert</source>
@@ -4458,7 +4402,7 @@
     </unit>
     <unit id="guest.banner.text">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:137,140</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:55,58</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.html:59,62</note>
       </notes>
       <segment>
@@ -4467,7 +4411,7 @@
     </unit>
     <unit id="guest.banner.cta">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:141,144</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:59,64</note>
         <note category="location">web/src/app/stats/shell/settings-page.component.html:63,68</note>
       </notes>
       <segment>
@@ -4476,7 +4420,7 @@
     </unit>
     <unit id="goals.intro">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:147,150</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:65,70</note>
       </notes>
       <segment>
         <source> Lege pro Tag, Woche und Monat eine Liste von Übungen mit Zielwerten an. Bei Tageszielen kannst du außerdem festlegen, an welchen Wochentagen das jeweilige Ziel gilt — perfekt für einen Push/Pull/Beine-Splitplan. </source>
@@ -4484,7 +4428,7 @@
     </unit>
     <unit id="goals.section.empty">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:171,172</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:89,91</note>
       </notes>
       <segment>
         <source> Noch keine Ziele angelegt. Füge unten dein erstes Ziel hinzu. </source>
@@ -4492,7 +4436,7 @@
     </unit>
     <unit id="goals.field.exercise">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:180,181</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:98,99</note>
       </notes>
       <segment>
         <source>Übung</source>
@@ -4500,7 +4444,7 @@
     </unit>
     <unit id="goals.weekdayLabel">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:223,225</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:139,141</note>
       </notes>
       <segment>
         <source>Aktiv an:</source>
@@ -4508,7 +4452,7 @@
     </unit>
     <unit id="goals.weekdayEveryDayHint">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:244,246</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:158,160</note>
       </notes>
       <segment>
         <source>Keine Auswahl = gilt jeden Tag.</source>
@@ -4516,7 +4460,7 @@
     </unit>
     <unit id="goals.addEntry">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:259,260</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:173,175</note>
       </notes>
       <segment>
         <source>Ziel hinzufügen</source>
@@ -4524,7 +4468,7 @@
     </unit>
     <unit id="goals.limitHint">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:263,264</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:177,179</note>
       </notes>
       <segment>
         <source> Maximal <ph id="0" equiv="INTERPOLATION" disp="{{ maxPerScope }}"/> Ziele pro Bereich. </source>
@@ -4532,7 +4476,7 @@
     </unit>
     <unit id="goals.linkBack.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:274,276</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:188,190</note>
       </notes>
       <segment>
         <source>Andere Einstellungen</source>
@@ -4540,7 +4484,7 @@
     </unit>
     <unit id="goals.linkBack.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:277,278</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:191,193</note>
       </notes>
       <segment>
         <source> Profil, Sichtbarkeit, Erinnerungen und Werbung verwalten. </source>
@@ -4548,7 +4492,7 @@
     </unit>
     <unit id="goals.linkBack.cta">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:286,288</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.html:196,199</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">tune</pc> Einstellungen öffnen </source>
@@ -4556,7 +4500,7 @@
     </unit>
     <unit id="goals.removeAria">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:431</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:78</note>
       </notes>
       <segment>
         <source>Ziel entfernen</source>
@@ -4564,15 +4508,71 @@
     </unit>
     <unit id="goals.weekdayAria">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:432</note>
+        <note category="location">web/src/app/goals/shell/goals-page.component.ts:79</note>
       </notes>
       <segment>
         <source>Wochentage</source>
       </segment>
     </unit>
+    <unit id="goals.weekday.short.mon">
+      <notes>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:4</note>
+      </notes>
+      <segment>
+        <source>Mo</source>
+      </segment>
+    </unit>
+    <unit id="goals.weekday.short.tue">
+      <notes>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:5</note>
+      </notes>
+      <segment>
+        <source>Di</source>
+      </segment>
+    </unit>
+    <unit id="goals.weekday.short.wed">
+      <notes>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:6</note>
+      </notes>
+      <segment>
+        <source>Mi</source>
+      </segment>
+    </unit>
+    <unit id="goals.weekday.short.thu">
+      <notes>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:7</note>
+      </notes>
+      <segment>
+        <source>Do</source>
+      </segment>
+    </unit>
+    <unit id="goals.weekday.short.fri">
+      <notes>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:8</note>
+      </notes>
+      <segment>
+        <source>Fr</source>
+      </segment>
+    </unit>
+    <unit id="goals.weekday.short.sat">
+      <notes>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:9</note>
+      </notes>
+      <segment>
+        <source>Sa</source>
+      </segment>
+    </unit>
+    <unit id="goals.weekday.short.sun">
+      <notes>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:10</note>
+      </notes>
+      <segment>
+        <source>So</source>
+      </segment>
+    </unit>
     <unit id="goals.section.daily.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:438</note>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:17</note>
       </notes>
       <segment>
         <source>Tagesziele</source>
@@ -4580,7 +4580,7 @@
     </unit>
     <unit id="goals.section.daily.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:439</note>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:18</note>
       </notes>
       <segment>
         <source>Was du an einzelnen Wochentagen schaffen willst.</source>
@@ -4588,7 +4588,7 @@
     </unit>
     <unit id="goals.section.weekly.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:444</note>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:23</note>
       </notes>
       <segment>
         <source>Wochenziele</source>
@@ -4596,7 +4596,7 @@
     </unit>
     <unit id="goals.section.weekly.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:445</note>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:24</note>
       </notes>
       <segment>
         <source>Summen pro Übung über die ganze Woche.</source>
@@ -4604,7 +4604,7 @@
     </unit>
     <unit id="goals.section.monthly.title">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:450</note>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:29</note>
       </notes>
       <segment>
         <source>Monatsziele</source>
@@ -4612,7 +4612,7 @@
     </unit>
     <unit id="goals.section.monthly.subtitle">
       <notes>
-        <note category="location">web/src/app/goals/shell/goals-page.component.ts:451</note>
+        <note category="location">web/src/app/goals/shell/goals-page.content.ts:30</note>
       </notes>
       <segment>
         <source>Größere Ziele über den ganzen Monat verteilt.</source>
@@ -9114,6 +9114,7 @@
     <unit id="settings.delete.confirmPlaceholder">
       <notes>
         <note category="location">web/src/app/stats/shell/settings-page.component.html:422,423</note>
+        <note category="location">web/src/app/stats/shell/settings-page.component.ts:103</note>
       </notes>
       <segment>
         <source>löschen</source>


### PR DESCRIPTION
## Summary

This branch carries two sets of changes:

### Goals-page refactor
- Extract debounced auto-save logic into `GoalsAutoSaveController` with dedicated unit tests (`goals-autosave.controller.ts` / `.spec.ts`)
- Externalize template (`goals-page.component.html`) and styles (`goals-page.component.scss`) from the inline component
- Move static weekday-label and scope-descriptor catalogs into `goals-page.content.ts`
- Slim down `goals-page.component.ts` from ~480 → ~30 lines

### i18n refresh
- Regenerated `web/src/locale/messages.xlf` (auto-generated by `extract-i18n`) so `location` notes point at the new source files after the goals-page split
- Translation gap detector reported **0 gaps** across all locales (en, fr, es, it, nl, el, la, no, zh) — no translation work needed

## Translation routine result

```
Detected 0 gap(s) — xliff:0 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, la, no, zh
```

## CI note

The initial e2e run failed on `landing-page.spec.ts` and `landing-auth-state.spec.ts` in under 2 seconds — Nx Cloud Self-Healing CI diagnosed this as an **environment/infrastructure issue unrelated to code changes**. Re-triggered by this push.