### PR TITLE
refactor(web): split training-plan.store actions into sibling modules (#456)

### DIFF
--- a/web/src/app/training-plans/training-plan-store.actions.ts
+++ b/web/src/app/training-plans/training-plan-store.actions.ts
@@ -1,0 +1,242 @@
+import { Injector } from '@angular/core';
+import type { WritableSignal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { UserContextService } from '@pu-auth/auth';
+import {
+  ExerciseFirestoreService,
+  UserTrainingPlanApiService,
+} from '@pu-stats/data-access';
+import { LiveDataStore } from '@pu-stats/data-access-state';
+import {
+  planDayByIndex,
+  TrainingPlan,
+  TrainingPlanDay,
+  trainingPlanDayExerciseId,
+  TRAINING_PLANS,
+  UserTrainingPlan,
+} from '@pu-stats/models';
+import { appendLocalOffset } from '@pu-stats/date';
+import {
+  addToSet,
+  planDayDate,
+  planDayRepsPayload,
+  removeFromSet,
+  sumRepsLoggedOn,
+} from './training-plan-store.math';
+import { isRepsMeasuredPlanDay } from './training-plan-store.selectors';
+
+/**
+ * Result of `logPlanDay` / `logTodayPlanDay`. Lets callers tailor
+ * UI feedback (snackbar message) to what actually happened: a
+ * fresh write, an idempotent skip, or a rejected request.
+ */
+export type LogPlanDayResult =
+  | 'logged' // pushup entry created + day marked done
+  | 'already-logged' // day was already covered by existing reps; only marked
+  | 'noop' // pre-conditions failed (no plan, rest day, future day, …)
+  | 'in-flight' // a concurrent call for the same day is still running
+  | 'not-ready'; // LiveDataStore hasn't finished its first sync yet
+
+/**
+ * Subset of the `TrainingPlanStore` instance the action functions read.
+ * Declared structurally so the actions live in their own module while the
+ * store stays a thin orchestrator of one-line wrappers. The full store
+ * (props + computed + the in-flight-lock signal) satisfies this shape.
+ */
+export interface TrainingPlanActionsStore {
+  _api: UserTrainingPlanApiService;
+  _findPlanById: (planId: string) => TrainingPlan | null;
+  _injector: Injector;
+  _live: InstanceType<typeof LiveDataStore>;
+  _user: UserContextService;
+  _isBrowser: boolean;
+  _writingDays: WritableSignal<ReadonlySet<number>>;
+  activeResource: { reload: () => void };
+  activePlan: () => UserTrainingPlan | null;
+  activeCatalog: () => TrainingPlan | null;
+  currentDayIndex: () => number | null;
+  todayDay: () => TrainingPlanDay | null;
+}
+
+type Store = TrainingPlanActionsStore;
+
+/**
+ * Calendar date (`YYYY-MM-DD`) for a 1-based plan day. Falls back to today's
+ * Berlin date if the plan is missing or the start date can't be parsed
+ * (defensive — caller already checks).
+ */
+export function planDayDateFor(store: Store, dayIndex: number): string {
+  return planDayDate(store.activePlan()?.startDate, dayIndex);
+}
+
+/** Sum of reps already logged on a given local date for one exercise.
+ *  Reads the `exerciseEntries` mirror filtered by id — post-cutover
+ *  pushups live there too (`exerciseId:'pushup'`), so no special case. */
+export function repsLoggedOn(
+  store: Store,
+  dateIso: string,
+  exerciseId: string
+): number {
+  return sumRepsLoggedOn(store._live.exerciseEntries(), dateIso, exerciseId);
+}
+
+/** Lazily resolve the Firestore-bound exercise API. Returns null when no
+ *  provider is registered (e.g. a test harness without `Firestore`). */
+export function resolveExerciseApi(
+  store: Store
+): ExerciseFirestoreService | null {
+  return store._injector.get(ExerciseFirestoreService, null);
+}
+
+/** Acquire an in-flight lock for a day. Returns false if already held. */
+export function acquireWriteLock(store: Store, dayIndex: number): boolean {
+  const set = store._writingDays();
+  if (set.has(dayIndex)) return false;
+  store._writingDays.set(addToSet(set, dayIndex));
+  return true;
+}
+
+export function releaseWriteLock(store: Store, dayIndex: number): void {
+  const set = store._writingDays();
+  if (!set.has(dayIndex)) return;
+  store._writingDays.set(removeFromSet(set, dayIndex));
+}
+
+/** All curated plans (re-exposed for component templates). */
+export function allPlans(): ReadonlyArray<TrainingPlan> {
+  return TRAINING_PLANS;
+}
+
+/** Mark today's plan day as done. Idempotent. No-op on rest days. */
+export async function markTodayDone(store: Store): Promise<void> {
+  const a = store.activePlan();
+  const idx = store.currentDayIndex();
+  const day = store.todayDay();
+  if (!a || idx === null || !day) return;
+  // Rest days are not part of the completion set — silently skip
+  // so a generic "mark today done" callback can't skew progress.
+  if (day.kind === 'rest') return;
+  if (a.completedDays.includes(idx)) return;
+  const userId = store._user.userIdSafe();
+  // `arrayUnion` so concurrent writes to *different* day indexes
+  // (e.g. auto-mark today + manual mark for yesterday in another
+  // tab) merge correctly server-side instead of clobbering.
+  await firstValueFrom(store._api.addCompletedDay(userId, idx));
+  store.activeResource.reload();
+}
+
+/**
+ * Log today's plan-prescribed reps and mark today as done. Thin
+ * wrapper around `logPlanDay(currentDayIndex)`.
+ */
+export async function logTodayPlanDay(store: Store): Promise<LogPlanDayResult> {
+  const idx = store.currentDayIndex();
+  if (idx === null) return 'noop';
+  return logPlanDay(store, idx);
+}
+
+/**
+ * Mark a specific day as done WITHOUT creating a pushup entry.
+ * Use this for "I already logged elsewhere" flows. For the
+ * common case (mark done + log the plan-prescribed reps) call
+ * `logPlanDay()` instead.
+ */
+export async function markDayDone(
+  store: Store,
+  dayIndex: number
+): Promise<void> {
+  const a = store.activePlan();
+  const c = store.activeCatalog();
+  if (!a || !c) return;
+  // Reject out-of-range or rest-day indexes — those should never
+  // count toward completion progress.
+  const day = planDayByIndex(c, dayIndex);
+  if (!day || day.kind === 'rest') return;
+  if (a.completedDays.includes(dayIndex)) return;
+  const userId = store._user.userIdSafe();
+  await firstValueFrom(store._api.addCompletedDay(userId, dayIndex));
+  store.activeResource.reload();
+}
+
+/**
+ * Log the plan-prescribed reps for a day AND mark the day as
+ * done. Idempotent: skips the pushup write if the calendar day
+ * is already covered by existing entries.
+ *
+ * The pushup entry is timestamped at noon (12:00) on the plan
+ * day's calendar date so a backfill for an earlier day still
+ * lands in the correct daily bucket.
+ *
+ * Guards (in order):
+ * - Plan must be active (status === 'active') and resolvable.
+ * - Day must be a non-rest, non-zero-target day in the plan.
+ * - Day must not be in the future relative to today.
+ * - `LiveDataStore` must have synced at least once, otherwise
+ *   `repsLoggedOn` returns 0 and we'd duplicate-write existing
+ *   entries on day-2 reload.
+ * - No concurrent call for the same day index (in-flight lock).
+ */
+export async function logPlanDay(
+  store: Store,
+  dayIndex: number
+): Promise<LogPlanDayResult> {
+  const a = store.activePlan();
+  const c = store.activeCatalog();
+  if (!a || !c || a.status !== 'active') return 'noop';
+  const day = planDayByIndex(c, dayIndex);
+  if (!day || day.kind === 'rest' || day.targetReps <= 0) return 'noop';
+  // All plan days route through exerciseEntries. Only reps-measured catalog
+  // exercises map onto a plan day's targetReps/sets. A time- or distance-
+  // measured day can't be honored with a reps payload, and createEntry needs
+  // a resolved user plus the lazily-resolved Firestore-backed exercise API —
+  // fail closed on any of these.
+  if (!isRepsMeasuredPlanDay(day)) return 'noop';
+  const exerciseId = trainingPlanDayExerciseId(day);
+  const exerciseApi = resolveExerciseApi(store);
+  if (!store._user.userIdSafe() || !exerciseApi) return 'noop';
+
+  const currentIdx = store.currentDayIndex();
+  if (currentIdx === null || dayIndex > currentIdx) return 'noop';
+
+  // The `exerciseEntries` mirror is empty until its Firestore listener
+  // has emitted at least once. Don't make a write decision off pre-sync
+  // data — it would top-up a day that's already covered as soon as the
+  // listener catches up. Post-cutover pushups live in that same mirror,
+  // so every exercise gates on `exerciseEntriesLoaded`.
+  if (store._isBrowser && !store._live.exerciseEntriesLoaded())
+    return 'not-ready';
+
+  if (!acquireWriteLock(store, dayIndex)) return 'in-flight';
+
+  try {
+    const dateIso = planDayDateFor(store, dayIndex);
+    const alreadyLogged = repsLoggedOn(store, dateIso, exerciseId);
+    const payload = planDayRepsPayload(day, alreadyLogged);
+    let result: LogPlanDayResult;
+
+    if (payload) {
+      const timestamp = appendLocalOffset(`${dateIso}T12:00`);
+      await firstValueFrom(
+        exerciseApi.createEntry(store._user.userIdSafe(), {
+          exerciseId,
+          timestamp,
+          reps: payload.reps,
+          sets: payload.sets,
+          source: 'plan',
+        })
+      );
+      result = 'logged';
+    } else {
+      result = 'already-logged';
+    }
+
+    if (!a.completedDays.includes(dayIndex)) {
+      const userId = store._user.userIdSafe();
+      await firstValueFrom(store._api.addCompletedDay(userId, dayIndex));
+    }
+    store.activeResource.reload();
+    return result;
+  } finally {
+    releaseWriteLock(store, dayIndex);
+  }
+}

--- a/web/src/app/training-plans/training-plan-store.hooks.ts
+++ b/web/src/app/training-plans/training-plan-store.hooks.ts
@@ -1,0 +1,85 @@
+import { DestroyRef, effect, inject } from '@angular/core';
+import type { WritableSignal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { trainingPlanDayExerciseId } from '@pu-stats/models';
+import { toBerlinIsoDate } from '@pu-stats/date';
+import { isRepsMeasuredPlanDay } from './training-plan-store.selectors';
+import {
+  acquireWriteLock,
+  releaseWriteLock,
+  repsLoggedOn,
+  type TrainingPlanActionsStore,
+} from './training-plan-store.actions';
+
+type HooksStore = TrainingPlanActionsStore & {
+  _dayTick: WritableSignal<number>;
+};
+
+/**
+ * Registers the store's browser-only init side effects. Must be called from a
+ * `withHooks.onInit` body so the `inject(DestroyRef)` and `effect()` calls run
+ * inside the store's injection context.
+ *
+ * 1. A coarse one-minute day tick so the Berlin-date-based `currentDayIndex`
+ *    rolls over within ~60 s of midnight even without Firestore activity.
+ * 2. An auto-mark effect that flips today's `completedDays` flag (no pushup
+ *    write) once reps logged elsewhere reach the plan target.
+ */
+export function registerTrainingPlanHooks(store: HooksStore): void {
+  if (!store._isBrowser) return;
+  const handle = setInterval(() => store._dayTick.update((n) => n + 1), 60_000);
+  inject(DestroyRef).onDestroy(() => clearInterval(handle));
+
+  // Auto-mark today as done when reps logged via Quick-Add / dialog reach the
+  // plan target. Read-only — never creates a pushup entry, just flips the
+  // `completedDays` flag so users who track in their own way still see plan
+  // progress.
+  effect(() => {
+    const a = store.activePlan();
+    const idx = store.currentDayIndex();
+    const day = store.todayDay();
+    if (!a || !day || idx === null) return;
+    // Skip on abandoned/completed plans — the doc still exists, but writes
+    // against it are noise (plus they'd drift the status-based banner state).
+    if (a.status !== 'active') return;
+    if (day.kind === 'rest' || day.targetReps <= 0) return;
+    // Matching logPlanDay: only reps-measured days can be honored off the
+    // exerciseEntries reps mirror. Auto-mark only flips the done flag (no
+    // write), so the resolved-user check isn't needed here.
+    if (!isRepsMeasuredPlanDay(day)) return;
+    const exerciseId = trainingPlanDayExerciseId(day);
+    if (a.completedDays.includes(idx)) return;
+    // Same readiness guard as `logPlanDay` — without this, a pre-sync mirror
+    // could appear to satisfy the target on stale state and trigger a false
+    // auto-mark. Post-cutover pushups live in the `exerciseEntries` feed too,
+    // so every exercise gates on `exerciseEntriesLoaded`.
+    if (!store._live.exerciseEntriesLoaded()) return;
+    // The same in-flight lock guards manual logPlanDay calls, so a fast
+    // Quick-Add + auto-mark can't double-write.
+    if (store._writingDays().has(idx)) return;
+    // Reps come from the `exerciseEntries` mirror (real-time Firestore), so
+    // manual logs propagate here without polling.
+    const todayIso = toBerlinIsoDate(new Date());
+    // Establish a tick dependency so this re-runs at midnight.
+    store._dayTick();
+    const todayReps = repsLoggedOn(store, todayIso, exerciseId);
+    if (todayReps >= day.targetReps) {
+      if (!acquireWriteLock(store, idx)) return;
+      const userId = store._user.userIdSafe();
+      // Use the atomic `arrayUnion` write so a concurrent manual mark for a
+      // different day index (e.g. from another tab) doesn't get clobbered.
+      // `effect()` is synchronous, so handle errors explicitly — an unhandled
+      // rejection here would surface in the browser console without context.
+      firstValueFrom(store._api.addCompletedDay(userId, idx))
+        .then(() => store.activeResource.reload())
+        .catch((error) => {
+          console.error('Failed to auto-mark training plan day as completed.', {
+            error,
+            planId: a.planId,
+            dayIndex: idx,
+          });
+        })
+        .finally(() => releaseWriteLock(store, idx));
+    }
+  });
+}

--- a/web/src/app/training-plans/training-plan-store.lifecycle.ts
+++ b/web/src/app/training-plans/training-plan-store.lifecycle.ts
@@ -1,0 +1,131 @@
+import { firstValueFrom } from 'rxjs';
+import { planDayByIndex, startDateForTargetDay } from '@pu-stats/models';
+import { toBerlinIsoDate } from '@pu-stats/date';
+import { nonRestDaysBeforeTarget } from './training-plan-store.math';
+import type { TrainingPlanActionsStore } from './training-plan-store.actions';
+
+type Store = TrainingPlanActionsStore;
+
+/**
+ * Activate a plan starting today (Berlin date). Overwrites any
+ * existing active plan — that is intentional: only one active
+ * plan at a time, and the user has confirmed the switch.
+ */
+export async function start(store: Store, planId: string): Promise<void> {
+  const userId = store._user.userIdSafe();
+  if (!userId) return;
+  const plan = store._findPlanById(planId);
+  if (!plan) return;
+  await firstValueFrom(
+    store._api.setPlan(userId, {
+      planId: plan.id,
+      startDate: toBerlinIsoDate(new Date()),
+      status: 'active',
+      completedDays: [],
+      skippedDays: [],
+    })
+  );
+  store.activeResource.reload();
+}
+
+/** Undo a day completion. */
+export async function unmarkDayDone(
+  store: Store,
+  dayIndex: number
+): Promise<void> {
+  const a = store.activePlan();
+  if (!a) return;
+  if (!a.completedDays.includes(dayIndex)) return;
+  const userId = store._user.userIdSafe();
+  await firstValueFrom(store._api.removeCompletedDay(userId, dayIndex));
+  store.activeResource.reload();
+}
+
+/**
+ * Mark a plan day as skipped (user chose not to do it). Skipped
+ * days are excluded from the completion percent denominator and
+ * the `isPlanCompleted` required-set.
+ *
+ * Idempotent on the skip side. Mutually exclusive with
+ * `completedDays`: the API atomically removes the same index from
+ * `completedDays` so a day can never be in both arrays.
+ *
+ * No-op for rest days (already excluded from progress) and for
+ * out-of-range indexes.
+ */
+export async function skipDay(store: Store, dayIndex: number): Promise<void> {
+  const a = store.activePlan();
+  const c = store.activeCatalog();
+  if (!a || !c) return;
+  const day = planDayByIndex(c, dayIndex);
+  if (!day || day.kind === 'rest') return;
+  if ((a.skippedDays ?? []).includes(dayIndex)) return;
+  const userId = store._user.userIdSafe();
+  await firstValueFrom(store._api.addSkippedDay(userId, dayIndex));
+  store.activeResource.reload();
+}
+
+/** Undo a skip. */
+export async function unskipDay(store: Store, dayIndex: number): Promise<void> {
+  const a = store.activePlan();
+  if (!a) return;
+  if (!(a.skippedDays ?? []).includes(dayIndex)) return;
+  const userId = store._user.userIdSafe();
+  await firstValueFrom(store._api.removeSkippedDay(userId, dayIndex));
+  store.activeResource.reload();
+}
+
+/**
+ * Re-anchor the plan so today maps to `targetDayIndex`. Adjusts
+ * `startDate` accordingly and bulk-marks all earlier non-rest,
+ * non-completed days as skipped so progress reflects "I jumped
+ * over these" rather than counting them as still-pending.
+ *
+ * - `targetDayIndex` must be in `[1, totalDays]` — otherwise no-op.
+ * - Days already in `completedDays` stay completed even if they're
+ *   now in the future relative to the new `startDate`.
+ * - Days that were previously skipped but are now `>= targetDay`
+ *   are removed from `skippedDays` so re-doing them is possible.
+ *
+ * Delegates to `_api.jumpToDay`, which runs a Firestore transaction.
+ * Recomputing `skippedDays` from the local snapshot and writing it via
+ * `setDoc({merge:true})` would silently drop concurrent
+ * `arrayUnion`/`arrayRemove` skip writes from another tab/device, since
+ * `merge: true` does not field-merge arrays.
+ */
+export async function jumpToDay(
+  store: Store,
+  targetDayIndex: number
+): Promise<void> {
+  const a = store.activePlan();
+  const c = store.activeCatalog();
+  if (!a || !c || a.status !== 'active') return;
+  if (targetDayIndex < 1 || targetDayIndex > c.totalDays) return;
+
+  const today = toBerlinIsoDate(new Date());
+  const newStartDate = startDateForTargetDay(
+    c.totalDays,
+    targetDayIndex,
+    today
+  );
+  if (!newStartDate) return;
+
+  const userId = store._user.userIdSafe();
+  await firstValueFrom(
+    store._api.jumpToDay(userId, {
+      newStartDate,
+      targetDayIndex,
+      nonRestDaysBeforeTarget: nonRestDaysBeforeTarget(c, targetDayIndex),
+    })
+  );
+  store.activeResource.reload();
+}
+
+/** Abandon the current plan (status → abandoned). */
+export async function abandon(store: Store): Promise<void> {
+  const a = store.activePlan();
+  if (!a) return;
+  const userId = store._user.userIdSafe();
+  await firstValueFrom(store._api.updatePlan(userId, { status: 'abandoned' }));
+  store.activeResource.reload();
+}

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -1,7 +1,5 @@
 import {
   computed,
-  DestroyRef,
-  effect,
   inject,
   Injector,
   InjectionToken,
@@ -18,52 +16,30 @@ import {
   withProps,
 } from '@ngrx/signals';
 import { UserContextService } from '@pu-auth/auth';
-import {
-  ExerciseFirestoreService,
-  UserTrainingPlanApiService,
-} from '@pu-stats/data-access';
+import { UserTrainingPlanApiService } from '@pu-stats/data-access';
 import { LiveDataStore } from '@pu-stats/data-access-state';
 import {
   currentPlanDayIndex,
   findPlanById,
   isPlanCompleted,
   planDayByIndex,
-  startDateForTargetDay,
   TrainingPlan,
   TrainingPlanDay,
-  trainingPlanDayExerciseId,
-  TRAINING_PLANS,
   UserTrainingPlan,
 } from '@pu-stats/models';
-import { appendLocalOffset, toBerlinIsoDate } from '@pu-stats/date';
-import { firstValueFrom, of } from 'rxjs';
-import {
-  addToSet,
-  computeCompletionPercent,
-  nonRestDaysBeforeTarget,
-  planDayDate,
-  planDayRepsPayload,
-  removeFromSet,
-  sumRepsLoggedOn,
-} from './training-plan-store.math';
+import { toBerlinIsoDate } from '@pu-stats/date';
+import { of } from 'rxjs';
+import { computeCompletionPercent } from './training-plan-store.math';
 import {
   dayTarget,
   isDayDone,
   isDaySkipped,
-  isRepsMeasuredPlanDay,
 } from './training-plan-store.selectors';
+import * as actions from './training-plan-store.actions';
+import * as lifecycle from './training-plan-store.lifecycle';
+import { registerTrainingPlanHooks } from './training-plan-store.hooks';
 
-/**
- * Result of `logPlanDay` / `logTodayPlanDay`. Lets callers tailor
- * UI feedback (snackbar message) to what actually happened: a
- * fresh write, an idempotent skip, or a rejected request.
- */
-export type LogPlanDayResult =
-  | 'logged' // pushup entry created + day marked done
-  | 'already-logged' // day was already covered by existing reps; only marked
-  | 'noop' // pre-conditions failed (no plan, rest day, future day, …)
-  | 'in-flight' // a concurrent call for the same day is still running
-  | 'not-ready'; // LiveDataStore hasn't finished its first sync yet
+export type { LogPlanDayResult } from './training-plan-store.actions';
 
 /**
  * Seam for resolving a curated plan by id so tests can drive a plan the
@@ -229,374 +205,23 @@ export const TrainingPlanStore = signalStore(
     };
   }),
   withMethods((store) => ({
-    /**
-     * Calendar date (`YYYY-MM-DD`) for a 1-based plan day. Falls
-     * back to today's Berlin date if the plan is missing or the
-     * start date can't be parsed (defensive — caller already
-     * checks).
-     */
-    _planDayDate(dayIndex: number): string {
-      return planDayDate(store.activePlan()?.startDate, dayIndex);
-    },
-
-    /** Sum of reps already logged on a given local date for one exercise.
-     *  Reads the `exerciseEntries` mirror filtered by id — post-cutover
-     *  pushups live there too (`exerciseId:'pushup'`), so no special case. */
-    _repsLoggedOn(dateIso: string, exerciseId: string): number {
-      return sumRepsLoggedOn(
-        store._live.exerciseEntries(),
-        dateIso,
-        exerciseId
-      );
-    },
-
-    /** Lazily resolve the Firestore-bound exercise API. Returns null when no
-     *  provider is registered (e.g. a test harness without `Firestore`). */
-    _resolveExerciseApi(): ExerciseFirestoreService | null {
-      return store._injector.get(ExerciseFirestoreService, null);
-    },
-
-    /** Acquire an in-flight lock for a day. Returns false if already held. */
-    _acquireWriteLock(dayIndex: number): boolean {
-      const set = store._writingDays();
-      if (set.has(dayIndex)) return false;
-      store._writingDays.set(addToSet(set, dayIndex));
-      return true;
-    },
-
-    _releaseWriteLock(dayIndex: number): void {
-      const set = store._writingDays();
-      if (!set.has(dayIndex)) return;
-      store._writingDays.set(removeFromSet(set, dayIndex));
-    },
-  })),
-  withMethods((store) => ({
     /** All curated plans (re-exposed for component templates). */
-    allPlans(): ReadonlyArray<TrainingPlan> {
-      return TRAINING_PLANS;
-    },
-
-    /**
-     * Activate a plan starting today (Berlin date). Overwrites any
-     * existing active plan — that is intentional: only one active
-     * plan at a time, and the user has confirmed the switch.
-     */
-    async start(planId: string): Promise<void> {
-      const userId = store._user.userIdSafe();
-      if (!userId) return;
-      const plan = store._findPlanById(planId);
-      if (!plan) return;
-      await firstValueFrom(
-        store._api.setPlan(userId, {
-          planId: plan.id,
-          startDate: toBerlinIsoDate(new Date()),
-          status: 'active',
-          completedDays: [],
-          skippedDays: [],
-        })
-      );
-      store.activeResource.reload();
-    },
-
-    /** Mark today's plan day as done. Idempotent. No-op on rest days. */
-    async markTodayDone(): Promise<void> {
-      const a = store.activePlan();
-      const idx = store.currentDayIndex();
-      const day = store.todayDay();
-      if (!a || idx === null || !day) return;
-      // Rest days are not part of the completion set — silently skip
-      // so a generic "mark today done" callback can't skew progress.
-      if (day.kind === 'rest') return;
-      if (a.completedDays.includes(idx)) return;
-      const userId = store._user.userIdSafe();
-      // `arrayUnion` so concurrent writes to *different* day indexes
-      // (e.g. auto-mark today + manual mark for yesterday in another
-      // tab) merge correctly server-side instead of clobbering.
-      await firstValueFrom(store._api.addCompletedDay(userId, idx));
-      store.activeResource.reload();
-    },
-
-    /**
-     * Log today's plan-prescribed reps and mark today as done. Thin
-     * wrapper around `logPlanDay(currentDayIndex)`.
-     */
-    async logTodayPlanDay(): Promise<LogPlanDayResult> {
-      const idx = store.currentDayIndex();
-      if (idx === null) return 'noop';
-      return this.logPlanDay(idx);
-    },
-
-    /**
-     * Mark a specific day as done WITHOUT creating a pushup entry.
-     * Use this for "I already logged elsewhere" flows. For the
-     * common case (mark done + log the plan-prescribed reps) call
-     * `logPlanDay()` instead.
-     */
-    async markDayDone(dayIndex: number): Promise<void> {
-      const a = store.activePlan();
-      const c = store.activeCatalog();
-      if (!a || !c) return;
-      // Reject out-of-range or rest-day indexes — those should never
-      // count toward completion progress.
-      const day = planDayByIndex(c, dayIndex);
-      if (!day || day.kind === 'rest') return;
-      if (a.completedDays.includes(dayIndex)) return;
-      const userId = store._user.userIdSafe();
-      await firstValueFrom(store._api.addCompletedDay(userId, dayIndex));
-      store.activeResource.reload();
-    },
-
-    /**
-     * Log the plan-prescribed reps for a day AND mark the day as
-     * done. Idempotent: skips the pushup write if the calendar day
-     * is already covered by existing entries.
-     *
-     * The pushup entry is timestamped at noon (12:00) on the plan
-     * day's calendar date so a backfill for an earlier day still
-     * lands in the correct daily bucket.
-     *
-     * Guards (in order):
-     * - Plan must be active (status === 'active') and resolvable.
-     * - Day must be a non-rest, non-zero-target day in the plan.
-     * - Day must not be in the future relative to today.
-     * - `LiveDataStore` must have synced at least once, otherwise
-     *   `_repsLoggedOn` returns 0 and we'd duplicate-write existing
-     *   entries on day-2 reload.
-     * - No concurrent call for the same day index (in-flight lock).
-     */
-    async logPlanDay(dayIndex: number): Promise<LogPlanDayResult> {
-      const a = store.activePlan();
-      const c = store.activeCatalog();
-      if (!a || !c || a.status !== 'active') return 'noop';
-      const day = planDayByIndex(c, dayIndex);
-      if (!day || day.kind === 'rest' || day.targetReps <= 0) return 'noop';
-      // All plan days route through exerciseEntries. Only reps-measured catalog
-      // exercises map onto a plan day's targetReps/sets. A time- or distance-
-      // measured day can't be honored with a reps payload, and createEntry needs
-      // a resolved user plus the lazily-resolved Firestore-backed exercise API —
-      // fail closed on any of these.
-      if (!isRepsMeasuredPlanDay(day)) return 'noop';
-      const exerciseId = trainingPlanDayExerciseId(day);
-      const exerciseApi = store._resolveExerciseApi();
-      if (!store._user.userIdSafe() || !exerciseApi) return 'noop';
-
-      const currentIdx = store.currentDayIndex();
-      if (currentIdx === null || dayIndex > currentIdx) return 'noop';
-
-      // The `exerciseEntries` mirror is empty until its Firestore listener
-      // has emitted at least once. Don't make a write decision off pre-sync
-      // data — it would top-up a day that's already covered as soon as the
-      // listener catches up. Post-cutover pushups live in that same mirror,
-      // so every exercise gates on `exerciseEntriesLoaded`.
-      if (store._isBrowser && !store._live.exerciseEntriesLoaded())
-        return 'not-ready';
-
-      if (!store._acquireWriteLock(dayIndex)) return 'in-flight';
-
-      try {
-        const dateIso = store._planDayDate(dayIndex);
-        const alreadyLogged = store._repsLoggedOn(dateIso, exerciseId);
-        const payload = planDayRepsPayload(day, alreadyLogged);
-        let result: LogPlanDayResult;
-
-        if (payload) {
-          const timestamp = appendLocalOffset(`${dateIso}T12:00`);
-          await firstValueFrom(
-            exerciseApi.createEntry(store._user.userIdSafe(), {
-              exerciseId,
-              timestamp,
-              reps: payload.reps,
-              sets: payload.sets,
-              source: 'plan',
-            })
-          );
-          result = 'logged';
-        } else {
-          result = 'already-logged';
-        }
-
-        if (!a.completedDays.includes(dayIndex)) {
-          const userId = store._user.userIdSafe();
-          await firstValueFrom(store._api.addCompletedDay(userId, dayIndex));
-        }
-        store.activeResource.reload();
-        return result;
-      } finally {
-        store._releaseWriteLock(dayIndex);
-      }
-    },
-
-    /** Undo a day completion. */
-    async unmarkDayDone(dayIndex: number): Promise<void> {
-      const a = store.activePlan();
-      if (!a) return;
-      if (!a.completedDays.includes(dayIndex)) return;
-      const userId = store._user.userIdSafe();
-      await firstValueFrom(store._api.removeCompletedDay(userId, dayIndex));
-      store.activeResource.reload();
-    },
-
-    /**
-     * Mark a plan day as skipped (user chose not to do it). Skipped
-     * days are excluded from the completion percent denominator and
-     * the `isPlanCompleted` required-set.
-     *
-     * Idempotent on the skip side. Mutually exclusive with
-     * `completedDays`: the API atomically removes the same index from
-     * `completedDays` so a day can never be in both arrays.
-     *
-     * No-op for rest days (already excluded from progress) and for
-     * out-of-range indexes.
-     */
-    async skipDay(dayIndex: number): Promise<void> {
-      const a = store.activePlan();
-      const c = store.activeCatalog();
-      if (!a || !c) return;
-      const day = planDayByIndex(c, dayIndex);
-      if (!day || day.kind === 'rest') return;
-      if ((a.skippedDays ?? []).includes(dayIndex)) return;
-      const userId = store._user.userIdSafe();
-      await firstValueFrom(store._api.addSkippedDay(userId, dayIndex));
-      store.activeResource.reload();
-    },
-
-    /** Undo a skip. */
-    async unskipDay(dayIndex: number): Promise<void> {
-      const a = store.activePlan();
-      if (!a) return;
-      if (!(a.skippedDays ?? []).includes(dayIndex)) return;
-      const userId = store._user.userIdSafe();
-      await firstValueFrom(store._api.removeSkippedDay(userId, dayIndex));
-      store.activeResource.reload();
-    },
-
-    /**
-     * Re-anchor the plan so today maps to `targetDayIndex`. Adjusts
-     * `startDate` accordingly and bulk-marks all earlier non-rest,
-     * non-completed days as skipped so progress reflects "I jumped
-     * over these" rather than counting them as still-pending.
-     *
-     * - `targetDayIndex` must be in `[1, totalDays]` — otherwise
-     *   no-op.
-     * - Days already in `completedDays` stay completed even if they're
-     *   now in the future relative to the new `startDate`.
-     * - Days that were previously skipped but are now `>= targetDay`
-     *   are removed from `skippedDays` so re-doing them is possible.
-     *
-     * Delegates to `_api.jumpToDay`, which runs a Firestore
-     * transaction. Recomputing `skippedDays` from the local snapshot
-     * and writing it via `setDoc({merge:true})` would silently drop
-     * concurrent `arrayUnion`/`arrayRemove` skip writes from another
-     * tab/device, since `merge: true` does not field-merge arrays.
-     */
-    async jumpToDay(targetDayIndex: number): Promise<void> {
-      const a = store.activePlan();
-      const c = store.activeCatalog();
-      if (!a || !c || a.status !== 'active') return;
-      if (targetDayIndex < 1 || targetDayIndex > c.totalDays) return;
-
-      const today = toBerlinIsoDate(new Date());
-      const newStartDate = startDateForTargetDay(
-        c.totalDays,
-        targetDayIndex,
-        today
-      );
-      if (!newStartDate) return;
-
-      const userId = store._user.userIdSafe();
-      await firstValueFrom(
-        store._api.jumpToDay(userId, {
-          newStartDate,
-          targetDayIndex,
-          nonRestDaysBeforeTarget: nonRestDaysBeforeTarget(c, targetDayIndex),
-        })
-      );
-      store.activeResource.reload();
-    },
-
-    /** Abandon the current plan (status → abandoned). */
-    async abandon(): Promise<void> {
-      const a = store.activePlan();
-      if (!a) return;
-      const userId = store._user.userIdSafe();
-      await firstValueFrom(
-        store._api.updatePlan(userId, { status: 'abandoned' })
-      );
-      store.activeResource.reload();
-    },
-
-    reload(): void {
-      store.activeResource.reload();
-    },
+    allPlans: () => actions.allPlans(),
+    start: (planId: string) => lifecycle.start(store, planId),
+    markTodayDone: () => actions.markTodayDone(store),
+    logTodayPlanDay: () => actions.logTodayPlanDay(store),
+    markDayDone: (dayIndex: number) => actions.markDayDone(store, dayIndex),
+    logPlanDay: (dayIndex: number) => actions.logPlanDay(store, dayIndex),
+    unmarkDayDone: (dayIndex: number) =>
+      lifecycle.unmarkDayDone(store, dayIndex),
+    skipDay: (dayIndex: number) => lifecycle.skipDay(store, dayIndex),
+    unskipDay: (dayIndex: number) => lifecycle.unskipDay(store, dayIndex),
+    jumpToDay: (targetDayIndex: number) =>
+      lifecycle.jumpToDay(store, targetDayIndex),
+    abandon: () => lifecycle.abandon(store),
+    reload: () => store.activeResource.reload(),
   })),
   withHooks({
-    onInit(store) {
-      // Browser-only: tick the day signal once a minute so the
-      // Berlin-date-based `currentDayIndex` updates within ~60 s of
-      // midnight even if no Firestore activity refreshes the
-      // `activePlan` resource.
-      if (!store._isBrowser) return;
-      const handle = setInterval(
-        () => store._dayTick.update((n) => n + 1),
-        60_000
-      );
-      inject(DestroyRef).onDestroy(() => clearInterval(handle));
-
-      // Auto-mark today as done when reps logged via Quick-Add /
-      // dialog reach the plan target. Read-only — never creates a
-      // pushup entry, just flips the `completedDays` flag so users
-      // who track in their own way still see plan progress.
-      effect(() => {
-        const a = store.activePlan();
-        const idx = store.currentDayIndex();
-        const day = store.todayDay();
-        if (!a || !day || idx === null) return;
-        // Skip on abandoned/completed plans — the doc still exists,
-        // but writes against it are noise (plus they'd drift the
-        // status-based banner state in the UI).
-        if (a.status !== 'active') return;
-        if (day.kind === 'rest' || day.targetReps <= 0) return;
-        // Matching logPlanDay: only reps-measured days can be honored off the
-        // exerciseEntries reps mirror. Auto-mark only flips the done flag (no
-        // write), so the resolved-user check isn't needed here.
-        if (!isRepsMeasuredPlanDay(day)) return;
-        const exerciseId = trainingPlanDayExerciseId(day);
-        if (a.completedDays.includes(idx)) return;
-        // Same readiness guard as `logPlanDay` — without this, a pre-sync
-        // mirror could appear to satisfy the target on stale state and
-        // trigger a false auto-mark. Post-cutover pushups live in the
-        // `exerciseEntries` feed too, so every exercise gates on
-        // `exerciseEntriesLoaded`.
-        if (!store._live.exerciseEntriesLoaded()) return;
-        // The same in-flight lock guards manual logPlanDay calls,
-        // so a fast Quick-Add + auto-mark can't double-write.
-        if (store._writingDays().has(idx)) return;
-        // Reps come from the `exerciseEntries` mirror (real-time Firestore),
-        // so manual logs propagate here without polling.
-        const todayIso = toBerlinIsoDate(new Date());
-        // Establish a tick dependency so this re-runs at midnight.
-        store._dayTick();
-        const todayReps = store._repsLoggedOn(todayIso, exerciseId);
-        if (todayReps >= day.targetReps) {
-          if (!store._acquireWriteLock(idx)) return;
-          const userId = store._user.userIdSafe();
-          // Use the atomic `arrayUnion` write so a concurrent
-          // manual mark for a different day index (e.g. from
-          // another tab) doesn't get clobbered. `effect()` is
-          // synchronous, so handle errors explicitly — an
-          // unhandled rejection here would surface in the
-          // browser console without context.
-          firstValueFrom(store._api.addCompletedDay(userId, idx))
-            .then(() => store.activeResource.reload())
-            .catch((error) => {
-              console.error(
-                'Failed to auto-mark training plan day as completed.',
-                { error, planId: a.planId, dayIndex: idx }
-              );
-            })
-            .finally(() => store._releaseWriteLock(idx));
-        }
-      });
-    },
+    onInit: (store) => registerTrainingPlanHooks(store),
   })
 );


### PR DESCRIPTION
## What

Follow-up for #456 — behaviour-preserving split of `training-plan.store.ts` to meet the ≤250 LOC rule. The store had already had its pure math/selectors extracted; the remaining bulk was the CRUD action methods + the `onInit` hooks. The store now stays a thin orchestrator (props + computed + one-line method wrappers) and delegates the bodies to focused sibling modules.

## Changes

| File | LOC | Notes |
| --- | --- | --- |
| `training-plan.store.ts` | 602 → **227** | thin orchestrator: props, computed, one-line method wrappers, `withHooks.onInit` delegate |
| `training-plan-store.actions.ts` | **239** | in-flight-lock + reps helpers and the day-logging/completion actions (`logPlanDay`, `markTodayDone`, `markDayDone`, `logTodayPlanDay`, `allPlans`); owns the `TrainingPlanActionsStore` ctx interface + `LogPlanDayResult` |
| `training-plan-store.lifecycle.ts` | **127** | plan-lifecycle actions (`start`, `skipDay`, `unskipDay`, `unmarkDayDone`, `jumpToDay`, `abandon`) |
| `training-plan-store.hooks.ts` | **84** | browser-only day-tick interval + auto-mark `effect`, registered from `withHooks.onInit` |

- The action/effect bodies become plain functions taking a structural `ctx` (the store). The store's public API is unchanged — method wrappers delegate, so components and the store spec call the same `store.start()` / `store.logPlanDay()` / etc.
- `LogPlanDayResult` is re-exported from the store so existing importers (`training-plan-detail.helpers.ts`, `training-plans-page.component.ts`) keep working.
- No `signalStoreFeature` introduced (none exists in the repo yet) — the ctx-function approach keeps the change low-risk and the bodies independently unit-testable.

## Verification
- `nx lint web` ✅
- `nx test web` — training-plans specs ✅ **110 pass** (store + math + selectors + detail + page)
- `nx build web -c development` ✅ (app-wide compile incl. the `LogPlanDayResult` re-export consumers)

Refs #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PA3m6EzDv9quWZCsEh79iM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced training plan management with day completion logging and automatic progress tracking.
  * Added ability to skip/unskip days, mark individual days as complete, and adjust plan timeline.
  * Implemented automatic daily evaluation of workout goals with completion status updates.
  * Added plan abandonment capability.

* **Refactor**
  * Reorganized training plan store logic for improved maintainability and separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->