### PR TITLE
fix(reminders): reject malformed quiet-hours tokens and invalid timezones

### DIFF
--- a/libs/stats/src/lib/models/reminder-config.models.spec.ts
+++ b/libs/stats/src/lib/models/reminder-config.models.spec.ts
@@ -66,6 +66,34 @@ describe('reminder-config quiet hours', () => {
     );
   });
 
+  it('should treat windows with out-of-range clock tokens as disabled', () => {
+    // given — 10:00 UTC, which would fall inside each window if the tokens
+    // were parsed leniently as real ranges
+    const now = new Date('2026-03-23T10:00:00Z');
+    const malformed = [
+      { from: '24:00', to: '01:00' },
+      { from: '-1:00', to: '11:00' },
+      { from: '09:00', to: '10:999' },
+      { from: '07:00:30', to: '11:00' },
+      { from: 'oops', to: '11:00' },
+    ];
+
+    // then — each malformed window is disabled, so quiet hours never trigger
+    for (const window of malformed) {
+      expect(isInQuietHours([window], 'UTC', now)).toBe(false);
+    }
+  });
+
+  it('should fall back to Europe/Berlin for an invalid IANA timezone instead of throwing', () => {
+    // given — 08:30 UTC is 09:30 Berlin (winter); a garbage zone must not throw
+    const now = new Date('2026-01-15T08:30:00Z');
+    const window = [{ from: '09:00', to: '10:00' }];
+
+    // then — resolves like the default zone, no RangeError escapes
+    expect(() => isInQuietHours(window, 'Not/AZone', now)).not.toThrow();
+    expect(isInQuietHours(window, 'Not/AZone', now)).toBe(true);
+  });
+
   it('should default a missing/empty timezone to Europe/Berlin', () => {
     // given — 08:30 UTC is 09:30 in Berlin (winter, UTC+1); the window only
     // matches when evaluated against Berlin, proving the default zone.

--- a/libs/stats/src/lib/models/reminder-config.models.spec.ts
+++ b/libs/stats/src/lib/models/reminder-config.models.spec.ts
@@ -76,6 +76,12 @@ describe('reminder-config quiet hours', () => {
       { from: '09:00', to: '10:999' },
       { from: '07:00:30', to: '11:00' },
       { from: 'oops', to: '11:00' },
+      // empty / whitespace segments (Number('') === 0)
+      { from: '09:', to: '11:00' },
+      { from: ':15', to: '11:00' },
+      // non-decimal numeric tokens that Number() would otherwise parse
+      { from: '1e1:00', to: '11:00' },
+      { from: '0x10:00', to: '11:00' },
     ];
 
     // then — each malformed window is disabled, so quiet hours never trigger

--- a/libs/stats/src/lib/models/reminder-config.models.ts
+++ b/libs/stats/src/lib/models/reminder-config.models.ts
@@ -56,9 +56,14 @@ function minutesInZone(timezone: string, now: Date): number {
 function toMinutes(hhmm: string): number {
   const segments = hhmm.split(':');
   if (segments.length !== 2) return Number.NaN;
-  const [h, m] = segments.map(Number);
-  if (!Number.isInteger(h) || !Number.isInteger(m)) return Number.NaN;
-  if (h < 0 || h > 23 || m < 0 || m > 59) return Number.NaN;
+  const [rawH, rawM] = segments;
+  // Require 1–2 plain decimal digits per segment. `Number()` alone would
+  // accept '' / ' ' (→ 0), '1e1', '0x10' and negatives, letting malformed
+  // windows slip through as real ranges.
+  if (!/^\d{1,2}$/.test(rawH) || !/^\d{1,2}$/.test(rawM)) return Number.NaN;
+  const h = Number(rawH);
+  const m = Number(rawM);
+  if (h > 23 || m > 59) return Number.NaN;
   return h * 60 + m;
 }
 

--- a/libs/stats/src/lib/models/reminder-config.models.ts
+++ b/libs/stats/src/lib/models/reminder-config.models.ts
@@ -26,23 +26,39 @@ export const QUICK_LOG_REPS_MAX = 500;
  */
 export const DEFAULT_REMINDER_TIMEZONE = 'Europe/Berlin';
 
-function minutesInZone(timezone: string, now: Date): number {
+function zonedParts(timezone: string, now: Date): Intl.DateTimeFormatPart[] {
   // `formatToParts` gives structured hour/minute parts, so we never depend on a
-  // locale's string layout. `% 24` collapses the midnight "24" some engines
-  // emit under hour12:false back to 0.
-  const parts = new Intl.DateTimeFormat('en-GB', {
+  // locale's string layout.
+  return new Intl.DateTimeFormat('en-GB', {
     timeZone: timezone,
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,
   }).formatToParts(now);
+}
+
+function minutesInZone(timezone: string, now: Date): number {
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = zonedParts(timezone, now);
+  } catch {
+    // An invalid IANA zone (legacy/partial/user-edited Firestore docs) makes
+    // `Intl.DateTimeFormat` throw a RangeError — never let a bad timezone
+    // string crash scheduling; fall back to the default zone.
+    parts = zonedParts(DEFAULT_REMINDER_TIMEZONE, now);
+  }
+  // `% 24` collapses the midnight "24" some engines emit under hour12:false.
   const hour = Number(parts.find((p) => p.type === 'hour')?.value) % 24;
   const minute = Number(parts.find((p) => p.type === 'minute')?.value);
   return hour * 60 + minute;
 }
 
 function toMinutes(hhmm: string): number {
-  const [h, m] = hhmm.split(':').map(Number);
+  const segments = hhmm.split(':');
+  if (segments.length !== 2) return Number.NaN;
+  const [h, m] = segments.map(Number);
+  if (!Number.isInteger(h) || !Number.isInteger(m)) return Number.NaN;
+  if (h < 0 || h > 23 || m < 0 || m > 59) return Number.NaN;
   return h * 60 + m;
 }
 


### PR DESCRIPTION
Follow-up to #491, addressing the CodeRabbit/Copilot review findings that were raised on that PR but not resolved before it merged.

## Findings addressed

1. **`toMinutes()` accepted out-of-range clock tokens** (Major). It only filtered `NaN`, so windows like `24:00–01:00`, `-1:00–11:00`, `09:00–10:999`, or `07:00:30–11:00` were parsed as *real* quiet-hours ranges instead of being disabled — contradicting the "malformed window = disabled" contract the shared helper promises, and able to suppress reminders at the wrong times in **both** tiers. Now validates segment count and `0–23` / `0–59` ranges, returning `NaN` for anything malformed.
2. **`minutesInZone()` threw `RangeError` on an invalid IANA timezone**. A legacy/partial/user-edited Firestore doc with a garbage `timezone` would throw out of scheduling (and the in-app `tick()` path isn't wrapped in a per-user try/catch). Now falls back to `DEFAULT_REMINDER_TIMEZONE` on a bad zone.
3. **Regression tests** for both — out-of-range tokens disabled, and an invalid zone resolving like the default without throwing.

## Tests
- `stats-models` 400 tests (was 398, +2), `pus-reminders` 37, `cloud-functions` all pass.
- lint (3 projects) + cloud-functions build green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quiet hours now handle invalid time zones gracefully by falling back to the default time zone instead of failing.
  * Malformed or out-of-range quiet-hours window times are now treated as disabled to avoid unexpected behavior.
  * Quiet-hours evaluation remains consistent while becoming more resilient to invalid or malformed time inputs.
* **Tests**
  * Added unit coverage for quiet-hours behavior with malformed window clock tokens and invalid time zones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->