### PR TITLE
test(sw-push): guard inlined constants against @pu-stats/models drift

### DIFF
--- a/libs/sw-push/project.json
+++ b/libs/sw-push/project.json
@@ -4,6 +4,8 @@
   "projectType": "application",
   "sourceRoot": "libs/sw-push/src",
   "tags": ["scope:sw-push"],
+  "//": "implicitDependency on stats-models so `nx affected` runs the constants drift-guard (constants-drift.spec.ts) when the canonical reminder models change. The guard reads those files via fs, not a TS import, so there is no import edge for Nx to infer.",
+  "implicitDependencies": ["stats-models"],
   "targets": {
     "build": {
       "executor": "nx:run-commands",

--- a/libs/sw-push/src/constants-drift.spec.ts
+++ b/libs/sw-push/src/constants-drift.spec.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { SW_QUICK_LOG_MAX, SW_SUPPORTED_LOCALES } from './handlers';
+
+/**
+ * `sw-push` is an isolated service-worker bundle (eslint `scope:sw-push` →
+ * `onlyDependOnLibsWithTags: []`), so it cannot import `@pu-stats/models` at
+ * runtime — the quick-log cap and locale list are inlined in `handlers.ts`.
+ *
+ * This guard reads the canonical model source as text (no module import, so no
+ * module-boundary violation) and fails CI if the inlined SW copies drift,
+ * mirroring how `firestore.rules` is pinned to the exercise catalog.
+ */
+const MODELS_DIR = join(__dirname, '..', '..', 'stats', 'src', 'lib', 'models');
+
+function readModelSource(file: string): string {
+  return readFileSync(join(MODELS_DIR, file), 'utf8');
+}
+
+describe('sw-push constants drift guard', () => {
+  it('should keep SW_QUICK_LOG_MAX in sync with QUICK_LOG_REPS_MAX', () => {
+    // given
+    const src = readModelSource('reminder-config.models.ts');
+    const match = src.match(/QUICK_LOG_REPS_MAX\s*=\s*(\d+)/);
+
+    // then
+    expect(match).not.toBeNull();
+    expect(SW_QUICK_LOG_MAX).toBe(match ? Number(match[1]) : NaN);
+  });
+
+  it('should keep SW_SUPPORTED_LOCALES in sync with SUPPORTED_REMINDER_LOCALES', () => {
+    // given
+    const src = readModelSource('reminder-i18n.models.ts');
+    const block = src.match(/SUPPORTED_REMINDER_LOCALES\s*=\s*\[([\s\S]*?)\]/);
+
+    // when
+    const canonical = [...(block?.[1].matchAll(/'([a-z-]+)'/g) ?? [])].map(
+      (m) => m[1]
+    );
+
+    // then
+    expect(canonical.length).toBeGreaterThan(0);
+    expect([...SW_SUPPORTED_LOCALES]).toEqual(canonical);
+  });
+});

--- a/libs/sw-push/src/handlers.ts
+++ b/libs/sw-push/src/handlers.ts
@@ -21,7 +21,7 @@ export const SW_PUSH_VERSION: string =
  * here too. The CF already sanitizes before sending; this guard catches stale
  * payloads from older deployments and any payload tampering.
  */
-const SW_QUICK_LOG_MAX = 500;
+export const SW_QUICK_LOG_MAX = 500;
 
 /**
  * Mirrored from `@pu-stats/models#SUPPORTED_REMINDER_LOCALES`. Inlined so
@@ -31,7 +31,7 @@ const SW_QUICK_LOG_MAX = 500;
  * the default and route to `/de/app...` instead of the locale-prefixed
  * URL.
  */
-const SW_SUPPORTED_LOCALES = [
+export const SW_SUPPORTED_LOCALES = [
   'de',
   'en',
   'fr',


### PR DESCRIPTION
Follow-up from the reminder-consistency audit (inconsistency #6).

`sw-push` is an isolated service-worker bundle — eslint pins `scope:sw-push` to `onlyDependOnLibsWithTags: []`, and no scope (not even `scope:app`) may import it. So `SW_QUICK_LOG_MAX` and `SW_SUPPORTED_LOCALES` are **hand-mirrored** from `@pu-stats/models` (`QUICK_LOG_REPS_MAX`, `SUPPORTED_REMINDER_LOCALES`) with only a "keep in sync" comment enforcing them. The gotchas doc records a real PR #249 regression from exactly this class of drift.

## Change
- Add `libs/sw-push/src/constants-drift.spec.ts`: reads the canonical model **source as text** (`fs`, not a module import — so it doesn't violate the `sw-push` module boundary) and asserts the inlined SW copies match. Mirrors how `firestore.rules` is pinned to the exercise catalog by a guard test.
- Export `SW_QUICK_LOG_MAX` / `SW_SUPPORTED_LOCALES` so the guard can read them.

Now: add/rename a reminder locale or change the quick-log cap in `@pu-stats/models` without updating the SW copies → `sw-push` CI fails.

## Tests
`sw-push` 2 suites / 29 tests pass; lint clean (no boundary violation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)