### PR TITLE
fix(reminders): throttle in-app tier so it doesn't re-fire on every start()

### DIFF
--- a/libs/reminders/src/lib/reminder.service.spec.ts
+++ b/libs/reminders/src/lib/reminder.service.spec.ts
@@ -93,6 +93,9 @@ describe('ReminderService', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    // Throttle state persists in localStorage across tests in jsdom; clear it
+    // so each test starts from a clean "never shown" baseline.
+    localStorage.clear();
 
     showNotificationSpy = jest.fn().mockResolvedValue(undefined);
 
@@ -330,6 +333,60 @@ describe('ReminderService', () => {
     await flushMicrotasks();
 
     expect(showNotificationSpy).not.toHaveBeenCalled();
+
+    service.stop();
+  });
+
+  it('should record the last-shown timestamp after displaying a reminder', async () => {
+    // given
+    const service = createService();
+
+    // when
+    service.start({ userId: 'u1' });
+    jest.advanceTimersByTime(5_000);
+    await flushMicrotasks();
+
+    // then
+    expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('pu:reminder:last-shown-at')).not.toBeNull();
+
+    service.stop();
+  });
+
+  it('should suppress the immediate tick when one was shown within the interval', async () => {
+    // given — a reminder was shown a minute ago on this device (interval 60m)
+    localStorage.setItem(
+      'pu:reminder:last-shown-at',
+      String(Date.now() - 60_000)
+    );
+    const service = createService();
+
+    // when
+    service.start({ userId: 'u1' });
+    jest.advanceTimersByTime(5_000);
+    await flushMicrotasks();
+
+    // then
+    expect(showNotificationSpy).not.toHaveBeenCalled();
+
+    service.stop();
+  });
+
+  it('should show again once the interval has elapsed since the last reminder', async () => {
+    // given — last shown 61 minutes ago, just past the 60-minute interval
+    localStorage.setItem(
+      'pu:reminder:last-shown-at',
+      String(Date.now() - 61 * 60_000)
+    );
+    const service = createService();
+
+    // when
+    service.start({ userId: 'u1' });
+    jest.advanceTimersByTime(5_000);
+    await flushMicrotasks();
+
+    // then
+    expect(showNotificationSpy).toHaveBeenCalledTimes(1);
 
     service.stop();
   });

--- a/libs/reminders/src/lib/reminder.service.ts
+++ b/libs/reminders/src/lib/reminder.service.ts
@@ -98,6 +98,15 @@ export class ReminderService {
     // Function already handles delivery, showing both causes duplicate sounds.
     if (this.shouldSkipInApp()) return;
 
+    // Throttle: start() fires an immediate tick and runs on every login /
+    // auth change, so without this a user who reloads the app gets a fresh
+    // reminder every few seconds. Suppress if one was already shown within the
+    // configured interval. Per-device (localStorage) — the server tier keeps
+    // its own lastSentAt in reminderDispatchState, which stays Admin-SDK only.
+    const intervalMs = (config.intervalMinutes ?? 60) * 60 * 1000;
+    const lastShownAt = this.readLastShownAt();
+    if (lastShownAt !== null && Date.now() - lastShownAt < intervalMs) return;
+
     const quote = await this.getNextQuote();
     if (!quote) return;
 
@@ -108,7 +117,7 @@ export class ReminderService {
       // supported on Android Chrome and throws "Illegal constructor". We
       // explicitly show via the /push/ registration so that a later
       // notificationclick is handled by sw-push (ngsw has no listener).
-      let shown = false;
+      let displayed = false;
       try {
         const reg = await this.pushSwRegistration.getRegistration();
         if (reg) {
@@ -121,12 +130,12 @@ export class ReminderService {
             renotify: true,
             data: { url: `/${this.locale}/app`, locale: this.locale },
           } as NotificationOptions);
-          shown = true;
+          displayed = true;
         }
       } catch {
         // SW notification failed — fall through to Notification() fallback
       }
-      if (!shown) {
+      if (!displayed) {
         try {
           const iconUrl = new URL('assets/pushup-logo.svg', document.baseURI)
             .href;
@@ -134,10 +143,35 @@ export class ReminderService {
             body: quote,
             icon: iconUrl,
           });
+          displayed = true;
         } catch {
           // Fallback also failed (e.g. Android Chrome) — give up silently
         }
       }
+      if (displayed) this.writeLastShownAt(Date.now());
+    }
+  }
+
+  private static readonly LAST_SHOWN_KEY = 'pu:reminder:last-shown-at';
+
+  private readLastShownAt(): number | null {
+    if (!this.isBrowser) return null;
+    try {
+      const raw = localStorage.getItem(ReminderService.LAST_SHOWN_KEY);
+      if (!raw) return null;
+      const ms = Number(raw);
+      return Number.isFinite(ms) ? ms : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private writeLastShownAt(ms: number): void {
+    if (!this.isBrowser) return;
+    try {
+      localStorage.setItem(ReminderService.LAST_SHOWN_KEY, String(ms));
+    } catch {
+      // Storage unavailable (private mode / quota) — throttle is best-effort.
     }
   }
 


### PR DESCRIPTION
Follow-up from the reminder-consistency audit (inconsistency #3, and the actionable part of #2).

## Problem
`ReminderService.start()` fires an immediate tick (after 5s) and is invoked by `ReminderOrchestrationService` on **every** non-anonymous login / auth change. The server tier throttles on `lastSentAt` in `reminderDispatchState`, but the in-app tier had **no** equivalent — so a user who reloads the app repeatedly received a fresh in-app reminder every few seconds.

## Change
Add a per-device throttle in `tick()`: skip if a reminder was already shown within `intervalMinutes`, persisted in `localStorage` (`pu:reminder:last-shown-at`), and record the timestamp after a successful show.

## Scope decision (re inconsistency #2 — snooze / cross-tier `lastSentAt`)
I deliberately did **not** wire the in-app tier to the server's `reminderDispatchState`:
- That collection is locked to `allow read, write: if false` (Admin SDK only) in `firestore.rules`; honoring server `snoozedUntil`/`lastSentAt` client-side would mean **opening a currently fully-locked security collection** to client reads.
- In-app notifications carry **no snooze button** (only push notifications do), so an in-app-tier user can't snooze from one — the gap only matters in the subscribed→unsubscribed edge.

Net: low benefit, real security surface. The per-device throttle here covers the actual user-visible problem (re-fire spam) with zero rules change. Cross-device snooze honoring can be a separate, explicitly-scoped change if desired.

## Tests
`pus-reminders` 40 tests (was 37, +3): records timestamp after showing; suppresses within interval; shows again once the interval elapses. Existing tests get `localStorage.clear()` in `beforeEach` (jsdom persists it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reminders are now throttled so they won’t appear repeatedly within a short interval.
  * Reminder timing is now remembered across app usage, reducing duplicate notifications after one has already been shown.
  * Improved notification delivery handling so the “last shown” time is only saved when a reminder actually appears.

* **Tests**
  * Added coverage for reminder display timing, suppression within the interval, and re-showing after the interval passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->