### PR TITLE
feat(reminders): add per-weekday reminder scheduling

### DIFF
--- a/data-store/functions/src/push/reminders.spec.ts
+++ b/data-store/functions/src/push/reminders.spec.ts
@@ -38,6 +38,36 @@ describe('push/reminders', () => {
       expect(result).toBe(true);
     });
 
+    it('respects weekday scheduling', () => {
+      // baseTime is 11:00 Berlin, same calendar day as UTC, so the Berlin
+      // weekday equals the UTC weekday for this instant.
+      const today = new Date(baseTime).getUTCDay();
+
+      const onScheduledDay: Partial<ReminderConfig> = {
+        enabled: true,
+        timezone: 'Europe/Berlin',
+        weekdays: [today],
+      };
+      expect(shouldSendReminder(onScheduledDay, null, baseTime, null)).toBe(
+        true
+      );
+
+      const onOtherDay: Partial<ReminderConfig> = {
+        enabled: true,
+        timezone: 'Europe/Berlin',
+        weekdays: [(today + 1) % 7],
+      };
+      expect(shouldSendReminder(onOtherDay, null, baseTime, null)).toBe(false);
+
+      // Empty weekdays means every day.
+      const everyDay: Partial<ReminderConfig> = {
+        enabled: true,
+        timezone: 'Europe/Berlin',
+        weekdays: [],
+      };
+      expect(shouldSendReminder(everyDay, null, baseTime, null)).toBe(true);
+    });
+
     it('respects quiet hours (non-midnight-crossing)', () => {
       // Quiet hours from 22:00 to 06:00 Berlin time
       const reminder: Partial<ReminderConfig> = {

--- a/data-store/functions/src/push/reminders.ts
+++ b/data-store/functions/src/push/reminders.ts
@@ -5,6 +5,7 @@
 
 import {
   isInQuietHours,
+  isReminderDayActive,
   normalizeReminderLocale,
   reminderBodyChoices,
   reminderLogLabel,
@@ -39,6 +40,13 @@ export function shouldSendReminder(
 ): boolean {
   // Reminder must be enabled
   if (!reminder?.enabled) return false;
+
+  // Weekday gate — shared with the in-app tier so both resolve the weekday in
+  // the same timezone. Empty/undefined weekdays means every day.
+  if (
+    !isReminderDayActive(reminder.weekdays, reminder.timezone, new Date(nowMs))
+  )
+    return false;
 
   // Quiet hours — shared with the in-app tier via @pu-stats/models so both
   // agree on timezone defaulting, time parsing, and boundary handling.

--- a/libs/reminders/src/lib/reminder.service.spec.ts
+++ b/libs/reminders/src/lib/reminder.service.spec.ts
@@ -372,6 +372,32 @@ describe('ReminderService', () => {
     service.stop();
   });
 
+  it('should fire the first reminder at the remaining throttle, not a full extra interval', async () => {
+    // given — last shown 30 minutes ago with a 60-minute interval
+    localStorage.setItem(
+      'pu:reminder:last-shown-at',
+      String(Date.now() - 30 * 60_000)
+    );
+    const service = createService();
+
+    // when — still throttled at the usual 5s immediate mark
+    service.start({ userId: 'u1' });
+    jest.advanceTimersByTime(5_000);
+    await flushMicrotasks();
+
+    // then
+    expect(showNotificationSpy).not.toHaveBeenCalled();
+
+    // when — the remaining ~30 minutes elapse (not a full 60-minute interval)
+    jest.advanceTimersByTime(30 * 60_000);
+    await flushMicrotasks();
+
+    // then
+    expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+
+    service.stop();
+  });
+
   it('should show again once the interval has elapsed since the last reminder', async () => {
     // given — last shown 61 minutes ago, just past the 60-minute interval
     localStorage.setItem(
@@ -387,6 +413,40 @@ describe('ReminderService', () => {
 
     // then
     expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+
+    service.stop();
+  });
+
+  it('should not show a notification on a weekday that is not scheduled', async () => {
+    // given — freeze on a Monday (UTC) so the weekday gate is deterministic
+    jest.setSystemTime(new Date('2026-03-23T12:00:00Z'));
+    const excludedDay = (new Date().getUTCDay() + 1) % 7;
+    const service = createService({ weekdays: [excludedDay] });
+
+    // when
+    service.start({ userId: 'u1' });
+    jest.advanceTimersByTime(5_000);
+    await flushMicrotasks();
+
+    // then
+    expect(showNotificationSpy).not.toHaveBeenCalled();
+
+    service.stop();
+  });
+
+  it('should show a notification on a scheduled weekday', async () => {
+    // given — freeze on a Monday (UTC) so the weekday gate is deterministic
+    jest.setSystemTime(new Date('2026-03-23T12:00:00Z'));
+    const today = new Date().getUTCDay();
+    const service = createService({ weekdays: [today] });
+
+    // when
+    service.start({ userId: 'u1' });
+    jest.advanceTimersByTime(5_000);
+    await flushMicrotasks();
+
+    // then
+    expect(showNotificationSpy).toHaveBeenCalled();
 
     service.stop();
   });

--- a/libs/reminders/src/lib/reminder.service.ts
+++ b/libs/reminders/src/lib/reminder.service.ts
@@ -3,6 +3,7 @@ import { isPlatformBrowser } from '@angular/common';
 import {
   DEFAULT_REMINDER_TIMEZONE,
   isInQuietHours,
+  isReminderDayActive,
   normalizeReminderLocale,
   reminderTitle,
 } from '@pu-stats/models';
@@ -53,13 +54,22 @@ export class ReminderService {
     if (!config?.enabled) return;
     if (this.permissionService.status() !== 'granted') return;
 
-    // Fire once after a short delay so the user gets immediate feedback
+    const intervalMs = (config.intervalMinutes ?? 60) * 60 * 1000;
+
+    // First tick: 5s for immediate feedback, unless a reminder was already
+    // shown within the interval — then wait out the remaining throttle so the
+    // first reminder isn't delayed by almost a full extra interval (the
+    // setInterval below is anchored at start()).
+    const lastShownAt = this.readLastShownAt();
+    const remainingThrottle =
+      lastShownAt !== null ? lastShownAt + intervalMs - Date.now() : 0;
+    const initialDelay = Math.max(5_000, remainingThrottle);
+
     this.initialTickTimeoutId = setTimeout(() => {
       this.initialTickTimeoutId = null;
       this.tick();
-    }, 5_000);
+    }, initialDelay);
 
-    const intervalMs = (config.intervalMinutes ?? 60) * 60 * 1000;
     this.intervalId = setInterval(() => this.tick(), intervalMs);
   }
 
@@ -85,12 +95,13 @@ export class ReminderService {
       return;
     }
 
-    if (
-      isInQuietHours(
-        config.quietHours ?? [],
-        config.timezone ?? DEFAULT_REMINDER_TIMEZONE
-      )
-    ) {
+    const timezone = config.timezone ?? DEFAULT_REMINDER_TIMEZONE;
+
+    // Weekday gate — only fire on the configured days. Shared with the server
+    // tier so both resolve the weekday in the same timezone.
+    if (!isReminderDayActive(config.weekdays, timezone)) return;
+
+    if (isInQuietHours(config.quietHours ?? [], timezone)) {
       return;
     }
 

--- a/libs/stats/src/lib/models/reminder-config.models.spec.ts
+++ b/libs/stats/src/lib/models/reminder-config.models.spec.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_REMINDER_TIMEZONE,
   isInQuietHours,
+  isReminderDayActive,
 } from './reminder-config.models';
 
 describe('reminder-config quiet hours', () => {
@@ -110,5 +111,49 @@ describe('reminder-config quiet hours', () => {
     expect(isInQuietHours(window, undefined, now)).toBe(true);
     expect(isInQuietHours(window, '', now)).toBe(true);
     expect(isInQuietHours(window, 'UTC', now)).toBe(false);
+  });
+});
+
+describe('reminder weekday scheduling', () => {
+  it('should be active every day when no weekdays are set', () => {
+    // given
+    const now = new Date('2026-03-23T10:00:00Z');
+
+    // then
+    expect(isReminderDayActive(undefined, 'UTC', now)).toBe(true);
+    expect(isReminderDayActive([], 'UTC', now)).toBe(true);
+  });
+
+  it('should only be active on the listed weekdays', () => {
+    // given
+    const now = new Date('2026-03-23T10:00:00Z');
+    const today = now.getUTCDay();
+
+    // then
+    expect(isReminderDayActive([today], 'UTC', now)).toBe(true);
+    expect(isReminderDayActive([(today + 1) % 7], 'UTC', now)).toBe(false);
+  });
+
+  it('should resolve the weekday in the configured timezone', () => {
+    // given — 23:30 UTC is already the next calendar day (00:30) in Berlin
+    const now = new Date('2026-01-15T23:30:00Z');
+    const utcDay = now.getUTCDay();
+    const berlinDay = (utcDay + 1) % 7;
+
+    // then
+    expect(isReminderDayActive([berlinDay], 'Europe/Berlin', now)).toBe(true);
+    expect(isReminderDayActive([utcDay], 'Europe/Berlin', now)).toBe(false);
+  });
+
+  it('should fall back to the default timezone for an invalid zone', () => {
+    // given
+    const now = new Date('2026-01-15T23:30:00Z');
+    const berlinDay = (now.getUTCDay() + 1) % 7;
+
+    // then
+    expect(() =>
+      isReminderDayActive([berlinDay], 'Not/AZone', now)
+    ).not.toThrow();
+    expect(isReminderDayActive([berlinDay], 'Not/AZone', now)).toBe(true);
   });
 });

--- a/libs/stats/src/lib/models/reminder-config.models.ts
+++ b/libs/stats/src/lib/models/reminder-config.models.ts
@@ -6,6 +6,12 @@ export interface ReminderConfig {
     to: string;
   }[];
   timezone: string;
+  /**
+   * Weekdays the reminder is active on, `0` = Sunday … `6` = Saturday (same
+   * convention as `ComplexGoalEntry.weekdays`). Empty or undefined means the
+   * reminder fires every day.
+   */
+  weekdays?: number[];
   lastQuoteFetchAt?: string;
   /**
    * One-tap pushup count surfaced as a notification action button. When set
@@ -65,6 +71,49 @@ function toMinutes(hhmm: string): number {
   const m = Number(rawM);
   if (h > 23 || m > 59) return Number.NaN;
   return h * 60 + m;
+}
+
+const WEEKDAY_SHORT_TO_INDEX: Readonly<Record<string, number>> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+/**
+ * Single source of truth for "is the reminder active on the current weekday".
+ * Shared by the in-app tier and the Cloud Function dispatcher so both resolve
+ * the weekday in the same timezone.
+ *
+ * - `weekdays` uses `0` = Sunday … `6` = Saturday.
+ * - An empty or undefined list means "every day" (no restriction).
+ */
+export function isReminderDayActive(
+  weekdays: ReadonlyArray<number> | undefined,
+  timezone: string = DEFAULT_REMINDER_TIMEZONE,
+  now: Date = new Date()
+): boolean {
+  if (!weekdays?.length) return true;
+
+  const tz = timezone || DEFAULT_REMINDER_TIMEZONE;
+  let short: string;
+  try {
+    short = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      weekday: 'short',
+    }).format(now);
+  } catch {
+    short = new Intl.DateTimeFormat('en-US', {
+      timeZone: DEFAULT_REMINDER_TIMEZONE,
+      weekday: 'short',
+    }).format(now);
+  }
+
+  const index = WEEKDAY_SHORT_TO_INDEX[short];
+  return index !== undefined && weekdays.includes(index);
 }
 
 /**

--- a/web/src/app/reminders/shell/reminder-form.store.spec.ts
+++ b/web/src/app/reminders/shell/reminder-form.store.spec.ts
@@ -59,6 +59,35 @@ describe('ReminderFormStore', () => {
     expect(store.dirty()).toBe(false);
   });
 
+  describe('weekday scheduling', () => {
+    it('initializes with no weekday restriction (every day)', () => {
+      expect(store.weekdays()).toEqual([]);
+    });
+
+    it('stores weekdays sorted and marks the form dirty', () => {
+      store.setWeekdays([5, 1, 3]);
+      expect(store.weekdays()).toEqual([1, 3, 5]);
+      expect(store.dirty()).toBe(true);
+    });
+
+    it('hydrates weekdays from config', () => {
+      store.syncFromConfig({ ...defaultConfig, weekdays: [1, 3] });
+      expect(store.weekdays()).toEqual([1, 3]);
+      expect(store.dirty()).toBe(false);
+    });
+
+    it('omits weekdays from the saved config when none are selected', () => {
+      const config = store.toConfig('Europe/Berlin');
+      expect(config.weekdays).toBeUndefined();
+    });
+
+    it('writes sorted weekdays to the saved config when selected', () => {
+      store.setWeekdays([6, 0, 2]);
+      const config = store.toConfig('Europe/Berlin');
+      expect(config.weekdays).toEqual([0, 2, 6]);
+    });
+  });
+
   describe('quickLog (one-tap notification action)', () => {
     it('initializes with quickLog disabled and the default count', () => {
       expect(store.quickLogEnabled()).toBe(false);

--- a/web/src/app/reminders/shell/reminder-form.store.ts
+++ b/web/src/app/reminders/shell/reminder-form.store.ts
@@ -16,6 +16,8 @@ type ReminderFormState = {
   enabled: boolean;
   intervalMinutes: number;
   quietHours: { from: string; to: string }[];
+  /** Active weekdays, 0=Sunday..6=Saturday. Empty means every day. */
+  weekdays: number[];
   /**
    * Whether the one-tap quick-log notification action is enabled. Tracked as
    * a separate flag so the count can be edited while the toggle is off
@@ -34,6 +36,7 @@ const initialState: ReminderFormState = {
   enabled: false,
   intervalMinutes: 60,
   quietHours: [],
+  weekdays: [],
   quickLogEnabled: false,
   quickLogReps: DEFAULT_QUICK_LOG_REPS,
   dirty: false,
@@ -66,6 +69,7 @@ export const ReminderFormStore = signalStore(
         enabled: config?.enabled ?? false,
         intervalMinutes: config?.intervalMinutes ?? 60,
         quietHours: config?.quietHours ? [...config.quietHours] : [],
+        weekdays: config?.weekdays ? [...config.weekdays] : [],
         quickLogEnabled: repsValid,
         quickLogReps: repsValid
           ? Math.min(normalizedReps as number, QUICK_LOG_REPS_MAX)
@@ -88,6 +92,13 @@ export const ReminderFormStore = signalStore(
 
     setInterval(value: number): void {
       patchState(store, { intervalMinutes: value, dirty: true });
+    },
+
+    setWeekdays(days: number[]): void {
+      patchState(store, {
+        weekdays: [...days].sort((a, b) => a - b),
+        dirty: true,
+      });
     },
 
     addQuietHour(): void {
@@ -151,6 +162,10 @@ export const ReminderFormStore = signalStore(
         quietHours: store.quietHours(),
         timezone,
       };
+      const weekdays = store.weekdays();
+      if (weekdays.length > 0) {
+        config.weekdays = [...weekdays].sort((a, b) => a - b);
+      }
       if (store.quickLogEnabled()) {
         const reps = Math.floor(store.quickLogReps());
         if (Number.isFinite(reps) && reps >= QUICK_LOG_REPS_MIN) {

--- a/web/src/app/reminders/shell/reminder-settings-section.component.ts
+++ b/web/src/app/reminders/shell/reminder-settings-section.component.ts
@@ -16,6 +16,7 @@ import { ReminderFormStore } from './reminder-form.store';
 import { parseInputNumber } from './reminders-page.helpers';
 import { ReminderQuietHoursComponent } from './reminder-quiet-hours.component';
 import { ReminderQuickLogComponent } from './reminder-quick-log.component';
+import { ReminderWeekdaysComponent } from './reminder-weekdays.component';
 
 @Component({
   selector: 'app-reminder-settings-section',
@@ -29,6 +30,7 @@ import { ReminderQuickLogComponent } from './reminder-quick-log.component';
     MatSlideToggleModule,
     ReminderQuietHoursComponent,
     ReminderQuickLogComponent,
+    ReminderWeekdaysComponent,
   ],
   template: `
     <section class="reminder-section">
@@ -116,6 +118,12 @@ import { ReminderQuickLogComponent } from './reminder-quick-log.component';
               >
             </mat-form-field>
           </div>
+
+          <app-reminder-weekdays
+            [weekdays]="form.weekdays()"
+            [saving]="form.saving()"
+            (weekdaysChange)="form.setWeekdays($event)"
+          />
 
           <app-reminder-quick-log
             [enabled]="form.quickLogEnabled()"

--- a/web/src/app/reminders/shell/reminder-weekdays.component.ts
+++ b/web/src/app/reminders/shell/reminder-weekdays.component.ts
@@ -1,0 +1,69 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+} from '@angular/core';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+
+interface WeekdayOption {
+  value: number;
+  label: string;
+}
+
+@Component({
+  selector: 'app-reminder-weekdays',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatButtonToggleModule],
+  template: `
+    <div>
+      <p class="field-label" i18n="@@reminder.weekdays.label">Wochentage</p>
+      <mat-button-toggle-group
+        multiple
+        [value]="weekdays()"
+        [disabled]="saving()"
+        (change)="weekdaysChange.emit($event.value)"
+        aria-label="Wochentage"
+        i18n-aria-label="@@reminder.weekdays.aria"
+      >
+        @for (day of days; track day.value) {
+          <mat-button-toggle [value]="day.value">{{
+            day.label
+          }}</mat-button-toggle>
+        }
+      </mat-button-toggle-group>
+      <p class="field-hint" i18n="@@reminder.weekdays.hint">
+        Keine Auswahl = jeden Tag
+      </p>
+    </div>
+  `,
+  styles: `
+    .field-label {
+      margin: 0 0 6px;
+      font-size: 0.85rem;
+      opacity: 0.75;
+    }
+    .field-hint {
+      margin: 6px 0 0;
+      font-size: 0.8rem;
+      opacity: 0.7;
+    }
+  `,
+})
+export class ReminderWeekdaysComponent {
+  readonly weekdays = input.required<number[]>();
+  readonly saving = input<boolean>(false);
+  readonly weekdaysChange = output<number[]>();
+
+  // 0 = Sunday … 6 = Saturday (matches ReminderConfig.weekdays); displayed
+  // Monday-first per German convention.
+  readonly days: WeekdayOption[] = [
+    { value: 1, label: $localize`:@@reminder.weekday.mon:Mo` },
+    { value: 2, label: $localize`:@@reminder.weekday.tue:Di` },
+    { value: 3, label: $localize`:@@reminder.weekday.wed:Mi` },
+    { value: 4, label: $localize`:@@reminder.weekday.thu:Do` },
+    { value: 5, label: $localize`:@@reminder.weekday.fri:Fr` },
+    { value: 6, label: $localize`:@@reminder.weekday.sat:Sa` },
+    { value: 0, label: $localize`:@@reminder.weekday.sun:So` },
+  ];
+}

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10090,5 +10090,65 @@
         <target>Διαγραφή χρήστη</target>
       </segment>
     </unit>
+    <unit id="reminder.weekdays.label">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.aria">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.hint">
+      <segment state="initial">
+        <source> Keine Auswahl = jeden Tag </source>
+        <target> Keine Auswahl = jeden Tag </target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.mon">
+      <segment state="initial">
+        <source>Mo</source>
+        <target>Mo</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.tue">
+      <segment state="initial">
+        <source>Di</source>
+        <target>Di</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.wed">
+      <segment state="initial">
+        <source>Mi</source>
+        <target>Mi</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.thu">
+      <segment state="initial">
+        <source>Do</source>
+        <target>Do</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.fri">
+      <segment state="initial">
+        <source>Fr</source>
+        <target>Fr</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sat">
+      <segment state="initial">
+        <source>Sa</source>
+        <target>Sa</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sun">
+      <segment state="initial">
+        <source>So</source>
+        <target>So</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10265,5 +10265,65 @@ Deine Position: # ·  Reps        </source>
         <target>Delete user</target>
       </segment>
     </unit>
+    <unit id="reminder.weekdays.label">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.aria">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.hint">
+      <segment state="initial">
+        <source> Keine Auswahl = jeden Tag </source>
+        <target> Keine Auswahl = jeden Tag </target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.mon">
+      <segment state="initial">
+        <source>Mo</source>
+        <target>Mo</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.tue">
+      <segment state="initial">
+        <source>Di</source>
+        <target>Di</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.wed">
+      <segment state="initial">
+        <source>Mi</source>
+        <target>Mi</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.thu">
+      <segment state="initial">
+        <source>Do</source>
+        <target>Do</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.fri">
+      <segment state="initial">
+        <source>Fr</source>
+        <target>Fr</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sat">
+      <segment state="initial">
+        <source>Sa</source>
+        <target>Sa</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sun">
+      <segment state="initial">
+        <source>So</source>
+        <target>So</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10086,5 +10086,65 @@
         <target>Eliminar usuario</target>
       </segment>
     </unit>
+    <unit id="reminder.weekdays.label">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.aria">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.hint">
+      <segment state="initial">
+        <source> Keine Auswahl = jeden Tag </source>
+        <target> Keine Auswahl = jeden Tag </target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.mon">
+      <segment state="initial">
+        <source>Mo</source>
+        <target>Mo</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.tue">
+      <segment state="initial">
+        <source>Di</source>
+        <target>Di</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.wed">
+      <segment state="initial">
+        <source>Mi</source>
+        <target>Mi</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.thu">
+      <segment state="initial">
+        <source>Do</source>
+        <target>Do</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.fri">
+      <segment state="initial">
+        <source>Fr</source>
+        <target>Fr</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sat">
+      <segment state="initial">
+        <source>Sa</source>
+        <target>Sa</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sun">
+      <segment state="initial">
+        <source>So</source>
+        <target>So</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9962,5 +9962,65 @@
         <target>Supprimer l'utilisateur</target>
       </segment>
     </unit>
+    <unit id="reminder.weekdays.label">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.aria">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.hint">
+      <segment state="initial">
+        <source> Keine Auswahl = jeden Tag </source>
+        <target> Keine Auswahl = jeden Tag </target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.mon">
+      <segment state="initial">
+        <source>Mo</source>
+        <target>Mo</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.tue">
+      <segment state="initial">
+        <source>Di</source>
+        <target>Di</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.wed">
+      <segment state="initial">
+        <source>Mi</source>
+        <target>Mi</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.thu">
+      <segment state="initial">
+        <source>Do</source>
+        <target>Do</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.fri">
+      <segment state="initial">
+        <source>Fr</source>
+        <target>Fr</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sat">
+      <segment state="initial">
+        <source>Sa</source>
+        <target>Sa</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sun">
+      <segment state="initial">
+        <source>So</source>
+        <target>So</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10090,5 +10090,65 @@
         <target>Elimina utente</target>
       </segment>
     </unit>
+    <unit id="reminder.weekdays.label">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.aria">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.hint">
+      <segment state="initial">
+        <source> Keine Auswahl = jeden Tag </source>
+        <target> Keine Auswahl = jeden Tag </target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.mon">
+      <segment state="initial">
+        <source>Mo</source>
+        <target>Mo</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.tue">
+      <segment state="initial">
+        <source>Di</source>
+        <target>Di</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.wed">
+      <segment state="initial">
+        <source>Mi</source>
+        <target>Mi</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.thu">
+      <segment state="initial">
+        <source>Do</source>
+        <target>Do</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.fri">
+      <segment state="initial">
+        <source>Fr</source>
+        <target>Fr</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sat">
+      <segment state="initial">
+        <source>Sa</source>
+        <target>Sa</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sun">
+      <segment state="initial">
+        <source>So</source>
+        <target>So</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -10090,5 +10090,65 @@
         <target>Utentem delere</target>
       </segment>
     </unit>
+    <unit id="reminder.weekdays.label">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.aria">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.hint">
+      <segment state="initial">
+        <source> Keine Auswahl = jeden Tag </source>
+        <target> Keine Auswahl = jeden Tag </target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.mon">
+      <segment state="initial">
+        <source>Mo</source>
+        <target>Mo</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.tue">
+      <segment state="initial">
+        <source>Di</source>
+        <target>Di</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.wed">
+      <segment state="initial">
+        <source>Mi</source>
+        <target>Mi</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.thu">
+      <segment state="initial">
+        <source>Do</source>
+        <target>Do</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.fri">
+      <segment state="initial">
+        <source>Fr</source>
+        <target>Fr</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sat">
+      <segment state="initial">
+        <source>Sa</source>
+        <target>Sa</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sun">
+      <segment state="initial">
+        <source>So</source>
+        <target>So</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10090,5 +10090,65 @@
         <target>Gebruiker verwijderen</target>
       </segment>
     </unit>
+    <unit id="reminder.weekdays.label">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.aria">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.hint">
+      <segment state="initial">
+        <source> Keine Auswahl = jeden Tag </source>
+        <target> Keine Auswahl = jeden Tag </target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.mon">
+      <segment state="initial">
+        <source>Mo</source>
+        <target>Mo</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.tue">
+      <segment state="initial">
+        <source>Di</source>
+        <target>Di</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.wed">
+      <segment state="initial">
+        <source>Mi</source>
+        <target>Mi</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.thu">
+      <segment state="initial">
+        <source>Do</source>
+        <target>Do</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.fri">
+      <segment state="initial">
+        <source>Fr</source>
+        <target>Fr</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sat">
+      <segment state="initial">
+        <source>Sa</source>
+        <target>Sa</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sun">
+      <segment state="initial">
+        <source>So</source>
+        <target>So</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9359,5 +9359,65 @@ Deine Position: # ·  Reps        </source>
         <target>Slett bruker</target>
       </segment>
     </unit>
+    <unit id="reminder.weekdays.label">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.aria">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.hint">
+      <segment state="initial">
+        <source> Keine Auswahl = jeden Tag </source>
+        <target> Keine Auswahl = jeden Tag </target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.mon">
+      <segment state="initial">
+        <source>Mo</source>
+        <target>Mo</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.tue">
+      <segment state="initial">
+        <source>Di</source>
+        <target>Di</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.wed">
+      <segment state="initial">
+        <source>Mi</source>
+        <target>Mi</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.thu">
+      <segment state="initial">
+        <source>Do</source>
+        <target>Do</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.fri">
+      <segment state="initial">
+        <source>Fr</source>
+        <target>Fr</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sat">
+      <segment state="initial">
+        <source>Sa</source>
+        <target>Sa</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sun">
+      <segment state="initial">
+        <source>So</source>
+        <target>So</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -5916,7 +5916,7 @@
     </unit>
     <unit id="reminder.section.title">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:35,37</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:37,39</note>
       </notes>
       <segment>
         <source>🔔 Erinnerungen / Reminders</source>
@@ -5924,7 +5924,7 @@
     </unit>
     <unit id="reminder.enabled.label">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:43,44</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:45,46</note>
       </notes>
       <segment>
         <source> Liegestütz-Erinnerungen aktivieren </source>
@@ -5932,7 +5932,7 @@
     </unit>
     <unit id="reminder.permission.denied.hint">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:51,53</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:53,55</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">warning</pc> Benachrichtigungen sind im Browser blockiert. Bitte in den Browser-Einstellungen erlauben. </source>
@@ -5940,7 +5940,7 @@
     </unit>
     <unit id="reminder.permission.granted">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:59,62</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:61,64</note>
       </notes>
       <segment>
         <source>Benachrichtigungen erlaubt</source>
@@ -5948,7 +5948,7 @@
     </unit>
     <unit id="reminder.permission.unsupported">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:67,69</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:69,71</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">info</pc> Dein Browser unterstützt keine Benachrichtigungen. </source>
@@ -5956,7 +5956,7 @@
     </unit>
     <unit id="reminder.interval.label">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:77,79</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:79,81</note>
       </notes>
       <segment>
         <source> Erinnerungsintervall </source>
@@ -5964,7 +5964,7 @@
     </unit>
     <unit id="reminder.interval.aria">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:83,84</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:85,86</note>
       </notes>
       <segment>
         <source>Intervall-Voreinstellungen</source>
@@ -5972,7 +5972,7 @@
     </unit>
     <unit id="reminder.interval.30min">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:87,89</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:89,91</note>
       </notes>
       <segment>
         <source>30 Min</source>
@@ -5980,7 +5980,7 @@
     </unit>
     <unit id="reminder.interval.1h">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:90,92</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:92,94</note>
       </notes>
       <segment>
         <source>1 Std</source>
@@ -5988,7 +5988,7 @@
     </unit>
     <unit id="reminder.interval.2h">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:93,95</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:95,97</note>
       </notes>
       <segment>
         <source>2 Std</source>
@@ -5996,7 +5996,7 @@
     </unit>
     <unit id="reminder.interval.4h">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:96,98</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:98,100</note>
       </notes>
       <segment>
         <source>4 Std</source>
@@ -6004,7 +6004,7 @@
     </unit>
     <unit id="reminder.interval.custom.label">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:102,104</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:104,106</note>
       </notes>
       <segment>
         <source>Benutzerdefiniert (Min)</source>
@@ -6012,7 +6012,7 @@
     </unit>
     <unit id="reminder.interval.hint">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:115,117</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:117,119</note>
       </notes>
       <segment>
         <source>15–480 Minuten</source>
@@ -6020,7 +6020,7 @@
     </unit>
     <unit id="reminder.save">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:149,151</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:157,159</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">save</pc> Erinnerungen speichern </source>
@@ -6028,10 +6028,90 @@
     </unit>
     <unit id="reminder.saved">
       <notes>
-        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:153,155</note>
+        <note category="location">web/src/app/reminders/shell/reminder-settings-section.component.ts:161,163</note>
       </notes>
       <segment>
         <source>Gespeichert.</source>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.label">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminder-weekdays.component.ts:20,22</note>
+      </notes>
+      <segment>
+        <source>Wochentage</source>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.aria">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminder-weekdays.component.ts:26,27</note>
+      </notes>
+      <segment>
+        <source>Wochentage</source>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.hint">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminder-weekdays.component.ts:36,40</note>
+      </notes>
+      <segment>
+        <source> Keine Auswahl = jeden Tag </source>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.mon">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminder-weekdays.component.ts:61</note>
+      </notes>
+      <segment>
+        <source>Mo</source>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.tue">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminder-weekdays.component.ts:62</note>
+      </notes>
+      <segment>
+        <source>Di</source>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.wed">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminder-weekdays.component.ts:63</note>
+      </notes>
+      <segment>
+        <source>Mi</source>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.thu">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminder-weekdays.component.ts:64</note>
+      </notes>
+      <segment>
+        <source>Do</source>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.fri">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminder-weekdays.component.ts:65</note>
+      </notes>
+      <segment>
+        <source>Fr</source>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sat">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminder-weekdays.component.ts:66</note>
+      </notes>
+      <segment>
+        <source>Sa</source>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sun">
+      <notes>
+        <note category="location">web/src/app/reminders/shell/reminder-weekdays.component.ts:67</note>
+      </notes>
+      <segment>
+        <source>So</source>
       </segment>
     </unit>
     <unit id="remindersHeaderTitle">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9587,5 +9587,65 @@
         <target>删除用户</target>
       </segment>
     </unit>
+    <unit id="reminder.weekdays.label">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.aria">
+      <segment state="initial">
+        <source>Wochentage</source>
+        <target>Wochentage</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekdays.hint">
+      <segment state="initial">
+        <source> Keine Auswahl = jeden Tag </source>
+        <target> Keine Auswahl = jeden Tag </target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.mon">
+      <segment state="initial">
+        <source>Mo</source>
+        <target>Mo</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.tue">
+      <segment state="initial">
+        <source>Di</source>
+        <target>Di</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.wed">
+      <segment state="initial">
+        <source>Mi</source>
+        <target>Mi</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.thu">
+      <segment state="initial">
+        <source>Do</source>
+        <target>Do</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.fri">
+      <segment state="initial">
+        <source>Fr</source>
+        <target>Fr</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sat">
+      <segment state="initial">
+        <source>Sa</source>
+        <target>Sa</target>
+      </segment>
+    </unit>
+    <unit id="reminder.weekday.sun">
+      <segment state="initial">
+        <source>So</source>
+        <target>So</target>
+      </segment>
+    </unit>
 </file>
 </xliff>


### PR DESCRIPTION
Follow-up from the reminder-consistency audit (inconsistency #8 — there was no day-of-week scheduling anywhere; only goals had `weekdays`).

## What
Let users restrict reminders to specific weekdays (e.g. weekdays only, weekends only).

- **Model**: optional `weekdays?: number[]` on `ReminderConfig` (`0`=Sunday … `6`=Saturday, matching `ComplexGoalEntry.weekdays`; empty/undefined = every day).
- **Shared helper**: `isReminderDayActive(weekdays, timezone, now)` in `@pu-stats/models`, so the in-app tier and the `dispatchPushReminders` Cloud Function resolve the active weekday in the **same** timezone (with the same invalid-zone fallback used by the quiet-hours helper).
- **Both tiers** gate on the weekday before the quiet-hours/interval checks.
- **Settings UI**: a Monday-first weekday toggle row (`ReminderWeekdaysComponent`, `mat-button-toggle-group multiple`) wired through `ReminderFormStore` (`weekdays` state, `setWeekdays`, `toConfig` emits a sorted list, omitted when empty).
- **i18n**: German source strings + seeded locale fallbacks via `extract-i18n` + `sync-xliff-locales` (the translate routine fills real translations).

No `firestore.rules` change needed — the `userConfigs` update rules don't constrain the `reminder` sub-map shape.

## Tests
- `stats-models` (+4: every-day default, listed-days, timezone resolution, invalid-zone fallback)
- `cloud-functions` (+weekday gate in `shouldSendReminder`)
- `pus-reminders` (+2: suppressed on unscheduled day, shown on scheduled day)
- `web` `ReminderFormStore` (+5: default/sorted/hydrate/omit-empty/sorted-save)
- All pass; web prod build (AOT + prerender) green.

> [!NOTE]
> Stacked behind the other reminder follow-ups off `main` (#492 validation, #494 throttle). All three touch reminder files; whichever merges first, rebase the others. This PR is independent in intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)