### PR TITLE
chore(i18n): fill missing translations (90 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10091,63 +10091,63 @@
       </segment>
     </unit>
     <unit id="reminder.weekdays.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Ημέρες εβδομάδας</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Ημέρες εβδομάδας</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.hint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Auswahl = jeden Tag </source>
-        <target> Keine Auswahl = jeden Tag </target>
+        <target> Χωρίς επιλογή = κάθε μέρα </target>
       </segment>
     </unit>
     <unit id="reminder.weekday.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Δευ</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Τρί</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Τετ</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Πέμ</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Παρ</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Σάβ</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Κυρ</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10266,63 +10266,63 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="reminder.weekdays.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Days of the week</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Days of the week</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.hint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Auswahl = jeden Tag </source>
-        <target> Keine Auswahl = jeden Tag </target>
+        <target> No selection = every day </target>
       </segment>
     </unit>
     <unit id="reminder.weekday.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Mon</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Tue</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Wed</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Thu</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Fri</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Sat</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Sun</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10087,63 +10087,63 @@
       </segment>
     </unit>
     <unit id="reminder.weekdays.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Días de la semana</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Días de la semana</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.hint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Auswahl = jeden Tag </source>
-        <target> Keine Auswahl = jeden Tag </target>
+        <target> Sin selección = cada día </target>
       </segment>
     </unit>
     <unit id="reminder.weekday.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Lun</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Mar</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Mié</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Jue</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Vie</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Sáb</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Dom</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9963,63 +9963,63 @@
       </segment>
     </unit>
     <unit id="reminder.weekdays.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Jours de la semaine</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Jours de la semaine</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.hint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Auswahl = jeden Tag </source>
-        <target> Keine Auswahl = jeden Tag </target>
+        <target> Aucune sélection = chaque jour </target>
       </segment>
     </unit>
     <unit id="reminder.weekday.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Lun</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Mar</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Mer</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Jeu</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Ven</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Sam</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Dim</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10091,63 +10091,63 @@
       </segment>
     </unit>
     <unit id="reminder.weekdays.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Giorni della settimana</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Giorni della settimana</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.hint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Auswahl = jeden Tag </source>
-        <target> Keine Auswahl = jeden Tag </target>
+        <target> Nessuna selezione = ogni giorno </target>
       </segment>
     </unit>
     <unit id="reminder.weekday.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Lun</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Mar</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Mer</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Gio</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Ven</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Sab</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Dom</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -10091,63 +10091,63 @@
       </segment>
     </unit>
     <unit id="reminder.weekdays.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Dies Hebdomadae</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Dies Hebdomadae</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.hint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Auswahl = jeden Tag </source>
-        <target> Keine Auswahl = jeden Tag </target>
+        <target> Nulla electa = omni die </target>
       </segment>
     </unit>
     <unit id="reminder.weekday.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Lun</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Mar</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Mer</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Iov</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Ven</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Sat</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Sol</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10091,63 +10091,63 @@
       </segment>
     </unit>
     <unit id="reminder.weekdays.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Weekdagen</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Weekdagen</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.hint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Auswahl = jeden Tag </source>
-        <target> Keine Auswahl = jeden Tag </target>
+        <target> Geen selectie = elke dag </target>
       </segment>
     </unit>
     <unit id="reminder.weekday.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Ma</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
         <target>Di</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Wo</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
         <target>Do</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Vr</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Za</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Zo</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9360,63 +9360,63 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="reminder.weekdays.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Ukedager</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>Ukedager</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.hint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Auswahl = jeden Tag </source>
-        <target> Keine Auswahl = jeden Tag </target>
+        <target> Intet valg = hver dag </target>
       </segment>
     </unit>
     <unit id="reminder.weekday.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>Man</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>Tir</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>Ons</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>Tor</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>Fre</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>Lør</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>Søn</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9588,63 +9588,63 @@
       </segment>
     </unit>
     <unit id="reminder.weekdays.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>星期</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wochentage</source>
-        <target>Wochentage</target>
+        <target>星期</target>
       </segment>
     </unit>
     <unit id="reminder.weekdays.hint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Auswahl = jeden Tag </source>
-        <target> Keine Auswahl = jeden Tag </target>
+        <target> 未选择 = 每天 </target>
       </segment>
     </unit>
     <unit id="reminder.weekday.mon">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mo</source>
-        <target>Mo</target>
+        <target>周一</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.tue">
-      <segment state="initial">
+      <segment state="translated">
         <source>Di</source>
-        <target>Di</target>
+        <target>周二</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.wed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Mi</source>
-        <target>Mi</target>
+        <target>周三</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.thu">
-      <segment state="initial">
+      <segment state="translated">
         <source>Do</source>
-        <target>Do</target>
+        <target>周四</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.fri">
-      <segment state="initial">
+      <segment state="translated">
         <source>Fr</source>
-        <target>Fr</target>
+        <target>周五</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sat">
-      <segment state="initial">
+      <segment state="translated">
         <source>Sa</source>
-        <target>Sa</target>
+        <target>周六</target>
       </segment>
     </unit>
     <unit id="reminder.weekday.sun">
-      <segment state="initial">
+      <segment state="translated">
         <source>So</source>
-        <target>So</target>
+        <target>周日</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
## Translation gaps filled

This PR translates the 10 reminder weekday UI strings that were missing across 9 target locales.

### Per-locale breakdown

- **en**: 10 units (Days of the week label/aria, hint, Mon–Sun abbreviations)
- **fr**: 10 units (Jours de la semaine, Lun–Dim)
- **es**: 10 units (Días de la semana, Lun–Dom)
- **it**: 10 units (Giorni della settimana, Lun–Dom)
- **nl**: 10 units (Weekdagen, Ma–Zo)
- **el**: 10 units (Ημέρες εβδομάδας, Δευ–Κυρ)
- **la**: 10 units (Dies Hebdomadae, Lun–Sol)
- **no**: 10 units (Ukedager, Man–Søn)
- **zh**: 10 units (星期, 周一–周日)

### Detector summary

`Detected 90 gap(s) — xliff:90 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, la, no, zh`

### Skipped

None — all 90 units were translated successfully.

---
*Generated by the Claude translations routine.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Afp2Njt4hvi7MW2RowNCRD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved weekday reminder text translations across multiple languages, including labels, hints, ARIA text, and day abbreviations.
  * Added proper localized strings for English, Greek, Spanish, French, Italian, Latin, Dutch, Norwegian, and Chinese.
  * Users will now see more accurate and consistent reminder weekday wording in these languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->