### PR TITLE
fix(ci): authenticate Firebase deploy via FIREBASE_TOKEN (firebase-tools WIF/STS "Premature close")

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -26,10 +26,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Pin Node instead of .nvmrc's lts/* (latest LTS, Node 24) for the deploy
+      # job: under that Node line firebase-tools' bundled node-fetch fails the WIF
+      # STS exchange with a "Premature close" (firebase/firebase-tools#10726), while
+      # gcloud/the auth action succeed. Node 22 LTS avoids that regression. The
+      # functions still ship to the nodejs24 runtime (build-time Node is unrelated).
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version-file: .nvmrc
+          node-version: '22'
 
       # Use corepack to install the exact pnpm version from package.json's
       # `packageManager` field. See ci.yml for background on why we avoid

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -83,26 +83,40 @@ jobs:
           find data-store/hosting-public -type f -name 'index.csr.html' -print0 | while IFS= read -r -d '' f; do
             cp "$f" "${f%index.csr.html}index.html"
           done
-      # Keyless auth via Workload Identity Federation. The action writes an
-      # external-account credential file and exports GOOGLE_APPLICATION_CREDENTIALS,
-      # which firebase-tools (and gcloud) pick up automatically for ADC.
+      # Keyless auth via Workload Identity Federation. token_format: access_token
+      # makes the action perform the OIDC→STS→SA-impersonation exchange itself and
+      # expose a short-lived OAuth2 access token (steps.auth.outputs.access_token).
+      # We hand that token to firebase-tools directly (FIREBASE_TOKEN below) instead
+      # of letting firebase-tools run its own ADC exchange: its autoAuth path is
+      # unreliable with WIF external-account credentials and fails with a generic
+      # "Failed to authenticate, have you run firebase login?" (firebase/firebase-tools#10726).
+      # The action still writes a credential file + exports GOOGLE_APPLICATION_CREDENTIALS,
+      # which gcloud uses reliably for any ADC-based steps.
       # vars.WIF_PROVIDER / vars.WIF_DEPLOY_SA are set by infra/setup-wif.sh.
       # Pinned to the v3.0.0 commit per GitHub's third-party-action hardening guidance.
       - name: Authenticate to Google Cloud (keyless, WIF)
+        id: auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: pushup-stats
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_DEPLOY_SA }}
-      # firebase-tools re-runs the OIDC→STS→impersonation token exchange on each
-      # invocation and surfaces any transient hop as "Failed to authenticate".
-      # Retry a few times before giving up; a genuine failure still fails the job.
+          token_format: access_token
+      # firebase-tools authenticates with the WIF access token minted above, passed
+      # as FIREBASE_TOKEN. firebase-tools tries to refresh it, gets a 400/401 (it is
+      # an access token, not a refresh token) and falls back to using it directly as
+      # a bearer — bypassing the flaky ADC exchange. The token is short-lived (1h) and
+      # scoped to cloud-platform, so it is not a reintroduced long-lived secret.
+      # Retry a few times to absorb transient deploy/network hiccups; a genuine
+      # failure still fails the job.
       - name: Deploy Hosting + Cloud Functions + Firestore rules & indexes
         working-directory: data-store
+        env:
+          FIREBASE_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
           for attempt in 1 2 3 4; do
             pnpm exec firebase deploy --only hosting,functions,firestore --project pushup-stats && exit 0
-            echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s (transient WIF token exchange)"
+            echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s"
             sleep 15
           done
           echo "::error::firebase deploy failed after 4 attempts"

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -83,15 +83,9 @@ jobs:
           find data-store/hosting-public -type f -name 'index.csr.html' -print0 | while IFS= read -r -d '' f; do
             cp "$f" "${f%index.csr.html}index.html"
           done
-      # Keyless auth via Workload Identity Federation. token_format: access_token
-      # makes the action perform the OIDC→STS→SA-impersonation exchange itself and
-      # expose a short-lived OAuth2 access token (steps.auth.outputs.access_token).
-      # We hand that token to firebase-tools directly (FIREBASE_TOKEN below) instead
-      # of letting firebase-tools run its own ADC exchange: its autoAuth path is
-      # unreliable with WIF external-account credentials and fails with a generic
-      # "Failed to authenticate, have you run firebase login?" (firebase/firebase-tools#10726).
-      # The action still writes a credential file + exports GOOGLE_APPLICATION_CREDENTIALS,
-      # which gcloud uses reliably for any ADC-based steps.
+      # Keyless auth via Workload Identity Federation. The action writes an
+      # external-account credential file and exports GOOGLE_APPLICATION_CREDENTIALS,
+      # which firebase-tools (and gcloud) pick up automatically for ADC.
       # vars.WIF_PROVIDER / vars.WIF_DEPLOY_SA are set by infra/setup-wif.sh.
       # Pinned to the v3.0.0 commit per GitHub's third-party-action hardening guidance.
       - name: Authenticate to Google Cloud (keyless, WIF)
@@ -101,22 +95,15 @@ jobs:
           project_id: pushup-stats
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_DEPLOY_SA }}
-          token_format: access_token
-      # firebase-tools authenticates with the WIF access token minted above, passed
-      # as FIREBASE_TOKEN. firebase-tools tries to refresh it, gets a 400/401 (it is
-      # an access token, not a refresh token) and falls back to using it directly as
-      # a bearer — bypassing the flaky ADC exchange. The token is short-lived (1h) and
-      # scoped to cloud-platform, so it is not a reintroduced long-lived secret.
-      # Retry a few times to absorb transient deploy/network hiccups; a genuine
-      # failure still fails the job.
+      # firebase-tools re-runs the OIDC→STS→impersonation token exchange on each
+      # invocation and surfaces any transient hop as "Failed to authenticate".
+      # Retry a few times before giving up; a genuine failure still fails the job.
       - name: Deploy Hosting + Cloud Functions + Firestore rules & indexes
         working-directory: data-store
-        env:
-          FIREBASE_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
           for attempt in 1 2 3 4; do
             pnpm exec firebase deploy --only hosting,functions,firestore --project pushup-stats && exit 0
-            echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s"
+            echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s (transient WIF token exchange)"
             sleep 15
           done
           echo "::error::firebase deploy failed after 4 attempts"

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -26,15 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Pin Node instead of .nvmrc's lts/* (latest LTS, Node 24) for the deploy
-      # job: under that Node line firebase-tools' bundled node-fetch fails the WIF
-      # STS exchange with a "Premature close" (firebase/firebase-tools#10726), while
-      # gcloud/the auth action succeed. Node 22 LTS avoids that regression. The
-      # functions still ship to the nodejs24 runtime (build-time Node is unrelated).
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version-file: .nvmrc
 
       # Use corepack to install the exact pnpm version from package.json's
       # `packageManager` field. See ci.yml for background on why we avoid
@@ -88,27 +83,28 @@ jobs:
           find data-store/hosting-public -type f -name 'index.csr.html' -print0 | while IFS= read -r -d '' f; do
             cp "$f" "${f%index.csr.html}index.html"
           done
-      # Keyless auth via Workload Identity Federation. The action writes an
-      # external-account credential file and exports GOOGLE_APPLICATION_CREDENTIALS,
-      # which firebase-tools (and gcloud) pick up automatically for ADC.
-      # vars.WIF_PROVIDER / vars.WIF_DEPLOY_SA are set by infra/setup-wif.sh.
-      # Pinned to the v3.0.0 commit per GitHub's third-party-action hardening guidance.
+      # WIF still provides gcloud's ADC (and is kept for any GCP CLI steps), but
+      # firebase-tools itself authenticates via FIREBASE_TOKEN below — its own
+      # WIF/STS exchange fails on the GitHub runners with a transport "Premature
+      # close" (firebase/firebase-tools#10726), which it reports as the generic
+      # "Failed to authenticate". vars.WIF_PROVIDER / vars.WIF_DEPLOY_SA are set by
+      # infra/setup-wif.sh. Pinned to the v3.0.0 commit per GitHub's third-party-
+      # action hardening guidance.
       - name: Authenticate to Google Cloud (keyless, WIF)
-        id: auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: pushup-stats
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_DEPLOY_SA }}
-      # firebase-tools' bundled google-auth-library/gaxios fails the WIF STS token
-      # exchange with a network-layer "Premature close" (the connection resets
-      # mid-response) while the auth action and gcloud reach STS fine — see
-      # firebase/firebase-tools#10726. --dns-result-order=ipv4first forces firebase
-      # onto the IPv4 path the working clients use, avoiding a flaky IPv6 hop.
+      # firebase-tools authenticates with FIREBASE_TOKEN (a `firebase login:ci`
+      # refresh token in repo secrets). It refreshes via oauth2.googleapis.com,
+      # bypassing the broken WIF/STS path entirely. requireAuth checks FIREBASE_TOKEN
+      # before ADC, so the credential file the auth step exported is not used here.
+      # Retry to absorb transient deploy/network hiccups; the final attempt fails fast.
       - name: Deploy Hosting + Cloud Functions + Firestore rules & indexes
         working-directory: data-store
         env:
-          NODE_OPTIONS: --max-old-space-size=6144 --dns-result-order=ipv4first
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
           for attempt in 1 2 3 4; do
             pnpm exec firebase deploy --only hosting,functions,firestore --project pushup-stats && exit 0

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -95,16 +95,22 @@ jobs:
           project_id: pushup-stats
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_DEPLOY_SA }}
-      # firebase-tools re-runs the OIDC→STS→impersonation token exchange on each
-      # invocation and surfaces any transient hop as "Failed to authenticate".
-      # Retry a few times before giving up; a genuine failure still fails the job.
+      # firebase-tools' bundled google-auth-library/gaxios fails the WIF STS token
+      # exchange with a network-layer "Premature close" (the connection resets
+      # mid-response) while the auth action and gcloud reach STS fine — see
+      # firebase/firebase-tools#10726. --dns-result-order=ipv4first forces firebase
+      # onto the IPv4 path the working clients use, avoiding a flaky IPv6 hop.
       - name: Deploy Hosting + Cloud Functions + Firestore rules & indexes
         working-directory: data-store
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144 --dns-result-order=ipv4first
         run: |
           for attempt in 1 2 3 4; do
             pnpm exec firebase deploy --only hosting,functions,firestore --project pushup-stats && exit 0
-            echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s (transient WIF token exchange)"
-            sleep 15
+            if [ "$attempt" -lt 4 ]; then
+              echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s"
+              sleep 15
+            fi
           done
           echo "::error::firebase deploy failed after 4 attempts"
           exit 1

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -106,6 +106,10 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "::error::FIREBASE_TOKEN secret is not set. Create it with 'firebase login:ci' and add it as a repo secret (see infra/README.md)."
+            exit 1
+          fi
           for attempt in 1 2 3 4; do
             pnpm exec firebase deploy --only hosting,functions,firestore --project pushup-stats && exit 0
             if [ "$attempt" -lt 4 ]; then

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -30,15 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Pin Node instead of .nvmrc's lts/* (latest LTS, Node 24) for the deploy
-      # job: under that Node line firebase-tools' bundled node-fetch fails the WIF
-      # STS exchange with a "Premature close" (firebase/firebase-tools#10726), while
-      # gcloud/the auth action succeed. Node 22 LTS avoids that regression. The
-      # functions still ship to the nodejs24 runtime (build-time Node is unrelated).
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version-file: .nvmrc
 
       # Use corepack to install the exact pnpm version from package.json's
       # `packageManager` field. See ci.yml for background on why we avoid
@@ -92,19 +87,18 @@ jobs:
           gcloud secrets describe GITHUB_TOKEN --project=pushup-stats-staging-867b7 2>/dev/null || \
             echo -n "placeholder-not-configured" | \
             gcloud secrets create GITHUB_TOKEN --data-file=- --project=pushup-stats-staging-867b7 --quiet
-      # firebase-tools' bundled google-auth-library/gaxios fails the WIF STS token
-      # exchange with a network-layer "Premature close" (the connection resets
-      # mid-response) while the auth action and gcloud reach STS fine — see
-      # firebase/firebase-tools#10726. --dns-result-order=ipv4first forces firebase
-      # onto the IPv4 path the working clients use, avoiding a flaky IPv6 hop.
-      # --debug keeps the underlying error visible until this is confirmed fixed.
+      # firebase-tools authenticates with FIREBASE_TOKEN (a `firebase login:ci`
+      # refresh token in repo secrets), refreshing via oauth2.googleapis.com and
+      # bypassing the broken WIF/STS path that surfaces as "Failed to authenticate"
+      # (firebase/firebase-tools#10726). The WIF step above still provides gcloud's
+      # ADC for the secret-bootstrap step. Retry to absorb transient hiccups.
       - name: Deploy Cloud Functions + Firestore rules & indexes to staging
         working-directory: data-store
         env:
-          NODE_OPTIONS: --max-old-space-size=6144 --dns-result-order=ipv4first
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
           for attempt in 1 2 3 4; do
-            pnpm exec firebase deploy --only functions,firestore --project staging --force --debug && exit 0
+            pnpm exec firebase deploy --only functions,firestore --project staging --force && exit 0
             if [ "$attempt" -lt 4 ]; then
               echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s"
               sleep 15
@@ -116,7 +110,7 @@ jobs:
         id: preview
         working-directory: data-store
         env:
-          NODE_OPTIONS: --max-old-space-size=6144 --dns-result-order=ipv4first
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
           DEPLOY_JSON=""
           for attempt in 1 2 3 4; do

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -97,6 +97,10 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "::error::FIREBASE_TOKEN secret is not set. Create it with 'firebase login:ci' and add it as a repo secret (see infra/README.md)."
+            exit 1
+          fi
           for attempt in 1 2 3 4; do
             pnpm exec firebase deploy --only functions,firestore --project staging --force && exit 0
             if [ "$attempt" -lt 4 ]; then

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -30,10 +30,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Pin Node instead of .nvmrc's lts/* (latest LTS, Node 24) for the deploy
+      # job: under that Node line firebase-tools' bundled node-fetch fails the WIF
+      # STS exchange with a "Premature close" (firebase/firebase-tools#10726), while
+      # gcloud/the auth action succeed. Node 22 LTS avoids that regression. The
+      # functions still ship to the nodejs24 runtime (build-time Node is unrelated).
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version-file: .nvmrc
+          node-version: '22'
 
       # Use corepack to install the exact pnpm version from package.json's
       # `packageManager` field. See ci.yml for background on why we avoid

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -70,45 +70,34 @@ jobs:
           find data-store/hosting-public -type f -name 'index.csr.html' -print0 | while IFS= read -r -d '' f; do
             cp "$f" "${f%index.csr.html}index.html"
           done
-      # Keyless auth via Workload Identity Federation. token_format: access_token
-      # makes the action perform the OIDC→STS→SA-impersonation exchange itself and
-      # expose a short-lived OAuth2 access token (steps.auth.outputs.access_token).
-      # We hand that token to firebase-tools directly (FIREBASE_TOKEN below) instead
-      # of letting firebase-tools run its own ADC exchange: its autoAuth path is
-      # unreliable with WIF external-account credentials and fails with a generic
-      # "Failed to authenticate, have you run firebase login?" (firebase/firebase-tools#10726).
-      # The action still writes a credential file + exports GOOGLE_APPLICATION_CREDENTIALS
-      # and CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, which gcloud uses reliably below.
+      # Keyless auth via Workload Identity Federation. The action writes an
+      # external-account credential file and exports GOOGLE_APPLICATION_CREDENTIALS
+      # (consumed by firebase-tools) and CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+      # (consumed by gcloud), so neither needs an explicit key file.
       # vars.WIF_PROVIDER_STAGING / vars.WIF_DEPLOY_SA_STAGING are set by infra/setup-wif.sh.
       # Pinned to the v3.0.0 commit per GitHub's third-party-action hardening guidance.
       - name: Authenticate to Google Cloud (keyless, WIF)
-        id: auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: pushup-stats-staging-867b7
           workload_identity_provider: ${{ vars.WIF_PROVIDER_STAGING }}
           service_account: ${{ vars.WIF_DEPLOY_SA_STAGING }}
-          token_format: access_token
       - name: Ensure GITHUB_TOKEN secret exists in staging
         run: |
           gcloud secrets describe GITHUB_TOKEN --project=pushup-stats-staging-867b7 2>/dev/null || \
             echo -n "placeholder-not-configured" | \
             gcloud secrets create GITHUB_TOKEN --data-file=- --project=pushup-stats-staging-867b7 --quiet
-      # firebase-tools authenticates with the WIF access token minted above, passed
-      # as FIREBASE_TOKEN. firebase-tools tries to refresh it, gets a 400/401 (it is
-      # an access token, not a refresh token) and falls back to using it directly as
-      # a bearer — bypassing the flaky ADC exchange. The token is short-lived (1h) and
-      # scoped to cloud-platform, so it is not a reintroduced long-lived secret.
-      # Retry a few times to absorb transient deploy/network hiccups; a genuine
-      # failure still fails the job.
+      # DIAGNOSTIC: --debug surfaces the underlying ADC error that firebase-tools
+      # otherwise hides behind the generic "Failed to authenticate" message, so we
+      # can pin down why the WIF external-account exchange is being rejected.
+      # firebase-tools re-runs the OIDC→STS→impersonation token exchange on each
+      # invocation; retry a few times before giving up.
       - name: Deploy Cloud Functions + Firestore rules & indexes to staging
         working-directory: data-store
-        env:
-          FIREBASE_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
           for attempt in 1 2 3 4; do
-            pnpm exec firebase deploy --only functions,firestore --project staging --force && exit 0
-            echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s"
+            pnpm exec firebase deploy --only functions,firestore --project staging --force --debug && exit 0
+            echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s (transient WIF token exchange)"
             sleep 15
           done
           echo "::error::firebase deploy failed after 4 attempts"
@@ -116,8 +105,6 @@ jobs:
       - name: Deploy Hosting preview channel
         id: preview
         working-directory: data-store
-        env:
-          FIREBASE_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
           DEPLOY_JSON=""
           for attempt in 1 2 3 4; do

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -70,32 +70,45 @@ jobs:
           find data-store/hosting-public -type f -name 'index.csr.html' -print0 | while IFS= read -r -d '' f; do
             cp "$f" "${f%index.csr.html}index.html"
           done
-      # Keyless auth via Workload Identity Federation. The action writes an
-      # external-account credential file and exports GOOGLE_APPLICATION_CREDENTIALS
-      # (consumed by firebase-tools) and CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
-      # (consumed by gcloud), so neither needs an explicit key file.
+      # Keyless auth via Workload Identity Federation. token_format: access_token
+      # makes the action perform the OIDC→STS→SA-impersonation exchange itself and
+      # expose a short-lived OAuth2 access token (steps.auth.outputs.access_token).
+      # We hand that token to firebase-tools directly (FIREBASE_TOKEN below) instead
+      # of letting firebase-tools run its own ADC exchange: its autoAuth path is
+      # unreliable with WIF external-account credentials and fails with a generic
+      # "Failed to authenticate, have you run firebase login?" (firebase/firebase-tools#10726).
+      # The action still writes a credential file + exports GOOGLE_APPLICATION_CREDENTIALS
+      # and CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, which gcloud uses reliably below.
       # vars.WIF_PROVIDER_STAGING / vars.WIF_DEPLOY_SA_STAGING are set by infra/setup-wif.sh.
       # Pinned to the v3.0.0 commit per GitHub's third-party-action hardening guidance.
       - name: Authenticate to Google Cloud (keyless, WIF)
+        id: auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: pushup-stats-staging-867b7
           workload_identity_provider: ${{ vars.WIF_PROVIDER_STAGING }}
           service_account: ${{ vars.WIF_DEPLOY_SA_STAGING }}
+          token_format: access_token
       - name: Ensure GITHUB_TOKEN secret exists in staging
         run: |
           gcloud secrets describe GITHUB_TOKEN --project=pushup-stats-staging-867b7 2>/dev/null || \
             echo -n "placeholder-not-configured" | \
             gcloud secrets create GITHUB_TOKEN --data-file=- --project=pushup-stats-staging-867b7 --quiet
-      # firebase-tools re-runs the OIDC→STS→impersonation token exchange on each
-      # invocation and surfaces any transient hop as "Failed to authenticate".
-      # Retry a few times before giving up; a genuine failure still fails the job.
+      # firebase-tools authenticates with the WIF access token minted above, passed
+      # as FIREBASE_TOKEN. firebase-tools tries to refresh it, gets a 400/401 (it is
+      # an access token, not a refresh token) and falls back to using it directly as
+      # a bearer — bypassing the flaky ADC exchange. The token is short-lived (1h) and
+      # scoped to cloud-platform, so it is not a reintroduced long-lived secret.
+      # Retry a few times to absorb transient deploy/network hiccups; a genuine
+      # failure still fails the job.
       - name: Deploy Cloud Functions + Firestore rules & indexes to staging
         working-directory: data-store
+        env:
+          FIREBASE_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
           for attempt in 1 2 3 4; do
             pnpm exec firebase deploy --only functions,firestore --project staging --force && exit 0
-            echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s (transient WIF token exchange)"
+            echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s"
             sleep 15
           done
           echo "::error::firebase deploy failed after 4 attempts"
@@ -103,6 +116,8 @@ jobs:
       - name: Deploy Hosting preview channel
         id: preview
         working-directory: data-store
+        env:
+          FIREBASE_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
           DEPLOY_JSON=""
           for attempt in 1 2 3 4; do
@@ -110,7 +125,7 @@ jobs:
               --expires 7d --project staging --json); then
               break
             fi
-            echo "::warning::channel deploy attempt $attempt failed; retrying in 15s (transient WIF token exchange)"
+            echo "::warning::channel deploy attempt $attempt failed; retrying in 15s"
             DEPLOY_JSON=""
             sleep 15
           done

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -87,24 +87,31 @@ jobs:
           gcloud secrets describe GITHUB_TOKEN --project=pushup-stats-staging-867b7 2>/dev/null || \
             echo -n "placeholder-not-configured" | \
             gcloud secrets create GITHUB_TOKEN --data-file=- --project=pushup-stats-staging-867b7 --quiet
-      # DIAGNOSTIC: --debug surfaces the underlying ADC error that firebase-tools
-      # otherwise hides behind the generic "Failed to authenticate" message, so we
-      # can pin down why the WIF external-account exchange is being rejected.
-      # firebase-tools re-runs the OIDC→STS→impersonation token exchange on each
-      # invocation; retry a few times before giving up.
+      # firebase-tools' bundled google-auth-library/gaxios fails the WIF STS token
+      # exchange with a network-layer "Premature close" (the connection resets
+      # mid-response) while the auth action and gcloud reach STS fine — see
+      # firebase/firebase-tools#10726. --dns-result-order=ipv4first forces firebase
+      # onto the IPv4 path the working clients use, avoiding a flaky IPv6 hop.
+      # --debug keeps the underlying error visible until this is confirmed fixed.
       - name: Deploy Cloud Functions + Firestore rules & indexes to staging
         working-directory: data-store
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144 --dns-result-order=ipv4first
         run: |
           for attempt in 1 2 3 4; do
             pnpm exec firebase deploy --only functions,firestore --project staging --force --debug && exit 0
-            echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s (transient WIF token exchange)"
-            sleep 15
+            if [ "$attempt" -lt 4 ]; then
+              echo "::warning::firebase deploy attempt $attempt failed; retrying in 15s"
+              sleep 15
+            fi
           done
           echo "::error::firebase deploy failed after 4 attempts"
           exit 1
       - name: Deploy Hosting preview channel
         id: preview
         working-directory: data-store
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144 --dns-result-order=ipv4first
         run: |
           DEPLOY_JSON=""
           for attempt in 1 2 3 4; do
@@ -112,9 +119,11 @@ jobs:
               --expires 7d --project staging --json); then
               break
             fi
-            echo "::warning::channel deploy attempt $attempt failed; retrying in 15s"
-            DEPLOY_JSON=""
-            sleep 15
+            if [ "$attempt" -lt 4 ]; then
+              echo "::warning::channel deploy attempt $attempt failed; retrying in 15s"
+              DEPLOY_JSON=""
+              sleep 15
+            fi
           done
           if [ -z "$DEPLOY_JSON" ]; then echo "::error::channel deploy failed after 4 attempts"; exit 1; fi
           echo "$DEPLOY_JSON"

--- a/infra/README.md
+++ b/infra/README.md
@@ -64,12 +64,28 @@ email are not sensitive. The old `FIREBASE_SERVICE_ACCOUNT_*` JSON-key secrets a
 no longer used; delete them once a deploy has succeeded (the script prints the
 exact `gh secret delete` commands).
 
-> **Transient auth note:** firebase-tools re-runs the OIDC→STS→impersonation token
-> exchange on every invocation, so a transient hop (or freshly-propagating
-> `workloadIdentityUser` binding right after `setup-wif.sh`) can surface as
-> `Failed to authenticate, have you run firebase login?`. The deploy workflows retry
-> the firebase commands a few times to absorb this; `gcloud` (used in the same jobs)
-> authenticates reliably from the same credential file.
+> **firebase-tools auth — why a `FIREBASE_TOKEN` secret is still needed.** WIF
+> provides `gcloud`'s ADC, but **firebase-tools** cannot use WIF on the GitHub
+> runners: its bundled `google-auth-library`/`gaxios` fails the STS token exchange
+> with a transport `Premature close`, which it reports as
+> `Failed to authenticate, have you run firebase login?`
+> ([firebase/firebase-tools#10726](https://github.com/firebase/firebase-tools/issues/10726)).
+> `gcloud` and the auth action perform the same exchange fine, so this is a
+> firebase-tools client defect, not a WIF/IAM problem. The deploy workflows
+> therefore pass `FIREBASE_TOKEN` (a `firebase login:ci` refresh token), which
+> firebase-tools refreshes via `oauth2.googleapis.com`, bypassing STS entirely.
+>
+> Set it up once:
+>
+> ```bash
+> firebase login:ci   # prints a refresh token
+> gh secret set FIREBASE_TOKEN -R WolfSoko/pushup-stats-service --body '<token>'
+> ```
+>
+> One token covers both projects (it authenticates as the user account, which has
+> access to prod + staging). Re-run `firebase login:ci` and update the secret if it
+> is ever revoked. Revisit this once firebase-tools fixes its WIF/STS handling — at
+> which point the workflows can drop `FIREBASE_TOKEN` and rely on WIF alone.
 
 ## Production Secrets Workflow
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -75,17 +75,22 @@ exact `gh secret delete` commands).
 > therefore pass `FIREBASE_TOKEN` (a `firebase login:ci` refresh token), which
 > firebase-tools refreshes via `oauth2.googleapis.com`, bypassing STS entirely.
 >
-> Set it up once:
+> Set it up once — **prefer a dedicated, least-privilege deployer Google account**
+> (e.g. `ci-deployer@…`) granted only the deploy roles on both Firebase projects,
+> rather than a personal account. The `FIREBASE_TOKEN` is a long-lived refresh
+> token, so scoping it to a throwaway deployer identity limits the blast radius if
+> it ever leaks (and the token can be revoked without affecting a human's account):
 >
 > ```bash
-> firebase login:ci   # prints a refresh token
+> firebase login:ci   # log in AS the dedicated deployer account; prints a refresh token
 > gh secret set FIREBASE_TOKEN -R WolfSoko/pushup-stats-service --body '<token>'
 > ```
 >
-> One token covers both projects (it authenticates as the user account, which has
-> access to prod + staging). Re-run `firebase login:ci` and update the secret if it
-> is ever revoked. Revisit this once firebase-tools fixes its WIF/STS handling — at
-> which point the workflows can drop `FIREBASE_TOKEN` and rely on WIF alone.
+> One token covers both projects (the deployer account needs access to prod +
+> staging). Revoke a leaked token with `firebase logout --token '<token>'`, then
+> re-issue and update the secret. Revisit this once firebase-tools fixes its
+> WIF/STS handling — at which point the workflows can drop `FIREBASE_TOKEN` and
+> rely on WIF alone.
 
 ## Production Secrets Workflow
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -64,17 +64,12 @@ email are not sensitive. The old `FIREBASE_SERVICE_ACCOUNT_*` JSON-key secrets a
 no longer used; delete them once a deploy has succeeded (the script prints the
 exact `gh secret delete` commands).
 
-> **Auth note:** firebase-tools' own ADC exchange is unreliable with WIF
-> external-account credentials — it surfaces a generic
-> `Failed to authenticate, have you run firebase login?`
-> ([firebase/firebase-tools#10726](https://github.com/firebase/firebase-tools/issues/10726)).
-> The deploy workflows therefore set `token_format: access_token` on the
-> `google-github-actions/auth` step (so the action runs the OIDC→STS→impersonation
-> exchange itself) and pass the minted short-lived token to firebase-tools via
-> `FIREBASE_TOKEN`, which firebase-tools uses directly as a bearer. `gcloud`
-> continues to authenticate from the exported credential file for any ADC-based
-> steps. The firebase commands still retry a few times to absorb transient
-> deploy/network hiccups.
+> **Transient auth note:** firebase-tools re-runs the OIDC→STS→impersonation token
+> exchange on every invocation, so a transient hop (or freshly-propagating
+> `workloadIdentityUser` binding right after `setup-wif.sh`) can surface as
+> `Failed to authenticate, have you run firebase login?`. The deploy workflows retry
+> the firebase commands a few times to absorb this; `gcloud` (used in the same jobs)
+> authenticates reliably from the same credential file.
 
 ## Production Secrets Workflow
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -64,12 +64,17 @@ email are not sensitive. The old `FIREBASE_SERVICE_ACCOUNT_*` JSON-key secrets a
 no longer used; delete them once a deploy has succeeded (the script prints the
 exact `gh secret delete` commands).
 
-> **Transient auth note:** firebase-tools re-runs the OIDC→STS→impersonation token
-> exchange on every invocation, so a transient hop (or freshly-propagating
-> `workloadIdentityUser` binding right after `setup-wif.sh`) can surface as
-> `Failed to authenticate, have you run firebase login?`. The deploy workflows retry
-> the firebase commands a few times to absorb this; `gcloud` (used in the same jobs)
-> authenticates reliably from the same credential file.
+> **Auth note:** firebase-tools' own ADC exchange is unreliable with WIF
+> external-account credentials — it surfaces a generic
+> `Failed to authenticate, have you run firebase login?`
+> ([firebase/firebase-tools#10726](https://github.com/firebase/firebase-tools/issues/10726)).
+> The deploy workflows therefore set `token_format: access_token` on the
+> `google-github-actions/auth` step (so the action runs the OIDC→STS→impersonation
+> exchange itself) and pass the minted short-lived token to firebase-tools via
+> `FIREBASE_TOKEN`, which firebase-tools uses directly as a bearer. `gcloud`
+> continues to authenticate from the exported credential file for any ADC-based
+> steps. The firebase commands still retry a few times to absorb transient
+> deploy/network hiccups.
 
 ## Production Secrets Workflow
 


### PR DESCRIPTION
## Problem

The Firebase deploy workflows (prod merge + staging PR) began failing ~2026-06-30 with `Error: Failed to authenticate, have you run firebase login?`, with no relevant repo change (they deployed fine on 2026-06-25).

## Root cause (pinned via `--debug`)

The `google-github-actions/auth` step writes a **valid** WIF credential, and `gcloud` / the auth action perform the OIDC→STS→impersonation exchange **successfully** in the same job. The failure is isolated to **firebase-tools' bundled `google-auth-library`/`gaxios`**, whose call to `https://sts.googleapis.com/v1/token` fails at the transport layer:

```
Error: Invalid response body while trying to fetch https://sts.googleapis.com/v1/token: Premature close
    at StsCredentials.exchangeToken (google-auth-library@9.15.1/.../stscredentials.js)
    at autoAuth (firebase-tools@14.27.0/lib/requireAuth.js)
```

firebase-tools collapses this into the generic "Failed to authenticate" (firebase/firebase-tools#10726). The connection resets mid-response, so the 4× retry can't absorb it. This is a firebase-tools HTTP-client defect, **not** a WIF/IAM problem.

## Approaches ruled out (verified in CI)

- **`FIREBASE_TOKEN` = WIF-minted access token** — firebase-tools treats it as a *refresh* token; the OAuth refresh returns `invalid_grant` → forced re-auth.
- **Bump firebase-tools to v15** — resolves the *same* `gaxios@6.7.1` / `google-auth-library@9.15.1`, and breaks the `@angular/fire ^14` peer dependency.
- **`--dns-result-order=ipv4first`** — still "Premature close".
- **Pin Node 20 / 22 / 24** — the failure is Node-version-independent.

## Fix in this PR

Authenticate firebase-tools with **`FIREBASE_TOKEN`** (a `firebase login:ci` refresh token, stored as a repo secret). `requireAuth` checks it before ADC and refreshes via `oauth2.googleapis.com`, **never touching the broken STS path**. The WIF auth step stays for `gcloud`'s ADC (staging secret-bootstrap step).

- Both deploy workflows pass `FIREBASE_TOKEN` to every `firebase` invocation.
- A missing/empty secret now fails the job fast with an actionable message (instead of the generic auth error).
- Retry loops no longer warn/sleep after the final attempt.
- `infra/README.md` documents setup and recommends a **dedicated least-privilege deployer account** for the token.

> ⚠️ **Requires a repo secret `FIREBASE_TOKEN`** before deploys go green — see `infra/README.md` (`firebase login:ci` → `gh secret set FIREBASE_TOKEN`).

This is a deliberate, documented trade-off: firebase-tools cannot currently use keyless WIF on the runners, so a single scoped refresh token is the reliable path until the upstream bug is fixed (at which point the workflows can drop `FIREBASE_TOKEN` and rely on WIF alone).

## Testing

Workflow-only change; no nx project sources touched. Validated by this PR's own `Deploy to Firebase Staging on PR` run once the secret is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Firebase deployment reliability for hosting, functions, and Firestore previews/merges.
  * Deployments now fail fast when required authentication is missing, reducing confusing retry failures.
  * Retry messages were simplified to better reflect the actual deployment behavior.

* **Documentation**
  * Updated deployment guidance to clarify the required authentication setup and how to create, reuse, and revoke the token used for Firebase deploys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->