### PR TITLE
feat(quick-add): label pushup quick actions and drop unfitting exercise icons

### DIFF
--- a/libs/quick-add/src/lib/quick-add-fab.component.html
+++ b/libs/quick-add/src/lib/quick-add-fab.component.html
@@ -78,7 +78,6 @@
             [attr.aria-label]="item.ariaLabel"
             (click)="onQuickAdd(item.suggestion)"
           >
-            <mat-icon>{{ item.icon }}</mat-icon>
             <span>{{ item.label }}</span>
           </button>
         }

--- a/libs/quick-add/src/lib/quick-add-fab.component.spec.ts
+++ b/libs/quick-add/src/lib/quick-add-fab.component.spec.ts
@@ -10,8 +10,7 @@ function pushupSuggestion(reps: number): QuickAddSuggestion {
   return {
     key: `pushup:${reps}`,
     reps,
-    icon: 'bolt',
-    label: `+${reps} Reps`,
+    label: `+${reps} Liegestütze`,
     ariaLabel: `${reps} Liegestütze hinzufügen`,
     exerciseId: 'pushup',
   };
@@ -136,16 +135,15 @@ describe('QuickAddFabComponent — goal dial item', () => {
       remainingToGoal: 42,
     });
 
-    expect(screen.getByText('+5 Reps')).toBeTruthy();
-    expect(screen.getByText('+10 Reps')).toBeTruthy();
-    expect(screen.getByText('+15 Reps')).toBeTruthy();
+    expect(screen.getByText('+5 Liegestütze')).toBeTruthy();
+    expect(screen.getByText('+10 Liegestütze')).toBeTruthy();
+    expect(screen.getByText('+15 Liegestütze')).toBeTruthy();
   });
 
-  it('Given a non-pushup suggestion, Then its localised label and icon render', async () => {
+  it('Given a non-pushup suggestion, Then its localised label renders without an exercise icon', async () => {
     const situps: QuickAddSuggestion = {
       key: 'abs.situps:10',
       reps: 10,
-      icon: 'self_improvement',
       label: '+10 Sit-ups',
       ariaLabel: '10 Sit-ups hinzufügen',
       exerciseId: 'abs.situps',
@@ -157,16 +155,13 @@ describe('QuickAddFabComponent — goal dial item', () => {
       name: /10 Sit-ups hinzufügen/i,
     });
     expect(button).toBeTruthy();
-    expect(button.querySelector('mat-icon')?.textContent).toContain(
-      'self_improvement'
-    );
+    expect(button.querySelector('mat-icon')).toBeNull();
   });
 
   it('When a quick item is clicked, Then the full suggestion is emitted', async () => {
     const situps: QuickAddSuggestion = {
       key: 'abs.situps:10',
       reps: 10,
-      icon: 'self_improvement',
       label: '+10 Sit-ups',
       ariaLabel: '10 Sit-ups hinzufügen',
       exerciseId: 'abs.situps',

--- a/libs/quick-add/src/lib/quick-add-fab.component.ts
+++ b/libs/quick-add/src/lib/quick-add-fab.component.ts
@@ -5,15 +5,14 @@ import { patchState, signalState } from '@ngrx/signals';
 
 /**
  * Pre-resolved quick-add the speed dial should render. Producers
- * (e.g. `AppDataFacade.quickAddSuggestions`) localise the label and
- * resolve the exercise's icon so the FAB stays presentation-only.
+ * (e.g. `AppDataFacade.quickAddSuggestions`) localise the label so the
+ * FAB stays presentation-only.
  * `exerciseId` is opaque to the FAB — it round-trips back through the
  * `quickAdd` output so the dispatcher can pick the right write target.
  */
 export interface QuickAddSuggestion {
   readonly key: string;
   readonly reps: number;
-  readonly icon: string;
   readonly label: string;
   readonly ariaLabel: string;
   readonly exerciseId: string;
@@ -28,7 +27,8 @@ interface DialItem {
     | 'goal'
     | 'auto-count'
     | 'exercise-timer';
-  readonly icon: string;
+  /** Functional glyph for the fixed dial items; quick-add items render label-only. */
+  readonly icon?: string;
   readonly label?: string;
   readonly ariaLabel?: string;
   readonly suggestion?: QuickAddSuggestion;
@@ -66,7 +66,6 @@ export class QuickAddFabComponent {
         (s): DialItem => ({
           value: s.reps,
           type: 'quick',
-          icon: s.icon,
           label: s.label,
           ariaLabel: s.ariaLabel,
           suggestion: s,

--- a/web/src/app/core/app-data.facade.spec.ts
+++ b/web/src/app/core/app-data.facade.spec.ts
@@ -198,6 +198,20 @@ describe('AppDataFacade', () => {
       ).toBe(true);
     });
 
+    it('Given default pushup suggestions, Then their labels carry the exercise name like other exercises', async () => {
+      userConfigApiMock.getConfig.mockReturnValue(
+        of({ userId: 'u1', dailyGoal: 100 })
+      );
+      const facade = setup();
+      await flushResources();
+
+      expect(facade.quickAddSuggestions().map((s) => s.label)).toEqual([
+        '+1 Liegestütze',
+        '+5 Liegestütze',
+        '+10 Liegestütze',
+      ]);
+    });
+
     it('Given configured quickAdds, Then only entries with inSpeedDial=true are returned', async () => {
       userConfigApiMock.getConfig.mockReturnValue(
         of({
@@ -218,7 +232,7 @@ describe('AppDataFacade', () => {
       expect(reps(facade)).toEqual([15, 50]);
     });
 
-    it('Given a configured exercise quick-add, Then the suggestion carries the catalog icon and a localised label', async () => {
+    it('Given a configured exercise quick-add, Then the suggestion carries a localised label', async () => {
       userConfigApiMock.getConfig.mockReturnValue(
         of({
           userId: 'u1',
@@ -241,7 +255,6 @@ describe('AppDataFacade', () => {
       const [s] = facade.quickAddSuggestions();
       expect(s.exerciseId).toBe('abs.situps');
       expect(s.reps).toBe(10);
-      expect(s.icon).toBe('self_improvement');
       expect(s.label).toContain('Sit-ups');
       expect(s.label).toContain('10');
     });
@@ -264,7 +277,7 @@ describe('AppDataFacade', () => {
 
     // A legacy / cross-device-edited config can carry `inSpeedDial: true`
     // alongside `mode: 'auto-count'` (which persists `reps: 0` as a
-    // sentinel). The FAB would otherwise surface a broken `+0 Reps`
+    // sentinel). The FAB would otherwise surface a broken `+0`
     // action that hits `quickAdd(0)`. Filter must drop both auto-count
     // rows and any non-positive reps.
     it('Given configured quickAdds with an auto-count entry in SpeedDial, Then it is filtered out', async () => {

--- a/web/src/app/core/app-data.facade.ts
+++ b/web/src/app/core/app-data.facade.ts
@@ -5,7 +5,6 @@ import { LiveDataStore } from '@pu-stats/data-access-state';
 import {
   type ComplexGoalEntry,
   complexGoalAppliesOnWeekday,
-  findExerciseDefinition,
   formatExerciseValue,
   PUSHUP_QUICK_ADD_EXERCISE_ID,
   type QuickAddConfig,
@@ -18,8 +17,6 @@ import {
 import { TrainingPlanStore } from '../training-plans/training-plan.store';
 import { UserConfigStore } from './user-config.store';
 import { exerciseDisplayName } from '../stats/i18n/exercise-display-names';
-
-const FALLBACK_QUICK_ICONS = ['bolt', 'flash_on', 'whatshot'] as const;
 
 /**
  * Per-exercise view of a single daily goal — exercise name, formatted
@@ -40,8 +37,7 @@ function pushupSuggestion(reps: number, slot: number): QuickAddSuggestion {
   return {
     key: `slot:${slot}`,
     reps,
-    icon: FALLBACK_QUICK_ICONS[slot] ?? 'bolt',
-    label: $localize`:@@quickAdd.fab.pushupRepsLabel:+${reps}:REPS: Reps`,
+    label: `+${reps} ${exerciseDisplayName(PUSHUP_QUICK_ADD_EXERCISE_ID)}`,
     ariaLabel: $localize`:@@quickAdd.fab.repAria:${reps}:REPS: Liegestütze hinzufügen`,
     exerciseId: PUSHUP_QUICK_ADD_EXERCISE_ID,
   };
@@ -55,13 +51,10 @@ function configuredSuggestion(
   if (exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID) {
     return pushupSuggestion(cfg.reps, slot);
   }
-  const def = findExerciseDefinition(exerciseId);
   const exerciseLabel = exerciseDisplayName(exerciseId);
-  const icon = def?.icon ?? 'fitness_center';
   return {
     key: `slot:${slot}`,
     reps: cfg.reps,
-    icon,
     label: `+${cfg.reps} ${exerciseLabel}`,
     ariaLabel: $localize`:@@quickAdd.fab.exerciseRepAria:${cfg.reps}:REPS: ${exerciseLabel}:EXERCISE: hinzufügen`,
     exerciseId,

--- a/web/src/app/core/app-data.facade.ts
+++ b/web/src/app/core/app-data.facade.ts
@@ -33,24 +33,11 @@ export interface DailyGoalItemView {
   readonly reached: boolean;
 }
 
-function pushupSuggestion(reps: number, slot: number): QuickAddSuggestion {
-  return {
-    key: `slot:${slot}`,
-    reps,
-    label: `+${reps} ${exerciseDisplayName(PUSHUP_QUICK_ADD_EXERCISE_ID)}`,
-    ariaLabel: $localize`:@@quickAdd.fab.repAria:${reps}:REPS: Liegestütze hinzufügen`,
-    exerciseId: PUSHUP_QUICK_ADD_EXERCISE_ID,
-  };
-}
-
 function configuredSuggestion(
   cfg: QuickAddConfig,
   slot: number
 ): QuickAddSuggestion {
   const exerciseId = cfg.exerciseId ?? PUSHUP_QUICK_ADD_EXERCISE_ID;
-  if (exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID) {
-    return pushupSuggestion(cfg.reps, slot);
-  }
   const exerciseLabel = exerciseDisplayName(exerciseId);
   return {
     key: `slot:${slot}`,
@@ -110,9 +97,17 @@ export class AppDataFacade {
         .slice(0, 3)
         .map((cfg, i) => configuredSuggestion(cfg, i));
     }
-    return this.adaptiveQuickAdd
-      .compute(this.recentEntries())
-      .map((reps, i) => pushupSuggestion(reps, i));
+    return this.adaptiveQuickAdd.compute(this.recentEntries()).map((reps, i) =>
+      configuredSuggestion(
+        {
+          reps,
+          inSpeedDial: true,
+          exerciseId: PUSHUP_QUICK_ADD_EXERCISE_ID,
+          mode: 'reps',
+        },
+        i
+      )
+    );
   });
 
   /**

--- a/web/src/app/core/quick-add-orchestration.service.spec.ts
+++ b/web/src/app/core/quick-add-orchestration.service.spec.ts
@@ -204,15 +204,13 @@ describe('QuickAddOrchestrationService.addSuggestion', () => {
   const pushupSuggestion: QuickAddSuggestion = {
     key: 'slot:0',
     reps: 10,
-    icon: 'bolt',
-    label: '+10 Reps',
+    label: '+10 Liegestütze',
     ariaLabel: '10 Liegestütze hinzufügen',
     exerciseId: 'pushup',
   };
   const situpsSuggestion: QuickAddSuggestion = {
     key: 'slot:1',
     reps: 12,
-    icon: 'self_improvement',
     label: '+12 Sit-ups',
     ariaLabel: '12 Sit-ups hinzufügen',
     exerciseId: 'abs.situps',

--- a/web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.spec.ts
+++ b/web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.spec.ts
@@ -323,7 +323,7 @@ describe('QuickAddConfigDialogComponent', () => {
 
   // Enabling Auto-Messung on a row that previously had `inSpeedDial: true`
   // would otherwise persist `reps: 0, inSpeedDial: true`, surfacing a
-  // broken `+0 Reps` FAB item. setAutoCount() must clear the SpeedDial
+  // broken `+0` FAB item. setAutoCount() must clear the SpeedDial
   // flag, and save() must defensively coerce it as well.
   describe('When auto-count is enabled on a slot that had inSpeedDial=true', () => {
     it('Then save persists inSpeedDial=false alongside mode "auto-count"', async () => {

--- a/web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts
+++ b/web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts
@@ -310,7 +310,7 @@ export class QuickAddConfigDialogComponent {
     if (!this.isAutoCountCapable(prev.exerciseId)) return;
     // Auto-count + SpeedDial is incoherent: the FAB pipeline only knows how
     // to fire a fixed-reps `quickAdd(n)` call, so a SpeedDial item paired
-    // with `reps: 0` would surface as a broken `+0 Reps` action. Force the
+    // with `reps: 0` would surface as a broken `+0` action. Force the
     // flag off here; the read-time facade filter
     // (`AppDataFacade.quickAddSuggestions`) defends against legacy configs.
     const inSpeedDial = checked ? false : prev.inSpeedDial;

--- a/web/src/app/stats/dashboard/quick-add-view-model.spec.ts
+++ b/web/src/app/stats/dashboard/quick-add-view-model.spec.ts
@@ -5,7 +5,7 @@ import {
 } from './quick-add-view-model';
 
 describe('toQuickAddViewModel', () => {
-  it('should label the pushup sentinel with the fitness fallback icon', () => {
+  it('should compose the pushup sentinel label from the exercise display name', () => {
     // given the legacy pushup sentinel in reps mode
     const vm = toQuickAddViewModel(
       {
@@ -20,12 +20,11 @@ describe('toQuickAddViewModel', () => {
     expect(vm.key).toBe('slot:0');
     expect(vm.exerciseId).toBe('pushup');
     expect(vm.reps).toBe(10);
-    expect(vm.icon).toBe('fitness_center');
     expect(vm.label).toBe(`+10 ${vm.exerciseLabel}`);
     expect(vm.exerciseLabel.length).toBeGreaterThan(0);
   });
 
-  it('should resolve a catalog exercise icon and reps label', () => {
+  it('should resolve a catalog exercise reps label', () => {
     // given a rep-based catalog exercise
     const vm = toQuickAddViewModel(
       { reps: 15, inSpeedDial: false, exerciseId: 'legs.squats', mode: 'reps' },
@@ -34,11 +33,10 @@ describe('toQuickAddViewModel', () => {
     // then
     expect(vm.key).toBe('slot:2');
     expect(vm.exerciseId).toBe('legs.squats');
-    expect(vm.icon.length).toBeGreaterThan(0);
     expect(vm.label).toBe(`+15 ${vm.exerciseLabel}`);
   });
 
-  it('should use the camera icon and drop the reps prefix for auto-count mode', () => {
+  it('should drop the reps prefix for auto-count mode', () => {
     // given an auto-count-capable exercise in auto-count mode
     const vm = toQuickAddViewModel(
       {
@@ -51,7 +49,6 @@ describe('toQuickAddViewModel', () => {
     );
     // then
     expect(vm.mode).toBe('auto-count');
-    expect(vm.icon).toBe('videocam');
     expect(vm.label).toBe(vm.exerciseLabel);
   });
 });

--- a/web/src/app/stats/dashboard/quick-add-view-model.ts
+++ b/web/src/app/stats/dashboard/quick-add-view-model.ts
@@ -1,6 +1,4 @@
 import {
-  findExerciseDefinition,
-  isAutoCountQuickAddExerciseId,
   PUSHUP_QUICK_ADD_EXERCISE_ID,
   type QuickAddConfig,
   type QuickAddMode,
@@ -20,8 +18,6 @@ export interface QuickAddButtonViewModel {
   readonly exerciseId: string;
   /** Rep count for `mode === 'reps'`; ignored for `'auto-count'`. */
   readonly reps: number;
-  /** Material icon name — exercise's catalog icon, with mode-aware fallbacks. */
-  readonly icon: string;
   /** Translated exercise display label (e.g. `"Liegestütze"`). */
   readonly exerciseLabel: string;
   /** Fully composed button label: `"+10 Liegestütze"` in reps mode, or
@@ -35,15 +31,7 @@ export function toQuickAddViewModel(
 ): QuickAddButtonViewModel {
   const exerciseId = config.exerciseId ?? PUSHUP_QUICK_ADD_EXERCISE_ID;
   const mode: QuickAddMode = config.mode ?? 'reps';
-  const def = findExerciseDefinition(exerciseId);
   const exerciseLabel = exerciseDisplayName(exerciseId);
-  // The catalog `icon` is the natural per-exercise glyph, with a
-  // `fitness_center` fallback for unknown ids; auto-count rows override
-  // to a camera icon to make the mode visually obvious.
-  const icon =
-    mode === 'auto-count' && isAutoCountQuickAddExerciseId(exerciseId)
-      ? 'videocam'
-      : (def?.icon ?? 'fitness_center');
   const repsLabel = mode === 'auto-count' ? '' : `+${config.reps} `;
   const label = `${repsLabel}${exerciseLabel}`;
   return {
@@ -51,7 +39,6 @@ export function toQuickAddViewModel(
     mode,
     exerciseId,
     reps: config.reps,
-    icon,
     exerciseLabel,
     label,
   };

--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -161,14 +161,12 @@
           [attr.data-exercise]="vm.exerciseId"
           (click)="addQuickEntryFromConfig(vm)"
         >
-          <mat-icon>{{ vm.icon }}</mat-icon>
           @if (vm.mode === 'auto-count') {
+            <mat-icon>videocam</mat-icon>
             <span>
               <span i18n="@@dashboard.quickAdd.autoPrefix">Auto:</span>
               {{ vm.exerciseLabel }}
             </span>
-          } @else if (vm.exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID) {
-            <span i18n="@@dashboard.quickAdd.button">+{{ vm.reps }} Reps</span>
           } @else {
             <span>+{{ vm.reps }} {{ vm.exerciseLabel }}</span>
           }
@@ -400,9 +398,6 @@
           >
             <mat-card>
               <mat-card-content>
-                <div class="tile-icon" aria-hidden="true">
-                  <mat-icon>{{ tileIcon(entry) }}</mat-icon>
-                </div>
                 <div class="tile-body">
                   <strong class="tile-title">{{
                     exerciseEntryLabel(entry)

--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -168,7 +168,7 @@
               {{ vm.exerciseLabel }}
             </span>
           } @else {
-            <span>+{{ vm.reps }} {{ vm.exerciseLabel }}</span>
+            <span>{{ vm.label }}</span>
           }
         </button>
       }

--- a/web/src/app/stats/shell/stats-dashboard.component.scss
+++ b/web/src/app/stats/shell/stats-dashboard.component.scss
@@ -605,24 +605,6 @@ h1 {
     }
   }
 
-  .tile-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border-radius: 10px;
-    background: rgba(83, 130, 220, 0.18);
-    color: #b6c9ee;
-    flex-shrink: 0;
-
-    mat-icon {
-      font-size: 20px;
-      width: 20px;
-      height: 20px;
-    }
-  }
-
   .tile-body {
     display: flex;
     flex-direction: column;
@@ -833,11 +815,6 @@ h1 {
         rgba(255, 255, 255, 0.95),
         rgba(248, 250, 252, 0.98)
       );
-    }
-
-    .tile-icon {
-      background: rgba(59, 130, 246, 0.12);
-      color: #3b82f6;
     }
 
     .tile-title {

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -358,9 +358,9 @@ describe('StatsDashboardComponent', () => {
         const text = fixture.nativeElement.textContent;
 
         // Then
-        expect(text).toContain('+10 Reps');
-        expect(text).toContain('+20 Reps');
-        expect(text).toContain('+30 Reps');
+        expect(text).toContain('+10 Liegestütze');
+        expect(text).toContain('+20 Liegestütze');
+        expect(text).toContain('+30 Liegestütze');
       });
 
       it('Then it should render the Schnellaktionen edit icon', () => {
@@ -445,22 +445,13 @@ describe('StatsDashboardComponent', () => {
         expect(cta.textContent).toContain('Zur Historie');
       });
 
-      it('Then tileIcon returns sports_gymnastics for all entry kinds', () => {
-        const component = fixture.componentInstance;
-        const pushupIcon = component.tileIcon({
-          _id: 'p',
-          kind: 'pushup',
-          timestamp: todayTs,
-          reps: 10,
-        } as unknown as Parameters<typeof component.tileIcon>[0]);
-        const exerciseIcon = component.tileIcon({
-          _id: 'e',
-          kind: 'exercise',
-          exerciseId: 'plank.standard',
-          timestamp: todayTs,
-        } as unknown as Parameters<typeof component.tileIcon>[0]);
-        expect(pushupIcon).toBe('sports_gymnastics');
-        expect(exerciseIcon).toBe('sports_gymnastics');
+      it('Then a recent-exercise tile renders without a decorative icon', () => {
+        const root = fixture.nativeElement as HTMLElement;
+        const tile = root.querySelector<HTMLElement>(
+          '[data-testid="dashboard-recent-exercise-tile"]'
+        );
+        expect(tile).toBeTruthy();
+        expect(tile?.querySelector('mat-icon')).toBeNull();
       });
 
       it('Then the Schnellaktionen card is rendered above the today-focus section', () => {
@@ -500,12 +491,12 @@ describe('StatsDashboardComponent', () => {
         await freshFixture.whenStable();
 
         const text = freshFixture.nativeElement.textContent;
-        expect(text).toContain('+15 Reps');
-        expect(text).toContain('+25 Reps');
-        expect(text).toContain('+50 Reps');
-        expect(text).not.toContain('+10 Reps');
-        expect(text).not.toContain('+20 Reps');
-        expect(text).not.toContain('+30 Reps');
+        expect(text).toContain('+15 Liegestütze');
+        expect(text).toContain('+25 Liegestütze');
+        expect(text).toContain('+50 Liegestütze');
+        expect(text).not.toContain('+10 Liegestütze');
+        expect(text).not.toContain('+20 Liegestütze');
+        expect(text).not.toContain('+30 Liegestütze');
       });
     });
   });
@@ -655,7 +646,6 @@ describe('StatsDashboardComponent', () => {
           mode: 'reps',
           exerciseId: 'pushup',
           reps: 12,
-          icon: 'fitness_center',
           exerciseLabel: 'Liegestütze',
           label: '+12 Liegestütze',
         });
@@ -682,7 +672,6 @@ describe('StatsDashboardComponent', () => {
           mode: 'reps',
           exerciseId: 'abs.situps',
           reps: 20,
-          icon: 'self_improvement',
           exerciseLabel: 'Sit-ups',
           label: '+20 Sit-ups',
         });
@@ -713,7 +702,6 @@ describe('StatsDashboardComponent', () => {
           mode: 'auto-count',
           exerciseId: 'legs.squats',
           reps: 0,
-          icon: 'videocam',
           exerciseLabel: 'Kniebeugen',
           label: 'Auto: Kniebeugen',
         });
@@ -736,7 +724,6 @@ describe('StatsDashboardComponent', () => {
           mode: 'auto-count',
           exerciseId: 'hinge.goodmorning',
           reps: 0,
-          icon: 'videocam',
           exerciseLabel: 'Good Morning',
           label: 'Auto: Good Morning',
         });

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -90,8 +90,6 @@ export class StatsDashboardComponent {
   readonly exerciseEntryLabel = (entry: UnifiedEntry): string =>
     exerciseDisplayName(entry.exerciseId);
 
-  readonly tileIcon = (_entry: UnifiedEntry): string => 'sports_gymnastics';
-
   readonly tileAriaLabel = (entry: UnifiedEntry): string => {
     const label = this.exerciseEntryLabel(entry);
     return $localize`:@@dashboard.tile.openInHistoryAria:${label}:label: in der Historie öffnen`;
@@ -129,12 +127,6 @@ export class StatsDashboardComponent {
   readonly monthlyGoalReached = this.store.monthlyGoalReached;
   readonly fillToGoalInFlight = this.quickAdd.fillToGoalInFlight;
   readonly quickAddButtons = this.store.quickAddButtons;
-  // Exposed for the template so the quick-add branch can compare against
-  // the canonical sentinel instead of the literal string 'pushup' —
-  // keeps one source of truth between the schema, the orchestrator, and
-  // the dashboard.
-  protected readonly PUSHUP_QUICK_ADD_EXERCISE_ID =
-    PUSHUP_QUICK_ADD_EXERCISE_ID;
   readonly adSlotDashboardInline = this.store.adSlotDashboardInline;
   readonly dashboardInlineAdsEnabled = this.store.dashboardInlineAdsEnabled;
   readonly planActive = this.store.planActive;

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -909,15 +909,6 @@
         <target>Ο ημερήσιος στόχος έχει ήδη επιτευχθεί</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.repAria">
-      <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:71</note>
-      </notes>
-      <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
-        <target><ph id="0" equiv="REPS" disp="reps"/> Προσθέστε push-ups</target>
-      </segment>
-    </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:75</note>
@@ -4635,15 +4626,6 @@
         <target>Προσθήκη <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.pushupRepsLabel">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
-        <target>+<ph id="0" equiv="REPS" disp="reps"/> Επ.</target>
-      </segment>
-    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>
@@ -6120,15 +6102,6 @@
       <segment state="translated">
         <source>Schnellaktionen bearbeiten</source>
         <target>Επεξεργασία γρήγορων ενεργειών</target>
-      </segment>
-    </unit>
-    <unit id="dashboard.quickAdd.button">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Επαν</target>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.reached">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -3030,15 +3030,6 @@ Deine Position: # ·  Reps        </source>
       
       
         </unit>
-    <unit id="dashboard.quickAdd.button">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ vm.reps }}" /> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ vm.reps }}" /> reps</target>
-      </segment>
-    </unit>
     <unit id="dashboard.quickAdd.autoPrefix">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html</note>
@@ -3118,15 +3109,6 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
         <target>Add <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
-      </segment>
-    </unit>
-    <unit id="quickAdd.fab.pushupRepsLabel">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
-        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
       </segment>
     </unit>
     <unit id="quickAddConfig.hintV2">
@@ -5663,12 +5645,6 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> Reps</source>
         <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}" /> Reps</target>
-      </segment>
-    </unit>
-    <unit id="quickAdd.fab.repAria">
-      <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps" /> Liegestütze hinzufügen</source>
-        <target>Add <ph id="0" equiv="REPS" disp="reps" /> push-ups</target>
       </segment>
     </unit>
     <unit id="quickAdd.success.create">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -909,15 +909,6 @@
         <target>Meta diaria ya cumplida</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.repAria">
-      <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:71</note>
-      </notes>
-      <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps" /> Liegestütze hinzufügen</source>
-        <target><ph id="0" equiv="REPS" disp="reps" /> Añadir flexiones</target>
-      </segment>
-    </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:75</note>
@@ -4635,15 +4626,6 @@
         <target>Añadir <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.pushupRepsLabel">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
-        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
-      </segment>
-    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>
@@ -6116,15 +6098,6 @@
       <segment state="translated">
         <source>Schnellaktionen bearbeiten</source>
         <target>Editar acciones rápidas</target>
-      </segment>
-    </unit>
-    <unit id="dashboard.quickAdd.button">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /> repeticiones</target>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.reached">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -909,15 +909,6 @@
         <target>Objectif quotidien déjà atteint</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.repAria">
-      <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:71</note>
-      </notes>
-      <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps" /> Liegestütze hinzufügen</source>
-        <target><ph id="0" equiv="REPS" disp="reps" /> Ajouter des pompes</target>
-      </segment>
-    </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:75</note>
@@ -4635,15 +4626,6 @@
         <target>Ajouter <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.pushupRepsLabel">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
-        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
-      </segment>
-    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>
@@ -6109,15 +6091,6 @@
       <segment state="translated">
         <source>Schnellaktionen bearbeiten</source>
         <target>Modifier les actions rapides</target>
-      </segment>
-    </unit>
-    <unit id="dashboard.quickAdd.button">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /> Reps</source>
-        <target>+ Représentants <ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /></target>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.reached">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -909,15 +909,6 @@
         <target>Obiettivo giornaliero già raggiunto</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.repAria">
-      <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:71</note>
-      </notes>
-      <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
-        <target><ph id="0" equiv="REPS" disp="reps"/> Aggiungi flessioni</target>
-      </segment>
-    </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:75</note>
@@ -4635,15 +4626,6 @@
         <target>Aggiungi <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.pushupRepsLabel">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
-        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
-      </segment>
-    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>
@@ -6120,15 +6102,6 @@
       <segment state="translated">
         <source>Schnellaktionen bearbeiten</source>
         <target>Modifica azioni rapide</target>
-      </segment>
-    </unit>
-    <unit id="dashboard.quickAdd.button">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Rip</target>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.reached">

--- a/web/src/locale/messages.la.xlf
+++ b/web/src/locale/messages.la.xlf
@@ -909,15 +909,6 @@
         <target>Cotidie metam iam consecuti</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.repAria">
-      <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:71</note>
-      </notes>
-      <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
-        <target><ph id="0" equiv="REPS" disp="reps"/> Add dis-ups</target>
-      </segment>
-    </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:75</note>
@@ -4635,15 +4626,6 @@
         <target><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> addere</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.pushupRepsLabel">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
-        <target>+<ph id="0" equiv="REPS" disp="reps"/> Rep.</target>
-      </segment>
-    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>
@@ -6120,15 +6102,6 @@
       <segment state="translated">
         <source>Schnellaktionen bearbeiten</source>
         <target>velox actiones recensere</target>
-      </segment>
-    </unit>
-    <unit id="dashboard.quickAdd.button">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</target>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.reached">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -909,15 +909,6 @@
         <target>Dagelijks doel al bereikt</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.repAria">
-      <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:71</note>
-      </notes>
-      <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
-        <target><ph id="0" equiv="REPS" disp="reps"/> Push-ups toevoegen</target>
-      </segment>
-    </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:75</note>
@@ -4635,15 +4626,6 @@
         <target><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> toevoegen</target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.pushupRepsLabel">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
-        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
-      </segment>
-    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>
@@ -6120,15 +6102,6 @@
       <segment state="translated">
         <source>Schnellaktionen bearbeiten</source>
         <target>Snelle acties bewerken</target>
-      </segment>
-    </unit>
-    <unit id="dashboard.quickAdd.button">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> reps</target>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.reached">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -2478,15 +2478,6 @@ Deine Position: # ·  Reps        </source>
             </segment>
 
         </unit>
-    <unit id="dashboard.quickAdd.button">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> Reps</source>
-        <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}"/> armhevninger</target>
-      </segment>
-    </unit>
     <unit id="quickActions.edit.aria">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html</note>
@@ -2557,15 +2548,6 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source><ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
         <target>Legg til <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
-      </segment>
-    </unit>
-    <unit id="quickAdd.fab.pushupRepsLabel">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
-        <target>+<ph id="0" equiv="REPS" disp="reps"/> Reps</target>
       </segment>
     </unit>
     <unit id="quickAddConfig.clearAria">
@@ -4687,12 +4669,6 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> Reps</source>
         <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> Reps</target>
-      </segment>
-    </unit>
-    <unit id="quickAdd.fab.repAria">
-      <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
-        <target>Legg til <ph id="0" equiv="REPS" disp="reps"/> armhevinger</target>
       </segment>
     </unit>
     <unit id="quickAdd.success.create">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -807,7 +807,7 @@
     </unit>
     <unit id="quickAdd.fab.open">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:98</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:97</note>
       </notes>
       <segment>
         <source>Schnellerfassung öffnen</source>
@@ -815,7 +815,7 @@
     </unit>
     <unit id="quickAdd.fab.close">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:99</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:98</note>
       </notes>
       <segment>
         <source>Schnellerfassung schließen</source>
@@ -823,7 +823,7 @@
     </unit>
     <unit id="quickAdd.fab.goalReached">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:100</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:99</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -831,7 +831,7 @@
     </unit>
     <unit id="quickAdd.fab.goalReachedAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:101</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:100</note>
       </notes>
       <segment>
         <source>Tagesziel bereits erreicht</source>
@@ -839,7 +839,7 @@
     </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:104</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:103</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="GAP" disp="gap"/> Liegestütze bis zum Tagesziel hinzufügen</source>
@@ -4198,17 +4198,9 @@
         <source>Artikel lesen</source>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.pushupRepsLabel">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:44</note>
-      </notes>
-      <segment>
-        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
-      </segment>
-    </unit>
     <unit id="quickAdd.fab.repAria">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:45</note>
+        <note category="location">web/src/app/core/app-data.facade.ts:41</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
@@ -4216,7 +4208,7 @@
     </unit>
     <unit id="quickAdd.fab.exerciseRepAria">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:66</note>
+        <note category="location">web/src/app/core/app-data.facade.ts:59</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="REPS" disp="cfg.reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
@@ -4224,7 +4216,7 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:332</note>
+        <note category="location">web/src/app/core/app-data.facade.ts:325</note>
         <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:43</note>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:123</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:385</note>
@@ -9348,7 +9340,7 @@
     <unit id="trainingPlans.kind.rest">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:80,81</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:264,266</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:262,264</note>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.html:202,203</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:108,109</note>
       </notes>
@@ -9379,7 +9371,7 @@
     <unit id="trainingPlans.reps">
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:88,90</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:277,279</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:275,277</note>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.html:211,212</note>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.html:217,218</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:126,128</note>
@@ -9453,17 +9445,9 @@
         <source>Auto:</source>
       </segment>
     </unit>
-    <unit id="dashboard.quickAdd.button">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:171,172</note>
-      </notes>
-      <segment>
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ vm.reps }}"/> Reps</source>
-      </segment>
-    </unit>
     <unit id="dashboard.goalFill.reached">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:192,194</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:190,192</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -9471,7 +9455,7 @@
     </unit>
     <unit id="dashboard.goalFill.fill">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:195,196</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:193,194</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ remainingToGoal() }}"/> bis zum Ziel</source>
@@ -9479,7 +9463,7 @@
     </unit>
     <unit id="quickAddNew">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:207,209</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:205,207</note>
       </notes>
       <segment>
         <source><pc id="0" equivStart="START_TAG_MAT_ICON" equivEnd="CLOSE_TAG_MAT_ICON" type="other" dispStart="&lt;mat-icon&gt;" dispEnd="&lt;/mat-icon&gt;">edit_note</pc> Neu </source>
@@ -9487,7 +9471,7 @@
     </unit>
     <unit id="dashboard.quickActions.speedDialHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:213,217</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:211,215</note>
       </notes>
       <segment>
         <source>Tipp: Über den schwebenden +‑Button unten rechts erfasst du von jeder Seite aus blitzschnell.</source>
@@ -9495,7 +9479,7 @@
     </unit>
     <unit id="todayFocusAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:222,223</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:220,221</note>
       </notes>
       <segment>
         <source>Tagesfokus</source>
@@ -9503,7 +9487,7 @@
     </unit>
     <unit id="dashboard.todayTotal">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:228,230</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:226,228</note>
       </notes>
       <segment>
         <source>Heute Gesamt</source>
@@ -9511,7 +9495,7 @@
     </unit>
     <unit id="goalProgressTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:239,241</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:237,239</note>
       </notes>
       <segment>
         <source>Zielfortschritt</source>
@@ -9519,7 +9503,7 @@
     </unit>
     <unit id="dashboard.goalEditAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:247,248</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:245,246</note>
       </notes>
       <segment>
         <source>Tagesziel in Einstellungen öffnen</source>
@@ -9527,9 +9511,9 @@
     </unit>
     <unit id="dashboard.dailyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:256,258</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:283</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:302,303</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:254,256</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:281</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:300,301</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -9537,7 +9521,7 @@
     </unit>
     <unit id="dashboard.restDay.configuredGoalHint">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:273,275</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:271,273</note>
       </notes>
       <segment>
         <source>Konfiguriertes Tagesziel:</source>
@@ -9545,7 +9529,7 @@
     </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:312,313</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:310,311</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -9553,7 +9537,7 @@
     </unit>
     <unit id="dashboard.monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:321,322</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:319,320</note>
       </notes>
       <segment>
         <source>Monat</source>
@@ -9561,7 +9545,7 @@
     </unit>
     <unit id="dashboard.lastEntryLinkAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:346,347</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:344,345</note>
       </notes>
       <segment>
         <source>Letzten Eintrag in der Historie öffnen</source>
@@ -9569,7 +9553,7 @@
     </unit>
     <unit id="lastEntryTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:350,351</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:348,349</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -9577,8 +9561,8 @@
     </unit>
     <unit id="dashboard.noEntryYet">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:360,362</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:426,429</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:358,360</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:421,424</note>
       </notes>
       <segment>
         <source>Noch kein Eintrag.</source>
@@ -9586,7 +9570,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:381,385</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:379,383</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -9594,7 +9578,7 @@
     </unit>
     <unit id="dashboard.latestExercises">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:386,387</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:384,385</note>
       </notes>
       <segment>
         <source>Letzte Übungen</source>
@@ -9602,7 +9586,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:433,434</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:428,429</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -9610,7 +9594,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:438,441</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:433,436</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -9618,7 +9602,7 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:444</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:439</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -9626,7 +9610,7 @@
     </unit>
     <unit id="dashboard.tile.openInHistoryAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:97</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:95</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="label" disp="label"/> in der Historie öffnen</source>
@@ -9634,7 +9618,7 @@
     </unit>
     <unit id="dashboard.share.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:100</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:98</note>
       </notes>
       <segment>
         <source>Tagesleistung teilen</source>
@@ -9642,7 +9626,7 @@
     </unit>
     <unit id="dashboard.share">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:101</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:99</note>
       </notes>
       <segment>
         <source>Teilen</source>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4198,17 +4198,9 @@
         <source>Artikel lesen</source>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.repAria">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:41</note>
-      </notes>
-      <segment>
-        <source><ph id="0" equiv="REPS" disp="reps"/> Liegestütze hinzufügen</source>
-      </segment>
-    </unit>
     <unit id="quickAdd.fab.exerciseRepAria">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:59</note>
+        <note category="location">web/src/app/core/app-data.facade.ts:46</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="REPS" disp="cfg.reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
@@ -4216,7 +4208,7 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:325</note>
+        <note category="location">web/src/app/core/app-data.facade.ts:322</note>
         <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:43</note>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:123</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:385</note>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -828,16 +828,6 @@
         <source>Tagesziel bereits erreicht</source>
       <target>每日目标已达成</target></segment>
     </unit>
-    <unit id="quickAdd.fab.repAria">
-      <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:71</note>
-      </notes>
-      <segment state="translated">
-        <source><ph id="0" equiv="REPS" disp="reps" /> Liegestütze hinzufügen</source>
-
-        <target>添加 <ph id="0" equiv="REPS" disp="reps" /> 个俯卧撑</target>
-      </segment>
-    </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
         <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:75</note>
@@ -5224,15 +5214,6 @@
         <target>添加 <ph id="0" equiv="REPS" disp="reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/></target>
       </segment>
     </unit>
-    <unit id="quickAdd.fab.pushupRepsLabel">
-      <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="REPS" disp="reps"/> Reps</source>
-        <target>+<ph id="0" equiv="REPS" disp="reps"/> 次</target>
-      </segment>
-    </unit>
     <unit id="save">
       <notes>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:84,85</note>
@@ -6677,14 +6658,6 @@
       <segment state="translated">
         <source>Schnellaktionen bearbeiten</source>
       <target>编辑快速操作</target></segment>
-    </unit>
-    <unit id="dashboard.quickAdd.button">
-      <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:208,209</note>
-      </notes>
-      <segment state="translated">
-        <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /> Reps</source>
-      <target>+<ph id="0" equiv="INTERPOLATION" disp="{{ reps }}" /> 次</target></segment>
     </unit>
     <unit id="dashboard.goalFill.reached">
       <notes>


### PR DESCRIPTION
## What

**Pushup quick actions now carry the exercise name like every other exercise.**
- Dashboard *Schnellaktionen* card: default/configured pushup buttons read `+10 Liegestütze` instead of `+10 Reps` (special-case branch in the template removed — the shared view-model label is used for all exercises).
- Speed dial (FAB): default pushup suggestions likewise read `+N Liegestütze`, composed from the shared exercise display name so the existing `@@exercise.category.pushup` translation is reused across all locales. The now-unused `@@quickAdd.fab.pushupRepsLabel` and `@@dashboard.quickAdd.button` XLIFF units were removed via `extract-i18n` + locale sync.

**Decorative exercise icons removed** from:
- the *Schnellaktionen* buttons (the auto-count camera icon stays — it marks the mode, not the exercise),
- the speed-dial quick-add items (functional dial icons — goal flag, timer, camera, feedback — stay),
- the *Letzte Übungen* tiles (every entry showed the same generic `sports_gymnastics` glyph).

The exercise catalog only has coarse category-level Material glyphs (all core exercises share `self_improvement`, dips get `open_with` arrows, …), so once arbitrary exercises are configurable the icons were misleading rather than informative. The labels now carry the meaning. `QuickAddSuggestion.icon` and `QuickAddButtonViewModel.icon` were deleted rather than shimmed.

## Tests

- Updated dashboard, FAB, view-model, facade and orchestration specs to the new labels/icon-less rendering; added regression tests that default pushup suggestions are labelled `+N Liegestütze` and that recent-exercise tiles render without a decorative icon.
- `pnpm nx run-many --target=test --projects=quick-add,web`: **1430/1430 web tests + quick-add suite pass.**
- `pnpm nx affected -t=lint,test,build -c=production`: lint and production build green. The `web:test` production-config run fails in `admin-*.spec.ts` — verified pre-existing on a clean `main` checkout (same failures with the working tree stashed), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsFBW4skPe6yRRPjbKxdCh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsFBW4skPe6yRRPjbKxdCh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Quick-add actions now show clearer exercise-based labels, such as localized push-up names, instead of generic repetition text.
  * Recent exercise tiles were simplified to display only the core entry details, without decorative icons.

* **Bug Fixes**
  * Quick-add buttons and dashboard actions now behave consistently with the updated label-only presentation.
  * Accessibility labels and quick-action interactions remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->