### PR TITLE
fix(blog): emit correct hreflang alternates for posts in 3+ locales

### DIFF
--- a/tools/src/generate-content.mjs
+++ b/tools/src/generate-content.mjs
@@ -115,8 +115,11 @@ function assertSafeLang(lang, sourcePath) {
  * BlogPost-shaped object per locale file. Folder name is the
  * cross-locale identifier; per-locale `slug` in frontmatter overrides
  * the URL slug for that locale (so `liegestuetze-fehler/en.md` can set
- * `slug: pushup-mistakes`). The other locale's slug becomes
- * `translationSlug` automatically — no manual cross-reference needed.
+ * `slug: pushup-mistakes`). Every post carries `alternateSlugs` — the
+ * map of every sibling locale's slug (including this post's own) —
+ * mirroring `scanMarkdownBlogPosts` in `generate-sitemap.js` so the
+ * runtime SEO service can emit a full hreflang set, not just a
+ * single bilingual pairing.
  */
 export function loadBlogPosts(contentRoot) {
   const blogRoot = join(contentRoot, 'blog');
@@ -172,14 +175,9 @@ export function loadBlogPosts(contentRoot) {
         keywords: Array.isArray(data.keywords) ? data.keywords.map(String) : [],
       };
       if (data.updatedAt) post.updatedAt = String(data.updatedAt);
-      // Build translationSlug: other-locale entry in same folder, if present.
-      // For bilingual (de/en) pairs the other locale's slug becomes translationSlug.
-      // For multi-locale folders this is omitted (sitemap handles hreflang separately).
-      const otherLangs = langs.filter((l) => l !== lang);
-      if (otherLangs.length === 1) {
-        const other = perLocale[otherLangs[0]];
-        post.translationSlug = other.data.slug ?? folder;
-      }
+      post.alternateSlugs = Object.fromEntries(
+        langs.map((l) => [l, perLocale[l].data.slug ?? folder])
+      );
       if (data.heroImage) post.heroImage = String(data.heroImage);
       if (data.heroImageAlt) post.heroImageAlt = String(data.heroImageAlt);
       if (data.heroImageCredit) {

--- a/tools/src/generate-content.spec.js
+++ b/tools/src/generate-content.spec.js
@@ -1,0 +1,95 @@
+const { execFileSync } = require('node:child_process');
+const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+const { tmpdir } = require('node:os');
+
+const GENERATOR = resolve(__dirname, 'generate-content.mjs');
+
+// `generate-content.mjs` is ESM; run `loadBlogPosts` in a throwaway node
+// subprocess (mirrors the execFileSync pattern in
+// detect-translation-gaps.spec.js) rather than importing it into this
+// CommonJS Jest test, since `tools/jest.config.cjs` only transforms
+// `.ts`/`.js`.
+function runLoadBlogPosts(contentRoot) {
+  const script = `
+    import { loadBlogPosts } from ${JSON.stringify(GENERATOR)};
+    process.stdout.write(JSON.stringify(loadBlogPosts(${JSON.stringify(contentRoot)})));
+  `;
+  const out = execFileSync('node', ['--input-type=module', '-e', script], {
+    encoding: 'utf-8',
+  });
+  return JSON.parse(out);
+}
+
+function writePost(contentRoot, folder, lang, frontmatter) {
+  const dir = join(contentRoot, 'blog', folder);
+  mkdirSync(dir, { recursive: true });
+  const yaml = Object.entries(frontmatter)
+    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+    .join('\n');
+  writeFileSync(join(dir, `${lang}.md`), `---\n${yaml}\n---\n\nBody text.\n`);
+}
+
+describe('loadBlogPosts', () => {
+  let contentRoot;
+
+  beforeEach(() => {
+    contentRoot = mkdtempSync(join(tmpdir(), 'generate-content-'));
+  });
+
+  afterEach(() => {
+    rmSync(contentRoot, { recursive: true, force: true });
+  });
+
+  it('maps every sibling locale to its own slug when a post has more than two translations', () => {
+    // given — a folder with 3 locale files, each with a different slug
+    // (regression: the old `translationSlug` field was only ever set
+    // for exactly-2-locale folders, so posts translated into 3+
+    // locales got no cross-locale slug mapping at all).
+    writePost(contentRoot, 'liegestuetze-fehler', 'de', {
+      slug: 'liegestuetze-fehler',
+      title: 'Titel',
+      description: 'Beschreibung',
+      publishedAt: '2026-04-30',
+    });
+    writePost(contentRoot, 'liegestuetze-fehler', 'en', {
+      slug: 'pushup-mistakes',
+      title: 'Title',
+      description: 'Description',
+      publishedAt: '2026-04-30',
+    });
+    writePost(contentRoot, 'liegestuetze-fehler', 'zh', {
+      slug: 'pushup-mistakes',
+      title: '标题',
+      description: '描述',
+      publishedAt: '2026-04-30',
+    });
+
+    // when
+    const posts = runLoadBlogPosts(contentRoot);
+    const zhPost = posts.find((post) => post.lang === 'zh');
+
+    // then
+    expect(zhPost.alternateSlugs).toEqual({
+      de: 'liegestuetze-fehler',
+      en: 'pushup-mistakes',
+      zh: 'pushup-mistakes',
+    });
+  });
+
+  it('maps to itself when a post has no sibling translations', () => {
+    // given
+    writePost(contentRoot, 'solo-post', 'de', {
+      slug: 'solo-post',
+      title: 'Titel',
+      description: 'Beschreibung',
+      publishedAt: '2026-04-30',
+    });
+
+    // when
+    const posts = runLoadBlogPosts(contentRoot);
+
+    // then
+    expect(posts[0].alternateSlugs).toEqual({ de: 'solo-post' });
+  });
+});

--- a/web/src/app/blog/blog-article.component.spec.ts
+++ b/web/src/app/blog/blog-article.component.spec.ts
@@ -1,0 +1,101 @@
+import { LOCALE_ID } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ActivatedRoute,
+  convertToParamMap,
+  provideRouter,
+} from '@angular/router';
+import { registerLocaleData } from '@angular/common';
+import localeZh from '@angular/common/locales/zh';
+import { BlogArticleComponent } from './blog-article.component';
+import { SeoService } from '../core/seo.service';
+import { findBlogPost } from './blog-posts.data';
+
+// The global test-setup only registers `de`/`fr` locale data; the zh
+// fixture below needs `zh` so the article template's DatePipe doesn't
+// throw NG0701 when rendering the zh post's `publishedAt`.
+registerLocaleData(localeZh);
+
+describe('BlogArticleComponent', () => {
+  let fixture: ComponentFixture<BlogArticleComponent>;
+  const seoMock = { update: vi.fn() };
+
+  function makeRoute(slug: string): ActivatedRoute {
+    const map = convertToParamMap({ slug });
+    return { snapshot: { paramMap: map } } as unknown as ActivatedRoute;
+  }
+
+  async function setup(slug: string, locale: string): Promise<void> {
+    vi.clearAllMocks();
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [BlogArticleComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: makeRoute(slug) },
+        { provide: SeoService, useValue: seoMock },
+        { provide: LOCALE_ID, useValue: locale },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BlogArticleComponent);
+    fixture.detectChanges();
+  }
+
+  describe('hreflang alternates', () => {
+    it('should pass every sibling locale slug through to SeoService for a post translated into more than two locales', async () => {
+      // given — "liegestuetze-fehler" ships in all 10 supported locales
+      // with a distinct slug per locale (regression: the old
+      // `translationSlug` field only ever covered exactly-2-locale
+      // posts, so the zh post produced no `de` alternate at all, and
+      // SeoService's x-default fallback then advertised the German
+      // site under the *zh* slug `pushup-mistakes` — a URL that never
+      // existed; the real German slug is `liegestuetze-fehler`).
+      const post = findBlogPost('pushup-mistakes', 'zh');
+      expect(post).toBeDefined();
+
+      // when
+      await setup('pushup-mistakes', 'zh');
+
+      // then
+      expect(seoMock.update).toHaveBeenCalledWith(
+        post?.title,
+        post?.description,
+        '/blog/pushup-mistakes',
+        expect.objectContaining({
+          alternates: expect.objectContaining({
+            de: '/blog/liegestuetze-fehler',
+            en: '/blog/pushup-mistakes',
+            zh: '/blog/pushup-mistakes',
+          }),
+        })
+      );
+    });
+
+    it('should map each locale to its own translated slug, not the German post slug, for a second post', async () => {
+      // given — same regression as above, checked against a different
+      // post family to guard against a fix that only special-cases one
+      // folder.
+      const post = findBlogPost('liegestuetze-ab-40', 'de');
+      expect(post).toBeDefined();
+
+      // when
+      await setup('liegestuetze-ab-40', 'de');
+
+      // then
+      expect(seoMock.update).toHaveBeenCalledWith(
+        post?.title,
+        post?.description,
+        '/blog/liegestuetze-ab-40',
+        expect.objectContaining({
+          alternates: expect.objectContaining({
+            de: '/blog/liegestuetze-ab-40',
+            en: '/blog/pushups-over-40',
+            zh: '/blog/pushups-over-40',
+          }),
+        })
+      );
+    });
+  });
+});

--- a/web/src/app/blog/blog-article.component.ts
+++ b/web/src/app/blog/blog-article.component.ts
@@ -304,14 +304,12 @@ export class BlogArticleComponent implements OnInit {
     // tell SeoService exactly which locales this article exists in
     // and what their slugs are. Locales without a translation get no
     // hreflang alternate — better than advertising URLs that 404.
-    const alternates: Record<string, string> = found.alternateSlugs
-      ? Object.fromEntries(
-          Object.entries(found.alternateSlugs).map(([lang, slug]) => [
-            lang,
-            `/blog/${slug}`,
-          ])
-        )
-      : { [found.lang]: `/blog/${found.slug}` };
+    const alternates: Record<string, string> = Object.fromEntries(
+      Object.entries(found.alternateSlugs).map(([lang, slug]) => [
+        lang,
+        `/blog/${slug}`,
+      ])
+    );
     this.seo.update(found.title, found.description, `/blog/${found.slug}`, {
       imageUrl: found.heroImage,
       imageAlt: found.heroImageAlt,

--- a/web/src/app/blog/blog-article.component.ts
+++ b/web/src/app/blog/blog-article.component.ts
@@ -300,17 +300,18 @@ export class BlogArticleComponent implements OnInit {
     this.post = found;
     const wordCount = countWords(found.content);
     this.readingTimeMinutes = readingMinutes(found.content);
-    // Blog posts have locale-specific slugs (`translationSlug`), so
-    // we tell SeoService exactly which locales this article exists in
+    // Blog posts have locale-specific slugs (`alternateSlugs`), so we
+    // tell SeoService exactly which locales this article exists in
     // and what their slugs are. Locales without a translation get no
     // hreflang alternate — better than advertising URLs that 404.
-    const otherLang = found.lang === 'de' ? 'en' : 'de';
-    const alternates: { de?: string; en?: string } = {
-      [found.lang]: `/blog/${found.slug}`,
-    };
-    if (found.translationSlug) {
-      alternates[otherLang] = `/blog/${found.translationSlug}`;
-    }
+    const alternates: Record<string, string> = found.alternateSlugs
+      ? Object.fromEntries(
+          Object.entries(found.alternateSlugs).map(([lang, slug]) => [
+            lang,
+            `/blog/${slug}`,
+          ])
+        )
+      : { [found.lang]: `/blog/${found.slug}` };
     this.seo.update(found.title, found.description, `/blog/${found.slug}`, {
       imageUrl: found.heroImage,
       imageAlt: found.heroImageAlt,

--- a/web/src/app/blog/blog-posts.types.ts
+++ b/web/src/app/blog/blog-posts.types.ts
@@ -12,8 +12,8 @@ export interface BlogPost {
   updatedAt?: string;
   content: string;
   keywords: string[];
-  /** Map of every locale this article is translated into, to that locale's slug (including this post's own locale) — enables full hreflang alternate sets on both the sitemap and the article page. */
-  alternateSlugs?: Record<string, string>;
+  /** Map of every locale this article is translated into, to that locale's slug (including this post's own locale) — enables full hreflang alternate sets on both the sitemap and the article page. Always populated by the content generator, even for a post with no sibling translations (self-mapped). */
+  alternateSlugs: Record<string, string>;
   /** Absolute URL of the hero image rendered above the article body and used for og:image. */
   heroImage?: string;
   /** Accessible alt text for the hero image. */

--- a/web/src/app/blog/blog-posts.types.ts
+++ b/web/src/app/blog/blog-posts.types.ts
@@ -12,8 +12,8 @@ export interface BlogPost {
   updatedAt?: string;
   content: string;
   keywords: string[];
-  /** Slug of the same article in the other locale — enables hreflang pairing in the sitemap. */
-  translationSlug?: string;
+  /** Map of every locale this article is translated into, to that locale's slug (including this post's own locale) — enables full hreflang alternate sets on both the sitemap and the article page. */
+  alternateSlugs?: Record<string, string>;
   /** Absolute URL of the hero image rendered above the article body and used for og:image. */
   heroImage?: string;
   /** Accessible alt text for the hero image. */

--- a/web/src/app/blog/generated/30-dagen-opdruk-challenge.nl.ts
+++ b/web/src/app/blog/generated/30-dagen-opdruk-challenge.nl.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-ups dagelijks verhogen",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "30-tage-liegestuetze-challenge",
+    "el": "triakonta-emerai-pieseos",
+    "en": "30-day-pushup-challenge",
+    "es": "desafio-flexiones-30-dias",
+    "fr": "defi-pompes-30-jours",
+    "it": "sfida-30-giorni-piegamenti",
+    "la": "provocatio-triginta-dierum",
+    "nl": "30-dagen-opdruk-challenge",
+    "no": "30-dagers-armhevning-utfordring",
+    "zh": "30-day-pushup-challenge"
+  },
   "heroImage": "https://images.unsplash.com/photo-1596079306903-9164c205f400?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleet die buiten opdrukken doet — de dagelijkse challenge in het gras.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/30-dagers-armhevning-utfordring.no.ts
+++ b/web/src/app/blog/generated/30-dagers-armhevning-utfordring.no.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "øke push-ups daglig",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "30-tage-liegestuetze-challenge",
+    "el": "triakonta-emerai-pieseos",
+    "en": "30-day-pushup-challenge",
+    "es": "desafio-flexiones-30-dias",
+    "fr": "defi-pompes-30-jours",
+    "it": "sfida-30-giorni-piegamenti",
+    "la": "provocatio-triginta-dierum",
+    "nl": "30-dagen-opdruk-challenge",
+    "no": "30-dagers-armhevning-utfordring",
+    "zh": "30-day-pushup-challenge"
+  },
   "heroImage": "https://images.unsplash.com/photo-1596079306903-9164c205f400?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Idrettsutøver som gjør en armhevning utendørs — den daglige utfordringen i gresset.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/30-day-pushup-challenge.en.ts
+++ b/web/src/app/blog/generated/30-day-pushup-challenge.en.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "increase push-ups daily",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "30-tage-liegestuetze-challenge",
+    "el": "triakonta-emerai-pieseos",
+    "en": "30-day-pushup-challenge",
+    "es": "desafio-flexiones-30-dias",
+    "fr": "defi-pompes-30-jours",
+    "it": "sfida-30-giorni-piegamenti",
+    "la": "provocatio-triginta-dierum",
+    "nl": "30-dagen-opdruk-challenge",
+    "no": "30-dagers-armhevning-utfordring",
+    "zh": "30-day-pushup-challenge"
+  },
   "heroImage": "https://images.unsplash.com/photo-1596079306903-9164c205f400?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlete doing an outdoor push-up — the daily challenge in the grass.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/30-day-pushup-challenge.zh.ts
+++ b/web/src/app/blog/generated/30-day-pushup-challenge.zh.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "每日增加俯卧撑",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "30-tage-liegestuetze-challenge",
+    "el": "triakonta-emerai-pieseos",
+    "en": "30-day-pushup-challenge",
+    "es": "desafio-flexiones-30-dias",
+    "fr": "defi-pompes-30-jours",
+    "it": "sfida-30-giorni-piegamenti",
+    "la": "provocatio-triginta-dierum",
+    "nl": "30-dagen-opdruk-challenge",
+    "no": "30-dagers-armhevning-utfordring",
+    "zh": "30-day-pushup-challenge"
+  },
   "heroImage": "https://images.unsplash.com/photo-1596079306903-9164c205f400?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "运动员在草坪上做俯卧撑——日常挑战。",
   "heroImageCredit": "图片：<a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/30-tage-liegestuetze-challenge.de.ts
+++ b/web/src/app/blog/generated/30-tage-liegestuetze-challenge.de.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Liegestütze täglich steigern",
     "Pushup Tracker App"
   ],
+  "alternateSlugs": {
+    "de": "30-tage-liegestuetze-challenge",
+    "el": "triakonta-emerai-pieseos",
+    "en": "30-day-pushup-challenge",
+    "es": "desafio-flexiones-30-dias",
+    "fr": "defi-pompes-30-jours",
+    "it": "sfida-30-giorni-piegamenti",
+    "la": "provocatio-triginta-dierum",
+    "nl": "30-dagen-opdruk-challenge",
+    "no": "30-dagers-armhevning-utfordring",
+    "zh": "30-day-pushup-challenge"
+  },
   "heroImage": "https://images.unsplash.com/photo-1596079306903-9164c205f400?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Sportler bei einer Outdoor-Liegestütze – tägliche Challenge im Grünen.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/armhevning-feil.no.ts
+++ b/web/src/app/blog/generated/armhevning-feil.no.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "hvordan gjøre push-ups riktig",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-fehler",
+    "el": "hamartiai-pieseos-ges",
+    "en": "pushup-mistakes",
+    "es": "errores-flexiones",
+    "fr": "erreurs-pompes",
+    "it": "errori-piegamenti",
+    "la": "errores-in-pressionibus",
+    "nl": "opdrukken-fouten",
+    "no": "armhevning-feil",
+    "zh": "pushup-mistakes"
+  },
   "heroImage": "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Idrettsmann i plankeposisjon på en treningskatt, nøytral hodestilling.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/armhevning-pusteteknikk.no.ts
+++ b/web/src/app/blog/generated/armhevning-pusteteknikk.no.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-up valsalva",
     "push-up maksimal innsats pust"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-atmung",
+    "el": "pnoe-pieseos-ges",
+    "en": "pushup-breathing",
+    "es": "respiracion-flexiones",
+    "fr": "respiration-pompes",
+    "it": "respirazione-piegamenti",
+    "la": "spiratio-in-pressionibus",
+    "nl": "opdrukken-ademhaling",
+    "no": "armhevning-pusteteknikk",
+    "zh": "pushup-breathing"
+  },
   "heroImage": "https://images.unsplash.com/photo-1599058917765-a780eda07a3e?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Utøver i plankeposisjon med fokusert uttrykk.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/armhevning-tracker-guide.no.ts
+++ b/web/src/app/blog/generated/armhevning-tracker-guide.no.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Pushup Tracker",
     "push-up fremgang sporing"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-tracker",
+    "el": "ichneutes-pieseos-ges",
+    "en": "pushup-tracker-guide",
+    "es": "guia-registro-flexiones",
+    "fr": "guide-suivi-pompes",
+    "it": "guida-tracker-piegamenti",
+    "la": "index-pressionum",
+    "nl": "opdruk-tracker-gids",
+    "no": "armhevning-tracker-guide",
+    "zh": "pushup-tracker-guide"
+  },
   "heroImage": "https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atlet gjør en ren armhevning på et tregulv – progresjon i fokus.",
   "heroImageCredit": "Bilde: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/armhevning-varianter.no.ts
+++ b/web/src/app/blog/generated/armhevning-varianter.no.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "hvilke muskler trener push-ups",
     "push-up progresjon hjemme"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-varianten",
+    "el": "pieseis-ges-poikiliai",
+    "en": "pushup-variations",
+    "es": "variaciones-flexiones",
+    "fr": "variantes-pompes",
+    "it": "varianti-piegamenti",
+    "la": "variationes-pressionum",
+    "nl": "opdrukken-variaties",
+    "no": "armhevning-varianter",
+    "zh": "pushup-variations"
+  },
   "heroImage": "https://images.unsplash.com/photo-1731341400836-baaa5535b8d5?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atlet utfører en armhevningsøvelse i et treningsområde.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/armhevninger-etter-40.no.ts
+++ b/web/src/app/blog/generated/armhevninger-etter-40.no.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-ups for eldre",
     "push-ups seniorer"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-ab-40",
+    "el": "pieseis-ges-meta-tessarakonta",
+    "en": "pushups-over-40",
+    "es": "flexiones-mayores-40",
+    "fr": "pompes-apres-40-ans",
+    "it": "piegamenti-dopo-i-40",
+    "la": "pressiones-post-xl-annos",
+    "nl": "opdrukken-na-40",
+    "no": "armhevninger-etter-40",
+    "zh": "pushups-over-40"
+  },
   "heroImage": "https://images.unsplash.com/photo-1638820858482-800bd51f63f1?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Idrettsutøver som utfører en ren armhevning utendørs – trening etter 40.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/armhevninger-for-kvinner.no.ts
+++ b/web/src/app/blog/generated/armhevninger-for-kvinner.no.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "push-up progresjon kvinner",
     "kne push-ups kvinner"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-frauen",
+    "el": "pieseis-ges-gynaixin",
+    "en": "pushups-for-women",
+    "es": "flexiones-mujeres",
+    "fr": "pompes-pour-femmes",
+    "it": "piegamenti-per-donne",
+    "la": "pressiones-pro-feminis",
+    "nl": "opdrukken-voor-vrouwen",
+    "no": "armhevninger-for-kvinner",
+    "zh": "pushups-for-women"
+  },
   "heroImage": "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Kvinnelig atlet som utfører en kontrollert armhevning på en utendørs treningstopp.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/armhevninger-hjertestudie.no.ts
+++ b/web/src/app/blog/generated/armhevninger-hjertestudie.no.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "JAMA push-ups",
     "kardiovaskulær fordel push-ups"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-herz-studie",
+    "el": "pieseis-ges-kardia-melete",
+    "en": "pushups-heart-study",
+    "es": "flexiones-salud-corazon",
+    "fr": "pompes-sante-cardiaque",
+    "it": "piegamenti-salute-cuore",
+    "la": "pressiones-et-cor-studium",
+    "nl": "opdrukken-hart-studie",
+    "no": "armhevninger-hjertestudie",
+    "zh": "pushups-heart-study"
+  },
   "heroImage": "https://images.unsplash.com/photo-1514512364185-4c2b0985be01?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Idrettsutøver i plankeposisjon på asfalt — armhevningskapasitetstesten.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/dagelijks-opdrukken.nl.ts
+++ b/web/src/app/blog/generated/dagelijks-opdrukken.nl.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "push-up gewoonte",
     "push-up gezondheid"
   ],
+  "alternateSlugs": {
+    "de": "taeglich-liegestuetze",
+    "el": "kathemerinai-pieseis-ges",
+    "en": "daily-pushups",
+    "es": "flexiones-diarias",
+    "fr": "pompes-quotidiennes",
+    "it": "piegamenti-quotidiani",
+    "la": "pressiones-cotidianae",
+    "nl": "dagelijks-opdrukken",
+    "no": "daglige-armhevninger",
+    "zh": "daily-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971639058-fab3c3109a00?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Vrouwelijke atleet die een opdruk doet — een dagelijkse trainingsroutine buiten.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/daglige-armhevninger.no.ts
+++ b/web/src/app/blog/generated/daglige-armhevninger.no.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "push-up vane",
     "push-up helse"
   ],
+  "alternateSlugs": {
+    "de": "taeglich-liegestuetze",
+    "el": "kathemerinai-pieseis-ges",
+    "en": "daily-pushups",
+    "es": "flexiones-diarias",
+    "fr": "pompes-quotidiennes",
+    "it": "piegamenti-quotidiani",
+    "la": "pressiones-cotidianae",
+    "nl": "dagelijks-opdrukken",
+    "no": "daglige-armhevninger",
+    "zh": "daily-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971639058-fab3c3109a00?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Kvinnelig idrettsutøver som gjør en armheving — en daglig treningsrutine ute.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/daily-pushups.en.ts
+++ b/web/src/app/blog/generated/daily-pushups.en.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "push-up habit",
     "push-up health"
   ],
+  "alternateSlugs": {
+    "de": "taeglich-liegestuetze",
+    "el": "kathemerinai-pieseis-ges",
+    "en": "daily-pushups",
+    "es": "flexiones-diarias",
+    "fr": "pompes-quotidiennes",
+    "it": "piegamenti-quotidiani",
+    "la": "pressiones-cotidianae",
+    "nl": "dagelijks-opdrukken",
+    "no": "daglige-armhevninger",
+    "zh": "daily-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971639058-fab3c3109a00?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Female athlete doing a push-up — a daily training routine outdoors.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/daily-pushups.zh.ts
+++ b/web/src/app/blog/generated/daily-pushups.zh.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "俯卧撑习惯",
     "俯卧撑健康"
   ],
+  "alternateSlugs": {
+    "de": "taeglich-liegestuetze",
+    "el": "kathemerinai-pieseis-ges",
+    "en": "daily-pushups",
+    "es": "flexiones-diarias",
+    "fr": "pompes-quotidiennes",
+    "it": "piegamenti-quotidiani",
+    "la": "pressiones-cotidianae",
+    "nl": "dagelijks-opdrukken",
+    "no": "daglige-armhevninger",
+    "zh": "daily-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971639058-fab3c3109a00?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "女性运动员在户外做日常训练俯卧撑。",
   "heroImageCredit": "图片：<a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/defi-pompes-30-jours.fr.ts
+++ b/web/src/app/blog/generated/defi-pompes-30-jours.fr.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "augmenter pompes chaque jour",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "30-tage-liegestuetze-challenge",
+    "el": "triakonta-emerai-pieseos",
+    "en": "30-day-pushup-challenge",
+    "es": "desafio-flexiones-30-dias",
+    "fr": "defi-pompes-30-jours",
+    "it": "sfida-30-giorni-piegamenti",
+    "la": "provocatio-triginta-dierum",
+    "nl": "30-dagen-opdruk-challenge",
+    "no": "30-dagers-armhevning-utfordring",
+    "zh": "30-day-pushup-challenge"
+  },
   "heroImage": "https://images.unsplash.com/photo-1596079306903-9164c205f400?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlète faisant des pompes en extérieur — le défi quotidien dans l'herbe.",
   "heroImageCredit": "Photo : <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/desafio-flexiones-30-dias.es.ts
+++ b/web/src/app/blog/generated/desafio-flexiones-30-dias.es.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "aumentar flexiones diarias",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "30-tage-liegestuetze-challenge",
+    "el": "triakonta-emerai-pieseos",
+    "en": "30-day-pushup-challenge",
+    "es": "desafio-flexiones-30-dias",
+    "fr": "defi-pompes-30-jours",
+    "it": "sfida-30-giorni-piegamenti",
+    "la": "provocatio-triginta-dierum",
+    "nl": "30-dagen-opdruk-challenge",
+    "no": "30-dagers-armhevning-utfordring",
+    "zh": "30-day-pushup-challenge"
+  },
   "heroImage": "https://images.unsplash.com/photo-1596079306903-9164c205f400?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta haciendo flexiones al aire libre — el reto diario en la hierba.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/erreurs-pompes.fr.ts
+++ b/web/src/app/blog/generated/erreurs-pompes.fr.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "comment faire des pompes correctement",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-fehler",
+    "el": "hamartiai-pieseos-ges",
+    "en": "pushup-mistakes",
+    "es": "errores-flexiones",
+    "fr": "erreurs-pompes",
+    "it": "errori-piegamenti",
+    "la": "errores-in-pressionibus",
+    "nl": "opdrukken-fouten",
+    "no": "armhevning-feil",
+    "zh": "pushup-mistakes"
+  },
   "heroImage": "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlète en position de planche sur un tapis d'entraînement, tête en position neutre.",
   "heroImageCredit": "Photo : <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/errores-flexiones.es.ts
+++ b/web/src/app/blog/generated/errores-flexiones.es.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "cómo hacer flexiones correctamente",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-fehler",
+    "el": "hamartiai-pieseos-ges",
+    "en": "pushup-mistakes",
+    "es": "errores-flexiones",
+    "fr": "erreurs-pompes",
+    "it": "errori-piegamenti",
+    "la": "errores-in-pressionibus",
+    "nl": "opdrukken-fouten",
+    "no": "armhevning-feil",
+    "zh": "pushup-mistakes"
+  },
   "heroImage": "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta en posición de plancha sobre una esterilla de entrenamiento, cabeza en posición neutra.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/errores-in-pressionibus.la.ts
+++ b/web/src/app/blog/generated/errores-in-pressionibus.la.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "quomodo pulsus recte facere",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-fehler",
+    "el": "hamartiai-pieseos-ges",
+    "en": "pushup-mistakes",
+    "es": "errores-flexiones",
+    "fr": "erreurs-pompes",
+    "it": "errori-piegamenti",
+    "la": "errores-in-pressionibus",
+    "nl": "opdrukken-fouten",
+    "no": "armhevning-feil",
+    "zh": "pushup-mistakes"
+  },
   "heroImage": "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athleta in positione plana super tapete exercitationis, capite in situ neutro.",
   "heroImageCredit": "Imago: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/errori-piegamenti.it.ts
+++ b/web/src/app/blog/generated/errori-piegamenti.it.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "come fare push-up correttamente",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-fehler",
+    "el": "hamartiai-pieseos-ges",
+    "en": "pushup-mistakes",
+    "es": "errores-flexiones",
+    "fr": "erreurs-pompes",
+    "it": "errori-piegamenti",
+    "la": "errores-in-pressionibus",
+    "nl": "opdrukken-fouten",
+    "no": "armhevning-feil",
+    "zh": "pushup-mistakes"
+  },
   "heroImage": "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta in posizione di plank su un tappetino da allenamento, posizione neutra della testa.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/flexiones-diarias.es.ts
+++ b/web/src/app/blog/generated/flexiones-diarias.es.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "hábito flexiones",
     "flexiones salud"
   ],
+  "alternateSlugs": {
+    "de": "taeglich-liegestuetze",
+    "el": "kathemerinai-pieseis-ges",
+    "en": "daily-pushups",
+    "es": "flexiones-diarias",
+    "fr": "pompes-quotidiennes",
+    "it": "piegamenti-quotidiani",
+    "la": "pressiones-cotidianae",
+    "nl": "dagelijks-opdrukken",
+    "no": "daglige-armhevninger",
+    "zh": "daily-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971639058-fab3c3109a00?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta femenina haciendo una flexión — una rutina de entrenamiento diario al aire libre.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/flexiones-mayores-40.es.ts
+++ b/web/src/app/blog/generated/flexiones-mayores-40.es.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "flexiones adultos mayores",
     "flexiones para mayores"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-ab-40",
+    "el": "pieseis-ges-meta-tessarakonta",
+    "en": "pushups-over-40",
+    "es": "flexiones-mayores-40",
+    "fr": "pompes-apres-40-ans",
+    "it": "piegamenti-dopo-i-40",
+    "la": "pressiones-post-xl-annos",
+    "nl": "opdrukken-na-40",
+    "no": "armhevninger-etter-40",
+    "zh": "pushups-over-40"
+  },
   "heroImage": "https://images.unsplash.com/photo-1638820858482-800bd51f63f1?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta haciendo una flexión limpia al aire libre — entrenamiento después de los 40.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/flexiones-mujeres.es.ts
+++ b/web/src/app/blog/generated/flexiones-mujeres.es.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "progresión flexiones mujeres",
     "flexiones rodillas mujeres"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-frauen",
+    "el": "pieseis-ges-gynaixin",
+    "en": "pushups-for-women",
+    "es": "flexiones-mujeres",
+    "fr": "pompes-pour-femmes",
+    "it": "piegamenti-per-donne",
+    "la": "pressiones-pro-feminis",
+    "nl": "opdrukken-voor-vrouwen",
+    "no": "armhevninger-for-kvinner",
+    "zh": "pushups-for-women"
+  },
   "heroImage": "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta femenina realizando una flexión controlada sobre una esterilla de entrenamiento al aire libre.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/flexiones-salud-corazon.es.ts
+++ b/web/src/app/blog/generated/flexiones-salud-corazon.es.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "JAMA flexiones",
     "beneficio cardiovascular flexiones"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-herz-studie",
+    "el": "pieseis-ges-kardia-melete",
+    "en": "pushups-heart-study",
+    "es": "flexiones-salud-corazon",
+    "fr": "pompes-sante-cardiaque",
+    "it": "piegamenti-salute-cuore",
+    "la": "pressiones-et-cor-studium",
+    "nl": "opdrukken-hart-studie",
+    "no": "armhevninger-hjertestudie",
+    "zh": "pushups-heart-study"
+  },
   "heroImage": "https://images.unsplash.com/photo-1514512364185-4c2b0985be01?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta en posición de plancha sobre asfalto — la prueba de capacidad de flexiones.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/guia-registro-flexiones.es.ts
+++ b/web/src/app/blog/generated/guia-registro-flexiones.es.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Pushup Tracker",
     "seguimiento progreso flexiones"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-tracker",
+    "el": "ichneutes-pieseos-ges",
+    "en": "pushup-tracker-guide",
+    "es": "guia-registro-flexiones",
+    "fr": "guide-suivi-pompes",
+    "it": "guida-tracker-piegamenti",
+    "la": "index-pressionum",
+    "nl": "opdruk-tracker-gids",
+    "no": "armhevning-tracker-guide",
+    "zh": "pushup-tracker-guide"
+  },
   "heroImage": "https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta haciendo una flexión limpia sobre un suelo de madera — el progreso en foco.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/guida-tracker-piegamenti.it.ts
+++ b/web/src/app/blog/generated/guida-tracker-piegamenti.it.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Pushup Tracker",
     "monitoraggio progresso push-up"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-tracker",
+    "el": "ichneutes-pieseos-ges",
+    "en": "pushup-tracker-guide",
+    "es": "guia-registro-flexiones",
+    "fr": "guide-suivi-pompes",
+    "it": "guida-tracker-piegamenti",
+    "la": "index-pressionum",
+    "nl": "opdruk-tracker-gids",
+    "no": "armhevning-tracker-guide",
+    "zh": "pushup-tracker-guide"
+  },
   "heroImage": "https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta che esegue un piegamento pulito su un pavimento di legno — il progresso in primo piano.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/guide-suivi-pompes.fr.ts
+++ b/web/src/app/blog/generated/guide-suivi-pompes.fr.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Pushup Tracker",
     "suivi progression pompes"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-tracker",
+    "el": "ichneutes-pieseos-ges",
+    "en": "pushup-tracker-guide",
+    "es": "guia-registro-flexiones",
+    "fr": "guide-suivi-pompes",
+    "it": "guida-tracker-piegamenti",
+    "la": "index-pressionum",
+    "nl": "opdruk-tracker-gids",
+    "no": "armhevning-tracker-guide",
+    "zh": "pushup-tracker-guide"
+  },
   "heroImage": "https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlète faisant une pompe propre sur un plancher en bois — la progression au premier plan.",
   "heroImageCredit": "Photo : <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/hamartiai-pieseos-ges.el.ts
+++ b/web/src/app/blog/generated/hamartiai-pieseos-ges.el.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "πώς να κάνετε push-ups σωστά",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-fehler",
+    "el": "hamartiai-pieseos-ges",
+    "en": "pushup-mistakes",
+    "es": "errores-flexiones",
+    "fr": "erreurs-pompes",
+    "it": "errori-piegamenti",
+    "la": "errores-in-pressionibus",
+    "nl": "opdrukken-fouten",
+    "no": "armhevning-feil",
+    "zh": "pushup-mistakes"
+  },
   "heroImage": "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Αθλητής σε θέση plank πάνω σε στρώμα γυμναστικής, κεφάλι σε ουδέτερη θέση.",
   "heroImageCredit": "Φωτογραφία: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/ichneutes-pieseos-ges.el.ts
+++ b/web/src/app/blog/generated/ichneutes-pieseos-ges.el.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Pushup Tracker",
     "παρακολούθηση προόδου push-up"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-tracker",
+    "el": "ichneutes-pieseos-ges",
+    "en": "pushup-tracker-guide",
+    "es": "guia-registro-flexiones",
+    "fr": "guide-suivi-pompes",
+    "it": "guida-tracker-piegamenti",
+    "la": "index-pressionum",
+    "nl": "opdruk-tracker-gids",
+    "no": "armhevning-tracker-guide",
+    "zh": "pushup-tracker-guide"
+  },
   "heroImage": "https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Αθλητής κάνει καθαρό push-up πάνω σε ξύλινο πάτωμα — η πρόοδος στο επίκεντρο.",
   "heroImageCredit": "Φωτογραφία: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/index-pressionum.la.ts
+++ b/web/src/app/blog/generated/index-pressionum.la.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Pushup Tracker",
     "progressus pulsuum prosequendi"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-tracker",
+    "el": "ichneutes-pieseos-ges",
+    "en": "pushup-tracker-guide",
+    "es": "guia-registro-flexiones",
+    "fr": "guide-suivi-pompes",
+    "it": "guida-tracker-piegamenti",
+    "la": "index-pressionum",
+    "nl": "opdruk-tracker-gids",
+    "no": "armhevning-tracker-guide",
+    "zh": "pushup-tracker-guide"
+  },
   "heroImage": "https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athleta pressionem puram in pavimento ligneo faciens — progressus in centro.",
   "heroImageCredit": "Imago: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/kathemerinai-pieseis-ges.el.ts
+++ b/web/src/app/blog/generated/kathemerinai-pieseis-ges.el.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "συνήθεια push-up",
     "push-up υγεία"
   ],
+  "alternateSlugs": {
+    "de": "taeglich-liegestuetze",
+    "el": "kathemerinai-pieseis-ges",
+    "en": "daily-pushups",
+    "es": "flexiones-diarias",
+    "fr": "pompes-quotidiennes",
+    "it": "piegamenti-quotidiani",
+    "la": "pressiones-cotidianae",
+    "nl": "dagelijks-opdrukken",
+    "no": "daglige-armhevninger",
+    "zh": "daily-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971639058-fab3c3109a00?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Αθλήτρια κάνει push-up — καθημερινή προπόνηση σε εξωτερικό χώρο.",
   "heroImageCredit": "Φωτογραφία: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/liegestuetze-ab-40.de.ts
+++ b/web/src/app/blog/generated/liegestuetze-ab-40.de.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Liegestütze Gelenke schonen",
     "Liegestütze Senioren"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-ab-40",
+    "el": "pieseis-ges-meta-tessarakonta",
+    "en": "pushups-over-40",
+    "es": "flexiones-mayores-40",
+    "fr": "pompes-apres-40-ans",
+    "it": "piegamenti-dopo-i-40",
+    "la": "pressiones-post-xl-annos",
+    "nl": "opdrukken-na-40",
+    "no": "armhevninger-etter-40",
+    "zh": "pushups-over-40"
+  },
   "heroImage": "https://images.unsplash.com/photo-1638820858482-800bd51f63f1?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Sportlerin bei einer sauberen Liegestütze im Grünen – Training ab 40.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/liegestuetze-atmung.de.ts
+++ b/web/src/app/blog/generated/liegestuetze-atmung.de.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Atemtechnik Krafttraining",
     "Liegestütze Maximalsatz"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-atmung",
+    "el": "pnoe-pieseos-ges",
+    "en": "pushup-breathing",
+    "es": "respiracion-flexiones",
+    "fr": "respiration-pompes",
+    "it": "respirazione-piegamenti",
+    "la": "spiratio-in-pressionibus",
+    "nl": "opdrukken-ademhaling",
+    "no": "armhevning-pusteteknikk",
+    "zh": "pushup-breathing"
+  },
   "heroImage": "https://images.unsplash.com/photo-1599058917765-a780eda07a3e?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlet in Plank-Position mit konzentriertem Gesichtsausdruck.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/liegestuetze-fehler.de.ts
+++ b/web/src/app/blog/generated/liegestuetze-fehler.de.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Schulter schmerzen Liegestütze",
     "Pushup Tracker App"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-fehler",
+    "el": "hamartiai-pieseos-ges",
+    "en": "pushup-mistakes",
+    "es": "errores-flexiones",
+    "fr": "erreurs-pompes",
+    "it": "errori-piegamenti",
+    "la": "errores-in-pressionibus",
+    "nl": "opdrukken-fouten",
+    "no": "armhevning-feil",
+    "zh": "pushup-mistakes"
+  },
   "heroImage": "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athletin in Plank-Position auf einer Trainingsmatte, neutrale Kopfhaltung.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/liegestuetze-frauen.de.ts
+++ b/web/src/app/blog/generated/liegestuetze-frauen.de.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "Liegestütze 4-Wochen Plan Frau",
     "Liegestütze ohne Kraft Frau"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-frauen",
+    "el": "pieseis-ges-gynaixin",
+    "en": "pushups-for-women",
+    "es": "flexiones-mujeres",
+    "fr": "pompes-pour-femmes",
+    "it": "piegamenti-per-donne",
+    "la": "pressiones-pro-feminis",
+    "nl": "opdrukken-voor-vrouwen",
+    "no": "armhevninger-for-kvinner",
+    "zh": "pushups-for-women"
+  },
   "heroImage": "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Sportlerin in einer kontrollierten Liegestütze auf einer Outdoor-Trainingsmatte.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/liegestuetze-herz-studie.de.ts
+++ b/web/src/app/blog/generated/liegestuetze-herz-studie.de.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "JAMA Liegestütze",
     "Liegestütze Herz-Kreislauf-Risiko"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-herz-studie",
+    "el": "pieseis-ges-kardia-melete",
+    "en": "pushups-heart-study",
+    "es": "flexiones-salud-corazon",
+    "fr": "pompes-sante-cardiaque",
+    "it": "piegamenti-salute-cuore",
+    "la": "pressiones-et-cor-studium",
+    "nl": "opdrukken-hart-studie",
+    "no": "armhevninger-hjertestudie",
+    "zh": "pushups-heart-study"
+  },
   "heroImage": "https://images.unsplash.com/photo-1514512364185-4c2b0985be01?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Sportlerin in Plank-Position auf Asphalt – Sinnbild für den Push-Up-Kapazitätstest.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/liegestuetze-steigern.de.ts
+++ b/web/src/app/blog/generated/liegestuetze-steigern.de.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Liegestütze lernen",
     "Pushup Tracker App"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-steigern",
+    "el": "pieseis-ges-anabasis",
+    "en": "pushup-progression",
+    "es": "progresion-flexiones",
+    "fr": "progression-pompes",
+    "it": "progressione-piegamenti",
+    "la": "progressio-pressionum",
+    "nl": "opdrukken-progressie",
+    "no": "okende-armhevninger",
+    "zh": "pushup-progression"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971457999-ca4ef48a9a71?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Sportler in roter Tanktop bei einer sauberen Liegestütze.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/liegestuetze-tracker.de.ts
+++ b/web/src/app/blog/generated/liegestuetze-tracker.de.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Pushup Tracker",
     "Liegestütze Fortschritt verfolgen"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-tracker",
+    "el": "ichneutes-pieseos-ges",
+    "en": "pushup-tracker-guide",
+    "es": "guia-registro-flexiones",
+    "fr": "guide-suivi-pompes",
+    "it": "guida-tracker-piegamenti",
+    "la": "index-pressionum",
+    "nl": "opdruk-tracker-gids",
+    "no": "armhevning-tracker-guide",
+    "zh": "pushup-tracker-guide"
+  },
   "heroImage": "https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Sportlerin bei einer sauberen Liegestütze auf Holzboden – Fortschritt im Blick.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/liegestuetze-varianten.de.ts
+++ b/web/src/app/blog/generated/liegestuetze-varianten.de.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "welche Muskeln bei Liegestützen",
     "Liegestütze fortgeschritten"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-varianten",
+    "el": "pieseis-ges-poikiliai",
+    "en": "pushup-variations",
+    "es": "variaciones-flexiones",
+    "fr": "variantes-pompes",
+    "it": "varianti-piegamenti",
+    "la": "variationes-pressionum",
+    "nl": "opdrukken-variaties",
+    "no": "armhevning-varianter",
+    "zh": "pushup-variations"
+  },
   "heroImage": "https://images.unsplash.com/photo-1731341400836-baaa5535b8d5?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Sportler bei einer Liegestütz-Variante im Trainingsraum.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/metodo-wim-hof-flexiones.es.ts
+++ b/web/src/app/blog/generated/metodo-wim-hof-flexiones.es.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "recuperación exposición frío",
     "respiración Wim Hof flexiones"
   ],
+  "alternateSlugs": {
+    "de": "wim-hof-liegestuetze",
+    "el": "wim-hof-pieseis-ges",
+    "en": "wim-hof-pushups",
+    "es": "metodo-wim-hof-flexiones",
+    "fr": "pompes-wim-hof",
+    "it": "metodo-wim-hof-piegamenti",
+    "la": "pressiones-wim-hof",
+    "nl": "wim-hof-opdrukken",
+    "no": "wim-hof-armhevninger",
+    "zh": "wim-hof-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta de pie en un paisaje helado — imágenes del método Wim Hof de respiración y frío.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/metodo-wim-hof-piegamenti.it.ts
+++ b/web/src/app/blog/generated/metodo-wim-hof-piegamenti.it.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "recupero esposizione freddo",
     "respirazione Wim Hof push-up"
   ],
+  "alternateSlugs": {
+    "de": "wim-hof-liegestuetze",
+    "el": "wim-hof-pieseis-ges",
+    "en": "wim-hof-pushups",
+    "es": "metodo-wim-hof-flexiones",
+    "fr": "pompes-wim-hof",
+    "it": "metodo-wim-hof-piegamenti",
+    "la": "pressiones-wim-hof",
+    "nl": "wim-hof-opdrukken",
+    "no": "wim-hof-armhevninger",
+    "zh": "wim-hof-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta in piedi in un paesaggio ghiacciato — immagini del Metodo Wim Hof di respiro e freddo.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/okende-armhevninger.no.ts
+++ b/web/src/app/blog/generated/okende-armhevninger.no.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "lære push-ups",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-steigern",
+    "el": "pieseis-ges-anabasis",
+    "en": "pushup-progression",
+    "es": "progresion-flexiones",
+    "fr": "progression-pompes",
+    "it": "progressione-piegamenti",
+    "la": "progressio-pressionum",
+    "nl": "opdrukken-progressie",
+    "no": "okende-armhevninger",
+    "zh": "pushup-progression"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971457999-ca4ef48a9a71?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atlet i rød topp som utfører en ren armhevning.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/opdruk-tracker-gids.nl.ts
+++ b/web/src/app/blog/generated/opdruk-tracker-gids.nl.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Pushup Tracker",
     "push-up voortgang volgen"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-tracker",
+    "el": "ichneutes-pieseos-ges",
+    "en": "pushup-tracker-guide",
+    "es": "guia-registro-flexiones",
+    "fr": "guide-suivi-pompes",
+    "it": "guida-tracker-piegamenti",
+    "la": "index-pressionum",
+    "nl": "opdruk-tracker-gids",
+    "no": "armhevning-tracker-guide",
+    "zh": "pushup-tracker-guide"
+  },
   "heroImage": "https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleet die een schone opdruk doet op een houten vloer — voortgang in beeld.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/opdrukken-ademhaling.nl.ts
+++ b/web/src/app/blog/generated/opdrukken-ademhaling.nl.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-up valsalva",
     "push-up maximale inspanning ademhaling"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-atmung",
+    "el": "pnoe-pieseos-ges",
+    "en": "pushup-breathing",
+    "es": "respiracion-flexiones",
+    "fr": "respiration-pompes",
+    "it": "respirazione-piegamenti",
+    "la": "spiratio-in-pressionibus",
+    "nl": "opdrukken-ademhaling",
+    "no": "armhevning-pusteteknikk",
+    "zh": "pushup-breathing"
+  },
   "heroImage": "https://images.unsplash.com/photo-1599058917765-a780eda07a3e?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleet in plankpositie met geconcentreerde uitdrukking.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/opdrukken-fouten.nl.ts
+++ b/web/src/app/blog/generated/opdrukken-fouten.nl.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "hoe push-ups correct doen",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-fehler",
+    "el": "hamartiai-pieseos-ges",
+    "en": "pushup-mistakes",
+    "es": "errores-flexiones",
+    "fr": "erreurs-pompes",
+    "it": "errori-piegamenti",
+    "la": "errores-in-pressionibus",
+    "nl": "opdrukken-fouten",
+    "no": "armhevning-feil",
+    "zh": "pushup-mistakes"
+  },
   "heroImage": "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleet in plankpositie op een trainingsmat, neutrale hoofdpositie.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/opdrukken-hart-studie.nl.ts
+++ b/web/src/app/blog/generated/opdrukken-hart-studie.nl.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "JAMA push-ups",
     "cardiovasculair voordeel push-ups"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-herz-studie",
+    "el": "pieseis-ges-kardia-melete",
+    "en": "pushups-heart-study",
+    "es": "flexiones-salud-corazon",
+    "fr": "pompes-sante-cardiaque",
+    "it": "piegamenti-salute-cuore",
+    "la": "pressiones-et-cor-studium",
+    "nl": "opdrukken-hart-studie",
+    "no": "armhevninger-hjertestudie",
+    "zh": "pushups-heart-study"
+  },
   "heroImage": "https://images.unsplash.com/photo-1514512364185-4c2b0985be01?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleet in plankpositie op asfalt — de opdruk-capaciteitstest.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/opdrukken-na-40.nl.ts
+++ b/web/src/app/blog/generated/opdrukken-na-40.nl.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-ups voor ouderen",
     "push-ups senioren"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-ab-40",
+    "el": "pieseis-ges-meta-tessarakonta",
+    "en": "pushups-over-40",
+    "es": "flexiones-mayores-40",
+    "fr": "pompes-apres-40-ans",
+    "it": "piegamenti-dopo-i-40",
+    "la": "pressiones-post-xl-annos",
+    "nl": "opdrukken-na-40",
+    "no": "armhevninger-etter-40",
+    "zh": "pushups-over-40"
+  },
   "heroImage": "https://images.unsplash.com/photo-1638820858482-800bd51f63f1?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleet die buiten een schone opdruk doet — trainen na je 40e.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/opdrukken-progressie.nl.ts
+++ b/web/src/app/blog/generated/opdrukken-progressie.nl.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-ups leren",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-steigern",
+    "el": "pieseis-ges-anabasis",
+    "en": "pushup-progression",
+    "es": "progresion-flexiones",
+    "fr": "progression-pompes",
+    "it": "progressione-piegamenti",
+    "la": "progressio-pressionum",
+    "nl": "opdrukken-progressie",
+    "no": "okende-armhevninger",
+    "zh": "pushup-progression"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971457999-ca4ef48a9a71?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleet in een rood mouwloos shirt die een schone opdruk doet.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/opdrukken-variaties.nl.ts
+++ b/web/src/app/blog/generated/opdrukken-variaties.nl.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "welke spieren trainen push-ups",
     "push-up progressie thuis"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-varianten",
+    "el": "pieseis-ges-poikiliai",
+    "en": "pushup-variations",
+    "es": "variaciones-flexiones",
+    "fr": "variantes-pompes",
+    "it": "varianti-piegamenti",
+    "la": "variationes-pressionum",
+    "nl": "opdrukken-variaties",
+    "no": "armhevning-varianter",
+    "zh": "pushup-variations"
+  },
   "heroImage": "https://images.unsplash.com/photo-1731341400836-baaa5535b8d5?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleet die een opdruk-variatie uitvoert in een trainingsruimte.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/opdrukken-voor-vrouwen.nl.ts
+++ b/web/src/app/blog/generated/opdrukken-voor-vrouwen.nl.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "push-up progressie vrouwen",
     "knie push-ups vrouwen"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-frauen",
+    "el": "pieseis-ges-gynaixin",
+    "en": "pushups-for-women",
+    "es": "flexiones-mujeres",
+    "fr": "pompes-pour-femmes",
+    "it": "piegamenti-per-donne",
+    "la": "pressiones-pro-feminis",
+    "nl": "opdrukken-voor-vrouwen",
+    "no": "armhevninger-for-kvinner",
+    "zh": "pushups-for-women"
+  },
   "heroImage": "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Vrouwelijke atleet die een gecontroleerde opdruk doet op een buitentrainingsmat.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/piegamenti-dopo-i-40.it.ts
+++ b/web/src/app/blog/generated/piegamenti-dopo-i-40.it.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-up per anziani",
     "push-up età avanzata"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-ab-40",
+    "el": "pieseis-ges-meta-tessarakonta",
+    "en": "pushups-over-40",
+    "es": "flexiones-mayores-40",
+    "fr": "pompes-apres-40-ans",
+    "it": "piegamenti-dopo-i-40",
+    "la": "pressiones-post-xl-annos",
+    "nl": "opdrukken-na-40",
+    "no": "armhevninger-etter-40",
+    "zh": "pushups-over-40"
+  },
   "heroImage": "https://images.unsplash.com/photo-1638820858482-800bd51f63f1?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta che esegue un piegamento pulito all'aperto — allenamento dopo i 40.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/piegamenti-per-donne.it.ts
+++ b/web/src/app/blog/generated/piegamenti-per-donne.it.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "progressione push-up donne",
     "push-up ginocchia donne"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-frauen",
+    "el": "pieseis-ges-gynaixin",
+    "en": "pushups-for-women",
+    "es": "flexiones-mujeres",
+    "fr": "pompes-pour-femmes",
+    "it": "piegamenti-per-donne",
+    "la": "pressiones-pro-feminis",
+    "nl": "opdrukken-voor-vrouwen",
+    "no": "armhevninger-for-kvinner",
+    "zh": "pushups-for-women"
+  },
   "heroImage": "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta femminile che esegue un piegamento controllato su un tappetino da allenamento all'aperto.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/piegamenti-quotidiani.it.ts
+++ b/web/src/app/blog/generated/piegamenti-quotidiani.it.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "abitudine push-up",
     "push-up salute"
   ],
+  "alternateSlugs": {
+    "de": "taeglich-liegestuetze",
+    "el": "kathemerinai-pieseis-ges",
+    "en": "daily-pushups",
+    "es": "flexiones-diarias",
+    "fr": "pompes-quotidiennes",
+    "it": "piegamenti-quotidiani",
+    "la": "pressiones-cotidianae",
+    "nl": "dagelijks-opdrukken",
+    "no": "daglige-armhevninger",
+    "zh": "daily-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971639058-fab3c3109a00?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta femminile che fa un piegamento — una routine di allenamento quotidiana all'aperto.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/piegamenti-salute-cuore.it.ts
+++ b/web/src/app/blog/generated/piegamenti-salute-cuore.it.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "JAMA push-up",
     "beneficio cardiovascolare push-up"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-herz-studie",
+    "el": "pieseis-ges-kardia-melete",
+    "en": "pushups-heart-study",
+    "es": "flexiones-salud-corazon",
+    "fr": "pompes-sante-cardiaque",
+    "it": "piegamenti-salute-cuore",
+    "la": "pressiones-et-cor-studium",
+    "nl": "opdrukken-hart-studie",
+    "no": "armhevninger-hjertestudie",
+    "zh": "pushups-heart-study"
+  },
   "heroImage": "https://images.unsplash.com/photo-1514512364185-4c2b0985be01?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta in posizione di plank su asfalto — il test di capacità di piegamenti.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pieseis-ges-anabasis.el.ts
+++ b/web/src/app/blog/generated/pieseis-ges-anabasis.el.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "μάθετε push-ups",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-steigern",
+    "el": "pieseis-ges-anabasis",
+    "en": "pushup-progression",
+    "es": "progresion-flexiones",
+    "fr": "progression-pompes",
+    "it": "progressione-piegamenti",
+    "la": "progressio-pressionum",
+    "nl": "opdrukken-progressie",
+    "no": "okende-armhevninger",
+    "zh": "pushup-progression"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971457999-ca4ef48a9a71?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Αθλητής με κόκκινο μπλουζάκι κάνει καθαρό push-up.",
   "heroImageCredit": "Φωτογραφία: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pieseis-ges-gynaixin.el.ts
+++ b/web/src/app/blog/generated/pieseis-ges-gynaixin.el.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "εξέλιξη push-ups γυναικών",
     "γόνατα push-ups γυναικών"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-frauen",
+    "el": "pieseis-ges-gynaixin",
+    "en": "pushups-for-women",
+    "es": "flexiones-mujeres",
+    "fr": "pompes-pour-femmes",
+    "it": "piegamenti-per-donne",
+    "la": "pressiones-pro-feminis",
+    "nl": "opdrukken-voor-vrouwen",
+    "no": "armhevninger-for-kvinner",
+    "zh": "pushups-for-women"
+  },
   "heroImage": "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Αθλήτρια κάνει ελεγχόμενο push-up σε στρώμα γυμναστικής σε εξωτερικό χώρο.",
   "heroImageCredit": "Φωτογραφία: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pieseis-ges-kardia-melete.el.ts
+++ b/web/src/app/blog/generated/pieseis-ges-kardia-melete.el.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "JAMA push-ups",
     "καρδιαγγειακό όφελος push-ups"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-herz-studie",
+    "el": "pieseis-ges-kardia-melete",
+    "en": "pushups-heart-study",
+    "es": "flexiones-salud-corazon",
+    "fr": "pompes-sante-cardiaque",
+    "it": "piegamenti-salute-cuore",
+    "la": "pressiones-et-cor-studium",
+    "nl": "opdrukken-hart-studie",
+    "no": "armhevninger-hjertestudie",
+    "zh": "pushups-heart-study"
+  },
   "heroImage": "https://images.unsplash.com/photo-1514512364185-4c2b0985be01?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Αθλητής σε θέση plank σε άσφαλτο — το τεστ ικανότητας στα push-ups.",
   "heroImageCredit": "Φωτογραφία: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pieseis-ges-meta-tessarakonta.el.ts
+++ b/web/src/app/blog/generated/pieseis-ges-meta-tessarakonta.el.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-ups για ηλικιωμένους",
     "push-ups για senior"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-ab-40",
+    "el": "pieseis-ges-meta-tessarakonta",
+    "en": "pushups-over-40",
+    "es": "flexiones-mayores-40",
+    "fr": "pompes-apres-40-ans",
+    "it": "piegamenti-dopo-i-40",
+    "la": "pressiones-post-xl-annos",
+    "nl": "opdrukken-na-40",
+    "no": "armhevninger-etter-40",
+    "zh": "pushups-over-40"
+  },
   "heroImage": "https://images.unsplash.com/photo-1638820858482-800bd51f63f1?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Αθλητής κάνει καθαρό push-up σε εξωτερικό χώρο — προπόνηση μετά τα 40.",
   "heroImageCredit": "Φωτογραφία: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pieseis-ges-poikiliai.el.ts
+++ b/web/src/app/blog/generated/pieseis-ges-poikiliai.el.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "ποιους μύες δουλεύουν τα push-ups",
     "εξέλιξη push-up στο σπίτι"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-varianten",
+    "el": "pieseis-ges-poikiliai",
+    "en": "pushup-variations",
+    "es": "variaciones-flexiones",
+    "fr": "variantes-pompes",
+    "it": "varianti-piegamenti",
+    "la": "variationes-pressionum",
+    "nl": "opdrukken-variaties",
+    "no": "armhevning-varianter",
+    "zh": "pushup-variations"
+  },
   "heroImage": "https://images.unsplash.com/photo-1731341400836-baaa5535b8d5?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Αθλητής εκτελεί παραλλαγή push-up σε χώρο προπόνησης.",
   "heroImageCredit": "Φωτογραφία: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pnoe-pieseos-ges.el.ts
+++ b/web/src/app/blog/generated/pnoe-pieseos-ges.el.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-up valsalva",
     "push-ups μέγιστη προσπάθεια αναπνοή"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-atmung",
+    "el": "pnoe-pieseos-ges",
+    "en": "pushup-breathing",
+    "es": "respiracion-flexiones",
+    "fr": "respiration-pompes",
+    "it": "respirazione-piegamenti",
+    "la": "spiratio-in-pressionibus",
+    "nl": "opdrukken-ademhaling",
+    "no": "armhevning-pusteteknikk",
+    "zh": "pushup-breathing"
+  },
   "heroImage": "https://images.unsplash.com/photo-1599058917765-a780eda07a3e?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Αθλητής σε θέση plank με συγκεντρωμένη έκφραση.",
   "heroImageCredit": "Φωτογραφία: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pompes-apres-40-ans.fr.ts
+++ b/web/src/app/blog/generated/pompes-apres-40-ans.fr.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "pompes seniors",
     "pompes pour adultes âgés"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-ab-40",
+    "el": "pieseis-ges-meta-tessarakonta",
+    "en": "pushups-over-40",
+    "es": "flexiones-mayores-40",
+    "fr": "pompes-apres-40-ans",
+    "it": "piegamenti-dopo-i-40",
+    "la": "pressiones-post-xl-annos",
+    "nl": "opdrukken-na-40",
+    "no": "armhevninger-etter-40",
+    "zh": "pushups-over-40"
+  },
   "heroImage": "https://images.unsplash.com/photo-1638820858482-800bd51f63f1?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlète faisant des pompes propres en extérieur — entraînement après 40 ans.",
   "heroImageCredit": "Photo : <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pompes-pour-femmes.fr.ts
+++ b/web/src/app/blog/generated/pompes-pour-femmes.fr.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "progression pompes femmes",
     "pompes genoux femmes"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-frauen",
+    "el": "pieseis-ges-gynaixin",
+    "en": "pushups-for-women",
+    "es": "flexiones-mujeres",
+    "fr": "pompes-pour-femmes",
+    "it": "piegamenti-per-donne",
+    "la": "pressiones-pro-feminis",
+    "nl": "opdrukken-voor-vrouwen",
+    "no": "armhevninger-for-kvinner",
+    "zh": "pushups-for-women"
+  },
   "heroImage": "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlète féminine effectuant une pompe contrôlée sur un tapis d'entraînement en extérieur.",
   "heroImageCredit": "Photo : <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pompes-quotidiennes.fr.ts
+++ b/web/src/app/blog/generated/pompes-quotidiennes.fr.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "habitude pompes",
     "pompes santé"
   ],
+  "alternateSlugs": {
+    "de": "taeglich-liegestuetze",
+    "el": "kathemerinai-pieseis-ges",
+    "en": "daily-pushups",
+    "es": "flexiones-diarias",
+    "fr": "pompes-quotidiennes",
+    "it": "piegamenti-quotidiani",
+    "la": "pressiones-cotidianae",
+    "nl": "dagelijks-opdrukken",
+    "no": "daglige-armhevninger",
+    "zh": "daily-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971639058-fab3c3109a00?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlète féminine faisant une pompe — une routine d'entraînement quotidienne en extérieur.",
   "heroImageCredit": "Photo : <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pompes-sante-cardiaque.fr.ts
+++ b/web/src/app/blog/generated/pompes-sante-cardiaque.fr.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "JAMA pompes",
     "bénéfice cardiovasculaire pompes"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-herz-studie",
+    "el": "pieseis-ges-kardia-melete",
+    "en": "pushups-heart-study",
+    "es": "flexiones-salud-corazon",
+    "fr": "pompes-sante-cardiaque",
+    "it": "piegamenti-salute-cuore",
+    "la": "pressiones-et-cor-studium",
+    "nl": "opdrukken-hart-studie",
+    "no": "armhevninger-hjertestudie",
+    "zh": "pushups-heart-study"
+  },
   "heroImage": "https://images.unsplash.com/photo-1514512364185-4c2b0985be01?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlète en position de planche sur l'asphalte — le test de capacité aux pompes.",
   "heroImageCredit": "Photo : <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pompes-wim-hof.fr.ts
+++ b/web/src/app/blog/generated/pompes-wim-hof.fr.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "récupération exposition froid",
     "respiration Wim Hof pompes"
   ],
+  "alternateSlugs": {
+    "de": "wim-hof-liegestuetze",
+    "el": "wim-hof-pieseis-ges",
+    "en": "wim-hof-pushups",
+    "es": "metodo-wim-hof-flexiones",
+    "fr": "pompes-wim-hof",
+    "it": "metodo-wim-hof-piegamenti",
+    "la": "pressiones-wim-hof",
+    "nl": "wim-hof-opdrukken",
+    "no": "wim-hof-armhevninger",
+    "zh": "wim-hof-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlète debout dans un paysage gelé — l'imagerie de la méthode Wim Hof entre souffle et froid.",
   "heroImageCredit": "Photo : <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pressiones-cotidianae.la.ts
+++ b/web/src/app/blog/generated/pressiones-cotidianae.la.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "consuetudo pulsuum",
     "salus pulsuum"
   ],
+  "alternateSlugs": {
+    "de": "taeglich-liegestuetze",
+    "el": "kathemerinai-pieseis-ges",
+    "en": "daily-pushups",
+    "es": "flexiones-diarias",
+    "fr": "pompes-quotidiennes",
+    "it": "piegamenti-quotidiani",
+    "la": "pressiones-cotidianae",
+    "nl": "dagelijks-opdrukken",
+    "no": "daglige-armhevninger",
+    "zh": "daily-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971639058-fab3c3109a00?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athleta femina pressionem faciens — consuetudo exercitationis cotidianae sub divo.",
   "heroImageCredit": "Imago: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pressiones-et-cor-studium.la.ts
+++ b/web/src/app/blog/generated/pressiones-et-cor-studium.la.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "JAMA pulsus",
     "beneficium cardiovasculare pulsuum"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-herz-studie",
+    "el": "pieseis-ges-kardia-melete",
+    "en": "pushups-heart-study",
+    "es": "flexiones-salud-corazon",
+    "fr": "pompes-sante-cardiaque",
+    "it": "piegamenti-salute-cuore",
+    "la": "pressiones-et-cor-studium",
+    "nl": "opdrukken-hart-studie",
+    "no": "armhevninger-hjertestudie",
+    "zh": "pushups-heart-study"
+  },
   "heroImage": "https://images.unsplash.com/photo-1514512364185-4c2b0985be01?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athleta in positione plana super asphaltum — probatio capacitatis pressionum.",
   "heroImageCredit": "Imago: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pressiones-post-xl-annos.la.ts
+++ b/web/src/app/blog/generated/pressiones-post-xl-annos.la.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "pulsus pro senioribus",
     "pulsus pro maioribus natu"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-ab-40",
+    "el": "pieseis-ges-meta-tessarakonta",
+    "en": "pushups-over-40",
+    "es": "flexiones-mayores-40",
+    "fr": "pompes-apres-40-ans",
+    "it": "piegamenti-dopo-i-40",
+    "la": "pressiones-post-xl-annos",
+    "nl": "opdrukken-na-40",
+    "no": "armhevninger-etter-40",
+    "zh": "pushups-over-40"
+  },
   "heroImage": "https://images.unsplash.com/photo-1638820858482-800bd51f63f1?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athleta pressionem puram sub divo faciens — exercitatio post quadragesimum annum.",
   "heroImageCredit": "Imago: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pressiones-pro-feminis.la.ts
+++ b/web/src/app/blog/generated/pressiones-pro-feminis.la.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "progressio pulsuum feminarum",
     "pulsus genuum feminis"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-frauen",
+    "el": "pieseis-ges-gynaixin",
+    "en": "pushups-for-women",
+    "es": "flexiones-mujeres",
+    "fr": "pompes-pour-femmes",
+    "it": "piegamenti-per-donne",
+    "la": "pressiones-pro-feminis",
+    "nl": "opdrukken-voor-vrouwen",
+    "no": "armhevninger-for-kvinner",
+    "zh": "pushups-for-women"
+  },
   "heroImage": "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athleta femina pressionem moderatam super tapete exercitationis sub divo faciens.",
   "heroImageCredit": "Imago: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pressiones-wim-hof.la.ts
+++ b/web/src/app/blog/generated/pressiones-wim-hof.la.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "recreatio expositione frigoris",
     "respiratio Wim Hof pulsuum"
   ],
+  "alternateSlugs": {
+    "de": "wim-hof-liegestuetze",
+    "el": "wim-hof-pieseis-ges",
+    "en": "wim-hof-pushups",
+    "es": "metodo-wim-hof-flexiones",
+    "fr": "pompes-wim-hof",
+    "it": "metodo-wim-hof-piegamenti",
+    "la": "pressiones-wim-hof",
+    "nl": "wim-hof-opdrukken",
+    "no": "wim-hof-armhevninger",
+    "zh": "wim-hof-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athleta in regione glaciali stans — imago Methodi Wim Hof de spiratione et frigore.",
   "heroImageCredit": "Imago: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/progresion-flexiones.es.ts
+++ b/web/src/app/blog/generated/progresion-flexiones.es.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "aprender flexiones",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-steigern",
+    "el": "pieseis-ges-anabasis",
+    "en": "pushup-progression",
+    "es": "progresion-flexiones",
+    "fr": "progression-pompes",
+    "it": "progressione-piegamenti",
+    "la": "progressio-pressionum",
+    "nl": "opdrukken-progressie",
+    "no": "okende-armhevninger",
+    "zh": "pushup-progression"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971457999-ca4ef48a9a71?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta con camiseta roja realizando una flexión limpia.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/progressio-pressionum.la.ts
+++ b/web/src/app/blog/generated/progressio-pressionum.la.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "discere pulsus",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-steigern",
+    "el": "pieseis-ges-anabasis",
+    "en": "pushup-progression",
+    "es": "progresion-flexiones",
+    "fr": "progression-pompes",
+    "it": "progressione-piegamenti",
+    "la": "progressio-pressionum",
+    "nl": "opdrukken-progressie",
+    "no": "okende-armhevninger",
+    "zh": "pushup-progression"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971457999-ca4ef48a9a71?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athleta in tunica rubra pressionem puram faciens.",
   "heroImageCredit": "Imago: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/progression-pompes.fr.ts
+++ b/web/src/app/blog/generated/progression-pompes.fr.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "apprendre pompes",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-steigern",
+    "el": "pieseis-ges-anabasis",
+    "en": "pushup-progression",
+    "es": "progresion-flexiones",
+    "fr": "progression-pompes",
+    "it": "progressione-piegamenti",
+    "la": "progressio-pressionum",
+    "nl": "opdrukken-progressie",
+    "no": "okende-armhevninger",
+    "zh": "pushup-progression"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971457999-ca4ef48a9a71?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlète en débardeur rouge effectuant une pompe propre.",
   "heroImageCredit": "Photo : <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/progressione-piegamenti.it.ts
+++ b/web/src/app/blog/generated/progressione-piegamenti.it.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "imparare push-up",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-steigern",
+    "el": "pieseis-ges-anabasis",
+    "en": "pushup-progression",
+    "es": "progresion-flexiones",
+    "fr": "progression-pompes",
+    "it": "progressione-piegamenti",
+    "la": "progressio-pressionum",
+    "nl": "opdrukken-progressie",
+    "no": "okende-armhevninger",
+    "zh": "pushup-progression"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971457999-ca4ef48a9a71?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta in canottiera rossa che esegue un piegamento pulito.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/provocatio-triginta-dierum.la.ts
+++ b/web/src/app/blog/generated/provocatio-triginta-dierum.la.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "augere pulsus cotidie",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "30-tage-liegestuetze-challenge",
+    "el": "triakonta-emerai-pieseos",
+    "en": "30-day-pushup-challenge",
+    "es": "desafio-flexiones-30-dias",
+    "fr": "defi-pompes-30-jours",
+    "it": "sfida-30-giorni-piegamenti",
+    "la": "provocatio-triginta-dierum",
+    "nl": "30-dagen-opdruk-challenge",
+    "no": "30-dagers-armhevning-utfordring",
+    "zh": "30-day-pushup-challenge"
+  },
   "heroImage": "https://images.unsplash.com/photo-1596079306903-9164c205f400?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athleta in herba pressionem faciens — provocatio cotidiana sub divo.",
   "heroImageCredit": "Imago: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushup-breathing.en.ts
+++ b/web/src/app/blog/generated/pushup-breathing.en.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-up valsalva",
     "max effort push-ups breathing"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-atmung",
+    "el": "pnoe-pieseos-ges",
+    "en": "pushup-breathing",
+    "es": "respiracion-flexiones",
+    "fr": "respiration-pompes",
+    "it": "respirazione-piegamenti",
+    "la": "spiratio-in-pressionibus",
+    "nl": "opdrukken-ademhaling",
+    "no": "armhevning-pusteteknikk",
+    "zh": "pushup-breathing"
+  },
   "heroImage": "https://images.unsplash.com/photo-1599058917765-a780eda07a3e?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlete in plank position with focused expression.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushup-breathing.zh.ts
+++ b/web/src/app/blog/generated/pushup-breathing.zh.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "俯卧撑瓦氏动作",
     "俯卧撑最大努力呼吸"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-atmung",
+    "el": "pnoe-pieseos-ges",
+    "en": "pushup-breathing",
+    "es": "respiracion-flexiones",
+    "fr": "respiration-pompes",
+    "it": "respirazione-piegamenti",
+    "la": "spiratio-in-pressionibus",
+    "nl": "opdrukken-ademhaling",
+    "no": "armhevning-pusteteknikk",
+    "zh": "pushup-breathing"
+  },
   "heroImage": "https://images.unsplash.com/photo-1599058917765-a780eda07a3e?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "运动员处于平板支撑位置，表情专注。",
   "heroImageCredit": "图片：<a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushup-mistakes.en.ts
+++ b/web/src/app/blog/generated/pushup-mistakes.en.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "how to do push-ups properly",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-fehler",
+    "el": "hamartiai-pieseos-ges",
+    "en": "pushup-mistakes",
+    "es": "errores-flexiones",
+    "fr": "erreurs-pompes",
+    "it": "errori-piegamenti",
+    "la": "errores-in-pressionibus",
+    "nl": "opdrukken-fouten",
+    "no": "armhevning-feil",
+    "zh": "pushup-mistakes"
+  },
   "heroImage": "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlete in plank position on a training mat, neutral head position.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushup-mistakes.zh.ts
+++ b/web/src/app/blog/generated/pushup-mistakes.zh.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "如何正确做俯卧撑",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-fehler",
+    "el": "hamartiai-pieseos-ges",
+    "en": "pushup-mistakes",
+    "es": "errores-flexiones",
+    "fr": "erreurs-pompes",
+    "it": "errori-piegamenti",
+    "la": "errores-in-pressionibus",
+    "nl": "opdrukken-fouten",
+    "no": "armhevning-feil",
+    "zh": "pushup-mistakes"
+  },
   "heroImage": "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "运动员在垫子上保持平板支撑，头部保持中立位置。",
   "heroImageCredit": "图片：<a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushup-progression.en.ts
+++ b/web/src/app/blog/generated/pushup-progression.en.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "learn push-ups",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-steigern",
+    "el": "pieseis-ges-anabasis",
+    "en": "pushup-progression",
+    "es": "progresion-flexiones",
+    "fr": "progression-pompes",
+    "it": "progressione-piegamenti",
+    "la": "progressio-pressionum",
+    "nl": "opdrukken-progressie",
+    "no": "okende-armhevninger",
+    "zh": "pushup-progression"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971457999-ca4ef48a9a71?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlete in a red tank top performing a clean push-up.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushup-progression.zh.ts
+++ b/web/src/app/blog/generated/pushup-progression.zh.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "学习俯卧撑",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-steigern",
+    "el": "pieseis-ges-anabasis",
+    "en": "pushup-progression",
+    "es": "progresion-flexiones",
+    "fr": "progression-pompes",
+    "it": "progressione-piegamenti",
+    "la": "progressio-pressionum",
+    "nl": "opdrukken-progressie",
+    "no": "okende-armhevninger",
+    "zh": "pushup-progression"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971457999-ca4ef48a9a71?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "穿着红色背心的运动员进行规范的俯卧撑。",
   "heroImageCredit": "图片：<a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushup-tracker-guide.en.ts
+++ b/web/src/app/blog/generated/pushup-tracker-guide.en.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Pushup Tracker",
     "push-up progress tracking"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-tracker",
+    "el": "ichneutes-pieseos-ges",
+    "en": "pushup-tracker-guide",
+    "es": "guia-registro-flexiones",
+    "fr": "guide-suivi-pompes",
+    "it": "guida-tracker-piegamenti",
+    "la": "index-pressionum",
+    "nl": "opdruk-tracker-gids",
+    "no": "armhevning-tracker-guide",
+    "zh": "pushup-tracker-guide"
+  },
   "heroImage": "https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlete doing a clean push-up on a wooden floor — progress in focus.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushup-tracker-guide.zh.ts
+++ b/web/src/app/blog/generated/pushup-tracker-guide.zh.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Pushup Tracker",
     "俯卧撑进度追踪"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-tracker",
+    "el": "ichneutes-pieseos-ges",
+    "en": "pushup-tracker-guide",
+    "es": "guia-registro-flexiones",
+    "fr": "guide-suivi-pompes",
+    "it": "guida-tracker-piegamenti",
+    "la": "index-pressionum",
+    "nl": "opdruk-tracker-gids",
+    "no": "armhevning-tracker-guide",
+    "zh": "pushup-tracker-guide"
+  },
   "heroImage": "https://images.unsplash.com/photo-1717821681365-36b0da044a75?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "运动员在木地板上做规范俯卧撑——进度是重点。",
   "heroImageCredit": "图片：<a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushup-variations.en.ts
+++ b/web/src/app/blog/generated/pushup-variations.en.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "what muscles do push-ups work",
     "push-up progression at home"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-varianten",
+    "el": "pieseis-ges-poikiliai",
+    "en": "pushup-variations",
+    "es": "variaciones-flexiones",
+    "fr": "variantes-pompes",
+    "it": "varianti-piegamenti",
+    "la": "variationes-pressionum",
+    "nl": "opdrukken-variaties",
+    "no": "armhevning-varianter",
+    "zh": "pushup-variations"
+  },
   "heroImage": "https://images.unsplash.com/photo-1731341400836-baaa5535b8d5?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlete performing a push-up variation in a training space.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushup-variations.zh.ts
+++ b/web/src/app/blog/generated/pushup-variations.zh.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "俯卧撑锻炼哪些肌肉",
     "居家俯卧撑进步"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-varianten",
+    "el": "pieseis-ges-poikiliai",
+    "en": "pushup-variations",
+    "es": "variaciones-flexiones",
+    "fr": "variantes-pompes",
+    "it": "varianti-piegamenti",
+    "la": "variationes-pressionum",
+    "nl": "opdrukken-variaties",
+    "no": "armhevning-varianter",
+    "zh": "pushup-variations"
+  },
   "heroImage": "https://images.unsplash.com/photo-1731341400836-baaa5535b8d5?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "运动员在训练空间中做俯卧撑变式。",
   "heroImageCredit": "图片：<a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushups-for-women.en.ts
+++ b/web/src/app/blog/generated/pushups-for-women.en.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "push-up progression women",
     "knee push-ups for women"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-frauen",
+    "el": "pieseis-ges-gynaixin",
+    "en": "pushups-for-women",
+    "es": "flexiones-mujeres",
+    "fr": "pompes-pour-femmes",
+    "it": "piegamenti-per-donne",
+    "la": "pressiones-pro-feminis",
+    "nl": "opdrukken-voor-vrouwen",
+    "no": "armhevninger-for-kvinner",
+    "zh": "pushups-for-women"
+  },
   "heroImage": "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Female athlete performing a controlled push-up on an outdoor training mat.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushups-for-women.zh.ts
+++ b/web/src/app/blog/generated/pushups-for-women.zh.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "女性俯卧撑进步",
     "女性跪姿俯卧撑"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-frauen",
+    "el": "pieseis-ges-gynaixin",
+    "en": "pushups-for-women",
+    "es": "flexiones-mujeres",
+    "fr": "pompes-pour-femmes",
+    "it": "piegamenti-per-donne",
+    "la": "pressiones-pro-feminis",
+    "nl": "opdrukken-voor-vrouwen",
+    "no": "armhevninger-for-kvinner",
+    "zh": "pushups-for-women"
+  },
   "heroImage": "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "女性运动员在室外垫子上进行规范的俯卧撑。",
   "heroImageCredit": "图片：<a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushups-heart-study.en.ts
+++ b/web/src/app/blog/generated/pushups-heart-study.en.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "JAMA push-ups",
     "push-ups cardiovascular benefit"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-herz-studie",
+    "el": "pieseis-ges-kardia-melete",
+    "en": "pushups-heart-study",
+    "es": "flexiones-salud-corazon",
+    "fr": "pompes-sante-cardiaque",
+    "it": "piegamenti-salute-cuore",
+    "la": "pressiones-et-cor-studium",
+    "nl": "opdrukken-hart-studie",
+    "no": "armhevninger-hjertestudie",
+    "zh": "pushups-heart-study"
+  },
   "heroImage": "https://images.unsplash.com/photo-1514512364185-4c2b0985be01?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlete in a plank position on asphalt — the push-up capacity test.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushups-heart-study.zh.ts
+++ b/web/src/app/blog/generated/pushups-heart-study.zh.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "JAMA俯卧撑",
     "俯卧撑心血管益处"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-herz-studie",
+    "el": "pieseis-ges-kardia-melete",
+    "en": "pushups-heart-study",
+    "es": "flexiones-salud-corazon",
+    "fr": "pompes-sante-cardiaque",
+    "it": "piegamenti-salute-cuore",
+    "la": "pressiones-et-cor-studium",
+    "nl": "opdrukken-hart-studie",
+    "no": "armhevninger-hjertestudie",
+    "zh": "pushups-heart-study"
+  },
   "heroImage": "https://images.unsplash.com/photo-1514512364185-4c2b0985be01?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "运动员在沥青地面上保持平板支撑位置 — 俯卧撑能力测试。",
   "heroImageCredit": "图片：<a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushups-over-40.en.ts
+++ b/web/src/app/blog/generated/pushups-over-40.en.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-ups for older adults",
     "push-ups for seniors"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-ab-40",
+    "el": "pieseis-ges-meta-tessarakonta",
+    "en": "pushups-over-40",
+    "es": "flexiones-mayores-40",
+    "fr": "pompes-apres-40-ans",
+    "it": "piegamenti-dopo-i-40",
+    "la": "pressiones-post-xl-annos",
+    "nl": "opdrukken-na-40",
+    "no": "armhevninger-etter-40",
+    "zh": "pushups-over-40"
+  },
   "heroImage": "https://images.unsplash.com/photo-1638820858482-800bd51f63f1?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlete doing a clean push-up outdoors — training after 40.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/pushups-over-40.zh.ts
+++ b/web/src/app/blog/generated/pushups-over-40.zh.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "老年人俯卧撑",
     "老人俯卧撑"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-ab-40",
+    "el": "pieseis-ges-meta-tessarakonta",
+    "en": "pushups-over-40",
+    "es": "flexiones-mayores-40",
+    "fr": "pompes-apres-40-ans",
+    "it": "piegamenti-dopo-i-40",
+    "la": "pressiones-post-xl-annos",
+    "nl": "opdrukken-na-40",
+    "no": "armhevninger-etter-40",
+    "zh": "pushups-over-40"
+  },
   "heroImage": "https://images.unsplash.com/photo-1638820858482-800bd51f63f1?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "运动员在户外做标准俯卧撑——40岁后训练。",
   "heroImageCredit": "图片：<a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/respiracion-flexiones.es.ts
+++ b/web/src/app/blog/generated/respiracion-flexiones.es.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "flexiones valsalva",
     "respiración flexiones esfuerzo máximo"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-atmung",
+    "el": "pnoe-pieseos-ges",
+    "en": "pushup-breathing",
+    "es": "respiracion-flexiones",
+    "fr": "respiration-pompes",
+    "it": "respirazione-piegamenti",
+    "la": "spiratio-in-pressionibus",
+    "nl": "opdrukken-ademhaling",
+    "no": "armhevning-pusteteknikk",
+    "zh": "pushup-breathing"
+  },
   "heroImage": "https://images.unsplash.com/photo-1599058917765-a780eda07a3e?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta en posición de plancha con expresión concentrada.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/respiration-pompes.fr.ts
+++ b/web/src/app/blog/generated/respiration-pompes.fr.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "pompes valsalva",
     "pompes effort maximal respiration"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-atmung",
+    "el": "pnoe-pieseos-ges",
+    "en": "pushup-breathing",
+    "es": "respiracion-flexiones",
+    "fr": "respiration-pompes",
+    "it": "respirazione-piegamenti",
+    "la": "spiratio-in-pressionibus",
+    "nl": "opdrukken-ademhaling",
+    "no": "armhevning-pusteteknikk",
+    "zh": "pushup-breathing"
+  },
   "heroImage": "https://images.unsplash.com/photo-1599058917765-a780eda07a3e?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlète en position de planche avec une expression concentrée.",
   "heroImageCredit": "Photo : <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/respirazione-piegamenti.it.ts
+++ b/web/src/app/blog/generated/respirazione-piegamenti.it.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "push-up valsalva",
     "respirazione push-up massimo sforzo"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-atmung",
+    "el": "pnoe-pieseos-ges",
+    "en": "pushup-breathing",
+    "es": "respiracion-flexiones",
+    "fr": "respiration-pompes",
+    "it": "respirazione-piegamenti",
+    "la": "spiratio-in-pressionibus",
+    "nl": "opdrukken-ademhaling",
+    "no": "armhevning-pusteteknikk",
+    "zh": "pushup-breathing"
+  },
   "heroImage": "https://images.unsplash.com/photo-1599058917765-a780eda07a3e?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta in posizione di plank con espressione concentrata.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/sfida-30-giorni-piegamenti.it.ts
+++ b/web/src/app/blog/generated/sfida-30-giorni-piegamenti.it.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "aumentare push-up al giorno",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "30-tage-liegestuetze-challenge",
+    "el": "triakonta-emerai-pieseos",
+    "en": "30-day-pushup-challenge",
+    "es": "desafio-flexiones-30-dias",
+    "fr": "defi-pompes-30-jours",
+    "it": "sfida-30-giorni-piegamenti",
+    "la": "provocatio-triginta-dierum",
+    "nl": "30-dagen-opdruk-challenge",
+    "no": "30-dagers-armhevning-utfordring",
+    "zh": "30-day-pushup-challenge"
+  },
   "heroImage": "https://images.unsplash.com/photo-1596079306903-9164c205f400?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta che esegue un piegamento all'aperto — la sfida quotidiana sull'erba.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/spiratio-in-pressionibus.la.ts
+++ b/web/src/app/blog/generated/spiratio-in-pressionibus.la.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "pulsus valsalva",
     "respiratio pulsuum maximi conatus"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-atmung",
+    "el": "pnoe-pieseos-ges",
+    "en": "pushup-breathing",
+    "es": "respiracion-flexiones",
+    "fr": "respiration-pompes",
+    "it": "respirazione-piegamenti",
+    "la": "spiratio-in-pressionibus",
+    "nl": "opdrukken-ademhaling",
+    "no": "armhevning-pusteteknikk",
+    "zh": "pushup-breathing"
+  },
   "heroImage": "https://images.unsplash.com/photo-1599058917765-a780eda07a3e?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athleta in positione plana cum vultu intento.",
   "heroImageCredit": "Imago: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/taeglich-liegestuetze.de.ts
+++ b/web/src/app/blog/generated/taeglich-liegestuetze.de.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "Liegestütze Gewohnheit",
     "Liegestütze Gesundheit"
   ],
+  "alternateSlugs": {
+    "de": "taeglich-liegestuetze",
+    "el": "kathemerinai-pieseis-ges",
+    "en": "daily-pushups",
+    "es": "flexiones-diarias",
+    "fr": "pompes-quotidiennes",
+    "it": "piegamenti-quotidiani",
+    "la": "pressiones-cotidianae",
+    "nl": "dagelijks-opdrukken",
+    "no": "daglige-armhevninger",
+    "zh": "daily-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1598971639058-fab3c3109a00?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Sportlerin bei einer Liegestütze – tägliches Training im Freien.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/triakonta-emerai-pieseos.el.ts
+++ b/web/src/app/blog/generated/triakonta-emerai-pieseos.el.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "αυξήστε push-ups καθημερινά",
     "Pushup Tracker app"
   ],
+  "alternateSlugs": {
+    "de": "30-tage-liegestuetze-challenge",
+    "el": "triakonta-emerai-pieseos",
+    "en": "30-day-pushup-challenge",
+    "es": "desafio-flexiones-30-dias",
+    "fr": "defi-pompes-30-jours",
+    "it": "sfida-30-giorni-piegamenti",
+    "la": "provocatio-triginta-dierum",
+    "nl": "30-dagen-opdruk-challenge",
+    "no": "30-dagers-armhevning-utfordring",
+    "zh": "30-day-pushup-challenge"
+  },
   "heroImage": "https://images.unsplash.com/photo-1596079306903-9164c205f400?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Αθλητής κάνει push-up σε εξωτερικό χώρο — η καθημερινή προπόνηση πάνω στο γρασίδι.",
   "heroImageCredit": "Φωτογραφία: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/variaciones-flexiones.es.ts
+++ b/web/src/app/blog/generated/variaciones-flexiones.es.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "qué músculos trabajan las flexiones",
     "progresión flexiones casa"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-varianten",
+    "el": "pieseis-ges-poikiliai",
+    "en": "pushup-variations",
+    "es": "variaciones-flexiones",
+    "fr": "variantes-pompes",
+    "it": "varianti-piegamenti",
+    "la": "variationes-pressionum",
+    "nl": "opdrukken-variaties",
+    "no": "armhevning-varianter",
+    "zh": "pushup-variations"
+  },
   "heroImage": "https://images.unsplash.com/photo-1731341400836-baaa5535b8d5?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta realizando una variación de flexiones en un espacio de entrenamiento.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/variantes-pompes.fr.ts
+++ b/web/src/app/blog/generated/variantes-pompes.fr.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "quels muscles travaillent les pompes",
     "progression pompes maison"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-varianten",
+    "el": "pieseis-ges-poikiliai",
+    "en": "pushup-variations",
+    "es": "variaciones-flexiones",
+    "fr": "variantes-pompes",
+    "it": "varianti-piegamenti",
+    "la": "variationes-pressionum",
+    "nl": "opdrukken-variaties",
+    "no": "armhevning-varianter",
+    "zh": "pushup-variations"
+  },
   "heroImage": "https://images.unsplash.com/photo-1731341400836-baaa5535b8d5?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlète réalisant une variante de pompe dans un espace d'entraînement.",
   "heroImageCredit": "Photo : <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/varianti-piegamenti.it.ts
+++ b/web/src/app/blog/generated/varianti-piegamenti.it.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "quali muscoli allenano i push-up",
     "progressione push-up casa"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-varianten",
+    "el": "pieseis-ges-poikiliai",
+    "en": "pushup-variations",
+    "es": "variaciones-flexiones",
+    "fr": "variantes-pompes",
+    "it": "varianti-piegamenti",
+    "la": "variationes-pressionum",
+    "nl": "opdrukken-variaties",
+    "no": "armhevning-varianter",
+    "zh": "pushup-variations"
+  },
   "heroImage": "https://images.unsplash.com/photo-1731341400836-baaa5535b8d5?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleta che esegue una variante di piegamenti in uno spazio di allenamento.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/variationes-pressionum.la.ts
+++ b/web/src/app/blog/generated/variationes-pressionum.la.ts
@@ -20,6 +20,18 @@ export const POST: BlogPost = {
     "qui musculi pulsus exercent",
     "progressio pulsuum domi"
   ],
+  "alternateSlugs": {
+    "de": "liegestuetze-varianten",
+    "el": "pieseis-ges-poikiliai",
+    "en": "pushup-variations",
+    "es": "variaciones-flexiones",
+    "fr": "variantes-pompes",
+    "it": "varianti-piegamenti",
+    "la": "variationes-pressionum",
+    "nl": "opdrukken-variaties",
+    "no": "armhevning-varianter",
+    "zh": "pushup-variations"
+  },
   "heroImage": "https://images.unsplash.com/photo-1731341400836-baaa5535b8d5?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athleta variationem pressionis in spatio exercitationis faciens.",
   "heroImageCredit": "Imago: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/wim-hof-armhevninger.no.ts
+++ b/web/src/app/blog/generated/wim-hof-armhevninger.no.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "kuldeeksponering restitusjon",
     "Wim Hof pust push-ups"
   ],
+  "alternateSlugs": {
+    "de": "wim-hof-liegestuetze",
+    "el": "wim-hof-pieseis-ges",
+    "en": "wim-hof-pushups",
+    "es": "metodo-wim-hof-flexiones",
+    "fr": "pompes-wim-hof",
+    "it": "metodo-wim-hof-piegamenti",
+    "la": "pressiones-wim-hof",
+    "nl": "wim-hof-opdrukken",
+    "no": "wim-hof-armhevninger",
+    "zh": "wim-hof-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atlet som står i et fryst landskap — Wim Hof-metoden bilde av pust og kulde.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/wim-hof-liegestuetze.de.ts
+++ b/web/src/app/blog/generated/wim-hof-liegestuetze.de.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "Kälteanwendung Regeneration",
     "Wim Hof Atmung Liegestütze"
   ],
+  "alternateSlugs": {
+    "de": "wim-hof-liegestuetze",
+    "el": "wim-hof-pieseis-ges",
+    "en": "wim-hof-pushups",
+    "es": "metodo-wim-hof-flexiones",
+    "fr": "pompes-wim-hof",
+    "it": "metodo-wim-hof-piegamenti",
+    "la": "pressiones-wim-hof",
+    "nl": "wim-hof-opdrukken",
+    "no": "wim-hof-armhevninger",
+    "zh": "wim-hof-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Sportler in verschneiter Landschaft – Sinnbild für die Wim Hof Methode.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/wim-hof-opdrukken.nl.ts
+++ b/web/src/app/blog/generated/wim-hof-opdrukken.nl.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "kou blootstelling herstel",
     "Wim Hof ademhaling push-ups"
   ],
+  "alternateSlugs": {
+    "de": "wim-hof-liegestuetze",
+    "el": "wim-hof-pieseis-ges",
+    "en": "wim-hof-pushups",
+    "es": "metodo-wim-hof-flexiones",
+    "fr": "pompes-wim-hof",
+    "it": "metodo-wim-hof-piegamenti",
+    "la": "pressiones-wim-hof",
+    "nl": "wim-hof-opdrukken",
+    "no": "wim-hof-armhevninger",
+    "zh": "wim-hof-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Atleet in een bevroren landschap — Wim Hof Methode beelden van adem en kou.",
   "heroImageCredit": "Foto: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/wim-hof-pieseis-ges.el.ts
+++ b/web/src/app/blog/generated/wim-hof-pieseis-ges.el.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "ανάκαμψη έκθεση κρύου",
     "αναπνοή Wim Hof push-ups"
   ],
+  "alternateSlugs": {
+    "de": "wim-hof-liegestuetze",
+    "el": "wim-hof-pieseis-ges",
+    "en": "wim-hof-pushups",
+    "es": "metodo-wim-hof-flexiones",
+    "fr": "pompes-wim-hof",
+    "it": "metodo-wim-hof-piegamenti",
+    "la": "pressiones-wim-hof",
+    "nl": "wim-hof-opdrukken",
+    "no": "wim-hof-armhevninger",
+    "zh": "wim-hof-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Αθλητής στέκεται σε παγωμένο τοπίο — εικόνα της Μεθόδου Wim Hof, αναπνοή και κρύο.",
   "heroImageCredit": "Φωτογραφία: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/wim-hof-pushups.en.ts
+++ b/web/src/app/blog/generated/wim-hof-pushups.en.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "cold exposure recovery",
     "Wim Hof breathing push-ups"
   ],
+  "alternateSlugs": {
+    "de": "wim-hof-liegestuetze",
+    "el": "wim-hof-pieseis-ges",
+    "en": "wim-hof-pushups",
+    "es": "metodo-wim-hof-flexiones",
+    "fr": "pompes-wim-hof",
+    "it": "metodo-wim-hof-piegamenti",
+    "la": "pressiones-wim-hof",
+    "nl": "wim-hof-opdrukken",
+    "no": "wim-hof-armhevninger",
+    "zh": "wim-hof-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "Athlete standing in a frozen landscape — Wim Hof Method imagery of breath and cold.",
   "heroImageCredit": "Photo: <a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/blog/generated/wim-hof-pushups.zh.ts
+++ b/web/src/app/blog/generated/wim-hof-pushups.zh.ts
@@ -21,6 +21,18 @@ export const POST: BlogPost = {
     "冷暴露恢复",
     "Wim Hof呼吸俯卧撑"
   ],
+  "alternateSlugs": {
+    "de": "wim-hof-liegestuetze",
+    "el": "wim-hof-pieseis-ges",
+    "en": "wim-hof-pushups",
+    "es": "metodo-wim-hof-flexiones",
+    "fr": "pompes-wim-hof",
+    "it": "metodo-wim-hof-piegamenti",
+    "la": "pressiones-wim-hof",
+    "nl": "wim-hof-opdrukken",
+    "no": "wim-hof-armhevninger",
+    "zh": "wim-hof-pushups"
+  },
   "heroImage": "https://images.unsplash.com/photo-1548690312-e3b507d8c110?auto=format&fit=crop&w=1600&q=80",
   "heroImageAlt": "运动员站在冰冻景观中——Wim Hof 呼吸法的呼吸和冷的意象。",
   "heroImageCredit": "图片：<a href=\"https://unsplash.com\" target=\"_blank\" rel=\"noopener noreferrer\">Unsplash</a>"

--- a/web/src/app/core/seo.service.ts
+++ b/web/src/app/core/seo.service.ts
@@ -41,7 +41,7 @@ export class SeoService {
       /**
        * Per-locale path overrides for hreflang alternates. Required
        * for routes whose slug differs by locale (e.g. blog posts with
-       * `translationSlug`). When omitted, the route is assumed to be
+       * `alternateSlugs`). When omitted, the route is assumed to be
        * locale-agnostic and the same path is advertised for every
        * supported locale. Locales not present in the map are skipped
        * so we never claim alternates for content that doesn't resolve


### PR DESCRIPTION
## Summary

- Fixes broken `hreflang` alternate links on blog posts that ship in more than two locales (i.e. all of them, since every blog folder now has all 10 supported locales). Example from the bug report: on `https://pushup-stats.com/zh/blog/pushup-mistakes`, the `x-default`/`de` alternate pointed to `https://pushup-stats.com/de/blog/pushup-mistakes` — a URL that 404s. The correct German URL is `https://pushup-stats.com/de/blog/liegestuetze-fehler`.
- Root cause: `BlogPost.translationSlug` (built in `tools/src/generate-content.mjs`) was only ever populated when a blog folder had *exactly* two locale files. Since every post now has all 10 locale files, `translationSlug` was never set, so `BlogArticleComponent` built an `alternates` map containing only the current locale — and `SeoService`'s `x-default` fallback then reused the *current locale's slug* under the German URL prefix.
- Replaces `translationSlug` with `alternateSlugs: Record<string, string>` — a full per-locale slug map, built the same way `generate-sitemap.js`'s `scanMarkdownBlogPosts` already builds it for the sitemap — so the article page's `<head>` and the sitemap agree.

## Changes

- `tools/src/generate-content.mjs`: `loadBlogPosts` now always emits `alternateSlugs` (every sibling locale → its slug) instead of the old two-locale-only `translationSlug`.
- `web/src/app/blog/blog-posts.types.ts`: `BlogPost.translationSlug` → `BlogPost.alternateSlugs`.
- `web/src/app/blog/blog-article.component.ts`: builds the full `SeoService` `alternates` map from `alternateSlugs` instead of a single hardcoded other-locale.
- Regenerated all 110 `web/src/app/blog/generated/*.ts` files via `pnpm nx run tools:generate-content` (adds `alternateSlugs` to each post; `sitemap.xml` output was already correct and unaffected).

## Test plan

- [x] `tools/src/generate-content.spec.js` (new): verifies `loadBlogPosts` maps every sibling locale's slug for a 3-locale post, and self-maps for a solo post.
- [x] `web/src/app/blog/blog-article.component.spec.ts` (new): regression test against the real `liegestuetze-fehler`/`pushup-mistakes` post family confirming `SeoService.update` receives `de: '/blog/liegestuetze-fehler'` (not `/blog/pushup-mistakes`) when viewing the zh post; plus a second post family for coverage.
- [x] `pnpm nx run tools:test` — 98 passed
- [x] `pnpm nx run web:test --include="**/blog-article.component.spec.ts" --include="**/seo.service.spec.ts"` — all passed
- [x] `pnpm nx run web:lint` — clean (pre-existing unrelated warnings only)
- [x] `npx tsc -p web/tsconfig.app.json --noEmit` — no errors
- [x] `pnpm nx run tools:generate-sitemap` — regenerated `sitemap.xml`, no diff (sitemap was already correct)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JeY6qFCoFdF4dVLKpvwFSF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full locale-to-URL alternate links for blog posts, improving language-specific navigation and search engine metadata.
  * Blog posts now support alternate slugs for every available locale, including the post’s own language.

* **Bug Fixes**
  * Fixed alternate-link generation for posts with more than two translations.
  * Improved SEO metadata so translated articles point to the correct localized blog URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->