### PR TITLE
Broaden About Us copy beyond pushups and fix medical-advice sentence

### DIFF
--- a/web/src/app/marketing/about/ueber-uns-page.component.ts
+++ b/web/src/app/marketing/about/ueber-uns-page.component.ts
@@ -13,26 +13,29 @@ import { RouterLink } from '@angular/router';
         <h2 i18n="@@about.who.title">Wer hinter Pushup Tracker steckt</h2>
         <p i18n="@@about.who.body1">
           Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben –
-          Softwareentwickler aus der Nähe von Hamburg und selbst täglicher
-          Liegestütze-Trainierender. Die App ist aus einem persönlichen
-          Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft
-          festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu
-          machen.
+          Softwareentwickler aus der Nähe von Hamburg und selbst täglich im
+          Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das
+          eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt
+          über Wochen und Monate sichtbar zu machen.
         </p>
         <p i18n="@@about.who.body2">
-          Was als kleines Wochenendprojekt begann, ist heute ein vollwertiger
-          Trainings-Tracker mit Trainingsplänen, Tageszielen, Streaks,
-          Bestenliste und automatischer Wiederholungszählung per Kamera –
-          komplett im Browser, kostenlos und ohne App-Store.
+          Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein
+          vollwertiger Trainings-Tracker für dutzende Übungen – von
+          Liegestützen, Klimmzügen und Kniebeugen über Planks und
+          Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit
+          Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer
+          Wiederholungszählung per Kamera – komplett im Browser, kostenlos und
+          ohne App-Store.
         </p>
       </section>
 
       <section>
         <h2 i18n="@@about.mission.title">Warum es diese Seite gibt</h2>
         <p i18n="@@about.mission.body">
-          Liegestütze sind die einfachste Kraftübung der Welt: kein Gerät, kein
-          Studio, keine Ausrede. Was den meisten fehlt, ist nicht die Übung,
-          sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer
+          Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten
+          Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen
+          keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern
+          die Kontinuität. Genau da setzt Pushup Tracker an – messbarer
           Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen
           lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit.
         </p>
@@ -44,8 +47,8 @@ import { RouterLink } from '@angular/router';
           Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung
           und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert
           werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine
-          medizinische Beratung – bei Vorerkrankungen oder Schmerzen gehört die
-          Frage zuerst zu Ärztin oder Arzt.
+          medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen
+          zuerst ärztlichen Rat.
         </p>
       </section>
 

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10127,15 +10127,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="translated">
-        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglicher Liegestütze-Trainierender. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Το Pushup Tracker αναπτύσσεται και λειτουργεί από τον Wolfram Sokollek — προγραμματιστή λογισμικού κοντά στο Αμβούργο και ο ίδιος καθημερινός λάτρης των push-up. Η εφαρμογή γεννήθηκε από μια προσωπική ανάγκη: να καταγράφει την προπόνησή του χωρίς χαρτιά και να κάνει την πρόοδο ορατή για εβδομάδες και μήνες. </target>
+      <segment state="initial">
+        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
+        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="translated">
-        <source> Was als kleines Wochenendprojekt begann, ist heute ein vollwertiger Trainings-Tracker mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Αυτό που ξεκίνησε ως ένα μικρό πρότζεκτ σαββατοκύριακου είναι σήμερα ένας πλήρης ιχνηλάτης προπόνησης με προγράμματα προπόνησης, καθημερινούς στόχους, σερί, πίνακα κατάταξης και αυτόματη καταμέτρηση επαναλήψεων μέσω κάμερας — εξ ολοκλήρου μέσα από το πρόγραμμα περιήγησης, δωρεάν και χωρίς κατάστημα εφαρμογών. </target>
+      <segment state="initial">
+        <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
+        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10145,9 +10145,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="translated">
-        <source> Liegestütze sind die einfachste Kraftübung der Welt: kein Gerät, kein Studio, keine Ausrede. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Οι push-up είναι η απλούστερη άσκηση δύναμης στον κόσμο: χωρίς εξοπλισμό, χωρίς γυμναστήριο, καμία δικαιολογία. Αυτό που λείπει από τους περισσότερους δεν είναι η άσκηση αλλά η συνέπεια. Ακριβώς εκεί έρχεται το Pushup Tracker — μετρήσιμη πρόοδος, μικροί καθημερινοί στόχοι και ένα σερί που δεν θέλεις να χαλάσεις μετατρέπουν λίγες επαναλήψεις σε μόνιμη συνήθεια. </target>
+      <segment state="initial">
+        <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
+        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10157,9 +10157,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="translated">
-        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – bei Vorerkrankungen oder Schmerzen gehört die Frage zuerst zu Ärztin oder Arzt. </source>
-        <target> Οι οδηγοί και τα άρθρα του blog βασίζονται σε προσωπική εμπειρία προπόνησης και σε γενικά αποδεκτές αρχές προπόνησης· όπου αναφέρονται μελέτες, υπάρχει σύνδεσμος μέσα στο άρθρο. Το περιεχόμενο δεν αντικαθιστά την ιατρική συμβουλή — σε περίπτωση προϋπάρχουσας πάθησης ή πόνου, συμβουλευτείτε πρώτα έναν γιατρό. </target>
+      <segment state="initial">
+        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
+        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10320,15 +10320,15 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="translated">
-        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglicher Liegestütze-Trainierender. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker is developed and run by Wolfram Sokollek — a software developer from near Hamburg and a daily pushup practitioner himself. The app grew out of a personal need: to track his own training without paper clutter and make progress visible over weeks and months. </target>
+      <segment state="initial">
+        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
+        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="translated">
-        <source> Was als kleines Wochenendprojekt begann, ist heute ein vollwertiger Trainings-Tracker mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> What started as a small weekend project is now a full-fledged training tracker with training plans, daily goals, streaks, a leaderboard, and automatic rep counting via camera — entirely in the browser, free, and without an app store. </target>
+      <segment state="initial">
+        <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
+        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10338,9 +10338,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="translated">
-        <source> Liegestütze sind die einfachste Kraftübung der Welt: kein Gerät, kein Studio, keine Ausrede. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Pushups are the simplest strength exercise in the world: no equipment, no gym, no excuse. What most people lack isn't the exercise itself but consistency. That's exactly where Pushup Tracker comes in — measurable progress, small daily goals, and a streak you don't want to break turn a few reps into a lasting habit. </target>
+      <segment state="initial">
+        <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
+        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10350,9 +10350,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="translated">
-        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – bei Vorerkrankungen oder Schmerzen gehört die Frage zuerst zu Ärztin oder Arzt. </source>
-        <target> The guides and blog posts are based on personal training experience and generally accepted training principles; where studies are cited, they're linked in the article. This content doesn't replace medical advice — if you have a pre-existing condition or pain, talk to a doctor first. </target>
+      <segment state="initial">
+        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
+        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10123,15 +10123,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="translated">
-        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglicher Liegestütze-Trainierender. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker es desarrollado y gestionado por Wolfram Sokollek, desarrollador de software cerca de Hamburgo y practicante diario de flexiones. La app nació de una necesidad personal: registrar su propio entrenamiento sin papeles sueltos y hacer visible el progreso a lo largo de semanas y meses. </target>
+      <segment state="initial">
+        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
+        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="translated">
-        <source> Was als kleines Wochenendprojekt begann, ist heute ein vollwertiger Trainings-Tracker mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Lo que comenzó como un pequeño proyecto de fin de semana es hoy un tracker de entrenamiento completo con planes de entrenamiento, objetivos diarios, rachas, tabla de clasificación y conteo automático de repeticiones por cámara, todo desde el navegador, gratis y sin tienda de apps. </target>
+      <segment state="initial">
+        <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
+        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10141,9 +10141,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="translated">
-        <source> Liegestütze sind die einfachste Kraftübung der Welt: kein Gerät, kein Studio, keine Ausrede. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Las flexiones son el ejercicio de fuerza más sencillo del mundo: sin equipo, sin gimnasio, sin excusas. Lo que le falta a la mayoría no es el ejercicio, sino la constancia. Ahí es exactamente donde entra Pushup Tracker: progreso medible, pequeños objetivos diarios y una racha que no querrás romper convierten unas pocas repeticiones en un hábito duradero. </target>
+      <segment state="initial">
+        <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
+        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10153,9 +10153,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="translated">
-        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – bei Vorerkrankungen oder Schmerzen gehört die Frage zuerst zu Ärztin oder Arzt. </source>
-        <target> Las guías y entradas del blog se basan en experiencia de entrenamiento propia y principios de entrenamiento generalmente aceptados; cuando se citan estudios, están enlazados en el artículo. Este contenido no sustituye el consejo médico: si tienes alguna afección previa o dolor, consulta primero a un médico. </target>
+      <segment state="initial">
+        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
+        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9999,15 +9999,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="translated">
-        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglicher Liegestütze-Trainierender. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker est développé et exploité par Wolfram Sokollek, développeur logiciel près de Hambourg et pratiquant quotidien de pompes. L'application est née d'un besoin personnel : suivre son propre entraînement sans paperasse et rendre les progrès visibles sur plusieurs semaines et mois. </target>
+      <segment state="initial">
+        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
+        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="translated">
-        <source> Was als kleines Wochenendprojekt begann, ist heute ein vollwertiger Trainings-Tracker mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Ce qui a commencé comme un petit projet de week-end est aujourd'hui un tracker d'entraînement complet avec plans d'entraînement, objectifs quotidiens, séries, classement et comptage automatique des répétitions par caméra — entièrement dans le navigateur, gratuit et sans app store. </target>
+      <segment state="initial">
+        <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
+        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10017,9 +10017,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="translated">
-        <source> Liegestütze sind die einfachste Kraftübung der Welt: kein Gerät, kein Studio, keine Ausrede. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Les pompes sont l'exercice de force le plus simple au monde : pas de matériel, pas de salle, pas d'excuse. Ce qui manque à la plupart des gens, ce n'est pas l'exercice mais la régularité. C'est exactement là qu'intervient Pushup Tracker — des progrès mesurables, de petits objectifs quotidiens et une série qu'on n'a pas envie de briser transforment quelques répétitions en habitude durable. </target>
+      <segment state="initial">
+        <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
+        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10029,9 +10029,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="translated">
-        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – bei Vorerkrankungen oder Schmerzen gehört die Frage zuerst zu Ärztin oder Arzt. </source>
-        <target> Les guides et articles de blog reposent sur une expérience d'entraînement personnelle et des principes d'entraînement généralement reconnus ; lorsque des études sont citées, elles sont liées dans l'article. Ces contenus ne remplacent pas un avis médical — en cas de problème de santé préexistant ou de douleur, consultez d'abord un médecin. </target>
+      <segment state="initial">
+        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
+        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10127,15 +10127,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="translated">
-        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglicher Liegestütze-Trainierender. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker è sviluppato e gestito da Wolfram Sokollek, sviluppatore software nei pressi di Amburgo e praticante quotidiano di flessioni. L'app è nata da un'esigenza personale: tenere traccia del proprio allenamento senza fogli sparsi e rendere visibili i progressi nel corso di settimane e mesi. </target>
+      <segment state="initial">
+        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
+        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="translated">
-        <source> Was als kleines Wochenendprojekt begann, ist heute ein vollwertiger Trainings-Tracker mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Ciò che è iniziato come un piccolo progetto del weekend è oggi un tracker di allenamento completo con piani di allenamento, obiettivi giornalieri, streak, classifica e conteggio automatico delle ripetizioni tramite fotocamera, tutto nel browser, gratuito e senza app store. </target>
+      <segment state="initial">
+        <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
+        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10145,9 +10145,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="translated">
-        <source> Liegestütze sind die einfachste Kraftübung der Welt: kein Gerät, kein Studio, keine Ausrede. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> I piegamenti sono l'esercizio di forza più semplice al mondo: nessun attrezzo, nessuna palestra, nessuna scusa. Ciò che manca alla maggior parte delle persone non è l'esercizio, ma la costanza. È esattamente qui che entra in gioco Pushup Tracker: progressi misurabili, piccoli obiettivi giornalieri e uno streak che non si vuole interrompere trasformano poche ripetizioni in un'abitudine duratura. </target>
+      <segment state="initial">
+        <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
+        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10157,9 +10157,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="translated">
-        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – bei Vorerkrankungen oder Schmerzen gehört die Frage zuerst zu Ärztin oder Arzt. </source>
-        <target> Le guide e gli articoli del blog si basano sull'esperienza di allenamento personale e su principi di allenamento generalmente riconosciuti; quando vengono citati studi, sono collegati nell'articolo. Questi contenuti non sostituiscono un consiglio medico: in caso di patologie pregresse o dolore, consultate prima un medico. </target>
+      <segment state="initial">
+        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
+        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10127,15 +10127,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="translated">
-        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglicher Liegestütze-Trainierender. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker wordt ontwikkeld en beheerd door Wolfram Sokollek, softwareontwikkelaar uit de buurt van Hamburg en zelf dagelijks push-up trainer. De app is ontstaan uit een persoonlijke behoefte: de eigen training bijhouden zonder papierwerk en de vooruitgang over weken en maanden zichtbaar maken. </target>
+      <segment state="initial">
+        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
+        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="translated">
-        <source> Was als kleines Wochenendprojekt begann, ist heute ein vollwertiger Trainings-Tracker mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Wat begon als een klein weekendproject, is nu een volwaardige trainingstracker met trainingsplannen, dagelijkse doelen, reeksen, ranglijst en automatische herhalingstelling via de camera — volledig in de browser, gratis en zonder app store. </target>
+      <segment state="initial">
+        <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
+        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10145,9 +10145,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="translated">
-        <source> Liegestütze sind die einfachste Kraftübung der Welt: kein Gerät, kein Studio, keine Ausrede. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Push-ups zijn de eenvoudigste krachtoefening ter wereld: geen apparatuur, geen sportschool, geen excuus. Wat de meeste mensen missen, is niet de oefening zelf, maar de consistentie. Precies daar komt Pushup Tracker om de hoek kijken — meetbare vooruitgang, kleine dagelijkse doelen en een reeks die je niet wilt verbreken maken van een paar herhalingen een blijvende gewoonte. </target>
+      <segment state="initial">
+        <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
+        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10157,9 +10157,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="translated">
-        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – bei Vorerkrankungen oder Schmerzen gehört die Frage zuerst zu Ärztin oder Arzt. </source>
-        <target> De gidsen en blogartikelen zijn gebaseerd op eigen trainingservaring en algemeen aanvaarde trainingsprincipes; waar studies worden aangehaald, zijn ze gelinkt in het artikel. Deze content vervangt geen medisch advies — bij een bestaande aandoening of pijn raadpleeg je eerst een arts. </target>
+      <segment state="initial">
+        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
+        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9414,15 +9414,15 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="translated">
-        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglicher Liegestütze-Trainierender. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker utvikles og drives av Wolfram Sokollek – programvareutvikler fra nær Hamburg og selv en daglig push-up-trener. Appen oppsto fra et personlig behov: å registrere egen trening uten lapper og gjøre fremgangen synlig over uker og måneder. </target>
+      <segment state="initial">
+        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
+        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="translated">
-        <source> Was als kleines Wochenendprojekt begann, ist heute ein vollwertiger Trainings-Tracker mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Det som startet som et lite helgeprosjekt, er i dag en fullverdig treningstracker med treningsplaner, daglige mål, streaks, resultatliste og automatisk repetisjonstelling via kamera – helt i nettleseren, gratis og uten app store. </target>
+      <segment state="initial">
+        <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
+        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -9432,9 +9432,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="translated">
-        <source> Liegestütze sind die einfachste Kraftübung der Welt: kein Gerät, kein Studio, keine Ausrede. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Push-ups er verdens enkleste styrkeøvelse: ikke noe utstyr, ikke noe treningsstudio, ingen unnskyldning. Det de fleste mangler, er ikke øvelsen, men kontinuiteten. Akkurat der kommer Pushup Tracker inn – målbar fremgang, små daglige mål og en streak man ikke vil bryte, gjør noen få repetisjoner til en varig vane. </target>
+      <segment state="initial">
+        <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
+        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -9444,9 +9444,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="translated">
-        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – bei Vorerkrankungen oder Schmerzen gehört die Frage zuerst zu Ärztin oder Arzt. </source>
-        <target> Guidene og blogginnleggene er basert på egen treningserfaring og allment aksepterte treningsprinsipper; der studier siteres, er de lenket i artikkelen. Innholdet erstatter ikke medisinsk rådgivning – ved eksisterende sykdommer eller smerter bør du først kontakte lege. </target>
+      <segment state="initial">
+        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
+        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -4779,20 +4779,20 @@
         <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:15,19</note>
       </notes>
       <segment>
-        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglicher Liegestütze-Trainierender. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
+        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
       </segment>
     </unit>
     <unit id="about.who.body2">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:23,26</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:22,27</note>
       </notes>
       <segment>
-        <source> Was als kleines Wochenendprojekt begann, ist heute ein vollwertiger Trainings-Tracker mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
+        <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
       </segment>
     </unit>
     <unit id="about.mission.title">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:31,32</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:32,33</note>
       </notes>
       <segment>
         <source>Warum es diese Seite gibt</source>
@@ -4800,15 +4800,15 @@
     </unit>
     <unit id="about.mission.body">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:33,37</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:34,39</note>
       </notes>
       <segment>
-        <source> Liegestütze sind die einfachste Kraftübung der Welt: kein Gerät, kein Studio, keine Ausrede. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
+        <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
       </segment>
     </unit>
     <unit id="about.content.title">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:42,43</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:44,45</note>
       </notes>
       <segment>
         <source>Wie unsere Inhalte entstehen</source>
@@ -4816,15 +4816,15 @@
     </unit>
     <unit id="about.content.body">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:44,48</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:46,50</note>
       </notes>
       <segment>
-        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – bei Vorerkrankungen oder Schmerzen gehört die Frage zuerst zu Ärztin oder Arzt. </source>
+        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
       </segment>
     </unit>
     <unit id="about.contact.title">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:53,55</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:55,57</note>
       </notes>
       <segment>
         <source>Kontakt</source>
@@ -4832,7 +4832,7 @@
     </unit>
     <unit id="about.contact.body">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:56,58</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:58,60</note>
       </notes>
       <segment>
         <source>Fragen, Feedback oder Fehler gefunden? Schreib uns:</source>
@@ -4840,7 +4840,7 @@
     </unit>
     <unit id="about.toImpressum">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:65,68</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:67,70</note>
       </notes>
       <segment>
         <source>Impressum</source>
@@ -4848,7 +4848,7 @@
     </unit>
     <unit id="about.toDatenschutz">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:71,74</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:73,76</note>
       </notes>
       <segment>
         <source>Datenschutz</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9631,15 +9631,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="translated">
-        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglicher Liegestütze-Trainierender. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker 由 Wolfram Sokollek 开发和运营——他是一名来自汉堡附近的软件开发者，也是每天坚持俯卧撑训练的人。这款应用源于个人需求：不用纸笔记录自己的训练，并让数周乃至数月的进步一目了然。 </target>
+      <segment state="initial">
+        <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
+        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="translated">
-        <source> Was als kleines Wochenendprojekt begann, ist heute ein vollwertiger Trainings-Tracker mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> 这个最初只是周末小项目的应用，如今已发展成一个功能完善的训练追踪工具，包含训练计划、每日目标、连续打卡记录、排行榜，以及通过摄像头自动计数——完全在浏览器中运行，免费且无需应用商店。 </target>
+      <segment state="initial">
+        <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
+        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -9649,9 +9649,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="translated">
-        <source> Liegestütze sind die einfachste Kraftübung der Welt: kein Gerät, kein Studio, keine Ausrede. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> 俯卧撑是世界上最简单的力量训练：不需要器材，不需要健身房，也没有借口。大多数人缺的不是训练动作本身，而是坚持。这正是 Pushup Tracker 发挥作用的地方——可衡量的进步、微小的每日目标，以及一份不忍中断的连续打卡记录，让寥寥数次训练变成持久的习惯。 </target>
+      <segment state="initial">
+        <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
+        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -9661,9 +9661,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="translated">
-        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – bei Vorerkrankungen oder Schmerzen gehört die Frage zuerst zu Ärztin oder Arzt. </source>
-        <target> 我们的指南和博客文章基于个人训练经验以及普遍认可的训练原则；如果引用了研究，会在文章中附上链接。这些内容不能替代医疗建议——如果你有既往病史或身体不适，请先咨询医生。 </target>
+      <segment state="initial">
+        <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
+        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">


### PR DESCRIPTION
## Was

Die "Über uns"-Seite (`ueber-uns-page.component.ts`) sprach ausschließlich von Liegestützen. Die App trackt inzwischen viele Übungskategorien (push, pull, squat, hinge, lunge, core, cardio, mobility), daher wurde die Copy entsprechend erweitert:

- **`about.who.body1`** – "täglicher Liegestütze-Trainierender" → "täglich im Training".
- **`about.who.body2`** – aus "Wochenendprojekt begann … Trainings-Tracker" wird ein Tracker "für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten".
- **`about.mission.body`** – nicht mehr "Liegestütze sind die einfachste Kraftübung der Welt", sondern "Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen …".
- **`about.content.body`** – der grammatikalisch kaputte Satz "gehört die Frage zuerst zu Ärztin oder Arzt" wird zu "hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat" (generisches Maskulinum bzw. hier ganz ohne gendered Nomen, ein vernünftiger Satz).

## i18n

Deutsche Quelltexte wurden geändert, daher `web:extract-i18n` + `sync-xliff-locales.mjs` ausgeführt. `messages.xlf` wurde neu generiert; die IDs bleiben unverändert. Die eigentlichen Übersetzungen aktualisiert die tägliche Translations-Routine — nicht händisch übersetzt.

## Tests

`pnpm nx run web:test --filter=ueber-uns` — grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019R9zpB6dJ3RzmnQwEjUfKj

---
_Generated by [Claude Code](https://claude.ai/code/session_019R9zpB6dJ3RzmnQwEjUfKj)_