### PR TITLE
chore(i18n): fill missing translations (32 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10127,15 +10127,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="initial">
+      <segment state="translated">
         <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
+        <target> Το Pushup Tracker αναπτύσσεται και λειτουργεί από τον Wolfram Sokollek – προγραμματιστή λογισμικού κοντά στο Αμβούργο, ο οποίος προπονείται και ο ίδιος καθημερινά. Η εφαρμογή γεννήθηκε από μια προσωπική ανάγκη: να καταγράφει τη δική του προπόνηση χωρίς χαρτιά και να κάνει ορατή την πρόοδο σε βάθος εβδομάδων και μηνών. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="initial">
+      <segment state="translated">
         <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
+        <target> Αυτό που ξεκίνησε ως ένα μικρό σαββατοκύριακο πρότζεκτ για push-ups είναι σήμερα ένα πλήρες εργαλείο παρακολούθησης προπόνησης για δεκάδες ασκήσεις – από push-ups, έλξεις και καθίσματα μέχρι planks, προβολές και ασκήσεις καρδιο και κινητικότητας. Με προγράμματα προπόνησης, καθημερινούς στόχους, σερί, κατάταξη και αυτόματη μέτρηση επαναλήψεων μέσω κάμερας – όλα μέσα στο πρόγραμμα περιήγησης, δωρεάν και χωρίς κατάστημα εφαρμογών. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10145,9 +10145,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
+        <target> Είτε πρόκειται για push-ups, καθίσματα ή έλξεις – οι περισσότερες ασκήσεις με το βάρος του σώματος δεν χρειάζονται εξοπλισμό, γυμναστήριο, και δεν αφήνουν περιθώριο για δικαιολογίες. Αυτό που λείπει στους περισσότερους δεν είναι η άσκηση, αλλά η συνέπεια. Ακριβώς εκεί μπαίνει το Pushup Tracker – μετρήσιμη πρόοδος, μικροί καθημερινοί στόχοι και ένα σερί που δεν θέλεις να χαλάσεις μετατρέπουν λίγες επαναλήψεις σε μόνιμη συνήθεια. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10157,9 +10157,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
-        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
+        <target> Οι οδηγοί και τα άρθρα του blog βασίζονται σε προσωπική εμπειρία προπόνησης και σε γενικά αποδεκτές αρχές προπόνησης· όπου αναφέρονται μελέτες, υπάρχει σύνδεσμος στο άρθρο. Το περιεχόμενο δεν υποκαθιστά την ιατρική συμβουλή – αν έχετε προϋπάρχουσα πάθηση ή πόνους, ζητήστε πρώτα ιατρική συμβουλή. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10320,15 +10320,15 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="initial">
+      <segment state="translated">
         <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
+        <target> Pushup Tracker is developed and run by Wolfram Sokollek – a software developer from near Hamburg who trains daily himself. The app grew out of a personal need: to track his own training without paper notes and to make progress visible over weeks and months. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="initial">
+      <segment state="translated">
         <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
+        <target> What began as a small weekend project for push-ups is today a full-fledged training tracker for dozens of exercises – from push-ups, pull-ups and squats to planks, lunges and cardio and mobility sessions. With training plans, daily goals, streaks, a leaderboard and automatic rep counting via camera – all in the browser, free and without an app store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10338,9 +10338,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
+        <target> Whether push-ups, squats or pull-ups – most bodyweight exercises need no equipment, no gym, and leave no excuse. What most people lack isn't the exercise, but consistency. That's exactly where Pushup Tracker comes in – measurable progress, small daily goals and a streak you don't want to break turn a few reps into a lasting habit. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10350,9 +10350,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
-        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
+        <target> The guides and blog articles are based on personal training experience and generally accepted training principles; where studies are cited, they're linked in the article. The content is not a substitute for medical advice – if you have a pre-existing condition or experience pain, seek medical advice first. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10123,15 +10123,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="initial">
+      <segment state="translated">
         <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
+        <target> Pushup Tracker está desarrollado y gestionado por Wolfram Sokollek, desarrollador de software cerca de Hamburgo que entrena a diario. La aplicación nació de una necesidad personal: registrar su propio entrenamiento sin papeleo y hacer visible el progreso a lo largo de semanas y meses. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="initial">
+      <segment state="translated">
         <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
+        <target> Lo que comenzó como un pequeño proyecto de fin de semana para flexiones es hoy un tracker de entrenamiento completo para docenas de ejercicios: flexiones, dominadas y sentadillas, planchas, zancadas y sesiones de cardio y movilidad. Con planes de entrenamiento, objetivos diarios, rachas, una clasificación y conteo automático de repeticiones por cámara, todo en el navegador, gratis y sin tienda de aplicaciones. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10141,9 +10141,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
+        <target> Ya sean flexiones, sentadillas o dominadas, la mayoría de los ejercicios con el peso corporal no necesitan equipo ni gimnasio, y no dejan excusa. Lo que le falta a la mayoría no es el ejercicio, sino la constancia. Justo ahí entra Pushup Tracker: el progreso medible, pequeñas metas diarias y una racha que no querrás romper convierten unas pocas repeticiones en un hábito duradero. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10153,9 +10153,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
-        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
+        <target> Las guías y artículos del blog se basan en experiencia propia de entrenamiento y en principios de entrenamiento generalmente aceptados; cuando se citan estudios, están enlazados en el artículo. El contenido no sustituye el consejo médico: si tienes alguna condición previa o dolores, consulta primero a un médico. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -9999,15 +9999,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="initial">
+      <segment state="translated">
         <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
+        <target> Pushup Tracker est développé et exploité par Wolfram Sokollek – développeur logiciel des environs de Hambourg, lui-même adepte d'un entraînement quotidien. L'application est née d'un besoin personnel : suivre son propre entraînement sans paperasse et rendre visibles les progrès sur des semaines et des mois. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="initial">
+      <segment state="translated">
         <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
+        <target> Ce qui a commencé comme un petit projet de week-end pour les pompes est aujourd'hui un tracker d'entraînement complet pour des dizaines d'exercices – des pompes, tractions et squats aux planches, fentes et séances de cardio et de mobilité. Avec des plans d'entraînement, des objectifs quotidiens, des séries, un classement et un comptage automatique des répétitions par caméra – le tout dans le navigateur, gratuit et sans app store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10017,9 +10017,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
+        <target> Pompes, squats ou tractions – la plupart des exercices au poids du corps ne nécessitent ni équipement, ni salle de sport, et ne laissent aucune excuse. Ce qui manque à la plupart des gens, ce n'est pas l'exercice, mais la régularité. C'est exactement là que Pushup Tracker intervient – des progrès mesurables, de petits objectifs quotidiens et une série qu'on n'a pas envie de briser transforment quelques répétitions en habitude durable. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10029,9 +10029,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
-        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
+        <target> Les guides et articles de blog s'appuient sur une expérience d'entraînement personnelle et des principes d'entraînement généralement reconnus ; lorsque des études sont citées, elles sont liées dans l'article. Le contenu ne remplace pas un avis médical – en cas de problème de santé préexistant ou de douleurs, consultez d'abord un médecin. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10127,15 +10127,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="initial">
+      <segment state="translated">
         <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
+        <target> Pushup Tracker è sviluppato e gestito da Wolfram Sokollek – sviluppatore software nei pressi di Amburgo e lui stesso allenato quotidianamente. L'app è nata da un'esigenza personale: tenere traccia del proprio allenamento senza fogli sparsi e rendere visibili i progressi nel corso di settimane e mesi. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="initial">
+      <segment state="translated">
         <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
+        <target> Quello che è iniziato come un piccolo progetto del weekend per i piegamenti oggi è un tracker di allenamento completo per decine di esercizi – da piegamenti, trazioni e squat a plank, affondi e sessioni di cardio e mobilità. Con piani di allenamento, obiettivi giornalieri, streak, classifica e conteggio automatico delle ripetizioni tramite fotocamera – tutto nel browser, gratis e senza app store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10145,9 +10145,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
+        <target> Che si tratti di piegamenti, squat o trazioni, la maggior parte degli esercizi a corpo libero non richiede attrezzatura, né una palestra, e non lascia scuse. Ciò che manca alla maggior parte delle persone non è l'esercizio, ma la costanza. Ed è proprio qui che interviene Pushup Tracker – progressi misurabili, piccoli obiettivi giornalieri e uno streak che non si vuole interrompere trasformano poche ripetizioni in un'abitudine duratura. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10157,9 +10157,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
-        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
+        <target> Le guide e gli articoli del blog si basano sull'esperienza personale di allenamento e su principi di allenamento generalmente riconosciuti; dove vengono citati studi, sono collegati nell'articolo. I contenuti non sostituiscono una consulenza medica – in caso di patologie pregresse o dolori, consulta prima un medico. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10127,15 +10127,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="initial">
+      <segment state="translated">
         <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
+        <target> Pushup Tracker wordt ontwikkeld en beheerd door Wolfram Sokollek – softwareontwikkelaar uit de buurt van Hamburg die zelf dagelijks traint. De app is ontstaan uit een persoonlijke behoefte: de eigen training bijhouden zonder papierwerk en de voortgang over weken en maanden zichtbaar maken. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="initial">
+      <segment state="translated">
         <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
+        <target> Wat begon als een klein weekendproject voor push-ups is inmiddels een volwaardige trainingstracker voor tientallen oefeningen – van push-ups, pull-ups en squats tot planks, uitvalspassen en cardio- en mobiliteitssessies. Met trainingsplannen, dagdoelen, streaks, een ranglijst en automatisch tellen van herhalingen via de camera – volledig in de browser, gratis en zonder app store. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -10145,9 +10145,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
+        <target> Of het nu push-ups, squats of pull-ups zijn – de meeste lichaamsgewichtoefeningen vereisen geen apparatuur, geen sportschool en laten geen excuus toe. Wat de meeste mensen missen, is niet de oefening, maar de consistentie. Precies daar komt Pushup Tracker om de hoek kijken – meetbare vooruitgang, kleine dagelijkse doelen en een streak die je niet wilt verbreken maken van een paar herhalingen een blijvende gewoonte. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -10157,9 +10157,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
-        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
+        <target> De gidsen en blogartikelen zijn gebaseerd op eigen trainingservaring en algemeen erkende trainingsprincipes; waar studies worden aangehaald, zijn ze in het artikel gelinkt. De inhoud vervangt geen medisch advies – raadpleeg bij bestaande aandoeningen of pijn eerst een arts. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9414,15 +9414,15 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="initial">
+      <segment state="translated">
         <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
+        <target> Pushup Tracker utvikles og driftes av Wolfram Sokollek – programvareutvikler fra området rundt Hamburg som selv trener daglig. Appen oppsto fra et personlig behov: å holde styr på egen trening uten papirlapper og gjøre fremgangen synlig over uker og måneder. </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="initial">
+      <segment state="translated">
         <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
+        <target> Det som begynte som et lite helgeprosjekt for push-ups, er i dag en fullverdig treningstracker for dusinvis av øvelser – fra push-ups, pull-ups og knebøy til planker, utfall og cardio- og mobilitetsøkter. Med treningsplaner, daglige mål, streaks, resultatliste og automatisk repetisjonstelling via kamera – helt i nettleseren, gratis og uten app-butikk. </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -9432,9 +9432,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
+        <target> Enten det er push-ups, knebøy eller pull-ups – de fleste kroppsvektøvelser krever ikke utstyr, ikke treningsstudio, og gir ingen unnskyldning. Det de fleste mangler, er ikke øvelsen, men kontinuiteten. Akkurat der kommer Pushup Tracker inn – målbar fremgang, små daglige mål og en streak man nødig vil bryte, gjør noen få repetisjoner til en varig vane. </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -9444,9 +9444,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
-        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
+        <target> Guidene og blogginnleggene er basert på egen treningserfaring og allment anerkjente treningsprinsipper; der studier siteres, er de lenket i artikkelen. Innholdet erstatter ikke medisinsk rådgivning – har du underliggende sykdom eller smerter, bør du først søke legehjelp. </target>
       </segment>
     </unit>
     <unit id="about.contact.title">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9631,15 +9631,15 @@
       </segment>
     </unit>
     <unit id="about.who.body1">
-      <segment state="initial">
+      <segment state="translated">
         <source> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </source>
-        <target> Pushup Tracker wird von Wolfram Sokollek entwickelt und betrieben – Softwareentwickler aus der Nähe von Hamburg und selbst täglich im Training. Die App ist aus einem persönlichen Bedürfnis entstanden: das eigene Training ohne Zettelwirtschaft festzuhalten und den Fortschritt über Wochen und Monate sichtbar zu machen. </target>
+        <target> Pushup Tracker 由 Wolfram Sokollek 开发和运营——他是一名来自汉堡附近的软件开发者,自己也每天坚持训练。这款应用源于一个个人需求:在没有纸笔记录的情况下追踪自己的训练,并让数周乃至数月的进步清晰可见。 </target>
       </segment>
     </unit>
     <unit id="about.who.body2">
-      <segment state="initial">
+      <segment state="translated">
         <source> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </source>
-        <target> Was als kleines Wochenendprojekt für Liegestütze begann, ist heute ein vollwertiger Trainings-Tracker für dutzende Übungen – von Liegestützen, Klimmzügen und Kniebeugen über Planks und Ausfallschritte bis hin zu Cardio- und Mobility-Einheiten. Mit Trainingsplänen, Tageszielen, Streaks, Bestenliste und automatischer Wiederholungszählung per Kamera – komplett im Browser, kostenlos und ohne App-Store. </target>
+        <target> 最初只是一个关于俯卧撑的小型周末项目,如今已发展成涵盖数十种练习的完整训练追踪工具——从俯卧撑、引体向上、深蹲,到平板支撑、弓步以及有氧和灵活性训练。配备训练计划、每日目标、连续记录、排行榜以及通过摄像头自动计数——完全在浏览器中运行,免费且无需应用商店。 </target>
       </segment>
     </unit>
     <unit id="about.mission.title">
@@ -9649,9 +9649,9 @@
       </segment>
     </unit>
     <unit id="about.mission.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
-        <target> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </target>
+        <target> 无论是俯卧撑、深蹲还是引体向上——大多数自重训练动作既不需要器械,也不需要健身房,更没有借口可找。大多数人缺少的不是练习本身,而是坚持。这正是 Pushup Tracker 的用武之地——可衡量的进步、小小的每日目标,以及一个让人舍不得中断的连续记录,能把寥寥几次重复变成持久的习惯。 </target>
       </segment>
     </unit>
     <unit id="about.content.title">
@@ -9661,9 +9661,9 @@
       </segment>
     </unit>
     <unit id="about.content.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
-        <target> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </target>
+        <target> 指南和博客文章基于个人训练经验以及公认的训练原则;如果引用了研究,文章中会附上链接。这些内容不能替代医疗建议——如有既往疾病或疼痛,请先咨询医生。 </target>
       </segment>
     </unit>
     <unit id="about.contact.title">


### PR DESCRIPTION
Fills XLIFF translation gaps detected by `tools/src/detect-translation-gaps.mjs`. The gaps were four About Us page strings (`about.who.body1`, `about.who.body2`, `about.mission.body`, `about.content.body`) still seeded with German fallback text in every non-German locale after the recent About Us copy rewrite.

## Touched locales

- `en`: 4 unit(s), 0 blog post(s), 0 wiki entry/entries
- `fr`: 4 unit(s), 0 blog post(s), 0 wiki entry/entries
- `es`: 4 unit(s), 0 blog post(s), 0 wiki entry/entries
- `it`: 4 unit(s), 0 blog post(s), 0 wiki entry/entries
- `nl`: 4 unit(s), 0 blog post(s), 0 wiki entry/entries
- `el`: 4 unit(s), 0 blog post(s), 0 wiki entry/entries
- `no`: 4 unit(s), 0 blog post(s), 0 wiki entry/entries
- `zh`: 4 unit(s), 0 blog post(s), 0 wiki entry/entries

## Skipped

None — all 32 detected gaps were translated.

## Detector summary

```
Detected 32 gap(s) — xliff:32 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh
```

## Verification

- `pnpm nx affected -t=lint,test,build -c=production --parallel=3` (base `origin/main`) — all green.
- No `content/blog` or `content/wiki` changes in this run, so `tools:generate-content` regenerated no new locale files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLT7cLxNuo1o2ao8r8kYXD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLT7cLxNuo1o2ao8r8kYXD)_