### PR TITLE
fix(web): harden spec isolation against wandering cross-file pollution

### DIFF
--- a/docs/gotchas/testing.md
+++ b/docs/gotchas/testing.md
@@ -1,9 +1,26 @@
 # Gotchas: Testing
 
+## The `web` runner shares one environment across every spec (`isolate: false`)
+
+`@angular/build:unit-test` runs Vitest with **`isolate: false`** (a deliberate default, "to align with the Karma/Jasmine experience"). Every spec file in `web` therefore shares **one** module registry, one jsdom `document`, and one set of globals — there is no per-file reset beyond what Angular's TestBed cleanup hook does. Any module-level or global mutation a spec leaves behind bleeds into whatever spec runs next **in the same worker**, so the victim is order- and worker-distribution-dependent: the same code fails a _different, wandering_ set of tests each run, and adding/removing any unrelated spec can shift which one breaks. Isolated (single-file) runs are always green, which is the tell.
+
+Consequences that have actually bitten us:
+
+- **Un-restored global spies carry their call history into the next file.** `vi.spyOn(console, 'error')` that is never restored stays installed on the shared `console`. A _later_ `vi.spyOn(console, 'error')` in a different spec then returns **that same mock, call history included** — so an unrelated test sees a phantom `console.error` call it never made. Always pair a global spy (`console`, `window`, `document`, `navigator`) with `afterEach(() => spy.mockRestore())`. Real regression: `sentry.spec.ts`'s `initSentryLazily` block leaked its console spy and intermittently failed `DeferredSentryErrorHandler`.
+- **`Functions` / Firebase DI split (`NG0201: No provider found for Functions`).** Never `vi.mock('@angular/fire/*')` in a `web` spec — see the dedicated note below. The admin surface injects the `CallableFunctionsService` seam instead.
+
+The general rule: a `web` spec must leave the shared world exactly as it found it. Reset shared signal mocks in `beforeEach`, restore every global spy in `afterEach`, and never mutate a `providedIn: 'root'` singleton in place.
+
+### The `web` setup file only runs if it is wired via `setupFiles`
+
+`web/src/test-setup.ts` (canvas/`getContext` stub for ng2-charts, `IntersectionObserver` stub, locale registration, `process` polyfill) is listed in `tsconfig.spec.json` `files` **for type-checking only** — that does _not_ execute it at runtime. The `@angular/build:unit-test` builder runs a setup file only when it is named in the target's **`setupFiles`** option (`web/project.json` → `targets.test.options.setupFiles`). If a global stub "has no effect," check that wiring first: a `throw` added to `test-setup.ts` that does **not** fail the run proves the file is dead config.
+
 ## Signal/mock isolation
 
 - **Shared signal mocks:** When tests mutate shared `signal()` mocks (e.g. `authStoreMock.error.set(...)`), always reset them in `beforeEach`. Otherwise tests become order-dependent.
 - **`window.location` spies:** `vitest.spyOn(window, 'location', 'get')` is NOT restored by `clearAllMocks()`. Add `afterEach(() => vitest.restoreAllMocks())` when using getter spies.
+- **`console`/global spies leak across files (`isolate: false`):** see the section above — an un-restored `vi.spyOn(console, …)` hands its call history to the next spec that spies on the same global. Always `mockRestore()` in `afterEach`.
+- **ng2-charts jsdom noise:** `BaseChartDirective` calls `canvas.getContext('2d')` on construction; jsdom has no canvas backend and emits a "Not implemented: HTMLCanvasElement.prototype.getContext" error per chart. `test-setup.ts` stubs `getContext` to return `null` (the directive's `render()` already bails on a falsy context, so behaviour is unchanged) purely to keep that noise from drowning real failures in the log.
 
 ## Angular test patterns
 

--- a/web/project.json
+++ b/web/project.json
@@ -208,7 +208,8 @@
         "tsConfig": "web/tsconfig.spec.json",
         "coverage": true,
         "watch": false,
-        "runnerConfig": "web/vitest.config.ts"
+        "runnerConfig": "web/vitest.config.ts",
+        "setupFiles": ["web/src/test-setup.ts"]
       }
     },
     "extract-i18n": {

--- a/web/src/app/core/observability/sentry.spec.ts
+++ b/web/src/app/core/observability/sentry.spec.ts
@@ -82,10 +82,24 @@ describe('DeferredSentryErrorHandler', () => {
 });
 
 describe('initSentryLazily', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     sentryInit.mockClear();
     createErrorHandler.mockClear();
     realErrorHandler.handleError.mockClear();
+    consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+  });
+
+  // Under the non-isolated `web` runner (isolate: false) `console` is shared
+  // across every spec file. An un-restored `vi.spyOn(console, 'error')` stays
+  // installed, so a later `vi.spyOn(console, 'error')` in another file returns
+  // this same mock together with its call history — surfacing phantom calls in
+  // unrelated tests. Always restore console spies. See docs/gotchas/testing.md.
+  afterEach(() => {
+    consoleError.mockRestore();
   });
 
   function appRefWith(handler: ErrorHandler): ApplicationRef {
@@ -118,7 +132,6 @@ describe('initSentryLazily', () => {
   it('should adopt the live Sentry error handler so buffered errors flush', async () => {
     // given
     const handler = new DeferredSentryErrorHandler();
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const buffered = new Error('startup');
     handler.handleError(buffered);
 

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -52,3 +52,15 @@ if (typeof globalThis.IntersectionObserver === 'undefined') {
   globalThis.IntersectionObserver =
     IntersectionObserverStub as unknown as typeof IntersectionObserver;
 }
+
+// ng2-charts' BaseChartDirective calls `canvas.getContext('2d')` in its
+// constructor. jsdom has no canvas backend, so it emits a noisy
+// "Not implemented: HTMLCanvasElement.prototype.getContext" error for every
+// chart component rendered across the suite, drowning real failures. The
+// directive already no-ops rendering when the context is falsy (`render()`
+// bails on `!ctx`), so returning null preserves behaviour while silencing the
+// jsdom noise.
+if (typeof HTMLCanvasElement !== 'undefined') {
+  HTMLCanvasElement.prototype.getContext = (() =>
+    null) as typeof HTMLCanvasElement.prototype.getContext;
+}


### PR DESCRIPTION
Closes #509

## Root cause

`@angular/build:unit-test` runs Vitest with **`isolate: false`** (a deliberate default, "to align with the Karma/Jasmine experience"). All 103 `web` spec files therefore share **one** module registry, one jsdom `document`, and one set of globals. Any module-level or global state a spec leaves behind bleeds into whichever spec runs next in the same worker — so the failure is order- and worker-distribution-dependent, and the victim *wanders* per run. Isolated single-file runs are always green, which is the tell described in the issue.

## Investigation

- Reproduced the wandering pollution with Vitest file/test shuffling (`sequence.shuffle`). One concrete, reliably reproducible instance surfaced (~30% of shuffled runs): `sentry.spec.ts`'s `initSentryLazily` block installs a `console.error` spy it never restores. Under `isolate: false` a *later* `vi.spyOn(console, 'error')` in another describe/file returns **that same mock, call history included**, so `DeferredSentryErrorHandler` intermittently saw a phantom `console.error(Error('startup'))` it never made.
- Traced the `NG0201: No provider found for Functions` admin symptom to the already-landed `CallableFunctionsService` DI seam + the "never `vi.mock('@angular/fire/*')` in web" rule — no such mock remains in the tree, so that specific vector is already contained. Could not re-trigger it across 30+ runs in the most pollution-prone configs; documented the seam pattern so it stays contained.
- Found that **`web/src/test-setup.ts` never actually executed at runtime** — it's listed in `tsconfig.spec.json` `files` for type-checking only, and the test target set no `setupFiles`. Its canvas stub, `IntersectionObserver` stub, locale registration, and `process` polyfill were all dead config. Proven with a `throw` probe that did not fail the run.

## Changes

- **`web/project.json`** — wire `test-setup.ts` via the test target's `setupFiles` so its stubs actually run.
- **`web/src/test-setup.ts`** — stub `HTMLCanvasElement.prototype.getContext` → `null` to silence the ng2-charts jsdom "getContext not implemented" noise (18+ error dumps/run that buried real failures). `BaseChartDirective.render()` already no-ops on a falsy context, so behaviour is unchanged.
- **`web/src/app/core/observability/sentry.spec.ts`** — restore the leaked `console.error` spy in `afterEach`.
- **`docs/gotchas/testing.md`** — document the `isolate: false` shared-environment root cause, the global-spy leak pattern, and the setup-file wiring requirement.

## Verification

- **5/5** consecutive default `pnpm nx test web` runs green, **0** getContext noise lines (was 18/run).
- **8/8** green under `sequence.shuffle` (files + tests) — the config that previously failed the sentry spec ~30% of the time.
- Test count unchanged: 103 files / 1454 tests, nothing skipped.
- `pnpm nx lint web` clean (only pre-existing unrelated e2e warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFiN62bwJERgUGi13gcpVy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFiN62bwJERgUGi13gcpVy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy test output from chart components by stubbing unsupported canvas behavior in the test environment.
  * Improved test reliability by preventing shared test state and lingering spies from affecting later specs.
* **Documentation**
  * Expanded guidance for Angular unit tests, including cleanup requirements, common failure patterns, and test setup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->