### PR TITLE
Repoint admin user display to exerciseEntries

### DIFF
--- a/data-store/firestore.rules
+++ b/data-store/firestore.rules
@@ -141,6 +141,12 @@ service cloud.firestore {
       allow read, write: if false; // Cloud Functions (Admin SDK) only
     }
 
+    // Precomputed per-user activity aggregate for the admin dashboard —
+    // internal only, no client access.
+    match /adminUserActivity/{userId} {
+      allow read, write: if false; // Cloud Functions (Admin SDK) only
+    }
+
     // Feedback — create-only for authenticated users. No read/update/delete from client.
     match /feedback/{feedbackId} {
       allow create: if request.auth != null

--- a/data-store/functions/src/admin/logic.ts
+++ b/data-store/functions/src/admin/logic.ts
@@ -26,7 +26,7 @@ export interface UserAccountInfo {
   displayName: string | null;
   email: string | null;
   anonymous: boolean;
-  pushupCount: number;
+  entryCount: number;
   lastEntry: string | null;
   createdAt: unknown;
   role: string | null;

--- a/data-store/functions/src/admin/user-data-ops.ts
+++ b/data-store/functions/src/admin/user-data-ops.ts
@@ -51,3 +51,21 @@ export async function readUserActivity(
   }
   return activity;
 }
+
+// Bounded source-of-truth check for whether a user has any entry on/after
+// `cutoff`. Used as a fallback in the inactive-anonymous cleanup for users
+// with no `adminUserActivity` aggregate yet (e.g. the window after deploy
+// before `backfillAdminUserActivity` has run) so an active user is never
+// deleted. Served by the (userId, timestamp) composite index.
+export async function hasEntrySince(
+  uid: string,
+  cutoff: string
+): Promise<boolean> {
+  const snap = await db
+    .collection('exerciseEntries')
+    .where('userId', '==', uid)
+    .where('timestamp', '>=', cutoff)
+    .limit(1)
+    .get();
+  return !snap.empty;
+}

--- a/data-store/functions/src/admin/user-data-ops.ts
+++ b/data-store/functions/src/admin/user-data-ops.ts
@@ -1,0 +1,53 @@
+import { db } from '../firebase-app';
+import { type UserActivityAggregate } from './user-entry-activity';
+
+// Hard-delete a user's exercise history. Post-cutover writes land in
+// `exerciseEntries`, but the pushup unification migration deliberately
+// left the legacy `pushups` source intact — so a full erasure must purge
+// both collections, otherwise pre-cutover rows outlive the deleted uid.
+// Pages through the results (`limit` + re-query) so a user with a huge
+// history never materialises more than one batch of docs at a time.
+export async function deleteUserExerciseData(uid: string): Promise<void> {
+  const BATCH_SIZE = 500;
+  for (const collection of ['exerciseEntries', 'pushups']) {
+    for (;;) {
+      const snap = await db
+        .collection(collection)
+        .where('userId', '==', uid)
+        .limit(BATCH_SIZE)
+        .get();
+      if (snap.empty) break;
+      const batch = db.batch();
+      for (const doc of snap.docs) {
+        batch.delete(doc.ref);
+      }
+      await batch.commit();
+      if (snap.size < BATCH_SIZE) break;
+    }
+  }
+}
+
+// Read the precomputed `adminUserActivity/{uid}` aggregates for the given
+// uids via `getAll` (fetch-by-reference, no 10-item `in`-query cap), so it
+// stays O(#uids) rather than scanning the whole `exerciseEntries`
+// collection. The `updateAdminUserActivityOnEntryWrite` trigger keeps the
+// docs current; `backfillAdminUserActivity` seeds history.
+export async function readUserActivity(
+  uids: string[]
+): Promise<Map<string, UserActivityAggregate>> {
+  const activity = new Map<string, UserActivityAggregate>();
+  if (uids.length === 0) return activity;
+
+  const collection = db.collection('adminUserActivity');
+  const CHUNK = 300;
+  for (let i = 0; i < uids.length; i += CHUNK) {
+    const refs = uids.slice(i, i + CHUNK).map((uid) => collection.doc(uid));
+    const snaps = await db.getAll(...refs);
+    for (const snap of snaps) {
+      if (snap.exists) {
+        activity.set(snap.id, snap.data() as UserActivityAggregate);
+      }
+    }
+  }
+  return activity;
+}

--- a/data-store/functions/src/admin/user-entry-activity.spec.ts
+++ b/data-store/functions/src/admin/user-entry-activity.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from '@jest/globals';
-import { aggregateEntryActivity } from './user-entry-activity';
+import {
+  aggregateEntryActivity,
+  nextActivityAggregate,
+} from './user-entry-activity';
 
 describe('aggregateEntryActivity', () => {
   it('should count entries and keep the latest timestamp per user', () => {
@@ -80,5 +83,138 @@ describe('aggregateEntryActivity', () => {
     // then — same-day activity counts as active (>= cutoff), earlier day does not
     expect(last >= '2026-06-23').toBe(true);
     expect(last >= '2026-06-24').toBe(false);
+  });
+});
+
+describe('nextActivityAggregate', () => {
+  it('should seed a fresh aggregate on the first create', () => {
+    // given no existing aggregate
+    // when a first entry is created
+    const { aggregate, needsRecompute } = nextActivityAggregate(null, null, {
+      timestamp: '2026-03-01T08:00:00.000Z',
+    });
+    // then
+    expect(aggregate).toEqual({
+      entryCount: 1,
+      lastEntry: '2026-03-01T08:00:00.000Z',
+    });
+    expect(needsRecompute).toBe(false);
+  });
+
+  it('should bump count and lastEntry when a newer entry is created', () => {
+    // given
+    const current = { entryCount: 2, lastEntry: '2026-03-01T08:00:00.000Z' };
+    // when
+    const { aggregate, needsRecompute } = nextActivityAggregate(current, null, {
+      timestamp: '2026-05-01T08:00:00.000Z',
+    });
+    // then
+    expect(aggregate).toEqual({
+      entryCount: 3,
+      lastEntry: '2026-05-01T08:00:00.000Z',
+    });
+    expect(needsRecompute).toBe(false);
+  });
+
+  it('should keep lastEntry when a create is older than the current max', () => {
+    // given
+    const current = { entryCount: 1, lastEntry: '2026-05-01T08:00:00.000Z' };
+    // when
+    const { aggregate } = nextActivityAggregate(current, null, {
+      timestamp: '2026-01-01T08:00:00.000Z',
+    });
+    // then
+    expect(aggregate).toEqual({
+      entryCount: 2,
+      lastEntry: '2026-05-01T08:00:00.000Z',
+    });
+  });
+
+  it('should decrement without recompute when a non-max entry is deleted', () => {
+    // given
+    const current = { entryCount: 3, lastEntry: '2026-05-01T08:00:00.000Z' };
+    // when an older entry is deleted
+    const { aggregate, needsRecompute } = nextActivityAggregate(
+      current,
+      { timestamp: '2026-01-01T08:00:00.000Z' },
+      null
+    );
+    // then
+    expect(aggregate).toEqual({
+      entryCount: 2,
+      lastEntry: '2026-05-01T08:00:00.000Z',
+    });
+    expect(needsRecompute).toBe(false);
+  });
+
+  it('should signal recompute when the max entry is deleted', () => {
+    // given
+    const current = { entryCount: 2, lastEntry: '2026-05-01T08:00:00.000Z' };
+    // when the latest entry is deleted
+    const { aggregate, needsRecompute } = nextActivityAggregate(
+      current,
+      { timestamp: '2026-05-01T08:00:00.000Z' },
+      null
+    );
+    // then — count drops, lastEntry is stale until the caller recomputes
+    expect(aggregate.entryCount).toBe(1);
+    expect(needsRecompute).toBe(true);
+  });
+
+  it('should not signal recompute on a same-timestamp update', () => {
+    // given
+    const current = { entryCount: 1, lastEntry: '2026-05-01T08:00:00.000Z' };
+    // when an entry is updated without changing its timestamp
+    const { aggregate, needsRecompute } = nextActivityAggregate(
+      current,
+      { timestamp: '2026-05-01T08:00:00.000Z' },
+      { timestamp: '2026-05-01T08:00:00.000Z' }
+    );
+    // then count is unchanged and no recompute is needed
+    expect(aggregate.entryCount).toBe(1);
+    expect(needsRecompute).toBe(false);
+  });
+
+  it('should signal recompute when the max entry is moved to an earlier time', () => {
+    // given
+    const current = { entryCount: 2, lastEntry: '2026-05-01T08:00:00.000Z' };
+    // when the max entry's timestamp moves earlier
+    const { needsRecompute } = nextActivityAggregate(
+      current,
+      { timestamp: '2026-05-01T08:00:00.000Z' },
+      { timestamp: '2026-02-01T08:00:00.000Z' }
+    );
+    // then
+    expect(needsRecompute).toBe(true);
+  });
+
+  it('should re-establish the max without recompute when an update moves later', () => {
+    // given
+    const current = { entryCount: 2, lastEntry: '2026-05-01T08:00:00.000Z' };
+    // when the max entry moves to an even later time
+    const { aggregate, needsRecompute } = nextActivityAggregate(
+      current,
+      { timestamp: '2026-05-01T08:00:00.000Z' },
+      { timestamp: '2026-06-01T08:00:00.000Z' }
+    );
+    // then
+    expect(aggregate).toEqual({
+      entryCount: 2,
+      lastEntry: '2026-06-01T08:00:00.000Z',
+    });
+    expect(needsRecompute).toBe(false);
+  });
+
+  it('should never drive entryCount below zero', () => {
+    // given a (corrupt) empty aggregate
+    const current = { entryCount: 0, lastEntry: null };
+    // when a delete arrives with nothing to remove
+    const { aggregate } = nextActivityAggregate(
+      current,
+      { timestamp: '2026-05-01T08:00:00.000Z' },
+      null
+    );
+    // then
+    expect(aggregate.entryCount).toBe(0);
   });
 });

--- a/data-store/functions/src/admin/user-entry-activity.spec.ts
+++ b/data-store/functions/src/admin/user-entry-activity.spec.ts
@@ -75,6 +75,29 @@ describe('aggregateEntryActivity', () => {
     expect(result.has('named-1')).toBe(false);
   });
 
+  it('should accumulate across calls when an existing map is passed as `into`', () => {
+    // given a first page already folded into a map
+    const acc = aggregateEntryActivity([
+      { userId: 'a', timestamp: '2026-01-01T08:00:00.000Z' },
+    ]);
+    // when a second page is folded into the same map
+    const result = aggregateEntryActivity(
+      [
+        { userId: 'a', timestamp: '2026-03-01T08:00:00.000Z' },
+        { userId: 'b', timestamp: '2026-02-01T08:00:00.000Z' },
+      ],
+      undefined,
+      acc
+    );
+    // then counts sum and the latest timestamp wins across pages
+    expect(result).toBe(acc);
+    expect(result.get('a')).toEqual({
+      count: 2,
+      lastTimestamp: '2026-03-01T08:00:00.000Z',
+    });
+    expect(result.get('b')?.count).toBe(1);
+  });
+
   it('should produce an ISO last timestamp that compares correctly against a date-only cutoff', () => {
     // given
     const entries = [{ userId: 'a', timestamp: '2026-06-23T05:00:00.000Z' }];

--- a/data-store/functions/src/admin/user-entry-activity.spec.ts
+++ b/data-store/functions/src/admin/user-entry-activity.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from '@jest/globals';
+import { aggregateEntryActivity } from './user-entry-activity';
+
+describe('aggregateEntryActivity', () => {
+  it('should count entries and keep the latest timestamp per user', () => {
+    // given
+    const entries = [
+      { userId: 'a', timestamp: '2026-01-01T08:00:00.000Z' },
+      { userId: 'a', timestamp: '2026-03-05T09:00:00.000Z' },
+      { userId: 'b', timestamp: '2026-02-02T10:00:00.000Z' },
+    ];
+    // when
+    const result = aggregateEntryActivity(entries);
+    // then
+    expect(result.get('a')).toEqual({
+      count: 2,
+      lastTimestamp: '2026-03-05T09:00:00.000Z',
+    });
+    expect(result.get('b')).toEqual({
+      count: 1,
+      lastTimestamp: '2026-02-02T10:00:00.000Z',
+    });
+  });
+
+  it('should ignore entries without a string userId', () => {
+    // given
+    const entries = [
+      { timestamp: '2026-01-01T08:00:00.000Z' },
+      { userId: '', timestamp: '2026-01-01T08:00:00.000Z' },
+      { userId: 42, timestamp: '2026-01-01T08:00:00.000Z' },
+      { userId: 'a', timestamp: '2026-01-01T08:00:00.000Z' },
+    ];
+    // when
+    const result = aggregateEntryActivity(entries);
+    // then
+    expect(result.size).toBe(1);
+    expect(result.get('a')?.count).toBe(1);
+  });
+
+  it('should treat a missing/non-string timestamp as no last entry but still count it', () => {
+    // given
+    const entries = [{ userId: 'a' }, { userId: 'a', timestamp: 123 }];
+    // when
+    const result = aggregateEntryActivity(entries);
+    // then
+    expect(result.get('a')).toEqual({ count: 2, lastTimestamp: null });
+  });
+
+  it('should keep a later timestamp even when it arrives after an empty one', () => {
+    // given
+    const entries = [
+      { userId: 'a' },
+      { userId: 'a', timestamp: '2026-05-05T00:00:00.000Z' },
+    ];
+    // when
+    const result = aggregateEntryActivity(entries);
+    // then
+    expect(result.get('a')?.lastTimestamp).toBe('2026-05-05T00:00:00.000Z');
+  });
+
+  it('should only aggregate the allowed user ids when onlyUserIds is given', () => {
+    // given
+    const entries = [
+      { userId: 'anon-1', timestamp: '2026-01-01T08:00:00.000Z' },
+      { userId: 'named-1', timestamp: '2026-01-02T08:00:00.000Z' },
+    ];
+    // when
+    const result = aggregateEntryActivity(entries, new Set(['anon-1']));
+    // then
+    expect(result.size).toBe(1);
+    expect(result.has('anon-1')).toBe(true);
+    expect(result.has('named-1')).toBe(false);
+  });
+
+  it('should produce an ISO last timestamp that compares correctly against a date-only cutoff', () => {
+    // given
+    const entries = [{ userId: 'a', timestamp: '2026-06-23T05:00:00.000Z' }];
+    // when
+    const last = aggregateEntryActivity(entries).get('a')?.lastTimestamp ?? '';
+    // then — same-day activity counts as active (>= cutoff), earlier day does not
+    expect(last >= '2026-06-23').toBe(true);
+    expect(last >= '2026-06-24').toBe(false);
+  });
+});

--- a/data-store/functions/src/admin/user-entry-activity.ts
+++ b/data-store/functions/src/admin/user-entry-activity.ts
@@ -1,0 +1,40 @@
+export interface EntryActivity {
+  count: number;
+  lastTimestamp: string | null;
+}
+
+/**
+ * Reduce raw `exerciseEntries` docs to a per-user activity summary
+ * (entry count + latest timestamp). Docs without a string `userId` are
+ * ignored. When `onlyUserIds` is given, entries for other users are
+ * skipped so the bulk-cleanup scan can restrict work to the anonymous
+ * subset. `lastTimestamp` is the raw ISO string, whose lexicographic
+ * order matches chronological order, so callers may compare it directly
+ * against a date-only cutoff.
+ */
+export function aggregateEntryActivity(
+  entries: Iterable<{ userId?: unknown; timestamp?: unknown }>,
+  onlyUserIds?: ReadonlySet<string>
+): Map<string, EntryActivity> {
+  const result = new Map<string, EntryActivity>();
+  for (const entry of entries) {
+    const userId = entry.userId;
+    if (typeof userId !== 'string' || !userId) continue;
+    if (onlyUserIds && !onlyUserIds.has(userId)) continue;
+
+    const ts = typeof entry.timestamp === 'string' ? entry.timestamp : '';
+    const existing = result.get(userId);
+    if (!existing) {
+      result.set(userId, { count: 1, lastTimestamp: ts || null });
+      continue;
+    }
+    existing.count += 1;
+    if (
+      ts &&
+      (existing.lastTimestamp === null || ts > existing.lastTimestamp)
+    ) {
+      existing.lastTimestamp = ts;
+    }
+  }
+  return result;
+}

--- a/data-store/functions/src/admin/user-entry-activity.ts
+++ b/data-store/functions/src/admin/user-entry-activity.ts
@@ -38,3 +38,55 @@ export function aggregateEntryActivity(
   }
   return result;
 }
+
+export interface UserActivityAggregate {
+  entryCount: number;
+  lastEntry: string | null;
+}
+
+/**
+ * Apply a single `exerciseEntries` write (create / update / delete) to a
+ * user's precomputed activity aggregate, keeping `adminListUsers` an
+ * O(#users) read instead of an O(#entries) scan.
+ *
+ * `entryCount` is a pure delta. `lastEntry` (max timestamp) can only be
+ * bumped up by the surviving entry, so most writes stay delta-only; the one
+ * case the delta can't resolve is removing/moving away from the entry that
+ * *was* the max, which may lower it — signalled via `needsRecompute` so the
+ * caller re-derives the true max from source. Pass `null` for the missing
+ * side of a create (`before`) or delete (`after`).
+ */
+export function nextActivityAggregate(
+  current: UserActivityAggregate | null,
+  before: { timestamp: string | null } | null,
+  after: { timestamp: string | null } | null
+): { aggregate: UserActivityAggregate; needsRecompute: boolean } {
+  const base = current ?? { entryCount: 0, lastEntry: null };
+  const beforeTs = before?.timestamp ?? null;
+  const afterTs = after?.timestamp ?? null;
+
+  const entryCount = Math.max(
+    0,
+    base.entryCount + (after ? 1 : 0) - (before ? 1 : 0)
+  );
+
+  let lastEntry = base.lastEntry;
+  if (afterTs && (lastEntry === null || afterTs > lastEntry)) {
+    lastEntry = afterTs;
+  }
+
+  // The entry whose timestamp leaves the collection with this write: a delete
+  // removes `beforeTs`; an update that changes the timestamp moves away from
+  // the old one. If that timestamp was the running max — and the surviving
+  // `afterTs` didn't re-establish an equal-or-higher one — the new max is
+  // unknowable from the delta alone.
+  const removedTs =
+    before && (!after || afterTs !== beforeTs) ? beforeTs : null;
+  const needsRecompute =
+    removedTs !== null &&
+    lastEntry !== null &&
+    removedTs === lastEntry &&
+    !(afterTs !== null && afterTs >= removedTs);
+
+  return { aggregate: { entryCount, lastEntry }, needsRecompute };
+}

--- a/data-store/functions/src/admin/user-entry-activity.ts
+++ b/data-store/functions/src/admin/user-entry-activity.ts
@@ -11,12 +11,17 @@ export interface EntryActivity {
  * subset. `lastTimestamp` is the raw ISO string, whose lexicographic
  * order matches chronological order, so callers may compare it directly
  * against a date-only cutoff.
+ *
+ * Pass an existing map as `into` to accumulate across calls — this lets the
+ * backfill fold one bounded page of entries at a time so peak memory stays
+ * O(#users) instead of O(#entries).
  */
 export function aggregateEntryActivity(
   entries: Iterable<{ userId?: unknown; timestamp?: unknown }>,
-  onlyUserIds?: ReadonlySet<string>
+  onlyUserIds?: ReadonlySet<string>,
+  into?: Map<string, EntryActivity>
 ): Map<string, EntryActivity> {
-  const result = new Map<string, EntryActivity>();
+  const result = into ?? new Map<string, EntryActivity>();
   for (const entry of entries) {
     const userId = entry.userId;
     if (typeof userId !== 'string' || !userId) continue;

--- a/data-store/functions/src/functions-admin-user-activity.ts
+++ b/data-store/functions/src/functions-admin-user-activity.ts
@@ -1,0 +1,143 @@
+import { logger } from 'firebase-functions';
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
+import { onCall } from 'firebase-functions/v2/https';
+
+import { batchArray } from './admin';
+import {
+  aggregateEntryActivity,
+  nextActivityAggregate,
+  type UserActivityAggregate,
+} from './admin/user-entry-activity';
+import { db } from './firebase-app';
+import { assertAdmin } from './functions-admin';
+
+// Per-user activity aggregate that keeps `adminListUsers` and the
+// inactive-anonymous cleanup O(#users) instead of scanning the whole
+// `exerciseEntries` collection. Written only by the Admin SDK (this trigger
+// + the backfill callable); clients are denied at the Firestore-rule layer.
+const ADMIN_USER_ACTIVITY_COLLECTION = 'adminUserActivity';
+const BACKFILL_BATCH_SIZE = 500;
+
+function timestampField(
+  data: Record<string, unknown> | undefined
+): { timestamp: string | null } | null {
+  if (!data) return null;
+  return {
+    timestamp: typeof data.timestamp === 'string' ? data.timestamp : null,
+  };
+}
+
+export const updateAdminUserActivityOnEntryWrite = onDocumentWritten(
+  { document: 'exerciseEntries/{entryId}', region: 'europe-west3' },
+  async (event) => {
+    const beforeData = event.data?.before?.data();
+    const afterData = event.data?.after?.data();
+
+    const userId = (afterData?.userId ?? beforeData?.userId) as
+      | string
+      | undefined;
+    if (!userId) {
+      logger.warn('updateAdminUserActivityOnEntryWrite: no userId, skipping');
+      return;
+    }
+
+    const before = timestampField(beforeData);
+    const after = timestampField(afterData);
+    const nowIso = new Date().toISOString();
+    const ref = db.collection(ADMIN_USER_ACTIVITY_COLLECTION).doc(userId);
+
+    await db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      const current = snap.exists
+        ? (snap.data() as UserActivityAggregate)
+        : null;
+
+      const { aggregate, needsRecompute } = nextActivityAggregate(
+        current,
+        before,
+        after
+      );
+
+      let lastEntry = aggregate.lastEntry;
+      if (needsRecompute) {
+        // The deleted/moved entry was the running max — re-derive the true
+        // latest timestamp from source. The (userId, timestamp) composite
+        // index serves this reversed.
+        const maxSnap = await tx.get(
+          db
+            .collection('exerciseEntries')
+            .where('userId', '==', userId)
+            .orderBy('timestamp', 'desc')
+            .limit(1)
+        );
+        const maxTs = maxSnap.empty
+          ? null
+          : (maxSnap.docs[0].data().timestamp as string | undefined);
+        lastEntry = typeof maxTs === 'string' ? maxTs : null;
+      }
+
+      tx.set(ref, {
+        entryCount: aggregate.entryCount,
+        lastEntry,
+        updatedAt: nowIso,
+      });
+    });
+
+    logger.info('updateAdminUserActivityOnEntryWrite', {
+      userId,
+      entryId: event.params?.entryId,
+    });
+  }
+);
+
+// Admin-callable one-shot rebuild of `adminUserActivity/{userId}` from all
+// `exerciseEntries`. Idempotent: recomputes the same docs. Fail-safe: defaults
+// to a dry-run so an accidental call never writes.
+export const backfillAdminUserActivity = onCall(
+  { region: 'europe-west3', timeoutSeconds: 540 },
+  async (request) => {
+    assertAdmin(request);
+
+    const dryRun = Boolean(request.data?.dryRun ?? true);
+
+    const snap = await db
+      .collection('exerciseEntries')
+      .select('userId', 'timestamp')
+      .get();
+    const activity = aggregateEntryActivity(snap.docs.map((doc) => doc.data()));
+
+    if (dryRun) {
+      return {
+        dryRun: true,
+        wouldWriteUsers: activity.size,
+        entries: snap.size,
+      };
+    }
+
+    const nowIso = new Date().toISOString();
+    let writtenUsers = 0;
+    for (const chunk of batchArray(
+      [...activity.entries()],
+      BACKFILL_BATCH_SIZE
+    )) {
+      const batch = db.batch();
+      for (const [userId, { count, lastTimestamp }] of chunk) {
+        batch.set(db.collection(ADMIN_USER_ACTIVITY_COLLECTION).doc(userId), {
+          entryCount: count,
+          lastEntry: lastTimestamp,
+          updatedAt: nowIso,
+        });
+        writtenUsers += 1;
+      }
+      await batch.commit();
+    }
+
+    logger.info('backfillAdminUserActivity', {
+      writtenUsers,
+      entries: snap.size,
+      by: request.auth?.uid,
+    });
+
+    return { writtenUsers, entries: snap.size };
+  }
+);

--- a/data-store/functions/src/functions-admin-user-activity.ts
+++ b/data-store/functions/src/functions-admin-user-activity.ts
@@ -1,3 +1,7 @@
+import {
+  FieldPath,
+  type QueryDocumentSnapshot,
+} from 'firebase-admin/firestore';
 import { logger } from 'firebase-functions';
 import { onDocumentWritten } from 'firebase-functions/v2/firestore';
 import { onCall } from 'firebase-functions/v2/https';
@@ -5,6 +9,7 @@ import { onCall } from 'firebase-functions/v2/https';
 import { batchArray } from './admin';
 import {
   aggregateEntryActivity,
+  type EntryActivity,
   nextActivityAggregate,
   type UserActivityAggregate,
 } from './admin/user-entry-activity';
@@ -17,6 +22,7 @@ import { assertAdmin } from './functions-admin';
 // + the backfill callable); clients are denied at the Firestore-rule layer.
 const ADMIN_USER_ACTIVITY_COLLECTION = 'adminUserActivity';
 const BACKFILL_BATCH_SIZE = 500;
+const BACKFILL_PAGE_SIZE = 5000;
 
 function timestampField(
   data: Record<string, unknown> | undefined
@@ -110,18 +116,35 @@ export const backfillAdminUserActivity = onCall(
     // (including a missing/falsy-but-not-false one) stays a dry-run.
     const dryRun = request.data?.dryRun !== false;
 
-    const snap = await db
-      .collection('exerciseEntries')
-      .select('userId', 'timestamp')
-      .get();
-    const activity = aggregateEntryActivity(snap.docs.map((doc) => doc.data()));
+    // Page through `exerciseEntries` by document id, folding each bounded
+    // page into a single per-user map, so peak memory stays O(#users)
+    // rather than materialising the whole collection at once. This backfill
+    // is load-bearing (the admin dashboard reads the aggregate post-deploy),
+    // so it must stay reliable as the collection grows.
+    const activity = new Map<string, EntryActivity>();
+    let entries = 0;
+    let cursor: QueryDocumentSnapshot | undefined;
+    for (;;) {
+      let query = db
+        .collection('exerciseEntries')
+        .select('userId', 'timestamp')
+        .orderBy(FieldPath.documentId())
+        .limit(BACKFILL_PAGE_SIZE);
+      if (cursor) query = query.startAfter(cursor);
+      const page = await query.get();
+      if (page.empty) break;
+      aggregateEntryActivity(
+        page.docs.map((doc) => doc.data()),
+        undefined,
+        activity
+      );
+      entries += page.size;
+      cursor = page.docs[page.docs.length - 1];
+      if (page.size < BACKFILL_PAGE_SIZE) break;
+    }
 
     if (dryRun) {
-      return {
-        dryRun: true,
-        wouldWriteUsers: activity.size,
-        entries: snap.size,
-      };
+      return { dryRun: true, wouldWriteUsers: activity.size, entries };
     }
 
     const nowIso = new Date().toISOString();
@@ -144,10 +167,10 @@ export const backfillAdminUserActivity = onCall(
 
     logger.info('backfillAdminUserActivity', {
       writtenUsers,
-      entries: snap.size,
+      entries,
       by: request.auth?.uid,
     });
 
-    return { writtenUsers, entries: snap.size };
+    return { writtenUsers, entries };
   }
 );

--- a/data-store/functions/src/functions-admin-user-activity.ts
+++ b/data-store/functions/src/functions-admin-user-activity.ts
@@ -106,7 +106,9 @@ export const backfillAdminUserActivity = onCall(
   async (request) => {
     assertAdmin(request);
 
-    const dryRun = Boolean(request.data?.dryRun ?? true);
+    // Fail-safe: only an explicit `dryRun: false` writes; any other value
+    // (including a missing/falsy-but-not-false one) stays a dry-run.
+    const dryRun = request.data?.dryRun !== false;
 
     const snap = await db
       .collection('exerciseEntries')

--- a/data-store/functions/src/functions-admin-user-activity.ts
+++ b/data-store/functions/src/functions-admin-user-activity.ts
@@ -33,10 +33,8 @@ export const updateAdminUserActivityOnEntryWrite = onDocumentWritten(
     const beforeData = event.data?.before?.data();
     const afterData = event.data?.after?.data();
 
-    const userId = (afterData?.userId ?? beforeData?.userId) as
-      | string
-      | undefined;
-    if (!userId) {
+    const userId = afterData?.userId ?? beforeData?.userId;
+    if (typeof userId !== 'string' || !userId) {
       logger.warn('updateAdminUserActivityOnEntryWrite: no userId, skipping');
       return;
     }
@@ -70,14 +68,15 @@ export const updateAdminUserActivityOnEntryWrite = onDocumentWritten(
       let lastEntry = aggregate.lastEntry;
       if (needsRecompute) {
         // The deleted/moved entry was the running max — re-derive the true
-        // latest timestamp from source. The (userId, timestamp) composite
-        // index serves this reversed.
+        // latest timestamp from source. `orderBy(asc).limitToLast(1)` returns
+        // the highest timestamp using the declared (userId, timestamp) ASC
+        // composite index in its native direction.
         const maxSnap = await tx.get(
           db
             .collection('exerciseEntries')
             .where('userId', '==', userId)
-            .orderBy('timestamp', 'desc')
-            .limit(1)
+            .orderBy('timestamp', 'asc')
+            .limitToLast(1)
         );
         const maxTs = maxSnap.empty
           ? null

--- a/data-store/functions/src/functions-admin-user-activity.ts
+++ b/data-store/functions/src/functions-admin-user-activity.ts
@@ -58,6 +58,15 @@ export const updateAdminUserActivityOnEntryWrite = onDocumentWritten(
         after
       );
 
+      if (aggregate.entryCount <= 0) {
+        // No entries remain — e.g. the user deleted their last entry, or a
+        // hard-delete/bulk-cleanup purged them all. Drop the aggregate rather
+        // than leave an orphaned zero doc. Converges to "deleted" even under
+        // out-of-order batch-delete triggers, since the final entryCount is 0.
+        tx.delete(ref);
+        return;
+      }
+
       let lastEntry = aggregate.lastEntry;
       if (needsRecompute) {
         // The deleted/moved entry was the running max — re-derive the true

--- a/data-store/functions/src/functions-admin.ts
+++ b/data-store/functions/src/functions-admin.ts
@@ -7,7 +7,7 @@ import {
   validateLeaderboardExclusionPayload,
   validateSetMigrationStatusPayload,
 } from './admin';
-import { aggregateEntryActivity } from './admin/user-entry-activity';
+import { type UserActivityAggregate } from './admin/user-entry-activity';
 import { db, DEMO_USER_ID } from './firebase-app';
 import { deleteAllPushSubscriptions } from './functions-push';
 
@@ -44,6 +44,27 @@ async function deleteUserExerciseData(uid: string): Promise<void> {
   }
 }
 
+// Read the precomputed `adminUserActivity/{uid}` aggregates for the given
+// uids. Reads are O(#uids) (chunked `in` on the document id), not a scan of
+// the whole `exerciseEntries` collection. The `updateAdminUserActivityOnEntryWrite`
+// trigger keeps the docs current; `backfillAdminUserActivity` seeds history.
+async function readUserActivity(
+  uids: string[]
+): Promise<Map<string, UserActivityAggregate>> {
+  const activity = new Map<string, UserActivityAggregate>();
+  for (let i = 0; i < uids.length; i += 10) {
+    const batch = uids.slice(i, i + 10);
+    const snaps = await db
+      .collection('adminUserActivity')
+      .where(admin.firestore.FieldPath.documentId(), 'in', batch)
+      .get();
+    for (const snap of snaps.docs) {
+      activity.set(snap.id, snap.data() as UserActivityAggregate);
+    }
+  }
+  return activity;
+}
+
 export const adminListUsers = onCall(
   { region: 'europe-west3', timeoutSeconds: 120 },
   async (request) => {
@@ -70,14 +91,7 @@ export const adminListUsers = onCall(
       }
     }
 
-    const entrySnap = await db
-      .collection('exerciseEntries')
-      .select('userId', 'timestamp')
-      .get();
-    const activity = aggregateEntryActivity(
-      entrySnap.docs.map((doc) => doc.data()),
-      new Set(uids)
-    );
+    const activity = await readUserActivity(uids);
 
     return authUsers.map((user) => {
       const config = configMap.get(user.uid) || {};
@@ -90,8 +104,8 @@ export const adminListUsers = onCall(
           null,
         email: (config as Record<string, unknown>).email || user.email || null,
         anonymous: user.providerData.length === 0,
-        entryCount: userActivity?.count ?? 0,
-        lastEntry: userActivity?.lastTimestamp ?? null,
+        entryCount: userActivity?.entryCount ?? 0,
+        lastEntry: userActivity?.lastEntry ?? null,
         createdAt: user.metadata.creationTime || null,
         role: user.customClaims?.admin === true ? 'admin' : null,
       };
@@ -201,29 +215,17 @@ export const adminBulkDeleteInactiveAnonymous = onCall(
       pageToken = result.pageToken;
     } while (pageToken);
 
-    const anonymousUserSet = new Set(anonymousUsers);
-    let activity = aggregateEntryActivity([]);
-    if (anonymousUsers.length > 0) {
-      // A user is "active" iff they have any entry on/after the cutoff, so
-      // only those entries need reading. ISO timestamps sort lexicographically
-      // against the date-only `cutoff`, so the range filter is exact and keeps
-      // the read volume proportional to recent activity, not full history.
-      const entrySnap = await db
-        .collection('exerciseEntries')
-        .where('timestamp', '>=', cutoff)
-        .select('userId', 'timestamp')
-        .get();
-      activity = aggregateEntryActivity(
-        entrySnap.docs.map((doc) => doc.data()),
-        anonymousUserSet
-      );
-    }
+    // A user is "active" iff their last entry is on/after the cutoff. Read the
+    // precomputed per-user aggregates (O(#anonymous)) instead of scanning the
+    // entry history. ISO `lastEntry` sorts lexicographically against the
+    // date-only `cutoff`, so the comparison is exact.
+    const activity = await readUserActivity(anonymousUsers);
 
     let deleted = 0;
     let skipped = 0;
 
     for (const uid of anonymousUsers) {
-      const lastTs = activity.get(uid)?.lastTimestamp;
+      const lastTs = activity.get(uid)?.lastEntry;
       if (lastTs && lastTs >= cutoff) {
         skipped++;
         continue;

--- a/data-store/functions/src/functions-admin.ts
+++ b/data-store/functions/src/functions-admin.ts
@@ -17,6 +17,27 @@ export function assertAdmin(request: {
   if (error) throw new HttpsError(error.code, error.message);
 }
 
+// Hard-delete a user's exercise history. Post-cutover writes land in
+// `exerciseEntries`, but the pushup unification migration deliberately
+// left the legacy `pushups` source intact — so a full erasure must purge
+// both collections, otherwise pre-cutover rows outlive the deleted uid.
+async function deleteUserExerciseData(uid: string): Promise<void> {
+  const BATCH_SIZE = 500;
+  for (const collection of ['exerciseEntries', 'pushups']) {
+    const snap = await db
+      .collection(collection)
+      .where('userId', '==', uid)
+      .get();
+    for (let i = 0; i < snap.docs.length; i += BATCH_SIZE) {
+      const batch = db.batch();
+      for (const doc of snap.docs.slice(i, i + BATCH_SIZE)) {
+        batch.delete(doc.ref);
+      }
+      await batch.commit();
+    }
+  }
+}
+
 export const adminListUsers = onCall(
   { region: 'europe-west3', timeoutSeconds: 120 },
   async (request) => {
@@ -45,7 +66,10 @@ export const adminListUsers = onCall(
 
     const entryCountMap = new Map<string, number>();
     const lastEntryMap = new Map<string, string>();
-    const entrySnap = await db.collection('exerciseEntries').get();
+    const entrySnap = await db
+      .collection('exerciseEntries')
+      .select('userId', 'timestamp')
+      .get();
     for (const doc of entrySnap.docs) {
       const data = doc.data();
       if (!data.userId) continue;
@@ -110,20 +134,7 @@ export const adminDeleteUser = onCall(
         );
     } else {
       await db.collection('userConfigs').doc(uid).delete();
-
-      const entrySnap = await db
-        .collection('exerciseEntries')
-        .where('userId', '==', uid)
-        .get();
-
-      const BATCH_SIZE = 500;
-      for (let i = 0; i < entrySnap.docs.length; i += BATCH_SIZE) {
-        const batch = db.batch();
-        for (const doc of entrySnap.docs.slice(i, i + BATCH_SIZE)) {
-          batch.delete(doc.ref);
-        }
-        await batch.commit();
-      }
+      await deleteUserExerciseData(uid);
     }
 
     await deleteAllPushSubscriptions(uid);
@@ -196,7 +207,10 @@ export const adminBulkDeleteInactiveAnonymous = onCall(
     const anonymousUserSet = new Set(anonymousUsers);
     const lastEntryMap = new Map<string, string>();
     if (anonymousUsers.length > 0) {
-      const entrySnap = await db.collection('exerciseEntries').get();
+      const entrySnap = await db
+        .collection('exerciseEntries')
+        .select('userId', 'timestamp')
+        .get();
       for (const doc of entrySnap.docs) {
         const data = doc.data();
         if (!data.userId || !anonymousUserSet.has(data.userId)) continue;
@@ -222,20 +236,7 @@ export const adminBulkDeleteInactiveAnonymous = onCall(
 
       await admin.auth().deleteUser(uid);
       await db.collection('userConfigs').doc(uid).delete();
-
-      const entrySnap = await db
-        .collection('exerciseEntries')
-        .where('userId', '==', uid)
-        .get();
-
-      const BATCH_SIZE = 500;
-      for (let i = 0; i < entrySnap.docs.length; i += BATCH_SIZE) {
-        const batch = db.batch();
-        for (const doc of entrySnap.docs.slice(i, i + BATCH_SIZE)) {
-          batch.delete(doc.ref);
-        }
-        await batch.commit();
-      }
+      await deleteUserExerciseData(uid);
 
       await deleteAllPushSubscriptions(uid);
       deleted++;

--- a/data-store/functions/src/functions-admin.ts
+++ b/data-store/functions/src/functions-admin.ts
@@ -7,6 +7,7 @@ import {
   validateLeaderboardExclusionPayload,
   validateSetMigrationStatusPayload,
 } from './admin';
+import { aggregateEntryActivity } from './admin/user-entry-activity';
 import { db, DEMO_USER_ID } from './firebase-app';
 import { deleteAllPushSubscriptions } from './functions-push';
 
@@ -21,19 +22,24 @@ export function assertAdmin(request: {
 // `exerciseEntries`, but the pushup unification migration deliberately
 // left the legacy `pushups` source intact — so a full erasure must purge
 // both collections, otherwise pre-cutover rows outlive the deleted uid.
+// Pages through the results (`limit` + re-query) so a user with a huge
+// history never materialises more than one batch of docs at a time.
 async function deleteUserExerciseData(uid: string): Promise<void> {
   const BATCH_SIZE = 500;
   for (const collection of ['exerciseEntries', 'pushups']) {
-    const snap = await db
-      .collection(collection)
-      .where('userId', '==', uid)
-      .get();
-    for (let i = 0; i < snap.docs.length; i += BATCH_SIZE) {
+    for (;;) {
+      const snap = await db
+        .collection(collection)
+        .where('userId', '==', uid)
+        .limit(BATCH_SIZE)
+        .get();
+      if (snap.empty) break;
       const batch = db.batch();
-      for (const doc of snap.docs.slice(i, i + BATCH_SIZE)) {
+      for (const doc of snap.docs) {
         batch.delete(doc.ref);
       }
       await batch.commit();
+      if (snap.size < BATCH_SIZE) break;
     }
   }
 }
@@ -64,27 +70,17 @@ export const adminListUsers = onCall(
       }
     }
 
-    const entryCountMap = new Map<string, number>();
-    const lastEntryMap = new Map<string, string>();
     const entrySnap = await db
       .collection('exerciseEntries')
       .select('userId', 'timestamp')
       .get();
-    for (const doc of entrySnap.docs) {
-      const data = doc.data();
-      if (!data.userId) continue;
-      entryCountMap.set(data.userId, (entryCountMap.get(data.userId) || 0) + 1);
-      const ts = data.timestamp as string;
-      if (
-        !lastEntryMap.has(data.userId) ||
-        ts > (lastEntryMap.get(data.userId) ?? '')
-      ) {
-        lastEntryMap.set(data.userId, ts);
-      }
-    }
+    const activity = aggregateEntryActivity(
+      entrySnap.docs.map((doc) => doc.data())
+    );
 
     return authUsers.map((user) => {
       const config = configMap.get(user.uid) || {};
+      const userActivity = activity.get(user.uid);
       return {
         uid: user.uid,
         displayName:
@@ -93,8 +89,8 @@ export const adminListUsers = onCall(
           null,
         email: (config as Record<string, unknown>).email || user.email || null,
         anonymous: user.providerData.length === 0,
-        entryCount: entryCountMap.get(user.uid) || 0,
-        lastEntry: lastEntryMap.get(user.uid) || null,
+        entryCount: userActivity?.count ?? 0,
+        lastEntry: userActivity?.lastTimestamp ?? null,
         createdAt: user.metadata.creationTime || null,
         role: user.customClaims?.admin === true ? 'admin' : null,
       };
@@ -205,30 +201,25 @@ export const adminBulkDeleteInactiveAnonymous = onCall(
     } while (pageToken);
 
     const anonymousUserSet = new Set(anonymousUsers);
-    const lastEntryMap = new Map<string, string>();
+    let activity = aggregateEntryActivity([]);
     if (anonymousUsers.length > 0) {
       const entrySnap = await db
         .collection('exerciseEntries')
         .select('userId', 'timestamp')
         .get();
-      for (const doc of entrySnap.docs) {
-        const data = doc.data();
-        if (!data.userId || !anonymousUserSet.has(data.userId)) continue;
-        const ts = String(data.timestamp || '').slice(0, 10);
-        if (
-          !lastEntryMap.has(data.userId) ||
-          ts > (lastEntryMap.get(data.userId) ?? '')
-        ) {
-          lastEntryMap.set(data.userId, ts);
-        }
-      }
+      // ISO timestamps sort lexicographically, so the raw `lastTimestamp`
+      // compares correctly against the date-only `cutoff` below.
+      activity = aggregateEntryActivity(
+        entrySnap.docs.map((doc) => doc.data()),
+        anonymousUserSet
+      );
     }
 
     let deleted = 0;
     let skipped = 0;
 
     for (const uid of anonymousUsers) {
-      const lastTs = lastEntryMap.get(uid);
+      const lastTs = activity.get(uid)?.lastTimestamp;
       if (lastTs && lastTs >= cutoff) {
         skipped++;
         continue;

--- a/data-store/functions/src/functions-admin.ts
+++ b/data-store/functions/src/functions-admin.ts
@@ -5,9 +5,11 @@ import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import {
   validateAdminAccess,
   validateLeaderboardExclusionPayload,
-  validateSetMigrationStatusPayload,
 } from './admin';
-import { type UserActivityAggregate } from './admin/user-entry-activity';
+import {
+  deleteUserExerciseData,
+  readUserActivity,
+} from './admin/user-data-ops';
 import { db, DEMO_USER_ID } from './firebase-app';
 import { deleteAllPushSubscriptions } from './functions-push';
 
@@ -16,58 +18,6 @@ export function assertAdmin(request: {
 }) {
   const error = validateAdminAccess(request.auth);
   if (error) throw new HttpsError(error.code, error.message);
-}
-
-// Hard-delete a user's exercise history. Post-cutover writes land in
-// `exerciseEntries`, but the pushup unification migration deliberately
-// left the legacy `pushups` source intact — so a full erasure must purge
-// both collections, otherwise pre-cutover rows outlive the deleted uid.
-// Pages through the results (`limit` + re-query) so a user with a huge
-// history never materialises more than one batch of docs at a time.
-async function deleteUserExerciseData(uid: string): Promise<void> {
-  const BATCH_SIZE = 500;
-  for (const collection of ['exerciseEntries', 'pushups']) {
-    for (;;) {
-      const snap = await db
-        .collection(collection)
-        .where('userId', '==', uid)
-        .limit(BATCH_SIZE)
-        .get();
-      if (snap.empty) break;
-      const batch = db.batch();
-      for (const doc of snap.docs) {
-        batch.delete(doc.ref);
-      }
-      await batch.commit();
-      if (snap.size < BATCH_SIZE) break;
-    }
-  }
-}
-
-// Read the precomputed `adminUserActivity/{uid}` aggregates for the given
-// uids. Reads are O(#uids) (chunked `in` on the document id), not a scan of
-// the whole `exerciseEntries` collection. The `updateAdminUserActivityOnEntryWrite`
-// trigger keeps the docs current; `backfillAdminUserActivity` seeds history.
-async function readUserActivity(
-  uids: string[]
-): Promise<Map<string, UserActivityAggregate>> {
-  const activity = new Map<string, UserActivityAggregate>();
-  if (uids.length === 0) return activity;
-
-  // `getAll` fetches by document reference in one round-trip per chunk, with
-  // no 10-item `in`-query cap, so this stays cheap even for large user lists.
-  const collection = db.collection('adminUserActivity');
-  const CHUNK = 300;
-  for (let i = 0; i < uids.length; i += CHUNK) {
-    const refs = uids.slice(i, i + CHUNK).map((uid) => collection.doc(uid));
-    const snaps = await db.getAll(...refs);
-    for (const snap of snaps) {
-      if (snap.exists) {
-        activity.set(snap.id, snap.data() as UserActivityAggregate);
-      }
-    }
-  }
-  return activity;
 }
 
 export const adminListUsers = onCall(
@@ -252,59 +202,5 @@ export const adminBulkDeleteInactiveAnonymous = onCall(
       by: request.auth?.uid,
     });
     return { deleted, skipped };
-  }
-);
-
-const MIGRATION_STATUS_COLLECTION = 'migrationStatus';
-
-export const getMigrationStatuses = onCall(
-  { region: 'europe-west3' },
-  async (request) => {
-    assertAdmin(request);
-    const snap = await db.collection(MIGRATION_STATUS_COLLECTION).get();
-    const statuses: Record<
-      string,
-      { completed: boolean; completedAt: string | null; completedBy: string }
-    > = {};
-    for (const doc of snap.docs) {
-      const data = doc.data();
-      statuses[doc.id] = {
-        completed: Boolean(data.completed),
-        completedAt: (data.completedAt as string | null) ?? null,
-        completedBy: (data.completedBy as string) ?? '',
-      };
-    }
-    return { statuses };
-  }
-);
-
-export const setMigrationStatus = onCall(
-  { region: 'europe-west3' },
-  async (request) => {
-    assertAdmin(request);
-
-    const validation = validateSetMigrationStatusPayload(request.data);
-    if (!validation.valid || !validation.id) {
-      throw new HttpsError('invalid-argument', validation.error ?? 'invalid');
-    }
-
-    const nowIso = new Date().toISOString();
-    const completed = validation.completed === true;
-    const doc = {
-      completed,
-      completedAt: completed ? nowIso : null,
-      completedBy: completed ? (request.auth?.uid ?? '') : '',
-    };
-    await db
-      .collection(MIGRATION_STATUS_COLLECTION)
-      .doc(validation.id)
-      .set(doc);
-
-    logger.info('setMigrationStatus', {
-      id: validation.id,
-      completed,
-      by: request.auth?.uid,
-    });
-    return { id: validation.id, ...doc };
   }
 );

--- a/data-store/functions/src/functions-admin.ts
+++ b/data-store/functions/src/functions-admin.ts
@@ -8,6 +8,7 @@ import {
 } from './admin';
 import {
   deleteUserExerciseData,
+  hasEntrySince,
   readUserActivity,
 } from './admin/user-data-ops';
 import { db, DEMO_USER_ID } from './firebase-app';
@@ -180,8 +181,16 @@ export const adminBulkDeleteInactiveAnonymous = onCall(
     let skipped = 0;
 
     for (const uid of anonymousUsers) {
-      const lastTs = activity.get(uid)?.lastEntry;
-      if (lastTs && lastTs >= cutoff) {
+      const aggregate = activity.get(uid);
+      if (aggregate) {
+        if (aggregate.lastEntry && aggregate.lastEntry >= cutoff) {
+          skipped++;
+          continue;
+        }
+      } else if (await hasEntrySince(uid, cutoff)) {
+        // No aggregate yet (e.g. the post-deploy window before the backfill
+        // ran) — fall back to a bounded source check so an active user is
+        // never deleted.
         skipped++;
         continue;
       }

--- a/data-store/functions/src/functions-admin.ts
+++ b/data-store/functions/src/functions-admin.ts
@@ -203,12 +203,15 @@ export const adminBulkDeleteInactiveAnonymous = onCall(
     const anonymousUserSet = new Set(anonymousUsers);
     let activity = aggregateEntryActivity([]);
     if (anonymousUsers.length > 0) {
+      // A user is "active" iff they have any entry on/after the cutoff, so
+      // only those entries need reading. ISO timestamps sort lexicographically
+      // against the date-only `cutoff`, so the range filter is exact and keeps
+      // the read volume proportional to recent activity, not full history.
       const entrySnap = await db
         .collection('exerciseEntries')
+        .where('timestamp', '>=', cutoff)
         .select('userId', 'timestamp')
         .get();
-      // ISO timestamps sort lexicographically, so the raw `lastTimestamp`
-      // compares correctly against the date-only `cutoff` below.
       activity = aggregateEntryActivity(
         entrySnap.docs.map((doc) => doc.data()),
         anonymousUserSet

--- a/data-store/functions/src/functions-admin.ts
+++ b/data-store/functions/src/functions-admin.ts
@@ -52,14 +52,19 @@ async function readUserActivity(
   uids: string[]
 ): Promise<Map<string, UserActivityAggregate>> {
   const activity = new Map<string, UserActivityAggregate>();
-  for (let i = 0; i < uids.length; i += 10) {
-    const batch = uids.slice(i, i + 10);
-    const snaps = await db
-      .collection('adminUserActivity')
-      .where(admin.firestore.FieldPath.documentId(), 'in', batch)
-      .get();
-    for (const snap of snaps.docs) {
-      activity.set(snap.id, snap.data() as UserActivityAggregate);
+  if (uids.length === 0) return activity;
+
+  // `getAll` fetches by document reference in one round-trip per chunk, with
+  // no 10-item `in`-query cap, so this stays cheap even for large user lists.
+  const collection = db.collection('adminUserActivity');
+  const CHUNK = 300;
+  for (let i = 0; i < uids.length; i += CHUNK) {
+    const refs = uids.slice(i, i + CHUNK).map((uid) => collection.doc(uid));
+    const snaps = await db.getAll(...refs);
+    for (const snap of snaps) {
+      if (snap.exists) {
+        activity.set(snap.id, snap.data() as UserActivityAggregate);
+      }
     }
   }
   return activity;

--- a/data-store/functions/src/functions-admin.ts
+++ b/data-store/functions/src/functions-admin.ts
@@ -43,22 +43,19 @@ export const adminListUsers = onCall(
       }
     }
 
-    const pushupCountMap = new Map<string, number>();
-    const lastPushupMap = new Map<string, string>();
-    const pushupSnap = await db.collection('pushups').get();
-    for (const doc of pushupSnap.docs) {
+    const entryCountMap = new Map<string, number>();
+    const lastEntryMap = new Map<string, string>();
+    const entrySnap = await db.collection('exerciseEntries').get();
+    for (const doc of entrySnap.docs) {
       const data = doc.data();
       if (!data.userId) continue;
-      pushupCountMap.set(
-        data.userId,
-        (pushupCountMap.get(data.userId) || 0) + 1
-      );
+      entryCountMap.set(data.userId, (entryCountMap.get(data.userId) || 0) + 1);
       const ts = data.timestamp as string;
       if (
-        !lastPushupMap.has(data.userId) ||
-        ts > (lastPushupMap.get(data.userId) ?? '')
+        !lastEntryMap.has(data.userId) ||
+        ts > (lastEntryMap.get(data.userId) ?? '')
       ) {
-        lastPushupMap.set(data.userId, ts);
+        lastEntryMap.set(data.userId, ts);
       }
     }
 
@@ -72,8 +69,8 @@ export const adminListUsers = onCall(
           null,
         email: (config as Record<string, unknown>).email || user.email || null,
         anonymous: user.providerData.length === 0,
-        pushupCount: pushupCountMap.get(user.uid) || 0,
-        lastEntry: lastPushupMap.get(user.uid) || null,
+        entryCount: entryCountMap.get(user.uid) || 0,
+        lastEntry: lastEntryMap.get(user.uid) || null,
         createdAt: user.metadata.creationTime || null,
         role: user.customClaims?.admin === true ? 'admin' : null,
       };
@@ -114,15 +111,15 @@ export const adminDeleteUser = onCall(
     } else {
       await db.collection('userConfigs').doc(uid).delete();
 
-      const pushupSnap = await db
-        .collection('pushups')
+      const entrySnap = await db
+        .collection('exerciseEntries')
         .where('userId', '==', uid)
         .get();
 
       const BATCH_SIZE = 500;
-      for (let i = 0; i < pushupSnap.docs.length; i += BATCH_SIZE) {
+      for (let i = 0; i < entrySnap.docs.length; i += BATCH_SIZE) {
         const batch = db.batch();
-        for (const doc of pushupSnap.docs.slice(i, i + BATCH_SIZE)) {
+        for (const doc of entrySnap.docs.slice(i, i + BATCH_SIZE)) {
           batch.delete(doc.ref);
         }
         await batch.commit();
@@ -197,18 +194,18 @@ export const adminBulkDeleteInactiveAnonymous = onCall(
     } while (pageToken);
 
     const anonymousUserSet = new Set(anonymousUsers);
-    const lastPushupMap = new Map<string, string>();
+    const lastEntryMap = new Map<string, string>();
     if (anonymousUsers.length > 0) {
-      const pushupSnap = await db.collection('pushups').get();
-      for (const doc of pushupSnap.docs) {
+      const entrySnap = await db.collection('exerciseEntries').get();
+      for (const doc of entrySnap.docs) {
         const data = doc.data();
         if (!data.userId || !anonymousUserSet.has(data.userId)) continue;
         const ts = String(data.timestamp || '').slice(0, 10);
         if (
-          !lastPushupMap.has(data.userId) ||
-          ts > (lastPushupMap.get(data.userId) ?? '')
+          !lastEntryMap.has(data.userId) ||
+          ts > (lastEntryMap.get(data.userId) ?? '')
         ) {
-          lastPushupMap.set(data.userId, ts);
+          lastEntryMap.set(data.userId, ts);
         }
       }
     }
@@ -217,7 +214,7 @@ export const adminBulkDeleteInactiveAnonymous = onCall(
     let skipped = 0;
 
     for (const uid of anonymousUsers) {
-      const lastTs = lastPushupMap.get(uid);
+      const lastTs = lastEntryMap.get(uid);
       if (lastTs && lastTs >= cutoff) {
         skipped++;
         continue;
@@ -226,15 +223,15 @@ export const adminBulkDeleteInactiveAnonymous = onCall(
       await admin.auth().deleteUser(uid);
       await db.collection('userConfigs').doc(uid).delete();
 
-      const pushupSnap = await db
-        .collection('pushups')
+      const entrySnap = await db
+        .collection('exerciseEntries')
         .where('userId', '==', uid)
         .get();
 
       const BATCH_SIZE = 500;
-      for (let i = 0; i < pushupSnap.docs.length; i += BATCH_SIZE) {
+      for (let i = 0; i < entrySnap.docs.length; i += BATCH_SIZE) {
         const batch = db.batch();
-        for (const doc of pushupSnap.docs.slice(i, i + BATCH_SIZE)) {
+        for (const doc of entrySnap.docs.slice(i, i + BATCH_SIZE)) {
           batch.delete(doc.ref);
         }
         await batch.commit();

--- a/data-store/functions/src/functions-admin.ts
+++ b/data-store/functions/src/functions-admin.ts
@@ -75,7 +75,8 @@ export const adminListUsers = onCall(
       .select('userId', 'timestamp')
       .get();
     const activity = aggregateEntryActivity(
-      entrySnap.docs.map((doc) => doc.data())
+      entrySnap.docs.map((doc) => doc.data()),
+      new Set(uids)
     );
 
     return authUsers.map((user) => {

--- a/data-store/functions/src/functions-migration-status.ts
+++ b/data-store/functions/src/functions-migration-status.ts
@@ -1,0 +1,60 @@
+import { logger } from 'firebase-functions';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+
+import { validateSetMigrationStatusPayload } from './admin';
+import { db } from './firebase-app';
+import { assertAdmin } from './functions-admin';
+
+const MIGRATION_STATUS_COLLECTION = 'migrationStatus';
+
+export const getMigrationStatuses = onCall(
+  { region: 'europe-west3' },
+  async (request) => {
+    assertAdmin(request);
+    const snap = await db.collection(MIGRATION_STATUS_COLLECTION).get();
+    const statuses: Record<
+      string,
+      { completed: boolean; completedAt: string | null; completedBy: string }
+    > = {};
+    for (const doc of snap.docs) {
+      const data = doc.data();
+      statuses[doc.id] = {
+        completed: Boolean(data.completed),
+        completedAt: (data.completedAt as string | null) ?? null,
+        completedBy: (data.completedBy as string) ?? '',
+      };
+    }
+    return { statuses };
+  }
+);
+
+export const setMigrationStatus = onCall(
+  { region: 'europe-west3' },
+  async (request) => {
+    assertAdmin(request);
+
+    const validation = validateSetMigrationStatusPayload(request.data);
+    if (!validation.valid || !validation.id) {
+      throw new HttpsError('invalid-argument', validation.error ?? 'invalid');
+    }
+
+    const nowIso = new Date().toISOString();
+    const completed = validation.completed === true;
+    const doc = {
+      completed,
+      completedAt: completed ? nowIso : null,
+      completedBy: completed ? (request.auth?.uid ?? '') : '',
+    };
+    await db
+      .collection(MIGRATION_STATUS_COLLECTION)
+      .doc(validation.id)
+      .set(doc);
+
+    logger.info('setMigrationStatus', {
+      id: validation.id,
+      completed,
+      by: request.auth?.uid,
+    });
+    return { id: validation.id, ...doc };
+  }
+);

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -20,6 +20,11 @@ export {
 } from './functions-admin';
 
 export {
+  backfillAdminUserActivity,
+  updateAdminUserActivityOnEntryWrite,
+} from './functions-admin-user-activity';
+
+export {
   adminCreateGithubIssue,
   adminDeleteFeedback,
   adminListFeedback,

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -15,14 +15,17 @@ export {
   adminDeleteUser,
   adminListUsers,
   adminSetLeaderboardExclusion,
-  getMigrationStatuses,
-  setMigrationStatus,
 } from './functions-admin';
 
 export {
   backfillAdminUserActivity,
   updateAdminUserActivityOnEntryWrite,
 } from './functions-admin-user-activity';
+
+export {
+  getMigrationStatuses,
+  setMigrationStatus,
+} from './functions-migration-status';
 
 export {
   adminCreateGithubIssue,

--- a/web/src/app/admin/admin-page.component.html
+++ b/web/src/app/admin/admin-page.component.html
@@ -31,7 +31,7 @@
         />
       </mat-form-field>
       <p class="bulk-hint" i18n="@@admin.bulk.hint">
-        Löscht anonyme Benutzer ohne Pushups in den letzten
+        Löscht anonyme Benutzer ohne Übungseinträge in den letzten
         {{ inactiveDays() }} Tagen.
       </p>
     </mat-card-content>
@@ -148,15 +148,15 @@
           </mat-cell>
         </ng-container>
 
-        <!-- pushupCount column -->
-        <ng-container matColumnDef="pushupCount">
+        <!-- entryCount column -->
+        <ng-container matColumnDef="entryCount">
           <mat-header-cell
             *matHeaderCellDef
             mat-sort-header
-            i18n="@@admin.col.pushups"
-            >Pushups</mat-header-cell
+            i18n="@@admin.col.entries"
+            >Einträge</mat-header-cell
           >
-          <mat-cell *matCellDef="let u">{{ u.pushupCount }}</mat-cell>
+          <mat-cell *matCellDef="let u">{{ u.entryCount }}</mat-cell>
         </ng-container>
 
         <!-- lastEntry column -->

--- a/web/src/app/admin/admin-page.component.spec.ts
+++ b/web/src/app/admin/admin-page.component.spec.ts
@@ -32,7 +32,7 @@ describe('AdminPageComponent', () => {
     displayName: 'Alice',
     email: 'alice@example.com',
     anonymous: false,
-    pushupCount: 12,
+    entryCount: 12,
     lastEntry: '2026-04-09T10:00:00.000Z',
     createdAt: '2026-01-01T00:00:00.000Z',
     role: null,

--- a/web/src/app/admin/admin-page.component.ts
+++ b/web/src/app/admin/admin-page.component.ts
@@ -67,7 +67,7 @@ export class AdminPageComponent {
     'displayName',
     'email',
     'anonymous',
-    'pushupCount',
+    'entryCount',
     'lastEntry',
     'createdAt',
     'actions',

--- a/web/src/app/admin/admin-page.helpers.spec.ts
+++ b/web/src/app/admin/admin-page.helpers.spec.ts
@@ -13,7 +13,7 @@ function makeUser(overrides: Partial<AdminUser> = {}): AdminUser {
     displayName: 'Alice',
     email: 'alice@example.com',
     anonymous: false,
-    pushupCount: 10,
+    entryCount: 10,
     lastEntry: '2026-01-02T08:00:00.000Z',
     createdAt: '2026-01-01T08:00:00.000Z',
     role: null,
@@ -69,13 +69,13 @@ describe('adminUserSortValue', () => {
     ).toBe(0);
   });
 
-  it('should return the raw pushupCount', () => {
+  it('should return the raw entryCount', () => {
     // given
     // when
     // then
-    expect(
-      adminUserSortValue(makeUser({ pushupCount: 42 }), 'pushupCount')
-    ).toBe(42);
+    expect(adminUserSortValue(makeUser({ entryCount: 42 }), 'entryCount')).toBe(
+      42
+    );
   });
 
   it('should convert lastEntry/createdAt to epoch ms and use 0 when null', () => {

--- a/web/src/app/admin/admin-page.helpers.ts
+++ b/web/src/app/admin/admin-page.helpers.ts
@@ -19,8 +19,8 @@ export function adminUserSortValue(
       return (item.email ?? '').toLowerCase();
     case 'anonymous':
       return item.anonymous ? 1 : 0;
-    case 'pushupCount':
-      return item.pushupCount;
+    case 'entryCount':
+      return item.entryCount;
     case 'lastEntry':
       return timeOf(item.lastEntry);
     case 'createdAt':

--- a/web/src/app/admin/admin-page.models.ts
+++ b/web/src/app/admin/admin-page.models.ts
@@ -3,7 +3,7 @@ export interface AdminUser {
   displayName: string | null;
   email: string | null;
   anonymous: boolean;
-  pushupCount: number;
+  entryCount: number;
   lastEntry: string | null;
   createdAt: string | null;
   role: string | null;

--- a/web/src/app/admin/user-details-dialog.component.spec.ts
+++ b/web/src/app/admin/user-details-dialog.component.spec.ts
@@ -19,7 +19,7 @@ describe('UserDetailsDialogComponent', () => {
     displayName: 'Alice',
     email: 'alice@example.com',
     anonymous: false,
-    pushupCount: 42,
+    entryCount: 42,
     lastEntry: '2026-04-20T10:00:00.000Z',
     createdAt: '2026-01-01T00:00:00.000Z',
     role: 'admin',

--- a/web/src/app/admin/user-details-dialog.component.ts
+++ b/web/src/app/admin/user-details-dialog.component.ts
@@ -35,8 +35,8 @@ import { AdminUser } from './admin-page.models';
         <dt i18n="@@admin.details.role">Rolle</dt>
         <dd>{{ user.role ?? emptyLabel }}</dd>
 
-        <dt i18n="@@admin.details.pushupCount">Pushups</dt>
-        <dd>{{ user.pushupCount }}</dd>
+        <dt i18n="@@admin.details.entryCount">Einträge</dt>
+        <dd>{{ user.entryCount }}</dd>
 
         <dt i18n="@@admin.details.lastEntry">Letzter Eintrag</dt>
         <dd>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -1016,15 +1016,6 @@
         <target>Ανων</target>
       </segment>
     </unit>
-    <unit id="admin.col.pushups">
-      <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:225,226</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Pushups</target>
-      </segment>
-    </unit>
     <unit id="admin.col.lastEntry">
       <notes>
         <note category="location">web/src/app/admin/admin-page.component.ts:236,238</note>
@@ -1329,15 +1320,6 @@
       <segment state="translated">
         <source>Rolle</source>
         <target>Ρόλος</target>
-      </segment>
-    </unit>
-    <unit id="admin.details.pushupCount">
-      <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:38,39</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Pushups</target>
       </segment>
     </unit>
     <unit id="admin.details.lastEntry">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10186,5 +10186,17 @@
         <target>Προστασία δεδομένων</target>
       </segment>
     </unit>
+    <unit id="admin.col.entries">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.entryCount">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10379,5 +10379,17 @@ Deine Position: # ·  Reps        </source>
         <target>Privacy Policy</target>
       </segment>
     </unit>
+    <unit id="admin.col.entries">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.entryCount">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -4819,12 +4819,6 @@ Deine Position: # ·  Reps        </source>
         <target>Anon</target>
       </segment>
     </unit>
-    <unit id="admin.col.pushups">
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Pushups</target>
-      </segment>
-    </unit>
     <unit id="admin.col.lastEntry">
       <segment state="translated">
         <source>Letzter Eintrag</source>
@@ -4901,12 +4895,6 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source>Rolle</source>
         <target>Role</target>
-      </segment>
-    </unit>
-    <unit id="admin.details.pushupCount">
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Pushups</target>
       </segment>
     </unit>
     <unit id="admin.details.lastEntry">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -1016,15 +1016,6 @@
         <target>Anónimo</target>
       </segment>
     </unit>
-    <unit id="admin.col.pushups">
-      <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:225,226</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Flexiones</target>
-      </segment>
-    </unit>
     <unit id="admin.col.lastEntry">
       <notes>
         <note category="location">web/src/app/admin/admin-page.component.ts:236,238</note>
@@ -1329,15 +1320,6 @@
       <segment state="translated">
         <source>Rolle</source>
         <target>Rol</target>
-      </segment>
-    </unit>
-    <unit id="admin.details.pushupCount">
-      <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:38,39</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Flexiones</target>
       </segment>
     </unit>
     <unit id="admin.details.lastEntry">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10182,5 +10182,17 @@
         <target>Protección de datos</target>
       </segment>
     </unit>
+    <unit id="admin.col.entries">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.entryCount">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -1016,15 +1016,6 @@
         <target>Anon</target>
       </segment>
     </unit>
-    <unit id="admin.col.pushups">
-      <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:225,226</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Pompes</target>
-      </segment>
-    </unit>
     <unit id="admin.col.lastEntry">
       <notes>
         <note category="location">web/src/app/admin/admin-page.component.ts:236,238</note>
@@ -1329,15 +1320,6 @@
       <segment state="translated">
         <source>Rolle</source>
         <target>Rôle</target>
-      </segment>
-    </unit>
-    <unit id="admin.details.pushupCount">
-      <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:38,39</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Pompes</target>
       </segment>
     </unit>
     <unit id="admin.details.lastEntry">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10058,5 +10058,17 @@
         <target>Protection des données</target>
       </segment>
     </unit>
+    <unit id="admin.col.entries">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.entryCount">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10186,5 +10186,17 @@
         <target>Tutela dei dati</target>
       </segment>
     </unit>
+    <unit id="admin.col.entries">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.entryCount">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -1016,15 +1016,6 @@
         <target>Anonimo</target>
       </segment>
     </unit>
-    <unit id="admin.col.pushups">
-      <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:225,226</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Flessioni sulle braccia</target>
-      </segment>
-    </unit>
     <unit id="admin.col.lastEntry">
       <notes>
         <note category="location">web/src/app/admin/admin-page.component.ts:236,238</note>
@@ -1329,15 +1320,6 @@
       <segment state="translated">
         <source>Rolle</source>
         <target>Ruolo</target>
-      </segment>
-    </unit>
-    <unit id="admin.details.pushupCount">
-      <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:38,39</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Flessioni sulle braccia</target>
       </segment>
     </unit>
     <unit id="admin.details.lastEntry">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10186,5 +10186,17 @@
         <target>Gegevensbescherming</target>
       </segment>
     </unit>
+    <unit id="admin.col.entries">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.entryCount">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -1016,15 +1016,6 @@
         <target>Anon</target>
       </segment>
     </unit>
-    <unit id="admin.col.pushups">
-      <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:225,226</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Push-ups</target>
-      </segment>
-    </unit>
     <unit id="admin.col.lastEntry">
       <notes>
         <note category="location">web/src/app/admin/admin-page.component.ts:236,238</note>
@@ -1329,15 +1320,6 @@
       <segment state="translated">
         <source>Rolle</source>
         <target>Rol</target>
-      </segment>
-    </unit>
-    <unit id="admin.details.pushupCount">
-      <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:38,39</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Push-ups</target>
       </segment>
     </unit>
     <unit id="admin.details.lastEntry">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -3843,12 +3843,6 @@ Deine Position: # ·  Reps        </source>
         <target>Anon</target>
       </segment>
     </unit>
-    <unit id="admin.col.pushups">
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Armhevninger</target>
-      </segment>
-    </unit>
     <unit id="admin.col.lastEntry">
       <segment state="translated">
         <source>Letzter Eintrag</source>
@@ -3925,12 +3919,6 @@ Deine Position: # ·  Reps        </source>
       <segment state="translated">
         <source>Rolle</source>
         <target>Rolle</target>
-      </segment>
-    </unit>
-    <unit id="admin.details.pushupCount">
-      <segment state="translated">
-        <source>Pushups</source>
-        <target>Armhevninger</target>
       </segment>
     </unit>
     <unit id="admin.details.lastEntry">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9473,5 +9473,17 @@ Deine Position: # ·  Reps        </source>
         <target>Personvern</target>
       </segment>
     </unit>
+    <unit id="admin.col.entries">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.entryCount">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2828,7 +2828,7 @@
         <note category="location">web/src/app/admin/admin-page.component.html:34,37</note>
       </notes>
       <segment>
-        <source> Löscht anonyme Benutzer ohne Pushups in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}"/> Tagen. </source>
+        <source> Löscht anonyme Benutzer ohne Übungseinträge in den letzten <ph id="0" equiv="INTERPOLATION" disp="{{ inactiveDays() }}"/> Tagen. </source>
       </segment>
     </unit>
     <unit id="admin.bulk.button">
@@ -2895,12 +2895,12 @@
         <source>Anon</source>
       </segment>
     </unit>
-    <unit id="admin.col.pushups">
+    <unit id="admin.col.entries">
       <notes>
         <note category="location">web/src/app/admin/admin-page.component.html:157,159</note>
       </notes>
       <segment>
-        <source>Pushups</source>
+        <source>Einträge</source>
       </segment>
     </unit>
     <unit id="admin.col.lastEntry">
@@ -3193,12 +3193,12 @@
         <source>Rolle</source>
       </segment>
     </unit>
-    <unit id="admin.details.pushupCount">
+    <unit id="admin.details.entryCount">
       <notes>
         <note category="location">web/src/app/admin/user-details-dialog.component.ts:38,39</note>
       </notes>
       <segment>
-        <source>Pushups</source>
+        <source>Einträge</source>
       </segment>
     </unit>
     <unit id="admin.details.lastEntry">
@@ -4792,7 +4792,7 @@
     </unit>
     <unit id="about.mission.title">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:32,33</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:33,34</note>
       </notes>
       <segment>
         <source>Warum es diese Seite gibt</source>
@@ -4800,7 +4800,7 @@
     </unit>
     <unit id="about.mission.body">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:34,39</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:35,40</note>
       </notes>
       <segment>
         <source> Ob Liegestütze, Kniebeugen oder Klimmzüge – die meisten Körpergewichtsübungen brauchen kein Gerät, kein Studio und lassen keine Ausrede zu. Was den meisten fehlt, ist nicht die Übung, sondern die Kontinuität. Genau da setzt Pushup Tracker an – messbarer Fortschritt, kleine Tagesziele und eine Streak, die man ungern reißen lässt, machen aus ein paar Wiederholungen eine dauerhafte Gewohnheit. </source>
@@ -4808,7 +4808,7 @@
     </unit>
     <unit id="about.content.title">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:44,45</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:45,46</note>
       </notes>
       <segment>
         <source>Wie unsere Inhalte entstehen</source>
@@ -4816,7 +4816,7 @@
     </unit>
     <unit id="about.content.body">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:46,50</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:47,51</note>
       </notes>
       <segment>
         <source> Die Guides und Blog-Artikel basieren auf eigener Trainingserfahrung und allgemein anerkannten Trainingsprinzipien; wo Studien zitiert werden, sind sie im Artikel verlinkt. Die Inhalte ersetzen keine medizinische Beratung – hol dir bei Vorerkrankungen oder Schmerzen zuerst ärztlichen Rat. </source>
@@ -4824,7 +4824,7 @@
     </unit>
     <unit id="about.contact.title">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:55,57</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:56,58</note>
       </notes>
       <segment>
         <source>Kontakt</source>
@@ -4832,7 +4832,7 @@
     </unit>
     <unit id="about.contact.body">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:58,60</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:59,61</note>
       </notes>
       <segment>
         <source>Fragen, Feedback oder Fehler gefunden? Schreib uns:</source>
@@ -4840,7 +4840,7 @@
     </unit>
     <unit id="about.toImpressum">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:67,70</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:68,71</note>
       </notes>
       <segment>
         <source>Impressum</source>
@@ -4848,7 +4848,7 @@
     </unit>
     <unit id="about.toDatenschutz">
       <notes>
-        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:73,76</note>
+        <note category="location">web/src/app/marketing/about/ueber-uns-page.component.ts:74,77</note>
       </notes>
       <segment>
         <source>Datenschutz</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -1880,14 +1880,6 @@
         <source>Anon</source>
       <target>匿名</target></segment>
     </unit>
-    <unit id="admin.col.pushups">
-      <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:225,226</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-      <target>俯卧撑</target></segment>
-    </unit>
     <unit id="admin.col.lastEntry">
       <notes>
         <note category="location">web/src/app/admin/admin-page.component.ts:236,238</note>
@@ -2159,14 +2151,6 @@
       <segment state="translated">
         <source>Rolle</source>
       <target>角色</target></segment>
-    </unit>
-    <unit id="admin.details.pushupCount">
-      <notes>
-        <note category="location">web/src/app/admin/user-details-dialog.component.ts:38,39</note>
-      </notes>
-      <segment state="translated">
-        <source>Pushups</source>
-      <target>俯卧撑</target></segment>
     </unit>
     <unit id="admin.details.lastEntry">
       <notes>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9690,5 +9690,17 @@
         <target>隐私政策</target>
       </segment>
     </unit>
+    <unit id="admin.col.entries">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.details.entryCount">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
 </file>
 </xliff>


### PR DESCRIPTION
## Problem

Der Admin-Bereich zeigt Aktivität pro User (Anzahl Einträge, letzter Eintrag) und die Bereinigung inaktiver anonymer User immer noch anhand der Legacy-`pushups`-Collection an. Nach dem Phase-7-Cutover werden neue Einträge aber ausschließlich in `exerciseEntries` (mit `exerciseId`) geschrieben — `pushups` erhält keine Writes mehr. Dadurch waren:

- der Zähler in der User-Tabelle und im Detail-Dialog veraltet/0,
- „Letzter Eintrag“ veraltet,
- die Erkennung inaktiver User in `adminBulkDeleteInactiveAnonymous` falsch (aktive User wurden nicht als aktiv erkannt).

## Änderungen

**Vorberechnetes Pro-User-Aggregat (`adminUserActivity/{uid}`)**
- Neuer Trigger `updateAdminUserActivityOnEntryWrite`: pflegt `entryCount` + `lastEntry` bei jedem `exerciseEntries`-Write per reinem Delta. Der Max-Timestamp wird nur dann aus der Quelle neu abgeleitet, wenn der Eintrag entfernt/verschoben wird, der zuvor das Maximum war (`orderBy(asc).limitToLast(1)` über den bestehenden `(userId, timestamp)`-Index). Fällt `entryCount` auf 0, wird der Aggregat-Doc gelöscht statt als Null-Doc zurückzubleiben.
- Neue Admin-Callable `backfillAdminUserActivity` (schreibt nur bei explizitem `dryRun: false`) seeded das Aggregat aus der Historie; idempotent und **paginiert** (Peak-Memory O(#users)). **Nach dem Deploy einmalig ausführen**, damit die Zähler für bestehende Nutzer gefüllt sind.
- `adminListUsers` und `adminBulkDeleteInactiveAnonymous` lesen die Aggregat-Docs jetzt via `getAll` (fetch-by-reference, O(#users)) statt die gesamte `exerciseEntries`-Collection zu scannen. Der Bulk-Delete fällt bei fehlendem Aggregat (z. B. Post-Deploy-Fenster vor dem Backfill) auf einen gebundenen `hasEntrySince`-Quellcheck zurück, damit kein aktiver User fälschlich gelöscht wird.
- Clients haben keinen Zugriff auf `adminUserActivity` (explizite Deny-Regel in `firestore.rules`).

**Löschung (Hard-Delete & Bulk-Cleanup)**
- `deleteUserExerciseData` purged bewusst **beide** Collections — `exerciseEntries` **und** die Legacy-`pushups`-Quelle (die Pushup-Unification-Migration lässt `pushups` absichtlich intakt, sonst würden pre-cutover-Zeilen mit der gelöschten UID verwaisen). Löschung erfolgt paginiert (`limit()` + Re-Query).

**Frontend (`web/src/app/admin/*`)**
- Feld `pushupCount` → `entryCount`; Tabellen-Spalte und Detail-Label „Pushups“ → „Einträge“, da der Zähler nun alle Übungen umfasst. Bulk-Hinweistext entsprechend angepasst.

**Struktur / i18n**
- IO-Helper (`admin/user-data-ops.ts`) und Migration-Status-Callables (`functions-migration-status.ts`) aus `functions-admin.ts` extrahiert (unter 250 LOC).
- Neue i18n-Units `admin.col.entries` / `admin.details.entryCount` extrahiert und in alle Ziel-Locales mit deutschem Fallback synchronisiert; verwaiste `admin.col.pushups` / `admin.details.pushupCount` entfernt.

## Tests

- Reine Reducer `aggregateEntryActivity` (Backfill, inkl. Seiten-Akkumulation) und `nextActivityAggregate` (Trigger-Delta inkl. Recompute-Fälle) mit eigenem Jest-Spec (Given-When-Then).
- cloud-functions: 419 Tests ✅, `tsc --noEmit` ✅, Build ✅. web: Lint ✅, `web:build -c production` (i18n + Prerender) ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ibroVe5cpuc6fSX5wDgkM