### PR TITLE
chore(i18n): fill missing translations (16 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10169,15 +10169,15 @@
       </segment>
     </unit>
     <unit id="admin.col.entries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Καταχωρήσεις</target>
       </segment>
     </unit>
     <unit id="admin.details.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Καταχωρήσεις</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10368,15 +10368,15 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.col.entries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entries</target>
       </segment>
     </unit>
     <unit id="admin.details.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entries</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10165,15 +10165,15 @@
       </segment>
     </unit>
     <unit id="admin.col.entries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entradas</target>
       </segment>
     </unit>
     <unit id="admin.details.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entradas</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10041,15 +10041,15 @@
       </segment>
     </unit>
     <unit id="admin.col.entries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entrées</target>
       </segment>
     </unit>
     <unit id="admin.details.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entrées</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10169,15 +10169,15 @@
       </segment>
     </unit>
     <unit id="admin.col.entries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Immissioni</target>
       </segment>
     </unit>
     <unit id="admin.details.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Immissioni</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10169,15 +10169,15 @@
       </segment>
     </unit>
     <unit id="admin.col.entries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Invoeren</target>
       </segment>
     </unit>
     <unit id="admin.details.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Invoeren</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9462,15 +9462,15 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.col.entries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Oppføringer</target>
       </segment>
     </unit>
     <unit id="admin.details.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Oppføringer</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9675,15 +9675,15 @@
       </segment>
     </unit>
     <unit id="admin.col.entries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>记录</target>
       </segment>
     </unit>
     <unit id="admin.details.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>记录</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
Fills missing XLIFF translations detected by `tools/src/detect-translation-gaps.mjs`. Both gap units (`admin.col.entries`, `admin.details.entryCount` — German source `Einträge`, an admin table column header / detail label) needed a target in every supported non-German locale.

- en: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- fr: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- es: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- it: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- nl: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- no: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- zh: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- el: 2 unit(s), 0 blog post(s), 0 wiki entry/entries

Translations were chosen to match existing terminology already used elsewhere in the app for the sibling string `Letzter Eintrag` (e.g. fr "entrée", es "entrada", it "immissione", nl "invoer", no "oppføring", el "καταχώρηση").

## Skipped

None — all 16 gaps were translated.

## Detector summary

```
Detected 16 gap(s) — xliff:16 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh
```

## Verification

- `pnpm nx run web:extract-i18n` + `node tools/src/sync-xliff-locales.mjs` re-run to confirm the detector reports 0 remaining gaps.
- `pnpm nx run web:lint` — pass.
- `pnpm nx run web:test` — pass.
- `pnpm nx run web:build -c production` — pass (2349 static routes prerendered across all locales).

`nx affected` reported no affected projects for this XLIFF-only change, so the targeted `web` project checks above were run directly per the pre-push checklist fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012h6cw3CaxKmZYBEHe3Mciy

---
_Generated by [Claude Code](https://claude.ai/code/session_012h6cw3CaxKmZYBEHe3Mciy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected admin “Entries” labels across Greek, English, Spanish, French, Italian, Dutch, Norwegian, and Chinese translations.
  * Completed previously untranslated labels in admin tables and entry details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->