### PR TITLE
feat(admin): view, sort and edit a user's exercise entries

### DIFF
--- a/data-store/functions/src/admin/user-entries.spec.ts
+++ b/data-store/functions/src/admin/user-entries.spec.ts
@@ -161,6 +161,35 @@ describe('admin/user-entries', () => {
       expect(result.valid).toBe(false);
     });
 
+    it('should treat a whitespace-only variantId as a clear (null)', () => {
+      // given / when
+      const result = validateUpdateUserEntryPayload({
+        uid: 'u',
+        entryId: 'e',
+        patch: { variantId: '   ' },
+      });
+
+      // then
+      expect(result).toEqual({
+        valid: true,
+        uid: 'u',
+        entryId: 'e',
+        patch: { variantId: null },
+      });
+    });
+
+    it('should trim surrounding whitespace from a variantId', () => {
+      // given / when
+      const result = validateUpdateUserEntryPayload({
+        uid: 'u',
+        entryId: 'e',
+        patch: { variantId: '  bodyweight  ' },
+      });
+
+      // then
+      expect(result.valid && result.patch.variantId).toBe('bodyweight');
+    });
+
     it('should pass through cleared breakdowns and a cleared variant', () => {
       // given / when
       const result = validateUpdateUserEntryPayload({

--- a/data-store/functions/src/admin/user-entries.spec.ts
+++ b/data-store/functions/src/admin/user-entries.spec.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  MAX_USER_ENTRIES_LIMIT,
+  validateListUserEntriesPayload,
+  validateUpdateUserEntryPayload,
+} from './user-entries';
+
+describe('admin/user-entries', () => {
+  describe('validateListUserEntriesPayload', () => {
+    it('should accept a bare uid and apply the default limit', () => {
+      // given / when
+      const result = validateListUserEntriesPayload({ uid: '  user-1  ' });
+
+      // then
+      expect(result).toEqual({ valid: true, uid: 'user-1', limit: 1000 });
+    });
+
+    it('should reject a missing or empty uid', () => {
+      // given / when / then
+      expect(validateListUserEntriesPayload({}).valid).toBe(false);
+      expect(validateListUserEntriesPayload({ uid: '   ' }).valid).toBe(false);
+      expect(validateListUserEntriesPayload(null).valid).toBe(false);
+    });
+
+    it('should cap an oversized limit at the maximum', () => {
+      // given / when
+      const result = validateListUserEntriesPayload({
+        uid: 'u',
+        limit: 999999,
+      });
+
+      // then
+      expect(result).toEqual({
+        valid: true,
+        uid: 'u',
+        limit: MAX_USER_ENTRIES_LIMIT,
+      });
+    });
+
+    it('should reject a non-positive or non-integer limit', () => {
+      // given / when / then
+      expect(validateListUserEntriesPayload({ uid: 'u', limit: 0 }).valid).toBe(
+        false
+      );
+      expect(
+        validateListUserEntriesPayload({ uid: 'u', limit: 1.5 }).valid
+      ).toBe(false);
+    });
+  });
+
+  describe('validateUpdateUserEntryPayload', () => {
+    it('should accept a valid patch and trim identifiers', () => {
+      // given / when
+      const result = validateUpdateUserEntryPayload({
+        uid: ' user-1 ',
+        entryId: ' entry-1 ',
+        patch: { reps: 30, timestamp: '2026-04-01T10:00:00.000Z' },
+      });
+
+      // then
+      expect(result).toEqual({
+        valid: true,
+        uid: 'user-1',
+        entryId: 'entry-1',
+        patch: { reps: 30, timestamp: '2026-04-01T10:00:00.000Z' },
+      });
+    });
+
+    it('should reject an attempt to change exerciseId', () => {
+      // given / when
+      const result = validateUpdateUserEntryPayload({
+        uid: 'u',
+        entryId: 'e',
+        patch: { exerciseId: 'legs.squats', reps: 10 },
+      });
+
+      // then
+      expect(result).toEqual({
+        valid: false,
+        error: 'exerciseId is immutable',
+      });
+    });
+
+    it('should reject an empty patch', () => {
+      // given / when
+      const result = validateUpdateUserEntryPayload({
+        uid: 'u',
+        entryId: 'e',
+        patch: {},
+      });
+
+      // then
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject a non-finite numeric field', () => {
+      // given / when
+      const result = validateUpdateUserEntryPayload({
+        uid: 'u',
+        entryId: 'e',
+        patch: { reps: Number.NaN },
+      });
+
+      // then
+      expect(result.valid).toBe(false);
+    });
+
+    it('should pass through cleared breakdowns and a cleared variant', () => {
+      // given / when
+      const result = validateUpdateUserEntryPayload({
+        uid: 'u',
+        entryId: 'e',
+        patch: { sets: [], variantId: null },
+      });
+
+      // then
+      expect(result).toEqual({
+        valid: true,
+        uid: 'u',
+        entryId: 'e',
+        patch: { sets: [], variantId: null },
+      });
+    });
+
+    it('should reject a non-number in a breakdown array', () => {
+      // given / when
+      const result = validateUpdateUserEntryPayload({
+        uid: 'u',
+        entryId: 'e',
+        patch: { sets: [10, 'x'] },
+      });
+
+      // then
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject missing uid, entryId, or patch', () => {
+      // given / when / then
+      expect(
+        validateUpdateUserEntryPayload({ entryId: 'e', patch: { reps: 1 } })
+          .valid
+      ).toBe(false);
+      expect(
+        validateUpdateUserEntryPayload({ uid: 'u', patch: { reps: 1 } }).valid
+      ).toBe(false);
+      expect(
+        validateUpdateUserEntryPayload({ uid: 'u', entryId: 'e' }).valid
+      ).toBe(false);
+    });
+  });
+});

--- a/data-store/functions/src/admin/user-entries.spec.ts
+++ b/data-store/functions/src/admin/user-entries.spec.ts
@@ -81,6 +81,50 @@ describe('admin/user-entries', () => {
       });
     });
 
+    it('should trim a whitespace-padded ISO timestamp', () => {
+      // given / when
+      const result = validateUpdateUserEntryPayload({
+        uid: 'u',
+        entryId: 'e',
+        patch: { timestamp: '  2026-04-01T12:30:00+02:00  ' },
+      });
+
+      // then
+      expect(result).toEqual({
+        valid: true,
+        uid: 'u',
+        entryId: 'e',
+        patch: { timestamp: '2026-04-01T12:30:00+02:00' },
+      });
+    });
+
+    it('should reject a malformed timestamp', () => {
+      // given / when
+      const result = validateUpdateUserEntryPayload({
+        uid: 'u',
+        entryId: 'e',
+        patch: { timestamp: 'not-a-timestamp' },
+      });
+
+      // then
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject an unknown patch field', () => {
+      // given / when
+      const result = validateUpdateUserEntryPayload({
+        uid: 'u',
+        entryId: 'e',
+        patch: { repss: 30 },
+      });
+
+      // then
+      expect(result).toEqual({
+        valid: false,
+        error: 'unknown patch field: repss',
+      });
+    });
+
     it('should reject an empty patch', () => {
       // given / when
       const result = validateUpdateUserEntryPayload({

--- a/data-store/functions/src/admin/user-entries.spec.ts
+++ b/data-store/functions/src/admin/user-entries.spec.ts
@@ -110,6 +110,18 @@ describe('admin/user-entries', () => {
       expect(result.valid).toBe(false);
     });
 
+    it('should reject a timestamp without a timezone suffix', () => {
+      // given / when — ambiguous local time would be parsed in the server locale
+      const result = validateUpdateUserEntryPayload({
+        uid: 'u',
+        entryId: 'e',
+        patch: { timestamp: '2026-04-01T12:30:00' },
+      });
+
+      // then
+      expect(result.valid).toBe(false);
+    });
+
     it('should reject an unknown patch field', () => {
       // given / when
       const result = validateUpdateUserEntryPayload({

--- a/data-store/functions/src/admin/user-entries.ts
+++ b/data-store/functions/src/admin/user-entries.ts
@@ -1,0 +1,155 @@
+/**
+ * Admin per-user exercise-entry management — pure payload validation.
+ *
+ * The Firestore rules only let a user read/write their own
+ * `exerciseEntries`, so an admin inspecting or correcting someone
+ * else's history has to go through the Admin SDK. These helpers validate
+ * the callable payloads before any Firestore I/O; the callables in
+ * `functions-admin-user-entries.ts` own the reads/writes.
+ */
+
+/** Upper bound for a single `adminListUserEntries` page. */
+export const MAX_USER_ENTRIES_LIMIT = 2000;
+const DEFAULT_USER_ENTRIES_LIMIT = 1000;
+
+export interface AdminEntryPatch {
+  timestamp?: string;
+  reps?: number;
+  durationSec?: number;
+  distanceM?: number;
+  weightKg?: number;
+  sets?: number[];
+  intervals?: number[];
+  /**
+   * `string` sets the variant, `null` clears it (the callable maps this
+   * to a Firestore `deleteField()`), `undefined` leaves it untouched.
+   */
+  variantId?: string | null;
+}
+
+const NUMERIC_FIELDS = [
+  'reps',
+  'durationSec',
+  'distanceM',
+  'weightKg',
+] as const;
+const BREAKDOWN_FIELDS = ['sets', 'intervals'] as const;
+
+/**
+ * Validates the `adminListUserEntries` payload: a non-empty `uid` and an
+ * optional positive integer `limit` capped at {@link MAX_USER_ENTRIES_LIMIT}.
+ */
+export function validateListUserEntriesPayload(
+  data: unknown
+):
+  | { valid: true; uid: string; limit: number }
+  | { valid: false; error: string } {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, error: 'payload must be an object' };
+  }
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.uid !== 'string' || obj.uid.trim().length === 0) {
+    return { valid: false, error: 'uid missing or empty' };
+  }
+  let limit = DEFAULT_USER_ENTRIES_LIMIT;
+  if (obj.limit !== undefined) {
+    if (
+      typeof obj.limit !== 'number' ||
+      !Number.isInteger(obj.limit) ||
+      obj.limit <= 0
+    ) {
+      return { valid: false, error: 'limit must be a positive integer' };
+    }
+    limit = Math.min(obj.limit, MAX_USER_ENTRIES_LIMIT);
+  }
+  return { valid: true, uid: obj.uid.trim(), limit };
+}
+
+function validateNumberArray(value: unknown): number[] | null {
+  if (!Array.isArray(value)) return null;
+  for (const n of value) {
+    if (typeof n !== 'number' || !Number.isFinite(n)) return null;
+  }
+  return value as number[];
+}
+
+/**
+ * Validates the `adminUpdateUserEntry` payload. Requires a non-empty
+ * `uid` and `entryId`, plus a `patch` object carrying at least one
+ * editable field. `exerciseId` is intentionally rejected — a different
+ * exercise must be modelled as delete + create so the per-exercise stats
+ * trigger can decrement the old aggregate (mirrors
+ * `ExerciseFirestoreService.updateEntry`). Per-field value bounds are
+ * NOT checked here; the callable runs the shared `validateExerciseEntry`
+ * against the catalog definition of the stored entry.
+ */
+export function validateUpdateUserEntryPayload(
+  data: unknown
+):
+  | { valid: true; uid: string; entryId: string; patch: AdminEntryPatch }
+  | { valid: false; error: string } {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, error: 'payload must be an object' };
+  }
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.uid !== 'string' || obj.uid.trim().length === 0) {
+    return { valid: false, error: 'uid missing or empty' };
+  }
+  if (typeof obj.entryId !== 'string' || obj.entryId.trim().length === 0) {
+    return { valid: false, error: 'entryId missing or empty' };
+  }
+  if (!obj.patch || typeof obj.patch !== 'object') {
+    return { valid: false, error: 'patch must be an object' };
+  }
+  const raw = obj.patch as Record<string, unknown>;
+  if ('exerciseId' in raw) {
+    return { valid: false, error: 'exerciseId is immutable' };
+  }
+
+  const patch: AdminEntryPatch = {};
+
+  if (raw.timestamp !== undefined) {
+    if (
+      typeof raw.timestamp !== 'string' ||
+      raw.timestamp.trim().length === 0
+    ) {
+      return { valid: false, error: 'timestamp must be a non-empty string' };
+    }
+    patch.timestamp = raw.timestamp;
+  }
+
+  for (const f of NUMERIC_FIELDS) {
+    if (raw[f] === undefined) continue;
+    if (typeof raw[f] !== 'number' || !Number.isFinite(raw[f])) {
+      return { valid: false, error: `${f} must be a finite number` };
+    }
+    patch[f] = raw[f] as number;
+  }
+
+  for (const f of BREAKDOWN_FIELDS) {
+    if (raw[f] === undefined) continue;
+    const arr = validateNumberArray(raw[f]);
+    if (arr === null) {
+      return { valid: false, error: `${f} must be an array of numbers` };
+    }
+    patch[f] = arr;
+  }
+
+  if (raw.variantId !== undefined) {
+    if (raw.variantId !== null && typeof raw.variantId !== 'string') {
+      return { valid: false, error: 'variantId must be a string or null' };
+    }
+    patch.variantId = raw.variantId as string | null;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return { valid: false, error: 'patch must contain at least one field' };
+  }
+
+  return {
+    valid: true,
+    uid: obj.uid.trim(),
+    entryId: obj.entryId.trim(),
+    patch,
+  };
+}

--- a/data-store/functions/src/admin/user-entries.ts
+++ b/data-store/functions/src/admin/user-entries.ts
@@ -172,7 +172,10 @@ export function validateUpdateUserEntryPayload(
     if (raw.variantId !== null && typeof raw.variantId !== 'string') {
       return { valid: false, error: 'variantId must be a string or null' };
     }
-    patch.variantId = raw.variantId as string | null;
+    // Trim, and treat a blank/whitespace-only value as `null` ("clear the
+    // variant") rather than writing it verbatim as a bogus variant id.
+    const trimmed = raw.variantId === null ? null : raw.variantId.trim();
+    patch.variantId = trimmed === '' ? null : trimmed;
   }
 
   if (Object.keys(patch).length === 0) {

--- a/data-store/functions/src/admin/user-entries.ts
+++ b/data-store/functions/src/admin/user-entries.ts
@@ -42,7 +42,8 @@ const KNOWN_PATCH_FIELDS: ReadonlySet<string> = new Set<string>([
   'variantId',
 ]);
 
-// ISO-8601 date-time with a *required* timezone suffix (`Z` or `±HH:MM`):
+// ISO-8601 date-time with a *required* timezone suffix (`Z`, `±HH:MM`, or
+// `±HHMM` — `appendLocalOffset` may emit the colon-less form):
 // the client only ever writes the stored `…Z` form or `appendLocalOffset`
 // output (`…+02:00`). Since the admin callable bypasses the Firestore rules
 // that pin this shape, re-check it here — `buildEntryUpdate` stores the value

--- a/data-store/functions/src/admin/user-entries.ts
+++ b/data-store/functions/src/admin/user-entries.ts
@@ -42,13 +42,15 @@ const KNOWN_PATCH_FIELDS: ReadonlySet<string> = new Set<string>([
   'variantId',
 ]);
 
-// ISO-8601-ish date-time: the client writes either the stored `…Z` form or
-// `appendLocalOffset` output (`…+02:00`). Since the admin callable bypasses
-// the Firestore rules that pin this shape, re-check it here — `buildEntryUpdate`
-// stores the value verbatim and `orderBy('timestamp')` / the activity
-// aggregate assume lexicographically-ordered ISO strings.
+// ISO-8601 date-time with a *required* timezone suffix (`Z` or `±HH:MM`):
+// the client only ever writes the stored `…Z` form or `appendLocalOffset`
+// output (`…+02:00`). Since the admin callable bypasses the Firestore rules
+// that pin this shape, re-check it here — `buildEntryUpdate` stores the value
+// verbatim and `orderBy('timestamp')` / the activity aggregate assume
+// unambiguous, lexicographically-ordered ISO strings. A timezone-less value
+// would be parsed in the server's locale and break that invariant.
 const ISO_TIMESTAMP_RE =
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/;
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/;
 
 function isIsoTimestamp(value: string): boolean {
   return ISO_TIMESTAMP_RE.test(value) && !Number.isNaN(Date.parse(value));

--- a/data-store/functions/src/admin/user-entries.ts
+++ b/data-store/functions/src/admin/user-entries.ts
@@ -35,6 +35,25 @@ const NUMERIC_FIELDS = [
 ] as const;
 const BREAKDOWN_FIELDS = ['sets', 'intervals'] as const;
 
+const KNOWN_PATCH_FIELDS: ReadonlySet<string> = new Set<string>([
+  'timestamp',
+  ...NUMERIC_FIELDS,
+  ...BREAKDOWN_FIELDS,
+  'variantId',
+]);
+
+// ISO-8601-ish date-time: the client writes either the stored `…Z` form or
+// `appendLocalOffset` output (`…+02:00`). Since the admin callable bypasses
+// the Firestore rules that pin this shape, re-check it here — `buildEntryUpdate`
+// stores the value verbatim and `orderBy('timestamp')` / the activity
+// aggregate assume lexicographically-ordered ISO strings.
+const ISO_TIMESTAMP_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/;
+
+function isIsoTimestamp(value: string): boolean {
+  return ISO_TIMESTAMP_RE.test(value) && !Number.isNaN(Date.parse(value));
+}
+
 /**
  * Validates the `adminListUserEntries` payload: a non-empty `uid` and an
  * optional positive integer `limit` capped at {@link MAX_USER_ENTRIES_LIMIT}.
@@ -105,17 +124,28 @@ export function validateUpdateUserEntryPayload(
   if ('exerciseId' in raw) {
     return { valid: false, error: 'exerciseId is immutable' };
   }
+  // Reject unknown keys rather than silently dropping them, so a typo like
+  // `repss` surfaces as an error instead of a no-op the admin thinks saved.
+  for (const key of Object.keys(raw)) {
+    if (!KNOWN_PATCH_FIELDS.has(key)) {
+      return { valid: false, error: `unknown patch field: ${key}` };
+    }
+  }
 
   const patch: AdminEntryPatch = {};
 
   if (raw.timestamp !== undefined) {
-    if (
-      typeof raw.timestamp !== 'string' ||
-      raw.timestamp.trim().length === 0
-    ) {
-      return { valid: false, error: 'timestamp must be a non-empty string' };
+    if (typeof raw.timestamp !== 'string') {
+      return { valid: false, error: 'timestamp must be a string' };
     }
-    patch.timestamp = raw.timestamp;
+    const ts = raw.timestamp.trim();
+    if (!isIsoTimestamp(ts)) {
+      return {
+        valid: false,
+        error: 'timestamp must be an ISO date-time string',
+      };
+    }
+    patch.timestamp = ts;
   }
 
   for (const f of NUMERIC_FIELDS) {

--- a/data-store/functions/src/functions-admin-user-entries.ts
+++ b/data-store/functions/src/functions-admin-user-entries.ts
@@ -109,13 +109,31 @@ export const adminUpdateUserEntry = onCall(
       );
     }
 
-    const def = findExerciseDefinition(String(data.exerciseId));
-    if (!def) {
-      throw new HttpsError('failed-precondition', 'Unbekannte Übung.');
-    }
-    const violation = validateExerciseEntry(patch, def, { partial: true });
-    if (violation) {
-      throw new HttpsError('invalid-argument', violation);
+    // Only the measurement/variant fields need catalog validation. A
+    // timestamp-only patch is allowed even for a stale exercise id whose
+    // catalog entry was renamed/removed — the edit dialog offers exactly
+    // that for such entries. Mirrors `ExerciseFirestoreService.updateEntry`,
+    // which validates only when a value field actually changes.
+    const needsCatalog = (
+      [
+        'reps',
+        'durationSec',
+        'distanceM',
+        'weightKg',
+        'sets',
+        'intervals',
+        'variantId',
+      ] as const
+    ).some((k) => patch[k] !== undefined);
+    if (needsCatalog) {
+      const def = findExerciseDefinition(String(data.exerciseId));
+      if (!def) {
+        throw new HttpsError('failed-precondition', 'Unbekannte Übung.');
+      }
+      const violation = validateExerciseEntry(patch, def, { partial: true });
+      if (violation) {
+        throw new HttpsError('invalid-argument', violation);
+      }
     }
 
     await ref.update(buildEntryUpdate(patch));

--- a/data-store/functions/src/functions-admin-user-entries.ts
+++ b/data-store/functions/src/functions-admin-user-entries.ts
@@ -19,8 +19,16 @@ const EXERCISE_ENTRIES_COLLECTION = 'exerciseEntries';
 // Admin-only read of a single user's exercise history. The Firestore
 // rules scope client reads to `userId == request.auth.uid`, so the
 // dashboard's per-user drill-down can't query this collection directly —
-// it goes through the Admin SDK here. Ordered newest-first and capped so
-// a user with a huge history never materialises unbounded.
+// it goes through the Admin SDK here. Returns the newest `limit` entries,
+// newest first, so a user with a huge history never materialises unbounded.
+//
+// Uses `orderBy(timestamp, asc).limitToLast(limit)` + a client-side
+// reverse rather than `orderBy(desc)`: the only declared composite index
+// is `(userId ASC, timestamp ASC)`, which serves this in its native
+// direction. A `desc` order would need a separate descending index and
+// otherwise fail with FAILED_PRECONDITION in production. Same trick the
+// `updateAdminUserActivityOnEntryWrite` trigger uses to read the max
+// timestamp.
 export const adminListUserEntries = onCall(
   { region: 'europe-west3', timeoutSeconds: 60 },
   async (request) => {
@@ -35,11 +43,11 @@ export const adminListUserEntries = onCall(
     const snap = await db
       .collection(EXERCISE_ENTRIES_COLLECTION)
       .where('userId', '==', uid)
-      .orderBy('timestamp', 'desc')
-      .limit(limit)
+      .orderBy('timestamp', 'asc')
+      .limitToLast(limit)
       .get();
 
-    return snap.docs.map((doc) => ({ _id: doc.id, ...doc.data() }));
+    return snap.docs.reverse().map((doc) => ({ _id: doc.id, ...doc.data() }));
   }
 );
 

--- a/data-store/functions/src/functions-admin-user-entries.ts
+++ b/data-store/functions/src/functions-admin-user-entries.ts
@@ -1,0 +1,120 @@
+import * as admin from 'firebase-admin';
+import { logger } from 'firebase-functions';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import {
+  findExerciseDefinition,
+  validateExerciseEntry,
+} from '@pu-stats/models';
+
+import {
+  type AdminEntryPatch,
+  validateListUserEntriesPayload,
+  validateUpdateUserEntryPayload,
+} from './admin/user-entries';
+import { db } from './firebase-app';
+import { assertAdmin } from './functions-admin';
+
+const EXERCISE_ENTRIES_COLLECTION = 'exerciseEntries';
+
+// Admin-only read of a single user's exercise history. The Firestore
+// rules scope client reads to `userId == request.auth.uid`, so the
+// dashboard's per-user drill-down can't query this collection directly —
+// it goes through the Admin SDK here. Ordered newest-first and capped so
+// a user with a huge history never materialises unbounded.
+export const adminListUserEntries = onCall(
+  { region: 'europe-west3', timeoutSeconds: 60 },
+  async (request) => {
+    assertAdmin(request);
+
+    const result = validateListUserEntriesPayload(request.data);
+    if (!result.valid) {
+      throw new HttpsError('invalid-argument', result.error);
+    }
+    const { uid, limit } = result;
+
+    const snap = await db
+      .collection(EXERCISE_ENTRIES_COLLECTION)
+      .where('userId', '==', uid)
+      .orderBy('timestamp', 'desc')
+      .limit(limit)
+      .get();
+
+    return snap.docs.map((doc) => ({ _id: doc.id, ...doc.data() }));
+  }
+);
+
+// Translate an admin entry patch into a Firestore update map. Cleared
+// breakdowns (`[]`) and a cleared variant (`null`) map to `deleteField()`
+// so the doc actually drops the stale value instead of silently keeping
+// it — mirrors `ExerciseFirestoreService.updateEntry`.
+function buildEntryUpdate(patch: AdminEntryPatch): Record<string, unknown> {
+  const update: Record<string, unknown> = {
+    updatedAt: new Date().toISOString(),
+  };
+  if (patch.timestamp !== undefined) update.timestamp = patch.timestamp;
+  for (const f of ['reps', 'durationSec', 'distanceM', 'weightKg'] as const) {
+    if (patch[f] !== undefined) update[f] = patch[f];
+  }
+  for (const f of ['sets', 'intervals'] as const) {
+    const v = patch[f];
+    if (v === undefined) continue;
+    update[f] = v.length === 0 ? admin.firestore.FieldValue.delete() : v;
+  }
+  if (patch.variantId !== undefined) {
+    update.variantId =
+      patch.variantId === null || patch.variantId === ''
+        ? admin.firestore.FieldValue.delete()
+        : patch.variantId;
+  }
+  return update;
+}
+
+// Admin-only patch of a single user's exercise entry. Verifies the entry
+// belongs to `uid` (so a stale/foreign entryId can't be edited), then
+// runs the same catalog-backed validation the client path uses before
+// writing. The `exerciseId` stays immutable — enforced in the payload
+// validator. The `updateExerciseStatsOnEntryWrite` and
+// `updateAdminUserActivityOnEntryWrite` triggers keep aggregates current.
+export const adminUpdateUserEntry = onCall(
+  { region: 'europe-west3', timeoutSeconds: 60 },
+  async (request) => {
+    assertAdmin(request);
+
+    const result = validateUpdateUserEntryPayload(request.data);
+    if (!result.valid) {
+      throw new HttpsError('invalid-argument', result.error);
+    }
+    const { uid, entryId, patch } = result;
+
+    const ref = db.collection(EXERCISE_ENTRIES_COLLECTION).doc(entryId);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      throw new HttpsError('not-found', 'Eintrag nicht gefunden.');
+    }
+    const data = snap.data() ?? {};
+    if (data.userId !== uid) {
+      throw new HttpsError(
+        'failed-precondition',
+        'Eintrag gehört nicht zu diesem Benutzer.'
+      );
+    }
+
+    const def = findExerciseDefinition(String(data.exerciseId));
+    if (!def) {
+      throw new HttpsError('failed-precondition', 'Unbekannte Übung.');
+    }
+    const violation = validateExerciseEntry(patch, def, { partial: true });
+    if (violation) {
+      throw new HttpsError('invalid-argument', violation);
+    }
+
+    await ref.update(buildEntryUpdate(patch));
+
+    logger.info('adminUpdateUserEntry', {
+      uid,
+      entryId,
+      by: request.auth?.uid,
+    });
+    return { ok: true };
+  }
+);

--- a/data-store/functions/src/functions-admin-user-entries.ts
+++ b/data-store/functions/src/functions-admin-user-entries.ts
@@ -47,7 +47,9 @@ export const adminListUserEntries = onCall(
       .limitToLast(limit)
       .get();
 
-    return snap.docs.reverse().map((doc) => ({ _id: doc.id, ...doc.data() }));
+    // `_id` last so the real doc id always wins over any stray `_id`
+    // field a document might carry from older data or a client bug.
+    return snap.docs.reverse().map((doc) => ({ ...doc.data(), _id: doc.id }));
   }
 );
 

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -23,6 +23,11 @@ export {
 } from './functions-admin-user-activity';
 
 export {
+  adminListUserEntries,
+  adminUpdateUserEntry,
+} from './functions-admin-user-entries';
+
+export {
   getMigrationStatuses,
   setMigrationStatus,
 } from './functions-migration-status';

--- a/web/src/app/admin/admin-page.component.html
+++ b/web/src/app/admin/admin-page.component.html
@@ -191,6 +191,14 @@
           <mat-cell *matCellDef="let u" (click)="$event.stopPropagation()">
             <button
               mat-icon-button
+              (click)="openEntriesDialog(u)"
+              [matTooltip]="entriesTooltip"
+              [attr.aria-label]="entriesAriaLabel(u)"
+            >
+              <mat-icon>list_alt</mat-icon>
+            </button>
+            <button
+              mat-icon-button
               color="warn"
               (click)="openDeleteDialog(u)"
               [matTooltip]="deleteUserTooltip"

--- a/web/src/app/admin/admin-page.component.spec.ts
+++ b/web/src/app/admin/admin-page.component.spec.ts
@@ -15,6 +15,7 @@ import {
 } from './callable-functions.testing';
 import { DeleteUserDialogComponent } from './delete-user-dialog.component';
 import { UserDetailsDialogComponent } from './user-details-dialog.component';
+import { UserEntriesDialogComponent } from './user-entries-dialog.component';
 
 const { callablesMock, setupCallables } = createCallablesMock();
 
@@ -131,10 +132,12 @@ describe('AdminPageComponent', () => {
       // call the (mocked-missing) adminDeleteUser callable.
       dialogOpenSpy.mockReturnValue(stubDialogRef(undefined));
 
-      // when
-      const deleteButton = fixture.nativeElement.querySelector(
+      // when — the delete button is the warn-colored (last) action button;
+      // the first action button now opens the entries dialog.
+      const actionButtons = fixture.nativeElement.querySelectorAll(
         'mat-cell.mat-column-actions button'
-      ) as HTMLButtonElement | null;
+      ) as NodeListOf<HTMLButtonElement>;
+      const deleteButton = actionButtons[actionButtons.length - 1] ?? null;
       expect(deleteButton).toBeTruthy();
       if (!deleteButton) return;
       deleteButton.dispatchEvent(
@@ -150,6 +153,50 @@ describe('AdminPageComponent', () => {
       // ... but the row click handler must NOT fire (stopPropagation works)
       expect(dialogOpenSpy).not.toHaveBeenCalledWith(
         UserDetailsDialogComponent,
+        expect.anything()
+      );
+    });
+  });
+
+  describe('openEntriesDialog', () => {
+    it('should open UserEntriesDialogComponent with the user wrapped in data', async () => {
+      // given
+      await createComponent();
+      dialogOpenSpy.mockReturnValue(stubDialogRef(undefined));
+
+      // when
+      component.openEntriesDialog(sampleUser);
+
+      // then
+      expect(dialogOpenSpy).toHaveBeenCalledWith(
+        UserEntriesDialogComponent,
+        expect.objectContaining({ data: { user: sampleUser } })
+      );
+    });
+
+    it('should open the entries dialog (not delete) from the first action button', async () => {
+      // given
+      await createComponent([sampleUser]);
+      dialogOpenSpy.mockReturnValue(stubDialogRef(undefined));
+
+      // when
+      const firstAction = fixture.nativeElement.querySelector(
+        'mat-cell.mat-column-actions button'
+      ) as HTMLButtonElement | null;
+      expect(firstAction).toBeTruthy();
+      if (!firstAction) return;
+      firstAction.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      );
+      await fixture.whenStable();
+
+      // then
+      expect(dialogOpenSpy).toHaveBeenCalledWith(
+        UserEntriesDialogComponent,
+        expect.objectContaining({ data: { user: sampleUser } })
+      );
+      expect(dialogOpenSpy).not.toHaveBeenCalledWith(
+        DeleteUserDialogComponent,
         expect.anything()
       );
     });

--- a/web/src/app/admin/admin-page.component.ts
+++ b/web/src/app/admin/admin-page.component.ts
@@ -25,6 +25,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { CallableFunctionsService } from './callable-functions.service';
 import { DeleteUserDialogComponent } from './delete-user-dialog.component';
 import { UserDetailsDialogComponent } from './user-details-dialog.component';
+import { UserEntriesDialogComponent } from './user-entries-dialog.component';
 import { AdminFeedbackSectionComponent } from './admin-feedback-section.component';
 import { PageHeaderComponent } from '../core/page-header/page-header.component';
 import { AdminUser, BulkDeleteResult } from './admin-page.models';
@@ -76,6 +77,7 @@ export class AdminPageComponent {
   readonly refreshTooltip = $localize`:@@admin.refresh:Neu laden`;
   readonly anonTooltip = $localize`:@@admin.col.anonTooltip:Anonym`;
   readonly deleteUserTooltip = $localize`:@@admin.user.deleteTooltip:Benutzer löschen`;
+  readonly entriesTooltip = $localize`:@@admin.user.entriesTooltip:Einträge anzeigen`;
   readonly loading = signal(false);
   readonly error = signal<string | null>(null);
   readonly users = signal<AdminUser[]>([]);
@@ -126,6 +128,19 @@ export class AdminPageComponent {
       width: 'min(92vw, 480px)',
       maxWidth: '92vw',
     });
+  }
+
+  openEntriesDialog(user: AdminUser): void {
+    this.dialog.open(UserEntriesDialogComponent, {
+      data: { user },
+      width: 'min(94vw, 720px)',
+      maxWidth: '94vw',
+    });
+  }
+
+  entriesAriaLabel(user: AdminUser): string {
+    const identifier = user.displayName ?? user.email ?? user.uid;
+    return $localize`:@@admin.row.entriesAria:Einträge anzeigen für ${identifier}:identifier:`;
   }
 
   detailsAriaLabel(user: AdminUser): string {

--- a/web/src/app/admin/entry-edit-dialog.component.spec.ts
+++ b/web/src/app/admin/entry-edit-dialog.component.spec.ts
@@ -1,0 +1,102 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { type ExerciseEntry } from '@pu-stats/models';
+import { AdminEntryEditDialogComponent } from './entry-edit-dialog.component';
+
+describe('AdminEntryEditDialogComponent', () => {
+  const closeSpy = vi.fn();
+
+  function setup(entry: ExerciseEntry) {
+    TestBed.configureTestingModule({
+      imports: [AdminEntryEditDialogComponent, MatDialogModule],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: entry },
+        { provide: MatDialogRef, useValue: { close: closeSpy } },
+      ],
+    });
+    const fixture = TestBed.createComponent(AdminEntryEditDialogComponent);
+    fixture.detectChanges();
+    return { fixture, component: fixture.componentInstance };
+  }
+
+  const repsEntry: ExerciseEntry = {
+    _id: 'e1',
+    userId: 'u1',
+    exerciseId: 'legs.squats',
+    timestamp: '2026-04-01T10:00:00.000Z',
+    reps: 30,
+    source: 'web',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the localized exercise name', () => {
+    // given / when
+    const { fixture } = setup(repsEntry);
+
+    // then
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Kniebeugen');
+  });
+
+  it('should seed the primary value from the stored entry', () => {
+    // given / when
+    const { component } = setup(repsEntry);
+
+    // then
+    expect(component.value()).toBe(30);
+  });
+
+  it('should not allow saving when nothing changed', () => {
+    // given
+    const { component } = setup(repsEntry);
+
+    // when / then
+    expect(component.canSave()).toBe(false);
+  });
+
+  it('should close with a patch of the changed value', () => {
+    // given
+    const { component } = setup(repsEntry);
+
+    // when
+    component.value.set(45);
+
+    // then
+    expect(component.canSave()).toBe(true);
+    component.save();
+    expect(closeSpy).toHaveBeenCalledWith({ reps: 45 });
+  });
+
+  it('should reject an out-of-range value (no save)', () => {
+    // given — squats cap is 500
+    const { component } = setup(repsEntry);
+
+    // when
+    component.value.set(9999);
+
+    // then
+    expect(component.canSave()).toBe(false);
+    component.save();
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  it('should only expose the timestamp field for a stale exercise id', () => {
+    // given / when
+    const { component, fixture } = setup({
+      ...repsEntry,
+      exerciseId: 'gone.forever',
+    });
+
+    // then
+    expect(component.def).toBeNull();
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Unbekannte Übung');
+  });
+});

--- a/web/src/app/admin/entry-edit-dialog.component.spec.ts
+++ b/web/src/app/admin/entry-edit-dialog.component.spec.ts
@@ -32,6 +32,24 @@ describe('AdminEntryEditDialogComponent', () => {
     source: 'web',
   };
 
+  const runningEntry: ExerciseEntry = {
+    _id: 'e2',
+    userId: 'u1',
+    exerciseId: 'cardio.running',
+    timestamp: '2026-04-02T08:00:00.000Z',
+    distanceM: 5000,
+    durationSec: 1500,
+    source: 'web',
+  };
+
+  function localInput(iso: string): string {
+    const d = new Date(iso);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(
+      d.getDate()
+    )}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -85,6 +103,33 @@ describe('AdminEntryEditDialogComponent', () => {
     expect(component.canSave()).toBe(false);
     component.save();
     expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  it('should seed the timestamp input in the viewer local timezone', () => {
+    // given / when — raw slice would misread a `…Z` timestamp when the
+    // viewer's tz is not UTC; the dialog must render the local wall-clock.
+    const { component } = setup(repsEntry);
+
+    // then
+    expect(component.timestamp()).toBe(localInput(repsEntry.timestamp));
+  });
+
+  it('should edit the companion value of a distance-time entry', () => {
+    // given
+    const { component } = setup(runningEntry);
+
+    // then — companion wiring resolves to duration
+    expect(component.companion).toBe('durationSec');
+    expect(component.companionLabel).toContain('Dauer');
+    expect(component.companionValue()).toBe(1500);
+
+    // when
+    component.companionValue.set(1600);
+
+    // then
+    expect(component.canSave()).toBe(true);
+    component.save();
+    expect(closeSpy).toHaveBeenCalledWith({ durationSec: 1600 });
   });
 
   it('should only expose the timestamp field for a stale exercise id', () => {

--- a/web/src/app/admin/entry-edit-dialog.component.ts
+++ b/web/src/app/admin/entry-edit-dialog.component.ts
@@ -1,0 +1,204 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { appendLocalOffset } from '@pu-stats/date';
+import {
+  type ExerciseDefinition,
+  type ExerciseEntry,
+  findExerciseDefinition,
+  measurementValueField,
+  validateExerciseEntry,
+} from '@pu-stats/models';
+import {
+  type AdminEntryEditForm,
+  buildEntryPatch,
+  companionField,
+  entryExerciseName,
+} from './user-entries.helpers';
+
+/**
+ * Admin edit dialog for a single exercise entry. Scope is intentionally
+ * narrow — timestamp, the primary measurement value and (where the
+ * measurement has one) the companion value. `exerciseId` is immutable
+ * (a different exercise is a delete + create, see
+ * {@link ExerciseFirestoreService.updateEntry}), so it is shown read-only.
+ * Closes with the minimal change patch, or `undefined` when nothing
+ * changed or the exercise id no longer resolves in the catalog.
+ */
+@Component({
+  selector: 'app-admin-entry-edit-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
+  template: `
+    <h2 mat-dialog-title i18n="@@admin.entry.edit.title">Eintrag bearbeiten</h2>
+    <mat-dialog-content class="edit-content">
+      <p class="exercise-name">{{ exerciseName }}</p>
+
+      <mat-form-field appearance="outline">
+        <mat-label i18n="@@admin.entry.edit.timestamp">Zeitpunkt</mat-label>
+        <input
+          matInput
+          type="datetime-local"
+          [value]="timestamp()"
+          (input)="timestamp.set(asValue($event))"
+        />
+      </mat-form-field>
+
+      @if (def) {
+        <mat-form-field appearance="outline">
+          <mat-label i18n="@@admin.entry.edit.value">Wert</mat-label>
+          <input
+            matInput
+            type="number"
+            [value]="value() ?? ''"
+            (input)="value.set(asNumber($event))"
+          />
+          <span matTextSuffix>{{ def.unit }}</span>
+        </mat-form-field>
+
+        @if (companion) {
+          <mat-form-field appearance="outline">
+            <mat-label>{{ companionLabel }}</mat-label>
+            <input
+              matInput
+              type="number"
+              [value]="companionValue() ?? ''"
+              (input)="companionValue.set(asNumber($event))"
+            />
+          </mat-form-field>
+        }
+      } @else {
+        <p class="stale-hint" i18n="@@admin.entry.edit.staleExercise">
+          Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden.
+        </p>
+      }
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close i18n="@@admin.entry.edit.cancel">
+        Abbrechen
+      </button>
+      <button
+        mat-flat-button
+        color="primary"
+        [disabled]="!canSave()"
+        (click)="save()"
+        i18n="@@admin.entry.edit.save"
+      >
+        Speichern
+      </button>
+    </mat-dialog-actions>
+  `,
+  styles: `
+    .edit-content {
+      min-width: min(92vw, 360px);
+      display: grid;
+      gap: 4px;
+      padding-top: 8px;
+    }
+    .exercise-name {
+      font-weight: 600;
+      margin: 0 0 8px;
+    }
+    mat-form-field {
+      width: 100%;
+    }
+    .stale-hint {
+      color: var(--mat-sys-on-surface-variant);
+      font-size: 0.85em;
+    }
+  `,
+})
+export class AdminEntryEditDialogComponent {
+  private readonly dialogRef =
+    inject<MatDialogRef<AdminEntryEditDialogComponent>>(MatDialogRef);
+  readonly entry = inject<ExerciseEntry>(MAT_DIALOG_DATA);
+
+  readonly def: ExerciseDefinition | null = findExerciseDefinition(
+    this.entry.exerciseId
+  );
+  readonly exerciseName = entryExerciseName(this.entry);
+  readonly companion = companionField(this.entry);
+  readonly companionLabel =
+    this.companion === 'durationSec'
+      ? $localize`:@@admin.entry.edit.duration:Dauer (s)`
+      : $localize`:@@admin.entry.edit.weight:Gewicht (kg)`;
+
+  private readonly originalLocal = this.entry.timestamp.slice(0, 16);
+  readonly timestamp = signal(this.originalLocal);
+  readonly value = signal<number | null>(this.initialPrimaryValue());
+  readonly companionValue = signal<number | null>(
+    this.companion ? (this.entry[this.companion] ?? null) : null
+  );
+
+  readonly canSave = computed(() => {
+    if (this.timestamp().length === 0) return false;
+    const patch = this.patch();
+    return patch !== null;
+  });
+
+  private patch(): Record<string, unknown> | null {
+    const built = buildEntryPatch(this.entry, this.formValue());
+    if (!built) return null;
+    if (this.def) {
+      const violation = validateExerciseEntry(built, this.def, {
+        partial: true,
+      });
+      if (violation) return null;
+    }
+    return built;
+  }
+
+  private formValue(): AdminEntryEditForm {
+    return {
+      timestamp: this.resolvedTimestamp(),
+      value: this.value(),
+      companion: this.companionValue(),
+    };
+  }
+
+  private resolvedTimestamp(): string {
+    return this.timestamp() === this.originalLocal
+      ? this.entry.timestamp
+      : appendLocalOffset(this.timestamp());
+  }
+
+  private initialPrimaryValue(): number | null {
+    if (!this.def) return null;
+    const field = measurementValueField(this.def.measurement);
+    return (this.entry[field] as number | undefined) ?? null;
+  }
+
+  save(): void {
+    const patch = this.patch();
+    if (!patch) return;
+    this.dialogRef.close(patch);
+  }
+
+  asValue(event: Event): string {
+    return (event.target as HTMLInputElement).value;
+  }
+
+  asNumber(event: Event): number | null {
+    const raw = (event.target as HTMLInputElement).value;
+    if (raw === '') return null;
+    const num = Number(raw);
+    return Number.isNaN(num) ? null : num;
+  }
+}

--- a/web/src/app/admin/entry-edit-dialog.component.ts
+++ b/web/src/app/admin/entry-edit-dialog.component.ts
@@ -34,8 +34,9 @@ import {
  * measurement has one) the companion value. `exerciseId` is immutable
  * (a different exercise is a delete + create, see
  * {@link ExerciseFirestoreService.updateEntry}), so it is shown read-only.
- * Closes with the minimal change patch, or `undefined` when nothing
- * changed or the exercise id no longer resolves in the catalog.
+ * Closes with the minimal change patch. When the exercise id no longer
+ * resolves in the catalog only the timestamp stays editable (the value
+ * fields are hidden), so the patch is timestamp-only in that case.
  */
 @Component({
   selector: 'app-admin-entry-edit-dialog',

--- a/web/src/app/admin/entry-edit-dialog.component.ts
+++ b/web/src/app/admin/entry-edit-dialog.component.ts
@@ -141,7 +141,7 @@ export class AdminEntryEditDialogComponent {
       ? $localize`:@@admin.entry.edit.duration:Dauer (s)`
       : $localize`:@@admin.entry.edit.weight:Gewicht (kg)`;
 
-  private readonly originalLocal = this.entry.timestamp.slice(0, 16);
+  private readonly originalLocal = this.isoToLocalInput(this.entry.timestamp);
   readonly timestamp = signal(this.originalLocal);
   readonly value = signal<number | null>(this.initialPrimaryValue());
   readonly companionValue = signal<number | null>(
@@ -178,6 +178,20 @@ export class AdminEntryEditDialogComponent {
     return this.timestamp() === this.originalLocal
       ? this.entry.timestamp
       : appendLocalOffset(this.timestamp());
+  }
+
+  // Render a stored instant as a `YYYY-MM-DDTHH:mm` string in the *viewer's*
+  // local timezone for the `datetime-local` input. Slicing the raw ISO
+  // prefix would misread entries stored in UTC (`…Z`) or another user's
+  // offset — an admin edits any user's entries, so their local tz may
+  // differ from the entry's. `appendLocalOffset` converts back on save.
+  private isoToLocalInput(iso: string): string {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso.slice(0, 16);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(
+      d.getDate()
+    )}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
   }
 
   private initialPrimaryValue(): number | null {

--- a/web/src/app/admin/user-entries-dialog.component.html
+++ b/web/src/app/admin/user-entries-dialog.component.html
@@ -1,0 +1,96 @@
+<h2 mat-dialog-title i18n="@@admin.entries.title">Einträge</h2>
+<mat-dialog-content class="entries-content">
+  <p class="user-line">
+    <span class="user-name">{{
+      user.displayName ?? user.email ?? user.uid
+    }}</span>
+    <button
+      mat-icon-button
+      (click)="loadEntries()"
+      [matTooltip]="refreshTooltip"
+      [attr.aria-label]="refreshTooltip"
+    >
+      <mat-icon>refresh</mat-icon>
+    </button>
+  </p>
+
+  @if (loading()) {
+    <div class="spinner-container">
+      <mat-spinner diameter="32" />
+    </div>
+  } @else if (error()) {
+    <p class="error-text">{{ error() }}</p>
+  } @else if (!entries().length) {
+    <p class="empty-text" i18n="@@admin.entries.empty">
+      Keine Einträge vorhanden.
+    </p>
+  } @else {
+    <div class="table-scroll">
+      <mat-table [dataSource]="dataSource" matSort #entriesSort="matSort">
+        <ng-container matColumnDef="timestamp">
+          <mat-header-cell
+            *matHeaderCellDef
+            mat-sort-header
+            i18n="@@admin.entries.col.timestamp"
+            >Zeitpunkt</mat-header-cell
+          >
+          <mat-cell *matCellDef="let e">{{
+            e.timestamp | date: 'short'
+          }}</mat-cell>
+        </ng-container>
+
+        <ng-container matColumnDef="exercise">
+          <mat-header-cell
+            *matHeaderCellDef
+            mat-sort-header
+            i18n="@@admin.entries.col.exercise"
+            >Übung</mat-header-cell
+          >
+          <mat-cell *matCellDef="let e">{{ exerciseName(e) }}</mat-cell>
+        </ng-container>
+
+        <ng-container matColumnDef="value">
+          <mat-header-cell
+            *matHeaderCellDef
+            mat-sort-header
+            i18n="@@admin.entries.col.value"
+            >Wert</mat-header-cell
+          >
+          <mat-cell *matCellDef="let e">{{ valueDisplay(e) }}</mat-cell>
+        </ng-container>
+
+        <ng-container matColumnDef="source">
+          <mat-header-cell
+            *matHeaderCellDef
+            mat-sort-header
+            i18n="@@admin.entries.col.source"
+            >Quelle</mat-header-cell
+          >
+          <mat-cell *matCellDef="let e">{{ e.source }}</mat-cell>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <mat-header-cell *matHeaderCellDef></mat-header-cell>
+          <mat-cell *matCellDef="let e">
+            <button
+              mat-icon-button
+              (click)="openEditDialog(e)"
+              [matTooltip]="editTooltip"
+              [attr.aria-label]="editTooltip"
+            >
+              <mat-icon>edit</mat-icon>
+            </button>
+          </mat-cell>
+        </ng-container>
+
+        <mat-header-row *matHeaderRowDef="displayedColumns" />
+        <mat-row *matRowDef="let row; columns: displayedColumns" />
+      </mat-table>
+    </div>
+  }
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close i18n="@@admin.entries.close">
+    Schließen
+  </button>
+</mat-dialog-actions>

--- a/web/src/app/admin/user-entries-dialog.component.scss
+++ b/web/src/app/admin/user-entries-dialog.component.scss
@@ -12,7 +12,7 @@
 
 .user-name {
   font-weight: 600;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .table-scroll {

--- a/web/src/app/admin/user-entries-dialog.component.scss
+++ b/web/src/app/admin/user-entries-dialog.component.scss
@@ -1,0 +1,39 @@
+.entries-content {
+  min-width: min(94vw, 640px);
+}
+
+.user-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 0 0 8px;
+}
+
+.user-name {
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  padding: 24px 0;
+}
+
+.error-text {
+  color: var(--mat-sys-error);
+}
+
+.empty-text {
+  color: var(--mat-sys-on-surface-variant);
+}
+
+mat-cell,
+mat-header-cell {
+  white-space: nowrap;
+}

--- a/web/src/app/admin/user-entries-dialog.component.spec.ts
+++ b/web/src/app/admin/user-entries-dialog.component.spec.ts
@@ -1,0 +1,146 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { type ExerciseEntry } from '@pu-stats/models';
+import { AdminUser } from './admin-page.models';
+import { CallableFunctionsService } from './callable-functions.service';
+import {
+  CallableRecord,
+  createCallablesMock,
+} from './callable-functions.testing';
+import { UserEntriesDialogComponent } from './user-entries-dialog.component';
+
+const { callablesMock, setupCallables } = createCallablesMock();
+
+describe('UserEntriesDialogComponent', () => {
+  let fixture: ComponentFixture<UserEntriesDialogComponent>;
+  let component: UserEntriesDialogComponent;
+  let dialogOpenSpy: ReturnType<typeof vi.spyOn>;
+
+  const user: AdminUser = {
+    uid: 'user-1',
+    displayName: 'Alice',
+    email: 'alice@example.com',
+    anonymous: false,
+    entryCount: 2,
+    lastEntry: '2026-04-02T08:00:00.000Z',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    role: null,
+  };
+
+  const entry: ExerciseEntry = {
+    _id: 'e1',
+    userId: 'user-1',
+    exerciseId: 'legs.squats',
+    timestamp: '2026-04-01T10:00:00.000Z',
+    reps: 30,
+    source: 'web',
+  };
+
+  function stubDialogRef<T>(result: T): MatDialogRef<unknown, T> {
+    return { afterClosed: () => of(result) } as MatDialogRef<unknown, T>;
+  }
+
+  async function createComponent(
+    entries: ExerciseEntry[] = [entry],
+    extraCallables: CallableRecord[] = []
+  ): Promise<void> {
+    setupCallables([
+      { name: 'adminListUserEntries', impl: async () => ({ data: entries }) },
+      ...extraCallables,
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [UserEntriesDialogComponent, MatDialogModule],
+      providers: [
+        { provide: CallableFunctionsService, useValue: callablesMock },
+        { provide: MAT_DIALOG_DATA, useValue: { user } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserEntriesDialogComponent);
+    component = fixture.componentInstance;
+    dialogOpenSpy = vi.spyOn(
+      fixture.debugElement.injector.get(MatDialog),
+      'open'
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should load the user entries via the adminListUserEntries callable', async () => {
+    // given / when
+    await createComponent();
+
+    // then
+    expect(callablesMock.call).toHaveBeenCalledWith('adminListUserEntries');
+    expect(component.entries().length).toBe(1);
+  });
+
+  it('should render a row per entry', async () => {
+    // given / when
+    await createComponent();
+
+    // then
+    const rows = fixture.nativeElement.querySelectorAll('mat-row');
+    expect(rows.length).toBe(1);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Kniebeugen');
+  });
+
+  it('should show the empty message when the user has no entries', async () => {
+    // given / when
+    await createComponent([]);
+
+    // then
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Keine Einträge');
+  });
+
+  it('should patch an entry via adminUpdateUserEntry and update the local row', async () => {
+    // given
+    const updateSpy = vi.fn(async () => ({ data: { ok: true } }));
+    await createComponent(
+      [entry],
+      [{ name: 'adminUpdateUserEntry', impl: updateSpy }]
+    );
+    dialogOpenSpy.mockReturnValue(stubDialogRef({ reps: 45 }));
+
+    // when
+    await component.openEditDialog(entry);
+
+    // then
+    expect(updateSpy).toHaveBeenCalledWith({
+      uid: 'user-1',
+      entryId: 'e1',
+      patch: { reps: 45 },
+    });
+    expect(component.entries()[0].reps).toBe(45);
+  });
+
+  it('should not call the update callable when the edit dialog is dismissed', async () => {
+    // given
+    const updateSpy = vi.fn(async () => ({ data: { ok: true } }));
+    await createComponent(
+      [entry],
+      [{ name: 'adminUpdateUserEntry', impl: updateSpy }]
+    );
+    dialogOpenSpy.mockReturnValue(stubDialogRef(undefined));
+
+    // when
+    await component.openEditDialog(entry);
+
+    // then
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app/admin/user-entries-dialog.component.ts
+++ b/web/src/app/admin/user-entries-dialog.component.ts
@@ -1,0 +1,135 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { firstValueFrom } from 'rxjs';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogModule,
+} from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { type ExerciseEntry } from '@pu-stats/models';
+import { CallableFunctionsService } from './callable-functions.service';
+import { AdminEntryEditDialogComponent } from './entry-edit-dialog.component';
+import { AdminUser } from './admin-page.models';
+import { errorMessage } from './admin-page.helpers';
+import {
+  adminEntrySortValue,
+  entryExerciseName,
+  entryValueDisplay,
+} from './user-entries.helpers';
+
+export interface UserEntriesDialogData {
+  user: AdminUser;
+}
+
+/**
+ * Admin drill-down into one user's exercise entries. Reads through the
+ * `adminListUserEntries` callable (client Firestore rules scope reads to
+ * the owner), renders a sortable table, and opens
+ * {@link AdminEntryEditDialogComponent} per row to patch an entry via
+ * `adminUpdateUserEntry`.
+ */
+@Component({
+  selector: 'app-user-entries-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DatePipe,
+    MatButtonModule,
+    MatDialogModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatSortModule,
+    MatTableModule,
+    MatTooltipModule,
+  ],
+  templateUrl: './user-entries-dialog.component.html',
+  styleUrl: './user-entries-dialog.component.scss',
+})
+export class UserEntriesDialogComponent {
+  private readonly data = inject<UserEntriesDialogData>(MAT_DIALOG_DATA);
+  private readonly callables = inject(CallableFunctionsService);
+  private readonly dialog = inject(MatDialog);
+
+  readonly user = this.data.user;
+  readonly displayedColumns = [
+    'timestamp',
+    'exercise',
+    'value',
+    'source',
+    'actions',
+  ];
+  readonly editTooltip = $localize`:@@admin.entry.editTooltip:Eintrag bearbeiten`;
+  readonly refreshTooltip = $localize`:@@admin.entries.refresh:Neu laden`;
+
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly entries = signal<ExerciseEntry[]>([]);
+
+  readonly dataSource = new MatTableDataSource<ExerciseEntry>([]);
+  private readonly sort = viewChild<MatSort>('entriesSort');
+
+  readonly exerciseName = entryExerciseName;
+  readonly valueDisplay = entryValueDisplay;
+
+  constructor() {
+    this.dataSource.sortingDataAccessor = adminEntrySortValue;
+    effect(() => {
+      this.dataSource.data = this.entries();
+    });
+    effect(() => {
+      const s = this.sort();
+      if (s) this.dataSource.sort = s;
+    });
+    this.loadEntries();
+  }
+
+  async loadEntries(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const fn = this.callables.call<{ uid: string }, ExerciseEntry[]>(
+        'adminListUserEntries'
+      );
+      const result = await fn({ uid: this.user.uid });
+      this.entries.set(result.data);
+    } catch (err) {
+      this.error.set(errorMessage(err));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async openEditDialog(entry: ExerciseEntry): Promise<void> {
+    const ref = this.dialog.open(AdminEntryEditDialogComponent, {
+      data: entry,
+      width: 'min(92vw, 420px)',
+      maxWidth: '92vw',
+    });
+    const patch = await firstValueFrom(ref.afterClosed());
+    if (!patch) return;
+
+    try {
+      const fn = this.callables.call('adminUpdateUserEntry');
+      await fn({ uid: this.user.uid, entryId: entry._id, patch });
+      this.entries.update((list) =>
+        list.map((e) =>
+          e._id === entry._id ? ({ ...e, ...patch } as ExerciseEntry) : e
+        )
+      );
+    } catch (err) {
+      this.error.set(errorMessage(err));
+    }
+  }
+}

--- a/web/src/app/admin/user-entries.helpers.spec.ts
+++ b/web/src/app/admin/user-entries.helpers.spec.ts
@@ -67,6 +67,14 @@ describe('user-entries.helpers', () => {
       );
     });
 
+    it('should normalise a malformed timestamp to 0', () => {
+      // given
+      const entry = repsEntry({ timestamp: 'not-a-date' });
+
+      // when / then — NaN would make MatSort unstable
+      expect(adminEntrySortValue(entry, 'timestamp')).toBe(0);
+    });
+
     it('should sort value by the primary measurement number', () => {
       // given / when / then
       expect(adminEntrySortValue(repsEntry({ reps: 42 }), 'value')).toBe(42);

--- a/web/src/app/admin/user-entries.helpers.spec.ts
+++ b/web/src/app/admin/user-entries.helpers.spec.ts
@@ -1,0 +1,144 @@
+import { type ExerciseEntry } from '@pu-stats/models';
+import {
+  adminEntrySortValue,
+  buildEntryPatch,
+  companionField,
+  primaryValue,
+} from './user-entries.helpers';
+
+function repsEntry(overrides: Partial<ExerciseEntry> = {}): ExerciseEntry {
+  return {
+    _id: 'e1',
+    userId: 'u1',
+    exerciseId: 'legs.squats',
+    timestamp: '2026-04-01T10:00:00.000Z',
+    reps: 30,
+    source: 'web',
+    ...overrides,
+  };
+}
+
+function runningEntry(overrides: Partial<ExerciseEntry> = {}): ExerciseEntry {
+  return {
+    _id: 'e2',
+    userId: 'u1',
+    exerciseId: 'cardio.running',
+    timestamp: '2026-04-02T08:00:00.000Z',
+    distanceM: 5000,
+    durationSec: 1500,
+    source: 'web',
+    ...overrides,
+  };
+}
+
+describe('user-entries.helpers', () => {
+  describe('primaryValue', () => {
+    it('should read the measurement value field for a known exercise', () => {
+      // given / when / then
+      expect(primaryValue(repsEntry())).toBe(30);
+      expect(primaryValue(runningEntry())).toBe(5000);
+    });
+
+    it('should fall back to a raw value for an unknown exercise', () => {
+      // given
+      const entry = repsEntry({ exerciseId: 'gone.forever', reps: 7 });
+
+      // when / then
+      expect(primaryValue(entry)).toBe(7);
+    });
+  });
+
+  describe('companionField', () => {
+    it('should report durationSec for distance-time and none for reps', () => {
+      // given / when / then
+      expect(companionField(runningEntry())).toBe('durationSec');
+      expect(companionField(repsEntry())).toBeUndefined();
+    });
+  });
+
+  describe('adminEntrySortValue', () => {
+    it('should sort timestamp as an epoch number', () => {
+      // given
+      const entry = repsEntry({ timestamp: '2026-04-01T10:00:00.000Z' });
+
+      // when / then
+      expect(adminEntrySortValue(entry, 'timestamp')).toBe(
+        new Date('2026-04-01T10:00:00.000Z').getTime()
+      );
+    });
+
+    it('should sort value by the primary measurement number', () => {
+      // given / when / then
+      expect(adminEntrySortValue(repsEntry({ reps: 42 }), 'value')).toBe(42);
+    });
+
+    it('should sort source case-insensitively', () => {
+      // given / when / then
+      expect(
+        adminEntrySortValue(repsEntry({ source: 'ANDROID' }), 'source')
+      ).toBe('android');
+    });
+  });
+
+  describe('buildEntryPatch', () => {
+    it('should return null when nothing changed', () => {
+      // given
+      const entry = repsEntry();
+
+      // when
+      const patch = buildEntryPatch(entry, {
+        timestamp: entry.timestamp,
+        value: entry.reps ?? null,
+        companion: null,
+      });
+
+      // then
+      expect(patch).toBeNull();
+    });
+
+    it('should patch only the changed timestamp', () => {
+      // given
+      const entry = repsEntry();
+
+      // when
+      const patch = buildEntryPatch(entry, {
+        timestamp: '2026-05-01T09:00:00.000Z',
+        value: entry.reps ?? null,
+        companion: null,
+      });
+
+      // then
+      expect(patch).toEqual({ timestamp: '2026-05-01T09:00:00.000Z' });
+    });
+
+    it('should patch the primary value into the measurement field', () => {
+      // given
+      const entry = repsEntry();
+
+      // when
+      const patch = buildEntryPatch(entry, {
+        timestamp: entry.timestamp,
+        value: 45,
+        companion: null,
+      });
+
+      // then
+      expect(patch).toEqual({ reps: 45 });
+    });
+
+    it('should patch the companion field for a distance-time entry', () => {
+      // given
+      const entry = runningEntry();
+
+      // when
+      const patch = buildEntryPatch(entry, {
+        timestamp: entry.timestamp,
+        value: entry.distanceM ?? null,
+        companion: 1600,
+      });
+
+      // then
+      expect(patch).toEqual({ durationSec: 1600 });
+    });
+  });
+});

--- a/web/src/app/admin/user-entries.helpers.ts
+++ b/web/src/app/admin/user-entries.helpers.ts
@@ -50,7 +50,11 @@ export function entryValueDisplay(entry: ExerciseEntry): string {
   return formatEntryDisplay(entry, def);
 }
 
-/** Raw primary measurement value, or 0 when the exercise is unknown. */
+/**
+ * Raw primary measurement value. For an unknown/stale exercise id (no
+ * catalog definition) it falls back to the first present numeric field
+ * (`reps` → `durationSec` → `distanceM`), or 0 when none is set.
+ */
 export function primaryValue(entry: ExerciseEntry): number {
   const def = findExerciseDefinition(entry.exerciseId);
   if (!def) return entry.reps ?? entry.durationSec ?? entry.distanceM ?? 0;

--- a/web/src/app/admin/user-entries.helpers.ts
+++ b/web/src/app/admin/user-entries.helpers.ts
@@ -1,0 +1,107 @@
+import {
+  type ExerciseEntry,
+  findExerciseDefinition,
+  formatEntryDisplay,
+  measurementCompanionValueField,
+  measurementValueField,
+} from '@pu-stats/models';
+import { exerciseDisplayName } from '../stats/i18n/exercise-display-names';
+
+type SortValue = string | number;
+
+/**
+ * Sort accessor for the admin per-user entry table. `timestamp` sorts
+ * chronologically (ISO strings order lexicographically, but the numeric
+ * epoch keeps parity with the user-list accessor), `exercise` by
+ * localized name, `value` by the primary measurement number, `source`
+ * alphabetically.
+ */
+export function adminEntrySortValue(
+  entry: ExerciseEntry,
+  property: string
+): SortValue {
+  switch (property) {
+    case 'timestamp':
+      return entry.timestamp ? new Date(entry.timestamp).getTime() : 0;
+    case 'exercise':
+      return entryExerciseName(entry).toLowerCase();
+    case 'value':
+      return primaryValue(entry);
+    case 'source':
+      return (entry.source ?? '').toLowerCase();
+    default:
+      return '';
+  }
+}
+
+/** Localized exercise name, falling back to the raw id for stale entries. */
+export function entryExerciseName(entry: ExerciseEntry): string {
+  return exerciseDisplayName(entry.exerciseId);
+}
+
+/**
+ * Human-readable value for a row (e.g. `30`, `5.00 km · 25:00 (5:00 /km)`).
+ * Uses the catalog definition; falls back to the raw primary number when
+ * the exercise id no longer resolves.
+ */
+export function entryValueDisplay(entry: ExerciseEntry): string {
+  const def = findExerciseDefinition(entry.exerciseId);
+  if (!def) return String(primaryValue(entry));
+  return formatEntryDisplay(entry, def);
+}
+
+/** Raw primary measurement value, or 0 when the exercise is unknown. */
+export function primaryValue(entry: ExerciseEntry): number {
+  const def = findExerciseDefinition(entry.exerciseId);
+  if (!def) return entry.reps ?? entry.durationSec ?? entry.distanceM ?? 0;
+  const field = measurementValueField(def.measurement);
+  return (entry[field] as number | undefined) ?? 0;
+}
+
+/** Companion value field for an entry, or `undefined` when it has none. */
+export function companionField(
+  entry: ExerciseEntry
+): 'durationSec' | 'weightKg' | undefined {
+  const def = findExerciseDefinition(entry.exerciseId);
+  if (!def) return undefined;
+  const companion = measurementCompanionValueField(def.measurement);
+  if (companion === 'durationSec') return 'durationSec';
+  if (def.measurement === 'weight') return 'weightKg';
+  return undefined;
+}
+
+export interface AdminEntryEditForm {
+  timestamp: string;
+  value: number | null;
+  companion: number | null;
+}
+
+/**
+ * Diffs the edit-form values against the original entry and returns the
+ * minimal patch of changed fields, or `null` when nothing changed. Keeps
+ * the callable payload small and avoids no-op writes that would bump
+ * `updatedAt` and re-trigger aggregates for nothing.
+ */
+export function buildEntryPatch(
+  entry: ExerciseEntry,
+  form: AdminEntryEditForm
+): Record<string, unknown> | null {
+  const patch: Record<string, unknown> = {};
+  if (form.timestamp && form.timestamp !== entry.timestamp) {
+    patch['timestamp'] = form.timestamp;
+  }
+  const def = findExerciseDefinition(entry.exerciseId);
+  if (def && form.value !== null) {
+    const field = measurementValueField(def.measurement);
+    if (form.value !== (entry[field] as number | undefined)) {
+      patch[field] = form.value;
+    }
+  }
+  const companion = companionField(entry);
+  if (companion && form.companion !== null) {
+    if (form.companion !== (entry[companion] as number | undefined)) {
+      patch[companion] = form.companion;
+    }
+  }
+  return Object.keys(patch).length > 0 ? patch : null;
+}

--- a/web/src/app/admin/user-entries.helpers.ts
+++ b/web/src/app/admin/user-entries.helpers.ts
@@ -21,8 +21,13 @@ export function adminEntrySortValue(
   property: string
 ): SortValue {
   switch (property) {
-    case 'timestamp':
-      return entry.timestamp ? new Date(entry.timestamp).getTime() : 0;
+    case 'timestamp': {
+      // Normalise a missing or malformed timestamp to 0 — `getTime()` returns
+      // NaN for an unparseable value, and NaN comparisons make MatSort's order
+      // unstable.
+      const time = entry.timestamp ? new Date(entry.timestamp).getTime() : 0;
+      return Number.isNaN(time) ? 0 : time;
+    }
     case 'exercise':
       return entryExerciseName(entry).toLowerCase();
     case 'value':

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10180,5 +10180,119 @@
         <target>Καταχωρήσεις</target>
       </segment>
     </unit>
+    <unit id="admin.user.entriesTooltip">
+      <segment state="initial">
+        <source>Einträge anzeigen</source>
+        <target>Einträge anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="admin.row.entriesAria">
+      <segment state="initial">
+        <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
+        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.title">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.staleExercise">
+      <segment state="initial">
+        <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
+        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.save">
+      <segment state="initial">
+        <source> Speichern </source>
+        <target> Speichern </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.duration">
+      <segment state="initial">
+        <source>Dauer (s)</source>
+        <target>Dauer (s)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.weight">
+      <segment state="initial">
+        <source>Gewicht (kg)</source>
+        <target>Gewicht (kg)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.title">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.empty">
+      <segment state="initial">
+        <source> Keine Einträge vorhanden. </source>
+        <target> Keine Einträge vorhanden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.exercise">
+      <segment state="initial">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.source">
+      <segment state="initial">
+        <source>Quelle</source>
+        <target>Quelle</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.close">
+      <segment state="initial">
+        <source> Schließen </source>
+        <target> Schließen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.editTooltip">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.refresh">
+      <segment state="initial">
+        <source>Neu laden</source>
+        <target>Neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10379,5 +10379,119 @@ Deine Position: # ·  Reps        </source>
         <target>Entries</target>
       </segment>
     </unit>
+    <unit id="admin.user.entriesTooltip">
+      <segment state="initial">
+        <source>Einträge anzeigen</source>
+        <target>Einträge anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="admin.row.entriesAria">
+      <segment state="initial">
+        <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
+        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.title">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.staleExercise">
+      <segment state="initial">
+        <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
+        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.save">
+      <segment state="initial">
+        <source> Speichern </source>
+        <target> Speichern </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.duration">
+      <segment state="initial">
+        <source>Dauer (s)</source>
+        <target>Dauer (s)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.weight">
+      <segment state="initial">
+        <source>Gewicht (kg)</source>
+        <target>Gewicht (kg)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.title">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.empty">
+      <segment state="initial">
+        <source> Keine Einträge vorhanden. </source>
+        <target> Keine Einträge vorhanden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.exercise">
+      <segment state="initial">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.source">
+      <segment state="initial">
+        <source>Quelle</source>
+        <target>Quelle</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.close">
+      <segment state="initial">
+        <source> Schließen </source>
+        <target> Schließen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.editTooltip">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.refresh">
+      <segment state="initial">
+        <source>Neu laden</source>
+        <target>Neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10176,5 +10176,119 @@
         <target>Entradas</target>
       </segment>
     </unit>
+    <unit id="admin.user.entriesTooltip">
+      <segment state="initial">
+        <source>Einträge anzeigen</source>
+        <target>Einträge anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="admin.row.entriesAria">
+      <segment state="initial">
+        <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
+        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.title">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.staleExercise">
+      <segment state="initial">
+        <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
+        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.save">
+      <segment state="initial">
+        <source> Speichern </source>
+        <target> Speichern </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.duration">
+      <segment state="initial">
+        <source>Dauer (s)</source>
+        <target>Dauer (s)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.weight">
+      <segment state="initial">
+        <source>Gewicht (kg)</source>
+        <target>Gewicht (kg)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.title">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.empty">
+      <segment state="initial">
+        <source> Keine Einträge vorhanden. </source>
+        <target> Keine Einträge vorhanden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.exercise">
+      <segment state="initial">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.source">
+      <segment state="initial">
+        <source>Quelle</source>
+        <target>Quelle</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.close">
+      <segment state="initial">
+        <source> Schließen </source>
+        <target> Schließen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.editTooltip">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.refresh">
+      <segment state="initial">
+        <source>Neu laden</source>
+        <target>Neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10052,5 +10052,119 @@
         <target>Entrées</target>
       </segment>
     </unit>
+    <unit id="admin.user.entriesTooltip">
+      <segment state="initial">
+        <source>Einträge anzeigen</source>
+        <target>Einträge anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="admin.row.entriesAria">
+      <segment state="initial">
+        <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
+        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.title">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.staleExercise">
+      <segment state="initial">
+        <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
+        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.save">
+      <segment state="initial">
+        <source> Speichern </source>
+        <target> Speichern </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.duration">
+      <segment state="initial">
+        <source>Dauer (s)</source>
+        <target>Dauer (s)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.weight">
+      <segment state="initial">
+        <source>Gewicht (kg)</source>
+        <target>Gewicht (kg)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.title">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.empty">
+      <segment state="initial">
+        <source> Keine Einträge vorhanden. </source>
+        <target> Keine Einträge vorhanden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.exercise">
+      <segment state="initial">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.source">
+      <segment state="initial">
+        <source>Quelle</source>
+        <target>Quelle</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.close">
+      <segment state="initial">
+        <source> Schließen </source>
+        <target> Schließen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.editTooltip">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.refresh">
+      <segment state="initial">
+        <source>Neu laden</source>
+        <target>Neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10180,5 +10180,119 @@
         <target>Immissioni</target>
       </segment>
     </unit>
+    <unit id="admin.user.entriesTooltip">
+      <segment state="initial">
+        <source>Einträge anzeigen</source>
+        <target>Einträge anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="admin.row.entriesAria">
+      <segment state="initial">
+        <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
+        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.title">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.staleExercise">
+      <segment state="initial">
+        <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
+        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.save">
+      <segment state="initial">
+        <source> Speichern </source>
+        <target> Speichern </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.duration">
+      <segment state="initial">
+        <source>Dauer (s)</source>
+        <target>Dauer (s)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.weight">
+      <segment state="initial">
+        <source>Gewicht (kg)</source>
+        <target>Gewicht (kg)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.title">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.empty">
+      <segment state="initial">
+        <source> Keine Einträge vorhanden. </source>
+        <target> Keine Einträge vorhanden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.exercise">
+      <segment state="initial">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.source">
+      <segment state="initial">
+        <source>Quelle</source>
+        <target>Quelle</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.close">
+      <segment state="initial">
+        <source> Schließen </source>
+        <target> Schließen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.editTooltip">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.refresh">
+      <segment state="initial">
+        <source>Neu laden</source>
+        <target>Neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10180,5 +10180,119 @@
         <target>Invoeren</target>
       </segment>
     </unit>
+    <unit id="admin.user.entriesTooltip">
+      <segment state="initial">
+        <source>Einträge anzeigen</source>
+        <target>Einträge anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="admin.row.entriesAria">
+      <segment state="initial">
+        <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
+        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.title">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.staleExercise">
+      <segment state="initial">
+        <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
+        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.save">
+      <segment state="initial">
+        <source> Speichern </source>
+        <target> Speichern </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.duration">
+      <segment state="initial">
+        <source>Dauer (s)</source>
+        <target>Dauer (s)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.weight">
+      <segment state="initial">
+        <source>Gewicht (kg)</source>
+        <target>Gewicht (kg)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.title">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.empty">
+      <segment state="initial">
+        <source> Keine Einträge vorhanden. </source>
+        <target> Keine Einträge vorhanden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.exercise">
+      <segment state="initial">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.source">
+      <segment state="initial">
+        <source>Quelle</source>
+        <target>Quelle</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.close">
+      <segment state="initial">
+        <source> Schließen </source>
+        <target> Schließen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.editTooltip">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.refresh">
+      <segment state="initial">
+        <source>Neu laden</source>
+        <target>Neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9473,5 +9473,119 @@ Deine Position: # ·  Reps        </source>
         <target>Oppføringer</target>
       </segment>
     </unit>
+    <unit id="admin.user.entriesTooltip">
+      <segment state="initial">
+        <source>Einträge anzeigen</source>
+        <target>Einträge anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="admin.row.entriesAria">
+      <segment state="initial">
+        <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
+        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.title">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.staleExercise">
+      <segment state="initial">
+        <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
+        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.save">
+      <segment state="initial">
+        <source> Speichern </source>
+        <target> Speichern </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.duration">
+      <segment state="initial">
+        <source>Dauer (s)</source>
+        <target>Dauer (s)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.weight">
+      <segment state="initial">
+        <source>Gewicht (kg)</source>
+        <target>Gewicht (kg)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.title">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.empty">
+      <segment state="initial">
+        <source> Keine Einträge vorhanden. </source>
+        <target> Keine Einträge vorhanden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.exercise">
+      <segment state="initial">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.source">
+      <segment state="initial">
+        <source>Quelle</source>
+        <target>Quelle</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.close">
+      <segment state="initial">
+        <source> Schließen </source>
+        <target> Schließen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.editTooltip">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.refresh">
+      <segment state="initial">
+        <source>Neu laden</source>
+        <target>Neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2728,7 +2728,7 @@
     <unit id="admin.refresh">
       <notes>
         <note category="location">web/src/app/admin/admin-feedback-section.component.ts:49</note>
-        <note category="location">web/src/app/admin/admin-page.component.ts:76</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:77</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -2921,7 +2921,7 @@
     </unit>
     <unit id="admin.col.anonTooltip">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:77</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:78</note>
       </notes>
       <segment>
         <source>Anonym</source>
@@ -2929,15 +2929,31 @@
     </unit>
     <unit id="admin.user.deleteTooltip">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:78</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:79</note>
       </notes>
       <segment>
         <source>Benutzer löschen</source>
       </segment>
     </unit>
+    <unit id="admin.user.entriesTooltip">
+      <notes>
+        <note category="location">web/src/app/admin/admin-page.component.ts:80</note>
+      </notes>
+      <segment>
+        <source>Einträge anzeigen</source>
+      </segment>
+    </unit>
+    <unit id="admin.row.entriesAria">
+      <notes>
+        <note category="location">web/src/app/admin/admin-page.component.ts:143</note>
+      </notes>
+      <segment>
+        <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
+      </segment>
+    </unit>
     <unit id="admin.row.detailsAria">
       <notes>
-        <note category="location">web/src/app/admin/admin-page.component.ts:133</note>
+        <note category="location">web/src/app/admin/admin-page.component.ts:148</note>
       </notes>
       <segment>
         <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier"/></source>
@@ -3013,6 +3029,70 @@
       </notes>
       <segment>
         <source> Löschen </source>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.title">
+      <notes>
+        <note category="location">web/src/app/admin/entry-edit-dialog.component.ts:45,46</note>
+      </notes>
+      <segment>
+        <source>Eintrag bearbeiten</source>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.timestamp">
+      <notes>
+        <note category="location">web/src/app/admin/entry-edit-dialog.component.ts:50,52</note>
+      </notes>
+      <segment>
+        <source>Zeitpunkt</source>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.value">
+      <notes>
+        <note category="location">web/src/app/admin/entry-edit-dialog.component.ts:61,63</note>
+      </notes>
+      <segment>
+        <source>Wert</source>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.staleExercise">
+      <notes>
+        <note category="location">web/src/app/admin/entry-edit-dialog.component.ts:84,87</note>
+      </notes>
+      <segment>
+        <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.cancel">
+      <notes>
+        <note category="location">web/src/app/admin/entry-edit-dialog.component.ts:90,93</note>
+      </notes>
+      <segment>
+        <source> Abbrechen </source>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.save">
+      <notes>
+        <note category="location">web/src/app/admin/entry-edit-dialog.component.ts:99,101</note>
+      </notes>
+      <segment>
+        <source> Speichern </source>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.duration">
+      <notes>
+        <note category="location">web/src/app/admin/entry-edit-dialog.component.ts:135</note>
+      </notes>
+      <segment>
+        <source>Dauer (s)</source>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.weight">
+      <notes>
+        <note category="location">web/src/app/admin/entry-edit-dialog.component.ts:136</note>
+      </notes>
+      <segment>
+        <source>Gewicht (kg)</source>
       </segment>
     </unit>
     <unit id="admin.migrations.status.completed">
@@ -3223,6 +3303,78 @@
       </notes>
       <segment>
         <source> Schließen </source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.title">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-dialog.component.html:1,2</note>
+      </notes>
+      <segment>
+        <source>Einträge</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.empty">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-dialog.component.html:25,28</note>
+      </notes>
+      <segment>
+        <source> Keine Einträge vorhanden. </source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.timestamp">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-dialog.component.html:35,37</note>
+      </notes>
+      <segment>
+        <source>Zeitpunkt</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.exercise">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-dialog.component.html:47,49</note>
+      </notes>
+      <segment>
+        <source>Übung</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.value">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-dialog.component.html:57,59</note>
+      </notes>
+      <segment>
+        <source>Wert</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.source">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-dialog.component.html:67,69</note>
+      </notes>
+      <segment>
+        <source>Quelle</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.close">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-dialog.component.html:94,96</note>
+      </notes>
+      <segment>
+        <source> Schließen </source>
+      </segment>
+    </unit>
+    <unit id="admin.entry.editTooltip">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-dialog.component.ts:67</note>
+      </notes>
+      <segment>
+        <source>Eintrag bearbeiten</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.refresh">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-dialog.component.ts:68</note>
+      </notes>
+      <segment>
+        <source>Neu laden</source>
       </segment>
     </unit>
     <unit id="app.title">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9686,5 +9686,119 @@
         <target>记录</target>
       </segment>
     </unit>
+    <unit id="admin.user.entriesTooltip">
+      <segment state="initial">
+        <source>Einträge anzeigen</source>
+        <target>Einträge anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="admin.row.entriesAria">
+      <segment state="initial">
+        <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
+        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.title">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.staleExercise">
+      <segment state="initial">
+        <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
+        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.save">
+      <segment state="initial">
+        <source> Speichern </source>
+        <target> Speichern </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.duration">
+      <segment state="initial">
+        <source>Dauer (s)</source>
+        <target>Dauer (s)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.edit.weight">
+      <segment state="initial">
+        <source>Gewicht (kg)</source>
+        <target>Gewicht (kg)</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.title">
+      <segment state="initial">
+        <source>Einträge</source>
+        <target>Einträge</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.empty">
+      <segment state="initial">
+        <source> Keine Einträge vorhanden. </source>
+        <target> Keine Einträge vorhanden. </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.timestamp">
+      <segment state="initial">
+        <source>Zeitpunkt</source>
+        <target>Zeitpunkt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.exercise">
+      <segment state="initial">
+        <source>Übung</source>
+        <target>Übung</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.value">
+      <segment state="initial">
+        <source>Wert</source>
+        <target>Wert</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.source">
+      <segment state="initial">
+        <source>Quelle</source>
+        <target>Quelle</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.close">
+      <segment state="initial">
+        <source> Schließen </source>
+        <target> Schließen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.editTooltip">
+      <segment state="initial">
+        <source>Eintrag bearbeiten</source>
+        <target>Eintrag bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.refresh">
+      <segment state="initial">
+        <source>Neu laden</source>
+        <target>Neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>


### PR DESCRIPTION
## Was

Der Admin-Bereich kann jetzt die **Trainingseinträge eines einzelnen Benutzers ansehen, sortieren und bearbeiten**.

In der Benutzertabelle gibt es pro Zeile eine neue Aktion **„Einträge"** (`list_alt`). Sie öffnet einen Dialog mit einer sortierbaren Material-Tabelle der `exerciseEntries` des Benutzers (Zeitpunkt, Übung, Wert, Quelle). Über die Bearbeiten-Aktion pro Zeile lässt sich ein Eintrag anpassen.

## Warum über Cloud Functions

Die `firestore.rules` beschränken Client-Zugriffe auf `exerciseEntries` auf den jeweiligen Eigentümer (`userId == request.auth.uid`). Ein Admin, der fremde Einträge liest/ändert, muss daher über das Admin SDK gehen. Dafür zwei neue Callables:

- **`adminListUserEntries`** — liest die Einträge eines Benutzers (neueste zuerst, gedeckelt auf max. 2000).
- **`adminUpdateUserEntry`** — patcht einen Eintrag. Prüft, dass der Eintrag zum Ziel-`uid` gehört, validiert den Patch gegen die Katalog-Definition (`validateExerciseEntry`, partial) und hält `exerciseId` unveränderlich (eine andere Übung ist ein Delete + Create, damit der Per-Exercise-Stats-Trigger korrekt dekrementiert).

Die bestehenden Trigger `updateExerciseStatsOnEntryWrite` und `updateAdminUserActivityOnEntryWrite` halten die Aggregate nach einem Edit automatisch konsistent — kein zusätzlicher Aggregat-Code nötig.

## Änderungen

**Backend**
- `admin/user-entries.ts` — reine Payload-Validierung (`validateListUserEntriesPayload`, `validateUpdateUserEntryPayload`) + Tests.
- `functions-admin-user-entries.ts` — die beiden Callables; in `index.ts` exportiert.

**Frontend**
- `user-entries-dialog.component.*` — sortierbare Tabelle, lädt über den Callable.
- `entry-edit-dialog.component.ts` — fokussierter Edit-Dialog (Zeitpunkt, primärer Messwert + ggf. Companion wie Dauer/Gewicht); Client-seitige Validierung gated „Speichern". Bei einer im Katalog nicht mehr auflösbaren `exerciseId` bleibt nur der Zeitpunkt editierbar.
- `user-entries.helpers.ts` — Sort-Accessor, Anzeige-Helfer, minimaler Patch-Diff.
- Admin-Seite: neue „Einträge"-Aktion + `openEntriesDialog`.

**Tests**
- Neue Specs für die Backend-Validierung, die Frontend-Helper und beide Dialoge; bestehende `admin-page`-Spec um die neue Aktion erweitert.
- `cloud-functions`: 430 Tests grün. Web-Admin-Specs grün. `web:build -c production` grün.

**i18n**
- 19 neue Strings extrahiert und via `sync-xliff-locales.mjs` als Fallback in alle Ziel-Locales übertragen (die Übersetzungs-Routine ersetzt sie später).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBPTZ5ZnGxm26jAJ3mycCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBPTZ5ZnGxm26jAJ3mycCN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin “Entries” dialog to browse a user’s exercise history with sorting, refresh, and empty/error states.
  * Added per-row editing in a dedicated dialog (timestamp plus supported value fields like reps, duration, weight), including handling for stale/unknown exercises.
* **Accessibility & Localization**
  * Added localized tooltips and ARIA labels for entries actions and edit dialogs.
* **Tests**
  * Added validation and UI tests covering listing, sorting, editing, and update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->