### PR TITLE
chore(i18n): fill missing translations (152 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10291,7 +10291,7 @@
     <unit id="admin.entries.refresh">
       <segment state="translated">
         <source>Neu laden</source>
-        <target>Ανανέωση</target>
+        <target>Επαναφόρτωση</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10181,117 +10181,117 @@
       </segment>
     </unit>
     <unit id="admin.user.entriesTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen</source>
-        <target>Einträge anzeigen</target>
+        <target>Εμφάνιση καταχωρήσεων</target>
       </segment>
     </unit>
     <unit id="admin.row.entriesAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <target>Εμφάνιση καταχωρήσεων για <ph id="0" equiv="identifier" disp="identifier"/></target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Επεξεργασία καταχώρησης</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Χρονική στιγμή</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Τιμή</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.staleExercise">
-      <segment state="initial">
+      <segment state="translated">
         <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
-        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+        <target> Άγνωστη άσκηση – μπορεί να επεξεργαστεί μόνο η χρονική στιγμή. </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Ακύρωση </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Speichern </source>
-        <target> Speichern </target>
+        <target> Αποθήκευση </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.duration">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dauer (s)</source>
-        <target>Dauer (s)</target>
+        <target>Διάρκεια (δευτ.)</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.weight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gewicht (kg)</source>
-        <target>Gewicht (kg)</target>
+        <target>Βάρος (κιλά)</target>
       </segment>
     </unit>
     <unit id="admin.entries.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Καταχωρήσεις</target>
       </segment>
     </unit>
     <unit id="admin.entries.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Einträge vorhanden. </source>
-        <target> Keine Einträge vorhanden. </target>
+        <target> Δεν υπάρχουν καταχωρήσεις. </target>
       </segment>
     </unit>
     <unit id="admin.entries.col.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Χρονική στιγμή</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Άσκηση</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Τιμή</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.source">
-      <segment state="initial">
+      <segment state="translated">
         <source>Quelle</source>
-        <target>Quelle</target>
+        <target>Πηγή</target>
       </segment>
     </unit>
     <unit id="admin.entries.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Κλείσιμο </target>
       </segment>
     </unit>
     <unit id="admin.entry.editTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Επεξεργασία καταχώρησης</target>
       </segment>
     </unit>
     <unit id="admin.entries.refresh">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neu laden</source>
-        <target>Neu laden</target>
+        <target>Ανανέωση</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10380,117 +10380,117 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.user.entriesTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen</source>
-        <target>Einträge anzeigen</target>
+        <target>Show entries</target>
       </segment>
     </unit>
     <unit id="admin.row.entriesAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <target>Show entries for <ph id="0" equiv="identifier" disp="identifier"/></target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Edit entry</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Timestamp</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Value</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.staleExercise">
-      <segment state="initial">
+      <segment state="translated">
         <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
-        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+        <target> Unknown exercise – only the timestamp can be edited. </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Cancel </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Speichern </source>
-        <target> Speichern </target>
+        <target> Save </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.duration">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dauer (s)</source>
-        <target>Dauer (s)</target>
+        <target>Duration (s)</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.weight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gewicht (kg)</source>
-        <target>Gewicht (kg)</target>
+        <target>Weight (kg)</target>
       </segment>
     </unit>
     <unit id="admin.entries.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entries</target>
       </segment>
     </unit>
     <unit id="admin.entries.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Einträge vorhanden. </source>
-        <target> Keine Einträge vorhanden. </target>
+        <target> No entries yet. </target>
       </segment>
     </unit>
     <unit id="admin.entries.col.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Timestamp</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Exercise</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Value</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.source">
-      <segment state="initial">
+      <segment state="translated">
         <source>Quelle</source>
-        <target>Quelle</target>
+        <target>Source</target>
       </segment>
     </unit>
     <unit id="admin.entries.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Close </target>
       </segment>
     </unit>
     <unit id="admin.entry.editTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Edit entry</target>
       </segment>
     </unit>
     <unit id="admin.entries.refresh">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neu laden</source>
-        <target>Neu laden</target>
+        <target>Reload</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10287,7 +10287,7 @@
     <unit id="admin.entries.refresh">
       <segment state="translated">
         <source>Neu laden</source>
-        <target>Actualizar</target>
+        <target>Recargar</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10177,117 +10177,117 @@
       </segment>
     </unit>
     <unit id="admin.user.entriesTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen</source>
-        <target>Einträge anzeigen</target>
+        <target>Mostrar entradas</target>
       </segment>
     </unit>
     <unit id="admin.row.entriesAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <target>Mostrar entradas para <ph id="0" equiv="identifier" disp="identifier"/></target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Editar entrada</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Fecha y hora</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Valor</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.staleExercise">
-      <segment state="initial">
+      <segment state="translated">
         <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
-        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+        <target> Ejercicio desconocido: solo se puede editar la fecha y hora. </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Cancelar </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Speichern </source>
-        <target> Speichern </target>
+        <target> Guardar </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.duration">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dauer (s)</source>
-        <target>Dauer (s)</target>
+        <target>Duración (s)</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.weight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gewicht (kg)</source>
-        <target>Gewicht (kg)</target>
+        <target>Peso (kg)</target>
       </segment>
     </unit>
     <unit id="admin.entries.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entradas</target>
       </segment>
     </unit>
     <unit id="admin.entries.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Einträge vorhanden. </source>
-        <target> Keine Einträge vorhanden. </target>
+        <target> No hay entradas disponibles. </target>
       </segment>
     </unit>
     <unit id="admin.entries.col.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Fecha y hora</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Ejercicio</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Valor</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.source">
-      <segment state="initial">
+      <segment state="translated">
         <source>Quelle</source>
-        <target>Quelle</target>
+        <target>Fuente</target>
       </segment>
     </unit>
     <unit id="admin.entries.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Cerrar </target>
       </segment>
     </unit>
     <unit id="admin.entry.editTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Editar entrada</target>
       </segment>
     </unit>
     <unit id="admin.entries.refresh">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neu laden</source>
-        <target>Neu laden</target>
+        <target>Actualizar</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10053,117 +10053,117 @@
       </segment>
     </unit>
     <unit id="admin.user.entriesTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen</source>
-        <target>Einträge anzeigen</target>
+        <target>Afficher les entrées</target>
       </segment>
     </unit>
     <unit id="admin.row.entriesAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <target>Afficher les entrées pour <ph id="0" equiv="identifier" disp="identifier"/></target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Modifier l'entrée</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Horodatage</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Valeur</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.staleExercise">
-      <segment state="initial">
+      <segment state="translated">
         <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
-        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+        <target> Exercice inconnu – seul l'horodatage peut être modifié. </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Annuler </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Speichern </source>
-        <target> Speichern </target>
+        <target> Enregistrer </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.duration">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dauer (s)</source>
-        <target>Dauer (s)</target>
+        <target>Durée (s)</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.weight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gewicht (kg)</source>
-        <target>Gewicht (kg)</target>
+        <target>Poids (kg)</target>
       </segment>
     </unit>
     <unit id="admin.entries.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entrées</target>
       </segment>
     </unit>
     <unit id="admin.entries.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Einträge vorhanden. </source>
-        <target> Keine Einträge vorhanden. </target>
+        <target> Aucune entrée disponible. </target>
       </segment>
     </unit>
     <unit id="admin.entries.col.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Horodatage</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Exercice</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Valeur</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.source">
-      <segment state="initial">
+      <segment state="translated">
         <source>Quelle</source>
-        <target>Quelle</target>
+        <target>Source</target>
       </segment>
     </unit>
     <unit id="admin.entries.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Fermer </target>
       </segment>
     </unit>
     <unit id="admin.entry.editTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Modifier l'entrée</target>
       </segment>
     </unit>
     <unit id="admin.entries.refresh">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neu laden</source>
-        <target>Neu laden</target>
+        <target>Actualiser</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10163,7 +10163,7 @@
     <unit id="admin.entries.refresh">
       <segment state="translated">
         <source>Neu laden</source>
-        <target>Actualiser</target>
+        <target>Recharger</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10291,7 +10291,7 @@
     <unit id="admin.entries.refresh">
       <segment state="translated">
         <source>Neu laden</source>
-        <target>Aggiorna</target>
+        <target>Ricarica</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10181,117 +10181,117 @@
       </segment>
     </unit>
     <unit id="admin.user.entriesTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen</source>
-        <target>Einträge anzeigen</target>
+        <target>Mostra voci</target>
       </segment>
     </unit>
     <unit id="admin.row.entriesAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <target>Mostra voci per <ph id="0" equiv="identifier" disp="identifier"/></target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Modifica voce</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Data e ora</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Valore</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.staleExercise">
-      <segment state="initial">
+      <segment state="translated">
         <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
-        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+        <target> Esercizio sconosciuto – è possibile modificare solo la data e l'ora. </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Annulla </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Speichern </source>
-        <target> Speichern </target>
+        <target> Salva </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.duration">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dauer (s)</source>
-        <target>Dauer (s)</target>
+        <target>Durata (s)</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.weight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gewicht (kg)</source>
-        <target>Gewicht (kg)</target>
+        <target>Peso (kg)</target>
       </segment>
     </unit>
     <unit id="admin.entries.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Voci</target>
       </segment>
     </unit>
     <unit id="admin.entries.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Einträge vorhanden. </source>
-        <target> Keine Einträge vorhanden. </target>
+        <target> Nessuna voce disponibile. </target>
       </segment>
     </unit>
     <unit id="admin.entries.col.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Data e ora</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Esercizio</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Valore</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.source">
-      <segment state="initial">
+      <segment state="translated">
         <source>Quelle</source>
-        <target>Quelle</target>
+        <target>Fonte</target>
       </segment>
     </unit>
     <unit id="admin.entries.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Chiudi </target>
       </segment>
     </unit>
     <unit id="admin.entry.editTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Modifica voce</target>
       </segment>
     </unit>
     <unit id="admin.entries.refresh">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neu laden</source>
-        <target>Neu laden</target>
+        <target>Aggiorna</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10183,19 +10183,19 @@
     <unit id="admin.user.entriesTooltip">
       <segment state="translated">
         <source>Einträge anzeigen</source>
-        <target>Vermeldingen weergeven</target>
+        <target>Invoeren weergeven</target>
       </segment>
     </unit>
     <unit id="admin.row.entriesAria">
       <segment state="translated">
         <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Vermeldingen weergeven voor <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <target>Invoeren weergeven voor <ph id="0" equiv="identifier" disp="identifier"/></target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.title">
       <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Vermelding bewerken</target>
+        <target>Invoer bewerken</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.timestamp">
@@ -10243,13 +10243,13 @@
     <unit id="admin.entries.title">
       <segment state="translated">
         <source>Einträge</source>
-        <target>Vermeldingen</target>
+        <target>Invoeren</target>
       </segment>
     </unit>
     <unit id="admin.entries.empty">
       <segment state="translated">
         <source> Keine Einträge vorhanden. </source>
-        <target> Geen vermeldingen beschikbaar. </target>
+        <target> Geen invoeren beschikbaar. </target>
       </segment>
     </unit>
     <unit id="admin.entries.col.timestamp">
@@ -10285,7 +10285,7 @@
     <unit id="admin.entry.editTooltip">
       <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Vermelding bewerken</target>
+        <target>Invoer bewerken</target>
       </segment>
     </unit>
     <unit id="admin.entries.refresh">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10291,7 +10291,7 @@
     <unit id="admin.entries.refresh">
       <segment state="translated">
         <source>Neu laden</source>
-        <target>Vernieuwen</target>
+        <target>Herladen</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10181,117 +10181,117 @@
       </segment>
     </unit>
     <unit id="admin.user.entriesTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen</source>
-        <target>Einträge anzeigen</target>
+        <target>Vermeldingen weergeven</target>
       </segment>
     </unit>
     <unit id="admin.row.entriesAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <target>Vermeldingen weergeven voor <ph id="0" equiv="identifier" disp="identifier"/></target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Vermelding bewerken</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Tijdstip</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Waarde</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.staleExercise">
-      <segment state="initial">
+      <segment state="translated">
         <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
-        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+        <target> Onbekende oefening – alleen het tijdstip kan worden bewerkt. </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Annuleren </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Speichern </source>
-        <target> Speichern </target>
+        <target> Opslaan </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.duration">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dauer (s)</source>
-        <target>Dauer (s)</target>
+        <target>Duur (s)</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.weight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gewicht (kg)</source>
         <target>Gewicht (kg)</target>
       </segment>
     </unit>
     <unit id="admin.entries.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Vermeldingen</target>
       </segment>
     </unit>
     <unit id="admin.entries.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Einträge vorhanden. </source>
-        <target> Keine Einträge vorhanden. </target>
+        <target> Geen vermeldingen beschikbaar. </target>
       </segment>
     </unit>
     <unit id="admin.entries.col.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Tijdstip</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Oefening</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Waarde</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.source">
-      <segment state="initial">
+      <segment state="translated">
         <source>Quelle</source>
-        <target>Quelle</target>
+        <target>Bron</target>
       </segment>
     </unit>
     <unit id="admin.entries.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Sluiten </target>
       </segment>
     </unit>
     <unit id="admin.entry.editTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Vermelding bewerken</target>
       </segment>
     </unit>
     <unit id="admin.entries.refresh">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neu laden</source>
-        <target>Neu laden</target>
+        <target>Vernieuwen</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9474,117 +9474,117 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.user.entriesTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen</source>
-        <target>Einträge anzeigen</target>
+        <target>Vis oppføringer</target>
       </segment>
     </unit>
     <unit id="admin.row.entriesAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <target>Vis oppføringer for <ph id="0" equiv="identifier" disp="identifier"/></target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Rediger oppføring</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Tidspunkt</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Verdi</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.staleExercise">
-      <segment state="initial">
+      <segment state="translated">
         <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
-        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+        <target> Ukjent øvelse – bare tidspunktet kan redigeres. </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Avbryt </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Speichern </source>
-        <target> Speichern </target>
+        <target> Lagre </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.duration">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dauer (s)</source>
-        <target>Dauer (s)</target>
+        <target>Varighet (s)</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.weight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gewicht (kg)</source>
-        <target>Gewicht (kg)</target>
+        <target>Vekt (kg)</target>
       </segment>
     </unit>
     <unit id="admin.entries.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Oppføringer</target>
       </segment>
     </unit>
     <unit id="admin.entries.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Einträge vorhanden. </source>
-        <target> Keine Einträge vorhanden. </target>
+        <target> Ingen oppføringer tilgjengelig. </target>
       </segment>
     </unit>
     <unit id="admin.entries.col.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>Tidspunkt</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>Øvelse</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>Verdi</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.source">
-      <segment state="initial">
+      <segment state="translated">
         <source>Quelle</source>
-        <target>Quelle</target>
+        <target>Kilde</target>
       </segment>
     </unit>
     <unit id="admin.entries.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Lukk </target>
       </segment>
     </unit>
     <unit id="admin.entry.editTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>Rediger oppføring</target>
       </segment>
     </unit>
     <unit id="admin.entries.refresh">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neu laden</source>
-        <target>Neu laden</target>
+        <target>Last inn på nytt</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9687,117 +9687,117 @@
       </segment>
     </unit>
     <unit id="admin.user.entriesTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen</source>
-        <target>Einträge anzeigen</target>
+        <target>显示记录</target>
       </segment>
     </unit>
     <unit id="admin.row.entriesAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></source>
-        <target>Einträge anzeigen für <ph id="0" equiv="identifier" disp="identifier"/></target>
+        <target>显示<ph id="0" equiv="identifier" disp="identifier"/>的记录</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>编辑记录</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>时间</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>值</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.staleExercise">
-      <segment state="initial">
+      <segment state="translated">
         <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
-        <target> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </target>
+        <target> 未知练习 – 只能编辑时间。 </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> 取消 </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.save">
-      <segment state="initial">
+      <segment state="translated">
         <source> Speichern </source>
-        <target> Speichern </target>
+        <target> 保存 </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.duration">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dauer (s)</source>
-        <target>Dauer (s)</target>
+        <target>时长（秒）</target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.weight">
-      <segment state="initial">
+      <segment state="translated">
         <source>Gewicht (kg)</source>
-        <target>Gewicht (kg)</target>
+        <target>重量（公斤）</target>
       </segment>
     </unit>
     <unit id="admin.entries.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>记录</target>
       </segment>
     </unit>
     <unit id="admin.entries.empty">
-      <segment state="initial">
+      <segment state="translated">
         <source> Keine Einträge vorhanden. </source>
-        <target> Keine Einträge vorhanden. </target>
+        <target> 暂无记录。 </target>
       </segment>
     </unit>
     <unit id="admin.entries.col.timestamp">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zeitpunkt</source>
-        <target>Zeitpunkt</target>
+        <target>时间</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.exercise">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung</source>
-        <target>Übung</target>
+        <target>训练</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.value">
-      <segment state="initial">
+      <segment state="translated">
         <source>Wert</source>
-        <target>Wert</target>
+        <target>值</target>
       </segment>
     </unit>
     <unit id="admin.entries.col.source">
-      <segment state="initial">
+      <segment state="translated">
         <source>Quelle</source>
-        <target>Quelle</target>
+        <target>来源</target>
       </segment>
     </unit>
     <unit id="admin.entries.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> 关闭 </target>
       </segment>
     </unit>
     <unit id="admin.entry.editTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag bearbeiten</source>
-        <target>Eintrag bearbeiten</target>
+        <target>编辑记录</target>
       </segment>
     </unit>
     <unit id="admin.entries.refresh">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neu laden</source>
-        <target>Neu laden</target>
+        <target>重新加载</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9719,7 +9719,7 @@
     <unit id="admin.entry.edit.staleExercise">
       <segment state="translated">
         <source> Unbekannte Übung – nur der Zeitpunkt kann bearbeitet werden. </source>
-        <target> 未知练习 – 只能编辑时间。 </target>
+        <target> 未知训练 – 只能编辑时间。 </target>
       </segment>
     </unit>
     <unit id="admin.entry.edit.cancel">


### PR DESCRIPTION
Fills XLIFF translation gaps seeded by `tools/src/sync-xliff-locales.mjs` — 19 units from the admin entries-editor feature (view/sort/edit a user's exercise entries) that landed in German only, now translated into all 8 target locales.

- `en`: 19 unit(s), 0 blog post(s), 0 wiki entry/entries
- `fr`: 19 unit(s), 0 blog post(s), 0 wiki entry/entries
- `es`: 19 unit(s), 0 blog post(s), 0 wiki entry/entries
- `it`: 19 unit(s), 0 blog post(s), 0 wiki entry/entries
- `nl`: 19 unit(s), 0 blog post(s), 0 wiki entry/entries
- `no`: 19 unit(s), 0 blog post(s), 0 wiki entry/entries
- `zh`: 19 unit(s), 0 blog post(s), 0 wiki entry/entries
- `el`: 19 unit(s), 0 blog post(s), 0 wiki entry/entries

## Skipped

None — all 152 detected gaps were translated.

## Detector summary

```
Detected 152 gap(s) — xliff:152 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh
```

All units flipped from `state="initial"` to `state="translated"`; existing translation terminology was matched against equivalent strings already in each locale file (e.g. `Übung`/`Exercise`/`Ejercicio`/`Άσκηση`, `Abbrechen`/`Cancel`/`Annuler`, `Einträge`/`Entries`/`Entrées`) for consistency. XLIFF placeholders (`<ph id="0" .../>`) preserved verbatim. `web/src/locale/messages.xlf` (auto-generated source) was left untouched.

Pre-push checklist (`pnpm nx affected -t=lint,test,build -c=production --parallel=3`) passed for the affected `web` and `web-e2e` projects.

🤖 Generated by the Claude translations routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbtKh7RZQdk7bUPY9hZdUW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Improved Admin entries interface translations in Greek, English, Spanish, French, Italian, Dutch, Norwegian, and Chinese.
  * Updated labels, tooltips, accessibility text, table headings, empty states, edit-entry dialogs, action buttons, and refresh controls.
  * Replaced untranslated or placeholder text with language-appropriate wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->