### PR TITLE
fix(web): wrap footer nav onto multiple rows on mobile

### DIFF
--- a/web/src/app/app.scss
+++ b/web/src/app/app.scss
@@ -267,12 +267,17 @@ mat-sidenav-content {
 
   nav {
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
     gap: 24px;
   }
 
   @media (max-width: 767px) {
     padding-bottom: 72px;
+
+    nav {
+      gap: 4px 12px;
+    }
   }
 }
 


### PR DESCRIPTION
## What

The footer navigation (`.app-footer nav`) was a single non-wrapping flex row of six links with a fixed `24px` gap. On mobile the combined width of the links plus gaps exceeded the viewport, making the footer too wide.

## Change

- Added `flex-wrap: wrap` to the footer nav so links flow onto multiple rows instead of overflowing.
- Below `768px`, tightened the gap to `4px 12px` so the wrapped rows stay compact and readable.

The result: on narrow screens the footer links break onto two (or more) rows and no longer force horizontal overflow, while the desktop single-row layout is unchanged.

## Testing

Pure SCSS layout change in `web/src/app/app.scss`. `pnpm nx lint web` passes (remaining warnings are pre-existing, in unrelated e2e files). Layout/`flex-wrap` behavior isn't observable in jsdom (Vitest), so there's no meaningful unit assertion to add — the change is media-query/layout only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAs9A7jJYwpm3A2A1qA6gC)_