### PR TITLE
chore(i18n): fill missing translations (16 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10295,15 +10295,15 @@
       </segment>
     </unit>
     <unit id="admin.entries.pageTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Καταχωρήσεις</target>
       </segment>
     </unit>
     <unit id="admin.entries.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Επιστροφή στη διαχείριση</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10494,15 +10494,15 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.entries.pageTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entries</target>
       </segment>
     </unit>
     <unit id="admin.entries.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Back to admin area</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10291,15 +10291,15 @@
       </segment>
     </unit>
     <unit id="admin.entries.pageTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entradas</target>
       </segment>
     </unit>
     <unit id="admin.entries.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Volver al área de administración</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10167,15 +10167,15 @@
       </segment>
     </unit>
     <unit id="admin.entries.pageTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entrées</target>
       </segment>
     </unit>
     <unit id="admin.entries.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Retour à l'espace admin</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10295,15 +10295,15 @@
       </segment>
     </unit>
     <unit id="admin.entries.pageTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Immissioni</target>
       </segment>
     </unit>
     <unit id="admin.entries.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Torna all'area amministrativa</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10295,15 +10295,15 @@
       </segment>
     </unit>
     <unit id="admin.entries.pageTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Invoeren</target>
       </segment>
     </unit>
     <unit id="admin.entries.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Terug naar beheergebied</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9588,15 +9588,15 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.entries.pageTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Oppføringer</target>
       </segment>
     </unit>
     <unit id="admin.entries.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Tilbake til administrasjonsområdet</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9801,15 +9801,15 @@
       </segment>
     </unit>
     <unit id="admin.entries.pageTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>记录</target>
       </segment>
     </unit>
     <unit id="admin.entries.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>返回管理区域</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
Fills XLIFF translation gaps detected by `tools/src/detect-translation-gaps.mjs` for two new admin-entries-page strings that were seeded as fallbacks (`state="initial"`, target == source) by `tools/src/sync-xliff-locales.mjs`.

## Touched locales

- `en`: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- `es`: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- `fr`: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- `it`: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- `nl`: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- `no`: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- `zh`: 2 unit(s), 0 blog post(s), 0 wiki entry/entries
- `el`: 2 unit(s), 0 blog post(s), 0 wiki entry/entries

Translated units (source `de`):

- `admin.entries.pageTitle` — "Einträge" — translated consistently with the existing `admin.col.entries` / `admin.details.entryCount` units.
- `admin.entries.backToAdmin` — "Zurück zum Admin-Bereich" — translated consistently with the existing `admin.migrations.backToAdmin` unit.

Both units were flipped from `state="initial"` to `state="translated"`.

## Skipped

None — all 16 detected gap items were translated.

## Detector summary

```
Detected 16 gap(s) — xliff:16 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh
```

Re-running the detector after these changes reports:

```
Detected 0 gap(s) — xliff:0 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh
```

## Pre-push checks

- `pnpm nx run web:lint` ✅
- `pnpm nx run web:test` ✅
- `pnpm nx run web:build -c production` ✅ (prerendered all locale routes)

🤖 Generated with an autonomous Claude Code translations routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KdjyT9sKeBkVb2qYn13dqm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Added and finalized translations for the admin entries page title and “Back to admin area” link in Greek, English, Spanish, French, Italian, Dutch, Norwegian, and Chinese.
  - Admin entries navigation is now displayed in the selected language instead of showing untranslated source text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->