### PR TITLE
fix(admin): declare (userId, timestamp DESC) index so user-entries query works in prod

### DIFF
--- a/data-store/firestore.indexes.json
+++ b/data-store/firestore.indexes.json
@@ -21,6 +21,14 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "exerciseEntries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
         { "fieldPath": "exerciseId", "order": "ASCENDING" },
         { "fieldPath": "timestamp", "order": "ASCENDING" }
       ]

--- a/data-store/functions/src/firestore-indexes.spec.ts
+++ b/data-store/functions/src/firestore-indexes.spec.ts
@@ -85,4 +85,25 @@ describe('firestore.indexes.json ⇄ delta-aggregation rebuild queries', () => {
     // then it is declared
     expect(declared).toBe(true);
   });
+
+  it('should declare the (userId ASC, timestamp DESC) index adminListUserEntries reads from', () => {
+    // given adminListUserEntries' newest-first fetch
+    // (where('userId','==').orderBy('timestamp','desc').limit(n)) — the
+    // descending timestamp order needs its own composite index; the ascending
+    // one does NOT serve it, so without this the callable throws
+    // FAILED_PRECONDITION and the admin entries page can't load
+    // when looking up its supporting composite index
+    const declared = indexes.some(
+      (idx) =>
+        idx.collectionGroup === 'exerciseEntries' &&
+        idx.queryScope === 'COLLECTION' &&
+        idx.fields.length === 2 &&
+        idx.fields[0].fieldPath === 'userId' &&
+        idx.fields[0].order === 'ASCENDING' &&
+        idx.fields[1].fieldPath === 'timestamp' &&
+        idx.fields[1].order === 'DESCENDING'
+    );
+    // then it is declared
+    expect(declared).toBe(true);
+  });
 });

--- a/data-store/functions/src/functions-admin-user-entries.ts
+++ b/data-store/functions/src/functions-admin-user-entries.ts
@@ -23,13 +23,12 @@ const EXERCISE_ENTRIES_COLLECTION = 'exerciseEntries';
 // it goes through the Admin SDK here. Returns the newest `limit` entries,
 // newest first, so a user with a huge history never materialises unbounded.
 //
-// Uses `orderBy(timestamp, asc).limitToLast(limit)` + a client-side
-// reverse rather than `orderBy(desc)`: the only declared composite index
-// is `(userId ASC, timestamp ASC)`, which serves this in its native
-// direction. A `desc` order would need a separate descending index and
-// otherwise fail with FAILED_PRECONDITION in production. Same trick the
-// `updateAdminUserActivityOnEntryWrite` trigger uses to read the max
-// timestamp.
+// `where('userId','==').orderBy('timestamp','desc')` needs the composite
+// index `(userId ASC, timestamp DESC)` (declared in `firestore.indexes.json`);
+// without it the query fails with FAILED_PRECONDITION. Note a `limitToLast`
+// on an *ascending* order would need this exact same descending index —
+// Firestore reverses the scan internally — so the ascending composite does
+// not serve this query.
 export const adminListUserEntries = onCall(
   { region: 'europe-west3', timeoutSeconds: 60 },
   async (request) => {
@@ -45,13 +44,11 @@ export const adminListUserEntries = onCall(
       const snap = await db
         .collection(EXERCISE_ENTRIES_COLLECTION)
         .where('userId', '==', uid)
-        .orderBy('timestamp', 'asc')
-        .limitToLast(limit)
+        .orderBy('timestamp', 'desc')
+        .limit(limit)
         .get();
 
-      return snap.docs
-        .reverse()
-        .map((doc) => serializeEntry(doc.id, doc.data()));
+      return snap.docs.map((doc) => serializeEntry(doc.id, doc.data()));
     } catch (err) {
       // Surface a clear, logged error instead of an opaque `internal`.
       // Log a string (stack when available), not the raw error, so a


### PR DESCRIPTION
## Was

Behebt die Ursache des in Produktion gemeldeten Fehlers **„Einträge konnten nicht geladen werden.“** (davor der opake „Internal“-Fehler) beim Öffnen der Admin-Einträge eines Users.

### Ursache

`adminListUserEntries` las die neuesten Einträge mit
`orderBy('timestamp','asc').limitToLast(limit)` — in der Annahme, der deklarierte
Index `(userId ASC, timestamp ASC)` bediene das. Tut er nicht: `limitToLast`
dreht den Scan intern um, Firestore braucht den Index daher in **absteigender**
Richtung `(userId ASC, timestamp DESC)`. Dieser Index war nie deklariert, also
scheiterte die Query in Produktion mit `FAILED_PRECONDITION` — seit #519.

Bestätigt aus dem Function-Log:
```
9 FAILED_PRECONDITION: The query requires an index. ... exerciseEntries ... userId ASC, timestamp DESC
```
Das Deploy-Pipeline war nie das Problem — sie deployt `firestore.indexes.json`
korrekt; die Datei enthielt schlicht den benötigten Index nicht.

### Änderungen

- **`firestore.indexes.json`**: Index `(userId ASC, timestamp DESC)` für
  `exerciseEntries` deklariert.
- **`functions-admin-user-entries.ts`**: Query auf
  `orderBy('timestamp','desc').limit(limit)` vereinfacht (direkt newest-first,
  kein client-seitiges `.reverse()`), irreführenden Kommentar korrigiert.
- **`firestore-indexes.spec.ts`**: Guard-Test, der den absteigenden Index
  einfordert, damit das nicht regressiert.

## Tests / Checks

- `cloud-functions`: Index-Guard-Specs grün (3), Build grün.

## Hinweis zum Deployment

Nach dem Merge deployt die Pipeline den neuen Index. Firestore **baut** den
Index dann asynchron (wenige Minuten für diese Collection); erst wenn sein
Status auf **Enabled** steht, lädt die Einträge-Seite. Alternativ lässt sich
der Index sofort über den Link aus dem Function-Log anlegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBPTZ5ZnGxm26jAJ3mycCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBPTZ5ZnGxm26jAJ3mycCN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved exercise history retrieval for administrative views by fetching the most recent entries directly.
  * Added the required database indexing to support faster, correctly ordered results.

* **Tests**
  * Added coverage to verify that the exercise history query uses the expected index configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->