### PR TITLE
fix: harden SSR proxy-header trust and switch stats-date specs to commonjs

### DIFF
--- a/libs/stats-date/tsconfig.spec.json
+++ b/libs/stats-date/tsconfig.spec.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "module": "preserve",
+    "module": "commonjs",
     "target": "es2016",
     "types": ["jest", "node"],
     "moduleResolution": "bundler"

--- a/web/src/server.ts
+++ b/web/src/server.ts
@@ -47,9 +47,15 @@ app.use(pinoHttp({ logger }));
 // handlers so it wraps every downstream response.
 app.use(compression());
 
-const angularApp = new AngularNodeAppEngine({
-  trustProxyHeaders: ['x-forwarded-host', 'x-forwarded-proto'],
-});
+// Only trust `x-forwarded-*` in production, where Firebase App Hosting /
+// Cloud Run sets and sanitizes these headers. In dev (`nx serve`) or behind
+// an untrusted proxy the server can be reachable directly, so trusting them
+// would let clients spoof host/proto and skew URL generation and redirects.
+const angularApp = new AngularNodeAppEngine(
+  isProduction
+    ? { trustProxyHeaders: ['x-forwarded-host', 'x-forwarded-proto'] }
+    : undefined
+);
 
 // Serve root-level files from the /de build output so they're
 // available at the domain root for crawlers, validators, and

--- a/web/src/server.ts
+++ b/web/src/server.ts
@@ -51,11 +51,11 @@ app.use(compression());
 // Cloud Run sets and sanitizes these headers. In dev (`nx serve`) or behind
 // an untrusted proxy the server can be reachable directly, so trusting them
 // would let clients spoof host/proto and skew URL generation and redirects.
-const angularApp = new AngularNodeAppEngine(
-  isProduction
-    ? { trustProxyHeaders: ['x-forwarded-host', 'x-forwarded-proto'] }
-    : undefined
-);
+const angularApp = new AngularNodeAppEngine({
+  trustProxyHeaders: isProduction
+    ? ['x-forwarded-host', 'x-forwarded-proto']
+    : false,
+});
 
 // Serve root-level files from the /de build output so they're
 // available at the domain root for crawlers, validators, and


### PR DESCRIPTION
## Summary

Follow-up to the merged Angular v22 / Nx 23.1 upgrade (#526), resolving the open review findings that carried over.

### Changes

- **`web/src/server.ts` — gate `trustProxyHeaders` behind production.** The SSR engine previously trusted `x-forwarded-*` headers unconditionally. In dev (`nx serve`) or behind an untrusted proxy the server can be reached directly, letting clients spoof host/proto and skew URL generation and redirects. It now only trusts these headers in production, where Firebase App Hosting / Cloud Run sets and sanitizes them.
- **`libs/stats-date/tsconfig.spec.json` — `module: "preserve"` → `"commonjs"`.** This lib was the lone outlier; every other lib with `moduleResolution: "bundler"` compiles its Jest specs as CommonJS. `preserve` could leave ESM `import`/`export` in the transpiled test output and break under Jest.

### Findings intentionally not changed

- **`@angular/fire` peer dep mismatch** — the newest published `@angular/fire` is `21.0.0-rc.0` (Angular 21 peer deps); there is no Angular-22-compatible release to upgrade to yet. Strict peer checking is already disabled in `.npmrc`, so install succeeds and the integration works. No action available until a v22 release ships.
- **`esModuleInterop: true` in `tsconfig.base.json`** — added deliberately during the v22 migration alongside other compiler-option adjustments; the merged build and full test suite pass with it. Reverting is a broad behavioral change with no observed breakage, so it's left as-is.

### Verification

- `pnpm nx test stats-date` — 36 tests pass with the CommonJS module setting.
- `pnpm nx build web --configuration=development` — the server change typechecks and builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GfVzDHviEcDne43Zf79v8

---
_Generated by [Claude Code](https://claude.ai/code/session_013GfVzDHviEcDne43Zf79v8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server security by restricting forwarded-header trust to production environments.
  * Reduced the risk of spoofed host and protocol headers during development and other non-production usage.

* **Tests**
  * Updated test compilation settings for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->