### PR TITLE
chore(i18n): fill missing translations (88 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10333,7 +10333,7 @@
     <unit id="admin.entries.meta.createdAt">
       <segment state="translated">
         <source>Registriert</source>
-        <target>Εγγεγραμμένος</target>
+        <target>Ημερομηνία εγγραφής</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.activePlan">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10307,69 +10307,69 @@
       </segment>
     </unit>
     <unit id="admin.entries.meta.uid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID</source>
         <target>UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Καταχωρήσεις</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.firstEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Erster Eintrag</source>
-        <target>Erster Eintrag</target>
+        <target>Πρώτη καταχώρηση</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.lastEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Letzter Eintrag</source>
-        <target>Letzter Eintrag</target>
+        <target>Τελευταία καταχώρηση</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.createdAt">
-      <segment state="initial">
+      <segment state="translated">
         <source>Registriert</source>
-        <target>Registriert</target>
+        <target>Εγγεγραμμένος</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.activePlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiver Plan</source>
-        <target>Aktiver Plan</target>
+        <target>Ενεργό σχέδιο</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.noPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktiver Plan</source>
-        <target>Kein aktiver Plan</target>
+        <target>Κανένα ενεργό σχέδιο</target>
       </segment>
     </unit>
     <unit id="admin.entries.copyUid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID kopieren</source>
-        <target>UID kopieren</target>
+        <target>Αντιγραφή UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.roleAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Admin</source>
-        <target>Admin</target>
+        <target>Διαχειριστής</target>
       </segment>
     </unit>
     <unit id="admin.entries.anonymous">
-      <segment state="initial">
+      <segment state="translated">
         <source>Anonym</source>
-        <target>Anonym</target>
+        <target>Ανώνυμος</target>
       </segment>
     </unit>
     <unit id="admin.entries.publicProfile">
-      <segment state="initial">
+      <segment state="translated">
         <source>Öffentliches Profil</source>
-        <target>Öffentliches Profil</target>
+        <target>Δημόσιο προφίλ</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10506,69 +10506,69 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.entries.meta.uid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID</source>
         <target>UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entries</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.firstEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Erster Eintrag</source>
-        <target>Erster Eintrag</target>
+        <target>First entry</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.lastEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Letzter Eintrag</source>
-        <target>Letzter Eintrag</target>
+        <target>Last entry</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.createdAt">
-      <segment state="initial">
+      <segment state="translated">
         <source>Registriert</source>
-        <target>Registriert</target>
+        <target>Registered</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.activePlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiver Plan</source>
-        <target>Aktiver Plan</target>
+        <target>Active plan</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.noPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktiver Plan</source>
-        <target>Kein aktiver Plan</target>
+        <target>No active plan</target>
       </segment>
     </unit>
     <unit id="admin.entries.copyUid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID kopieren</source>
-        <target>UID kopieren</target>
+        <target>Copy UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.roleAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Admin</source>
         <target>Admin</target>
       </segment>
     </unit>
     <unit id="admin.entries.anonymous">
-      <segment state="initial">
+      <segment state="translated">
         <source>Anonym</source>
-        <target>Anonym</target>
+        <target>Anonymous</target>
       </segment>
     </unit>
     <unit id="admin.entries.publicProfile">
-      <segment state="initial">
+      <segment state="translated">
         <source>Öffentliches Profil</source>
-        <target>Öffentliches Profil</target>
+        <target>Public profile</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10303,69 +10303,69 @@
       </segment>
     </unit>
     <unit id="admin.entries.meta.uid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID</source>
         <target>UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entradas</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.firstEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Erster Eintrag</source>
-        <target>Erster Eintrag</target>
+        <target>Primera entrada</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.lastEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Letzter Eintrag</source>
-        <target>Letzter Eintrag</target>
+        <target>Última entrada</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.createdAt">
-      <segment state="initial">
+      <segment state="translated">
         <source>Registriert</source>
-        <target>Registriert</target>
+        <target>Registrado</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.activePlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiver Plan</source>
-        <target>Aktiver Plan</target>
+        <target>Plan activo</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.noPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktiver Plan</source>
-        <target>Kein aktiver Plan</target>
+        <target>Sin plan activo</target>
       </segment>
     </unit>
     <unit id="admin.entries.copyUid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID kopieren</source>
-        <target>UID kopieren</target>
+        <target>Copiar UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.roleAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Admin</source>
         <target>Admin</target>
       </segment>
     </unit>
     <unit id="admin.entries.anonymous">
-      <segment state="initial">
+      <segment state="translated">
         <source>Anonym</source>
-        <target>Anonym</target>
+        <target>Anónimo</target>
       </segment>
     </unit>
     <unit id="admin.entries.publicProfile">
-      <segment state="initial">
+      <segment state="translated">
         <source>Öffentliches Profil</source>
-        <target>Öffentliches Profil</target>
+        <target>Perfil público</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10211,13 +10211,13 @@
     <unit id="admin.entries.meta.activePlan">
       <segment state="translated">
         <source>Aktiver Plan</source>
-        <target>Forfait actif</target>
+        <target>Plan d'entraînement actif</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.noPlan">
       <segment state="translated">
         <source>Kein aktiver Plan</source>
-        <target>Aucun forfait actif</target>
+        <target>Aucun plan d'entraînement actif</target>
       </segment>
     </unit>
     <unit id="admin.entries.copyUid">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10179,69 +10179,69 @@
       </segment>
     </unit>
     <unit id="admin.entries.meta.uid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID</source>
         <target>UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Entrées</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.firstEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Erster Eintrag</source>
-        <target>Erster Eintrag</target>
+        <target>Première entrée</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.lastEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Letzter Eintrag</source>
-        <target>Letzter Eintrag</target>
+        <target>Dernière entrée</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.createdAt">
-      <segment state="initial">
+      <segment state="translated">
         <source>Registriert</source>
-        <target>Registriert</target>
+        <target>Inscrit</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.activePlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiver Plan</source>
-        <target>Aktiver Plan</target>
+        <target>Forfait actif</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.noPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktiver Plan</source>
-        <target>Kein aktiver Plan</target>
+        <target>Aucun forfait actif</target>
       </segment>
     </unit>
     <unit id="admin.entries.copyUid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID kopieren</source>
-        <target>UID kopieren</target>
+        <target>Copier l'UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.roleAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Admin</source>
         <target>Admin</target>
       </segment>
     </unit>
     <unit id="admin.entries.anonymous">
-      <segment state="initial">
+      <segment state="translated">
         <source>Anonym</source>
-        <target>Anonym</target>
+        <target>Anonyme</target>
       </segment>
     </unit>
     <unit id="admin.entries.publicProfile">
-      <segment state="initial">
+      <segment state="translated">
         <source>Öffentliches Profil</source>
-        <target>Öffentliches Profil</target>
+        <target>Profil public</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10307,69 +10307,69 @@
       </segment>
     </unit>
     <unit id="admin.entries.meta.uid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID</source>
         <target>UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Voci</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.firstEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Erster Eintrag</source>
-        <target>Erster Eintrag</target>
+        <target>Prima immissione</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.lastEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Letzter Eintrag</source>
-        <target>Letzter Eintrag</target>
+        <target>Ultima immissione</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.createdAt">
-      <segment state="initial">
+      <segment state="translated">
         <source>Registriert</source>
-        <target>Registriert</target>
+        <target>Registrato</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.activePlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiver Plan</source>
-        <target>Aktiver Plan</target>
+        <target>Piano attivo</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.noPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktiver Plan</source>
-        <target>Kein aktiver Plan</target>
+        <target>Nessun piano attivo</target>
       </segment>
     </unit>
     <unit id="admin.entries.copyUid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID kopieren</source>
-        <target>UID kopieren</target>
+        <target>Copia UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.roleAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Admin</source>
         <target>Admin</target>
       </segment>
     </unit>
     <unit id="admin.entries.anonymous">
-      <segment state="initial">
+      <segment state="translated">
         <source>Anonym</source>
-        <target>Anonym</target>
+        <target>Anonimo</target>
       </segment>
     </unit>
     <unit id="admin.entries.publicProfile">
-      <segment state="initial">
+      <segment state="translated">
         <source>Öffentliches Profil</source>
-        <target>Öffentliches Profil</target>
+        <target>Profilo pubblico</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10315,7 +10315,7 @@
     <unit id="admin.entries.meta.entryCount">
       <segment state="translated">
         <source>Einträge</source>
-        <target>Voci</target>
+        <target>Immissioni</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.firstEntry">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10307,69 +10307,69 @@
       </segment>
     </unit>
     <unit id="admin.entries.meta.uid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID</source>
         <target>UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Invoeren</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.firstEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Erster Eintrag</source>
-        <target>Erster Eintrag</target>
+        <target>Eerste invoer</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.lastEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Letzter Eintrag</source>
-        <target>Letzter Eintrag</target>
+        <target>Laatste invoer</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.createdAt">
-      <segment state="initial">
+      <segment state="translated">
         <source>Registriert</source>
-        <target>Registriert</target>
+        <target>Geregistreerd</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.activePlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiver Plan</source>
-        <target>Aktiver Plan</target>
+        <target>Actief plan</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.noPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktiver Plan</source>
-        <target>Kein aktiver Plan</target>
+        <target>Geen actief plan</target>
       </segment>
     </unit>
     <unit id="admin.entries.copyUid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID kopieren</source>
-        <target>UID kopieren</target>
+        <target>UID kopiëren</target>
       </segment>
     </unit>
     <unit id="admin.entries.roleAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Admin</source>
         <target>Admin</target>
       </segment>
     </unit>
     <unit id="admin.entries.anonymous">
-      <segment state="initial">
+      <segment state="translated">
         <source>Anonym</source>
-        <target>Anonym</target>
+        <target>Anoniem</target>
       </segment>
     </unit>
     <unit id="admin.entries.publicProfile">
-      <segment state="initial">
+      <segment state="translated">
         <source>Öffentliches Profil</source>
-        <target>Öffentliches Profil</target>
+        <target>Openbaar profiel</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9600,69 +9600,69 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.entries.meta.uid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID</source>
         <target>UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>Oppføringer</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.firstEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Erster Eintrag</source>
-        <target>Erster Eintrag</target>
+        <target>Første oppføring</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.lastEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Letzter Eintrag</source>
-        <target>Letzter Eintrag</target>
+        <target>Siste oppføring</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.createdAt">
-      <segment state="initial">
+      <segment state="translated">
         <source>Registriert</source>
-        <target>Registriert</target>
+        <target>Registrert</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.activePlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiver Plan</source>
-        <target>Aktiver Plan</target>
+        <target>Aktiv plan</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.noPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktiver Plan</source>
-        <target>Kein aktiver Plan</target>
+        <target>Ingen aktiv plan</target>
       </segment>
     </unit>
     <unit id="admin.entries.copyUid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID kopieren</source>
-        <target>UID kopieren</target>
+        <target>Kopier UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.roleAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Admin</source>
         <target>Admin</target>
       </segment>
     </unit>
     <unit id="admin.entries.anonymous">
-      <segment state="initial">
+      <segment state="translated">
         <source>Anonym</source>
         <target>Anonym</target>
       </segment>
     </unit>
     <unit id="admin.entries.publicProfile">
-      <segment state="initial">
+      <segment state="translated">
         <source>Öffentliches Profil</source>
-        <target>Öffentliches Profil</target>
+        <target>Offentlig profil</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9827,13 +9827,13 @@
     <unit id="admin.entries.meta.firstEntry">
       <segment state="translated">
         <source>Erster Eintrag</source>
-        <target>首次训练</target>
+        <target>首次记录</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.lastEntry">
       <segment state="translated">
         <source>Letzter Eintrag</source>
-        <target>最后一次训练</target>
+        <target>最后一次记录</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.createdAt">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9813,69 +9813,69 @@
       </segment>
     </unit>
     <unit id="admin.entries.meta.uid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID</source>
         <target>UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.entryCount">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge</source>
-        <target>Einträge</target>
+        <target>记录</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.firstEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Erster Eintrag</source>
-        <target>Erster Eintrag</target>
+        <target>首次训练</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.lastEntry">
-      <segment state="initial">
+      <segment state="translated">
         <source>Letzter Eintrag</source>
-        <target>Letzter Eintrag</target>
+        <target>最后一次训练</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.createdAt">
-      <segment state="initial">
+      <segment state="translated">
         <source>Registriert</source>
-        <target>Registriert</target>
+        <target>注册时间</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.activePlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiver Plan</source>
-        <target>Aktiver Plan</target>
+        <target>当前活跃计划</target>
       </segment>
     </unit>
     <unit id="admin.entries.meta.noPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktiver Plan</source>
-        <target>Kein aktiver Plan</target>
+        <target>无当前活跃计划</target>
       </segment>
     </unit>
     <unit id="admin.entries.copyUid">
-      <segment state="initial">
+      <segment state="translated">
         <source>UID kopieren</source>
-        <target>UID kopieren</target>
+        <target>复制 UID</target>
       </segment>
     </unit>
     <unit id="admin.entries.roleAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Admin</source>
-        <target>Admin</target>
+        <target>管理员</target>
       </segment>
     </unit>
     <unit id="admin.entries.anonymous">
-      <segment state="initial">
+      <segment state="translated">
         <source>Anonym</source>
-        <target>Anonym</target>
+        <target>匿名</target>
       </segment>
     </unit>
     <unit id="admin.entries.publicProfile">
-      <segment state="initial">
+      <segment state="translated">
         <source>Öffentliches Profil</source>
-        <target>Öffentliches Profil</target>
+        <target>公开资料</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
Fills XLIFF translation gaps detected by `tools/src/detect-translation-gaps.mjs`. All 88 gaps were seeded-fallback `admin.entries.*` units (11 keys × 8 locales) with `state="initial"` and `<target>` equal to `<source>`.

## Touched locales

- `en`: 11 unit(s), 0 blog post(s), 0 wiki entry/entries
- `fr`: 11 unit(s), 0 blog post(s), 0 wiki entry/entries
- `es`: 11 unit(s), 0 blog post(s), 0 wiki entry/entries
- `it`: 11 unit(s), 0 blog post(s), 0 wiki entry/entries
- `nl`: 11 unit(s), 0 blog post(s), 0 wiki entry/entries
- `no`: 11 unit(s), 0 blog post(s), 0 wiki entry/entries
- `el`: 11 unit(s), 0 blog post(s), 0 wiki entry/entries
- `zh`: 11 unit(s), 0 blog post(s), 0 wiki entry/entries

Terminology was cross-checked against existing translated units in the same files (e.g. `admin.entries.title`, `admin.col.anonTooltip`, `trainingPlans.active.title`, `admin.col.lastEntry`) to keep wording consistent with the rest of the admin UI.

## Skipped

None — all 88 detected gaps were translated.

## Detector summary

```
Detected 88 gap(s) — xliff:88 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh
```

Re-running the detector after this change reports `has_gaps=false` (0 gaps).

## Notes

- `web/src/locale/messages.xlf` (auto-generated extraction source) was **not** committed — only line-number `<note>` drift from re-running `extract-i18n`, no content changes.
- `libs/stats/src/lib/models/exercise-wiki-content.generated.ts` showed unrelated pre-existing drift from `content/wiki` on `main` (triggered by the build's `tools:generate-content` dependency) — left untouched since this PR makes no content/markdown changes.
- Pre-push checks (`pnpm nx affected -t=lint,test,build -c=production --parallel=3`) pass.

🤖 Generated by an autonomous Claude Code translation routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NZdtJkFRyJDwA59MFiGdNc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added complete translations for Admin entry metadata and action labels in Greek, English, Spanish, French, Italian, Dutch, Norwegian, and Chinese.
  * Localized labels for entry counts, timestamps, registration and plan status, UID actions, roles, anonymity, and public profiles.
  * Replaced untranslated placeholder text with finalized localized content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->