### PR TITLE
fix(build): raise Angular prerender per-route timeout to 120s

### DIFF
--- a/docs/gotchas/build-and-tooling.md
+++ b/docs/gotchas/build-and-tooling.md
@@ -15,10 +15,11 @@ collateral, not root causes).
 The pnpm patch `patches/@angular__build.patch` (registered in
 `pnpm-workspace.yaml` under `patchedDependencies`) raises the budget to 120 s.
 `tools/src/prerender-timeout-patch-guard.spec.js` fails CI if the patch is
-dropped or stops applying. After an Angular upgrade, refresh it with
-`pnpm patch @angular/build` + `pnpm patch-commit` (re-apply the same one-line
-change in both worker files) instead of deleting it — or delete patch, guard
-test, and this section together once upstream makes the timeout configurable.
+dropped or stops applying. After an Angular upgrade, refresh it instead of
+deleting it: `pnpm patch @angular/build` prints an edit directory — re-apply
+the same one-line change in both worker files there, then run
+`pnpm patch-commit <edit-dir>`. Delete patch, guard test, and this section
+together only once upstream makes the timeout configurable.
 
 ## Transient build flakes
 

--- a/docs/gotchas/build-and-tooling.md
+++ b/docs/gotchas/build-and-tooling.md
@@ -1,5 +1,25 @@
 # Gotchas: Build & Tooling
 
+## Prerender per-route timeout is patched (30 s → 120 s)
+
+`@angular/build` hard-codes `AbortSignal.timeout(30_000)` per prerendered route
+(`src/utils/server-rendering/render-worker.js` and
+`routes-extractor-worker.js`) with no configuration option (verified up to
+22.1.0-next). The App Hosting production build prerenders ~2400 routes
+(9 locales, `sourceMap: true`) close to the 6 GB heap ceiling — a single GC
+pause or slow route past 30 s aborts the **entire** ~30-minute build: the log
+shows one `AbortError ... TimeoutError` on the first route, then a cascade of
+`Error: Terminating worker thread` on every other in-flight route (those are
+collateral, not root causes).
+
+The pnpm patch `patches/@angular__build.patch` (registered in
+`pnpm-workspace.yaml` under `patchedDependencies`) raises the budget to 120 s.
+`tools/src/prerender-timeout-patch-guard.spec.js` fails CI if the patch is
+dropped or stops applying. After an Angular upgrade, refresh it with
+`pnpm patch @angular/build` + `pnpm patch-commit` (re-apply the same one-line
+change in both worker files) instead of deleting it — or delete patch, guard
+test, and this section together once upstream makes the timeout configurable.
+
 ## Transient build flakes
 
 **`Inlining of fonts failed ... fonts.googleapis.com/icon?family=Material+Icons`** is a network flake during `web:build`, **not a code bug**. Retry `pnpm nx run web:build -c production` after a few seconds.

--- a/patches/@angular__build.patch
+++ b/patches/@angular__build.patch
@@ -1,0 +1,26 @@
+diff --git a/src/utils/server-rendering/render-worker.js b/src/utils/server-rendering/render-worker.js
+index 016e54a55f1b316f9fba9ae81f92ed367795200f..27d25b7652861ddb1e30ff8e0ed47a7680312487 100755
+--- a/src/utils/server-rendering/render-worker.js
++++ b/src/utils/server-rendering/render-worker.js
+@@ -58,7 +58,7 @@ async function renderPage({ url }) {
+     const angularServerApp = getOrCreateAngularServerApp({
+         allowStaticRouteRender: true,
+     });
+-    const response = await angularServerApp.handle(new Request(new URL(url, serverURL), { signal: AbortSignal.timeout(30_000) }));
++    const response = await angularServerApp.handle(new Request(new URL(url, serverURL), { signal: AbortSignal.timeout(120_000) }));
+     if (!response) {
+         return null;
+     }
+diff --git a/src/utils/server-rendering/routes-extractor-worker.js b/src/utils/server-rendering/routes-extractor-worker.js
+index b346011a15318c67c5f916d0aca73871fd1862b8..e2fe454a4b7793060bb44acfd1566b8af1eea55e 100755
+--- a/src/utils/server-rendering/routes-extractor-worker.js
++++ b/src/utils/server-rendering/routes-extractor-worker.js
+@@ -61,7 +61,7 @@ async function extractRoutes() {
+         url: serverURL,
+         invokeGetPrerenderParams: outputMode !== undefined,
+         includePrerenderFallbackRoutes: outputMode === schema_1.OutputMode.Server,
+-        signal: AbortSignal.timeout(30_000),
++        signal: AbortSignal.timeout(120_000),
+     });
+     return {
+         errors,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@angular/build':
+    hash: fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0
+    path: patches/@angular__build.patch
+
 importers:
 
   .:
@@ -152,7 +157,7 @@ importers:
         version: 22.0.7
       '@angular/build':
         specifier: 22.0.7
-        version: 22.0.7(618990100da157f0dba4214b8366d199)
+        version: 22.0.7(patch_hash=fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0)(618990100da157f0dba4214b8366d199)
       '@angular/cli':
         specifier: 22.0.7
         version: 22.0.7(@types/node@25.9.1)
@@ -179,7 +184,7 @@ importers:
         version: 2.0.1
       '@nx/angular':
         specifier: 23.1.0
-        version: 23.1.0(ef7ba69b50e1d0fe180f58729ae00aa4)
+        version: 23.1.0(f2a39145f21a5b5f886ff392bd5e3e01)
       '@nx/devkit':
         specifier: 23.1.0
         version: 23.1.0(nx@23.1.0(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.41(@swc/helpers@0.5.23))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.41(@swc/helpers@0.5.23)))
@@ -11935,7 +11940,7 @@ snapshots:
       '@angular-devkit/architect': 0.2200.7
       '@angular-devkit/build-webpack': 0.2200.7(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack-cli@7.0.3)(webpack@5.106.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3)))(webpack@5.106.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3))
       '@angular-devkit/core': 22.0.7
-      '@angular/build': 22.0.7(fdc8541fc2252c8ab257e01d87502e11)
+      '@angular/build': 22.0.7(patch_hash=fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0)(fdc8541fc2252c8ab257e01d87502e11)
       '@angular/compiler-cli': 22.0.7(@angular/compiler@22.0.7)(typescript@6.0.3)
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
@@ -12155,7 +12160,7 @@ snapshots:
       eslint: 10.5.0(jiti@2.4.2)
       typescript: 6.0.3
 
-  '@angular/build@22.0.7(618990100da157f0dba4214b8366d199)':
+  '@angular/build@22.0.7(patch_hash=fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0)(618990100da157f0dba4214b8366d199)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2200.7
@@ -12211,7 +12216,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@22.0.7(fdc8541fc2252c8ab257e01d87502e11)':
+  '@angular/build@22.0.7(patch_hash=fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0)(fdc8541fc2252c8ab257e01d87502e11)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2200.7
@@ -15584,9 +15589,9 @@ snapshots:
 
   '@napi-rs/wasm-runtime@1.0.7':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -15783,7 +15788,7 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
-  '@nx/angular@23.1.0(ef7ba69b50e1d0fe180f58729ae00aa4)':
+  '@nx/angular@23.1.0(f2a39145f21a5b5f886ff392bd5e3e01)':
     dependencies:
       '@angular-devkit/core': 22.0.7
       '@angular-devkit/schematics': 22.0.7
@@ -15808,7 +15813,7 @@ snapshots:
       webpack-merge: 5.10.0
     optionalDependencies:
       '@angular-devkit/build-angular': 22.0.7(4bc9dc16f0b3372842cf1a43ceaa0a21)
-      '@angular/build': 22.0.7(618990100da157f0dba4214b8366d199)
+      '@angular/build': 22.0.7(patch_hash=fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0)(618990100da157f0dba4214b8366d199)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@minify-html/node'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ allowBuilds:
   '@firebase/util': true
   '@nestjs/core': true
   '@parcel/watcher': true
+  '@sentry/cli': true
   '@swc/core': true
   esbuild: true
   less: true
@@ -12,14 +13,15 @@ allowBuilds:
   msgpackr-extract: true
   nx: true
   protobufjs: true
-  '@sentry/cli': true
   re2: true
   unrs-resolver: true
+patchedDependencies:
+  '@angular/build': patches/@angular__build.patch
 
 peerDependencyRules:
   allowedVersions:
-    '@angular/core': '21'
     '@angular/common': '21'
+    '@angular/core': '21'
     '@angular/platform-browser': '21'
     '@angular/platform-browser-dynamic': '21'
     'rxjs': '7.8'

--- a/tools/src/prerender-timeout-patch-guard.spec.js
+++ b/tools/src/prerender-timeout-patch-guard.spec.js
@@ -1,0 +1,77 @@
+const { existsSync, readFileSync } = require('node:fs');
+const { dirname, join, resolve } = require('node:path');
+const { parse } = require('yaml');
+
+const ROOT = resolve(__dirname, '../..');
+const WORKSPACE_CONFIG = resolve(ROOT, 'pnpm-workspace.yaml');
+
+const PRERENDER_WORKER_FILES = [
+  'src/utils/server-rendering/render-worker.js',
+  'src/utils/server-rendering/routes-extractor-worker.js',
+];
+const RAISED_TIMEOUT = 'AbortSignal.timeout(120_000)';
+const UPSTREAM_TIMEOUT = 'AbortSignal.timeout(30_000)';
+
+/**
+ * Locks in the pnpm patch that raises @angular/build's hard-coded 30 s
+ * per-route prerender timeout to 120 s (patches/@angular__build.patch).
+ *
+ * The App Hosting production build prerenders ~2400 routes (9 locales) with
+ * `sourceMap: true` near the 6 GB heap limit; a single GC pause or slow route
+ * exceeding the 30 s budget aborts the whole ~30-minute build (AbortError on
+ * one route, then "Terminating worker thread" on every in-flight route).
+ * Upstream offers no configuration for this timeout as of 22.x.
+ *
+ * If an Angular upgrade drops or breaks the patch, refresh it via
+ * `pnpm patch @angular/build` instead of deleting it — see
+ * docs/gotchas/build-and-tooling.md.
+ */
+describe('@angular/build prerender-timeout patch', () => {
+  it('should register the patch in pnpm-workspace.yaml and ship the patch file', () => {
+    // given pnpm only applies patches listed under patchedDependencies
+    const workspace = parse(readFileSync(WORKSPACE_CONFIG, 'utf-8'));
+    // when resolving the configured patch file for @angular/build
+    const patchPath = workspace.patchedDependencies?.['@angular/build'];
+    // then the entry exists and points at a committed patch file
+    expect(patchPath).toBeDefined();
+    expect(existsSync(resolve(ROOT, patchPath))).toBe(true);
+  });
+
+  it('should raise the timeout for both prerender workers in the patch file', () => {
+    // given the patch file registered in pnpm-workspace.yaml
+    const workspace = parse(readFileSync(WORKSPACE_CONFIG, 'utf-8'));
+    const patch = readFileSync(
+      resolve(ROOT, workspace.patchedDependencies['@angular/build']),
+      'utf-8'
+    );
+    for (const workerFile of PRERENDER_WORKER_FILES) {
+      // when looking at the hunk for each worker that renders/extracts routes
+      expect(patch).toContain(`--- a/${workerFile}`);
+      expect(patch).toContain(`+++ b/${workerFile}`);
+    }
+    // then it swaps the upstream 30 s budget for the raised 120 s one
+    const addedLines = patch
+      .split('\n')
+      .filter((line) => line.startsWith('+') && !line.startsWith('+++'));
+    expect(
+      addedLines.filter((line) => line.includes(RAISED_TIMEOUT))
+    ).toHaveLength(PRERENDER_WORKER_FILES.length);
+    expect(addedLines.some((line) => line.includes(UPSTREAM_TIMEOUT))).toBe(
+      false
+    );
+  });
+
+  it('should apply the raised timeout to the installed @angular/build', () => {
+    // given the workspace's resolved @angular/build installation
+    const installedRoot = dirname(
+      require.resolve('@angular/build/package.json', { paths: [ROOT] })
+    );
+    for (const workerFile of PRERENDER_WORKER_FILES) {
+      // when reading the worker that owns the per-route abort signal
+      const source = readFileSync(join(installedRoot, workerFile), 'utf-8');
+      // then the patched 120 s budget is in effect and the 30 s one is gone
+      expect(source).toContain(RAISED_TIMEOUT);
+      expect(source).not.toContain(UPSTREAM_TIMEOUT);
+    }
+  });
+});

--- a/tools/src/prerender-timeout-patch-guard.spec.js
+++ b/tools/src/prerender-timeout-patch-guard.spec.js
@@ -45,20 +45,23 @@ describe('@angular/build prerender-timeout patch', () => {
       'utf-8'
     );
     for (const workerFile of PRERENDER_WORKER_FILES) {
-      // when looking at the hunk for each worker that renders/extracts routes
-      expect(patch).toContain(`--- a/${workerFile}`);
-      expect(patch).toContain(`+++ b/${workerFile}`);
+      // when isolating the diff section of the worker that renders/extracts routes
+      const section = patch
+        .split(/^diff --git /m)
+        .find((part) => part.includes(`--- a/${workerFile}`));
+      expect(section).toBeDefined();
+      // then that worker's own hunk swaps the upstream 30 s budget for 120 s
+      const lines = section.split('\n');
+      expect(
+        lines.some((l) => l.startsWith('-') && l.includes(UPSTREAM_TIMEOUT))
+      ).toBe(true);
+      expect(
+        lines.some((l) => l.startsWith('+') && l.includes(RAISED_TIMEOUT))
+      ).toBe(true);
+      expect(
+        lines.some((l) => l.startsWith('+') && l.includes(UPSTREAM_TIMEOUT))
+      ).toBe(false);
     }
-    // then it swaps the upstream 30 s budget for the raised 120 s one
-    const addedLines = patch
-      .split('\n')
-      .filter((line) => line.startsWith('+') && !line.startsWith('+++'));
-    expect(
-      addedLines.filter((line) => line.includes(RAISED_TIMEOUT))
-    ).toHaveLength(PRERENDER_WORKER_FILES.length);
-    expect(addedLines.some((line) => line.includes(UPSTREAM_TIMEOUT))).toBe(
-      false
-    );
   });
 
   it('should apply the raised timeout to the installed @angular/build', () => {


### PR DESCRIPTION
## Problem

App Hosting rollout build `0ee184f5-34cb-4de5-9a64-9905a2af4914` (commit c8417fd, #530) failed after 29 minutes. Root cause in the log: prerendering `/fr/blog/pushup-progression` hit an `AbortError … TimeoutError: The operation was aborted due to timeout` — every subsequent `Error: Terminating worker thread` on the other `/fr/*` routes is just collateral from the worker pool being destroyed after that first failure.

`@angular/build` hard-codes `AbortSignal.timeout(30_000)` per prerendered route in `src/utils/server-rendering/render-worker.js` and `routes-extractor-worker.js`, with no configuration option (verified up to `22.1.0-next.4`). The production build prerenders ~2400 routes (9 locales, `sourceMap: true`) close to the 6 GB heap ceiling (`NODE_OPTIONS=--max-old-space-size=6144` in `apphosting.yaml`, added after earlier OOMs), so a single GC pause or slow route past 30 s aborts the entire build. #530 only changed `admin.entries.*` translation strings — the failing route's content was untouched, confirming this is a capacity flake, not a regression.

## Fix

- **`patches/@angular__build.patch`** (registered under `patchedDependencies` in `pnpm-workspace.yaml`): raises the per-route budget from 30 s to 120 s in both prerender workers. One-line change per file, no behavioral change for routes that render in time.
- **`tools/src/prerender-timeout-patch-guard.spec.js`**: guard spec that fails CI if the patch is dropped from `pnpm-workspace.yaml`, the patch file loses the raised timeout, or the installed `@angular/build` no longer carries it (e.g. after an Angular upgrade that silently skips the patch).
- **`docs/gotchas/build-and-tooling.md`**: documents the pitfall and the refresh procedure for future Angular upgrades.

## Verification

- `pnpm nx test tools` — all tests pass, including the 3 new guard assertions.
- `pnpm exec eslint` on the new spec — clean.
- `pnpm nx run web:build -c development` — full build succeeds with the patched `@angular/build` applied (verified `node_modules` resolves to the patched instance with `AbortSignal.timeout(120_000)`).
- The real proof is the next App Hosting rollout: with a 4× budget, the observed marginal timeout (typical route ≈ 2 s; one outlier > 30 s) has ample headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HhgdfDoBNLGeSJ71e4gmi

---
_Generated by [Claude Code](https://claude.ai/code/session_012HhgdfDoBNLGeSJ71e4gmi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended prerendering route timeouts from 30 seconds to 120 seconds, helping prevent long-running routes from aborting builds.

* **Tests**
  * Added automated checks to verify the timeout adjustment remains applied after tooling updates.

* **Documentation**
  * Documented the prerender timeout behavior, workaround, and maintenance steps for future Angular upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->