### PR TITLE
fix(build): cap App Hosting prerender workers to stop memory thrash

### DIFF
--- a/apphosting.staging.yaml
+++ b/apphosting.staging.yaml
@@ -25,6 +25,13 @@ env:
     availability:
       - BUILD
 
+  # Match prod: cap prerender workers so the ~8 GB App Hosting builder
+  # doesn't thrash during the ~2400-route prerender (see apphosting.yaml).
+  - variable: NG_BUILD_MAX_WORKERS
+    value: '2'
+    availability:
+      - BUILD
+
   # Override apphosting.yaml's `secret: SENTRY_AUTH_TOKEN` binding with a plain
   # placeholder value. App Hosting MERGES this file onto apphosting.yaml by
   # variable name, and base-only entries persist — so merely omitting the secret

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -50,6 +50,18 @@ env:
     availability:
       - BUILD
 
+  # The App Hosting builder has ~8 GB RAM total; the main build process
+  # needs the 6 GB heap above, and each prerender worker thread adds its
+  # own V8 isolate on top. With the default 4 workers the ~2400-route
+  # prerender thrashes into memory-pressure stalls late in the build —
+  # single routes hang > 120 s and abort the whole build (see
+  # docs/gotchas/build-and-tooling.md). Two workers keep peak memory
+  # inside the machine.
+  - variable: NG_BUILD_MAX_WORKERS
+    value: '2'
+    availability:
+      - BUILD
+
 # Grant access to secrets in Cloud Secret Manager.
 # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters
 scripts:

--- a/docs/gotchas/build-and-tooling.md
+++ b/docs/gotchas/build-and-tooling.md
@@ -1,25 +1,33 @@
 # Gotchas: Build & Tooling
 
-## Prerender per-route timeout is patched (30 s → 120 s)
+## App Hosting prerender: worker cap + patched per-route timeout
 
-`@angular/build` hard-codes `AbortSignal.timeout(30_000)` per prerendered route
-(`src/utils/server-rendering/render-worker.js` and
-`routes-extractor-worker.js`) with no configuration option (verified up to
-22.1.0-next). The App Hosting production build prerenders ~2400 routes
-(9 locales, `sourceMap: true`) close to the 6 GB heap ceiling — a single GC
-pause or slow route past 30 s aborts the **entire** ~30-minute build: the log
-shows one `AbortError ... TimeoutError` on the first route, then a cascade of
+The App Hosting production build prerenders ~2400 routes (9 locales,
+`sourceMap: true`) on a builder with ~8 GB RAM. The main build process needs
+the 6 GB heap from `NODE_OPTIONS`, and each prerender worker thread adds its
+own V8 isolate on top — with the default 4 workers the machine thrashes into
+memory-pressure stalls late in the build, where a single route can hang for
+**minutes** (observed > 120 s). One hung route aborts the **entire** build:
+the log shows one `AbortError ... TimeoutError`, then a cascade of
 `Error: Terminating worker thread` on every other in-flight route (those are
-collateral, not root causes).
+collateral, not root causes). The same build takes ~3 minutes on GitHub's
+16 GB runners — the workload only fails on the memory-starved builder.
 
-The pnpm patch `patches/@angular__build.patch` (registered in
-`pnpm-workspace.yaml` under `patchedDependencies`) raises the budget to 120 s.
-`tools/src/prerender-timeout-patch-guard.spec.js` fails CI if the patch is
-dropped or stops applying. After an Angular upgrade, refresh it instead of
-deleting it: `pnpm patch @angular/build` prints an edit directory — re-apply
-the same one-line change in both worker files there, then run
-`pnpm patch-commit <edit-dir>`. Delete patch, guard test, and this section
-together only once upstream makes the timeout configurable.
+Two defenses, both locked in by
+`tools/src/prerender-timeout-patch-guard.spec.js`:
+
+1. **`NG_BUILD_MAX_WORKERS=2`** as a BUILD-time env var in `apphosting.yaml`
+   and `apphosting.staging.yaml` — the primary fix; keeps peak memory inside
+   the machine. (`@angular/build` defaults to `min(4, cores - 1)` workers.)
+2. **`patches/@angular__build.patch`** (registered in `pnpm-workspace.yaml`
+   under `patchedDependencies`) raises the hard-coded 30 s per-route
+   `AbortSignal.timeout` in `render-worker.js` / `routes-extractor-worker.js`
+   to 300 s as headroom — upstream has no config option for it (verified up to
+   22.1.0-next). After an Angular upgrade, refresh it instead of deleting it:
+   `pnpm patch @angular/build` prints an edit directory — re-apply the same
+   one-line change in both worker files there, then run
+   `pnpm patch-commit <edit-dir>`. Delete patch, guard test, and this section
+   together only once upstream makes the timeout configurable.
 
 ## Transient build flakes
 

--- a/patches/@angular__build.patch
+++ b/patches/@angular__build.patch
@@ -7,7 +7,7 @@ index 016e54a55f1b316f9fba9ae81f92ed367795200f..27d25b7652861ddb1e30ff8e0ed47a76
          allowStaticRouteRender: true,
      });
 -    const response = await angularServerApp.handle(new Request(new URL(url, serverURL), { signal: AbortSignal.timeout(30_000) }));
-+    const response = await angularServerApp.handle(new Request(new URL(url, serverURL), { signal: AbortSignal.timeout(120_000) }));
++    const response = await angularServerApp.handle(new Request(new URL(url, serverURL), { signal: AbortSignal.timeout(300_000) }));
      if (!response) {
          return null;
      }
@@ -20,7 +20,7 @@ index b346011a15318c67c5f916d0aca73871fd1862b8..e2fe454a4b7793060bb44acfd1566b8a
          invokeGetPrerenderParams: outputMode !== undefined,
          includePrerenderFallbackRoutes: outputMode === schema_1.OutputMode.Server,
 -        signal: AbortSignal.timeout(30_000),
-+        signal: AbortSignal.timeout(120_000),
++        signal: AbortSignal.timeout(300_000),
      });
      return {
          errors,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@angular/build':
-    hash: fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0
+    hash: 3e2747ad4b831603b60d13617118b946bc0f2e3bcbf316781e19a18c96364e9e
     path: patches/@angular__build.patch
 
 importers:
@@ -157,7 +157,7 @@ importers:
         version: 22.0.7
       '@angular/build':
         specifier: 22.0.7
-        version: 22.0.7(patch_hash=fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0)(618990100da157f0dba4214b8366d199)
+        version: 22.0.7(patch_hash=3e2747ad4b831603b60d13617118b946bc0f2e3bcbf316781e19a18c96364e9e)(618990100da157f0dba4214b8366d199)
       '@angular/cli':
         specifier: 22.0.7
         version: 22.0.7(@types/node@25.9.1)
@@ -184,7 +184,7 @@ importers:
         version: 2.0.1
       '@nx/angular':
         specifier: 23.1.0
-        version: 23.1.0(f2a39145f21a5b5f886ff392bd5e3e01)
+        version: 23.1.0(b00a27b5787f83ee68b98b0f4f92ad72)
       '@nx/devkit':
         specifier: 23.1.0
         version: 23.1.0(nx@23.1.0(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.41(@swc/helpers@0.5.23))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.41(@swc/helpers@0.5.23)))
@@ -11940,7 +11940,7 @@ snapshots:
       '@angular-devkit/architect': 0.2200.7
       '@angular-devkit/build-webpack': 0.2200.7(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack-cli@7.0.3)(webpack@5.106.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3)))(webpack@5.106.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3))
       '@angular-devkit/core': 22.0.7
-      '@angular/build': 22.0.7(patch_hash=fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0)(fdc8541fc2252c8ab257e01d87502e11)
+      '@angular/build': 22.0.7(patch_hash=3e2747ad4b831603b60d13617118b946bc0f2e3bcbf316781e19a18c96364e9e)(fdc8541fc2252c8ab257e01d87502e11)
       '@angular/compiler-cli': 22.0.7(@angular/compiler@22.0.7)(typescript@6.0.3)
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
@@ -12160,7 +12160,7 @@ snapshots:
       eslint: 10.5.0(jiti@2.4.2)
       typescript: 6.0.3
 
-  '@angular/build@22.0.7(patch_hash=fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0)(618990100da157f0dba4214b8366d199)':
+  '@angular/build@22.0.7(patch_hash=3e2747ad4b831603b60d13617118b946bc0f2e3bcbf316781e19a18c96364e9e)(618990100da157f0dba4214b8366d199)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2200.7
@@ -12216,7 +12216,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@22.0.7(patch_hash=fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0)(fdc8541fc2252c8ab257e01d87502e11)':
+  '@angular/build@22.0.7(patch_hash=3e2747ad4b831603b60d13617118b946bc0f2e3bcbf316781e19a18c96364e9e)(fdc8541fc2252c8ab257e01d87502e11)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2200.7
@@ -15788,7 +15788,7 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
-  '@nx/angular@23.1.0(f2a39145f21a5b5f886ff392bd5e3e01)':
+  '@nx/angular@23.1.0(b00a27b5787f83ee68b98b0f4f92ad72)':
     dependencies:
       '@angular-devkit/core': 22.0.7
       '@angular-devkit/schematics': 22.0.7
@@ -15813,7 +15813,7 @@ snapshots:
       webpack-merge: 5.10.0
     optionalDependencies:
       '@angular-devkit/build-angular': 22.0.7(4bc9dc16f0b3372842cf1a43ceaa0a21)
-      '@angular/build': 22.0.7(patch_hash=fa4bc95e1eaef457f5776af6783f8b7c2200bf4fdd9e30d0c0f11134cbf939e0)(618990100da157f0dba4214b8366d199)
+      '@angular/build': 22.0.7(patch_hash=3e2747ad4b831603b60d13617118b946bc0f2e3bcbf316781e19a18c96364e9e)(618990100da157f0dba4214b8366d199)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@minify-html/node'

--- a/tools/src/prerender-timeout-patch-guard.spec.js
+++ b/tools/src/prerender-timeout-patch-guard.spec.js
@@ -9,18 +9,22 @@ const PRERENDER_WORKER_FILES = [
   'src/utils/server-rendering/render-worker.js',
   'src/utils/server-rendering/routes-extractor-worker.js',
 ];
-const RAISED_TIMEOUT = 'AbortSignal.timeout(120_000)';
+const RAISED_TIMEOUT = 'AbortSignal.timeout(300_000)';
 const UPSTREAM_TIMEOUT = 'AbortSignal.timeout(30_000)';
 
 /**
- * Locks in the pnpm patch that raises @angular/build's hard-coded 30 s
- * per-route prerender timeout to 120 s (patches/@angular__build.patch).
+ * Locks in the two defenses against App Hosting prerender build failures:
+ * the pnpm patch raising @angular/build's hard-coded 30 s per-route prerender
+ * timeout to 300 s (patches/@angular__build.patch), and the
+ * NG_BUILD_MAX_WORKERS=2 cap in both apphosting configs.
  *
- * The App Hosting production build prerenders ~2400 routes (9 locales) with
- * `sourceMap: true` near the 6 GB heap limit; a single GC pause or slow route
- * exceeding the 30 s budget aborts the whole ~30-minute build (AbortError on
- * one route, then "Terminating worker thread" on every in-flight route).
- * Upstream offers no configuration for this timeout as of 22.x.
+ * The App Hosting builder has ~8 GB RAM; the main build process needs a 6 GB
+ * heap and each prerender worker thread adds its own V8 isolate. With the
+ * default 4 workers the ~2400-route prerender (9 locales, `sourceMap: true`)
+ * thrashes into memory-pressure stalls late in the build — a single route
+ * hanging past the timeout aborts the whole build (AbortError on one route,
+ * then "Terminating worker thread" on every in-flight route). Upstream offers
+ * no configuration for the timeout as of 22.x.
  *
  * If an Angular upgrade drops or breaks the patch, refresh it via
  * `pnpm patch @angular/build` instead of deleting it — see
@@ -72,9 +76,26 @@ describe('@angular/build prerender-timeout patch', () => {
     for (const workerFile of PRERENDER_WORKER_FILES) {
       // when reading the worker that owns the per-route abort signal
       const source = readFileSync(join(installedRoot, workerFile), 'utf-8');
-      // then the patched 120 s budget is in effect and the 30 s one is gone
+      // then the patched 300 s budget is in effect and the 30 s one is gone
       expect(source).toContain(RAISED_TIMEOUT);
       expect(source).not.toContain(UPSTREAM_TIMEOUT);
     }
   });
+
+  it.each(['apphosting.yaml', 'apphosting.staging.yaml'])(
+    'should cap prerender workers at BUILD time in %s',
+    (configFile) => {
+      // given the ~8 GB App Hosting builder that thrashes with 4 workers
+      const config = parse(readFileSync(resolve(ROOT, configFile), 'utf-8'));
+      // when App Hosting resolves the build-time environment
+      const workersEntry = (config.env ?? []).find(
+        (entry) => entry && entry.variable === 'NG_BUILD_MAX_WORKERS'
+      );
+      // then the worker cap is bound at BUILD availability and stays small
+      expect(workersEntry).toBeDefined();
+      expect(workersEntry.availability).toEqual(['BUILD']);
+      expect(Number(workersEntry.value)).toBeGreaterThanOrEqual(1);
+      expect(Number(workersEntry.value)).toBeLessThanOrEqual(2);
+    }
+  );
 });


### PR DESCRIPTION
## Problem

Rollout `3b76768d` still failed **with the 120 s timeout patch from #532 active** (the stack traces show the `patch_hash` path). Route `/zh/blog/pushups-for-women` hung past 120 s — so the failure is not a slow render, it's the build machine stalling.

Diagnosis: the App Hosting builder has ~8 GB RAM. The main build process runs at its 6 GB heap (`NODE_OPTIONS=--max-old-space-size=6144`, added after earlier OOMs), and each prerender worker thread adds its own V8 isolate on top. With the default `min(4, cores-1)` workers, the ~2400-route / 9-locale prerender pushes the machine into memory-pressure thrash late in the build, where single renders stall indefinitely. Corroboration: the identical workload (staging config, all 9 locales) completes in **~3 minutes on GitHub's 16 GB runners**; only the memory-starved App Hosting builder takes 22–29 minutes and dies. Both observed failures (`/fr/...` in build `0ee184f5`, `/zh/...` in `3b76768d`) struck deep into the locale sequence, when accumulated memory peaks.

## Fix

- **Primary — `NG_BUILD_MAX_WORKERS=2`** as a BUILD-time env var in `apphosting.yaml` and `apphosting.staging.yaml`: halves concurrent prerender isolates and keeps peak memory inside the machine.
- **Secondary — timeout patch raised 120 s → 300 s** (`patches/@angular__build.patch`): extra headroom so a transient stall degrades the build instead of killing it.
- **Guard spec extended** (`tools/src/prerender-timeout-patch-guard.spec.js`): now also asserts both apphosting configs bind `NG_BUILD_MAX_WORKERS` at BUILD availability with a value ≤ 2, alongside the updated patch assertions.
- **`docs/gotchas/build-and-tooling.md`** rewritten for the real root cause (memory starvation, not per-route slowness).

## Verification

- `pnpm nx test tools` — 91/91 pass, including the new worker-cap guards and the existing apphosting Sentry guards over the edited YAML files.
- `pnpm exec eslint` on the changed spec — clean.
- Patched `@angular/build` verified in `node_modules` with `AbortSignal.timeout(300_000)` in both prerender workers.
- Definitive proof is the next App Hosting rollout; if it still stalls with 2 workers, the fallback lever is dropping prerender from the App Hosting build entirely (the runtime is full SSR with a static cache, so those routes would render on demand) — kept out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HhgdfDoBNLGeSJ71e4gmi

---
_Generated by [Claude Code](https://claude.ai/code/session_012HhgdfDoBNLGeSJ71e4gmi)_