### PR TITLE
chore(android): target Android 16 (API level 36) in TWA wrapper

### DIFF
--- a/mobile/android-twa/app/build.gradle
+++ b/mobile/android-twa/app/build.gradle
@@ -56,9 +56,9 @@ android {
     defaultConfig {
         applicationId "com.pushupstats.app"
         minSdkVersion 21
-        targetSdkVersion 35
-        versionCode 2
-        versionName "2"
+        targetSdkVersion 36
+        versionCode 3
+        versionName "3"
 
         // The name for the application
         resValue "string", "appName", twaManifest.name

--- a/mobile/android-twa/twa-manifest.json
+++ b/mobile/android-twa/twa-manifest.json
@@ -20,8 +20,8 @@
     "path": "/home/wolf/repo/pushup-stats-service/mobile/android-twa/android.keystore",
     "alias": "android"
   },
-  "appVersionName": "2",
-  "appVersionCode": 2,
+  "appVersionName": "3",
+  "appVersionCode": 3,
   "shortcuts": [],
   "generatorApp": "bubblewrap-cli",
   "webManifestUrl": "https://pushup-stats.com/de/manifest.webmanifest",
@@ -56,5 +56,5 @@
   "fileHandlers": [],
   "launchHandlerClientMode": "",
   "displayOverride": [],
-  "appVersion": "2"
+  "appVersion": "3"
 }


### PR DESCRIPTION
## Summary

Updates the Android TWA wrapper (`mobile/android-twa`, Bubblewrap-generated) to target **Android 16 (API level 36)**, per the Play Console target-API requirement.

- `app/build.gradle`: `targetSdkVersion` 35 → **36** (`compileSdkVersion` was already 36)
- `app/build.gradle`: `versionCode` 2 → **3**, `versionName` "2" → **"3"** so the retargeted build can be uploaded to Play
- `twa-manifest.json`: `appVersion`/`appVersionName`/`appVersionCode` synced to 3 so a future `bubblewrap update` regenerates the project with the same values

`minSdkVersion` stays at 21 — the Play requirement is about the *target* SDK ("must target Android 16 (API level 36) or higher"); raising the minimum would drop support for existing devices.

## Notes

- `manifest-checksum.txt` was already stale relative to `twa-manifest.json` before this change (earlier manual edits didn't refresh it either); Bubblewrap rewrites it on the next `update`, so it's left untouched.
- The Android wrapper is outside the Nx workspace and not built by CI; no Nx projects are affected (`mobile/` has no project.json and isn't referenced by nx.json / pnpm-workspace.yaml). There is no test harness for the generated wrapper, so no tests apply to this change.
- Not verified with a local Gradle build — this environment has no Android SDK. The only functional change is the `targetSdkVersion` value; a release build + Play upload (Bubblewrap/Gradle on a machine with the SDK and keystore) is still needed to ship it.
- Heads-up for the release build: with targetSdk 36, Android 16 enforces edge-to-edge without the SDK-35 opt-out. Chrome handles the drawing inside the TWA, but it's worth a quick visual check of the status/navigation bar areas on an Android 16 device before rolling out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvJ3m9bSHdadf7C8jeXZd4

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvJ3m9bSHdadf7C8jeXZd4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Android app to target the latest supported SDK level.
  * Released version 3 of the Android app with updated version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->