### PR TITLE
feat(build): restore App Hosting web build from Nx Cloud remote cache

### DIFF
--- a/apphosting.staging.yaml
+++ b/apphosting.staging.yaml
@@ -47,6 +47,16 @@ env:
     availability:
       - BUILD
 
+  # Same merge pitfall as SENTRY_AUTH_TOKEN above: override the inherited
+  # `secret:` binding with a plain value, because the staging project has no
+  # NX_CLOUD_ACCESS_TOKEN secret and a dangling secret reference fails the
+  # rollout at bind time. An invalid token only degrades Nx Cloud to a 401
+  # warning with no cache — the build itself proceeds.
+  - variable: NX_CLOUD_ACCESS_TOKEN
+    value: 'unused-on-staging'
+    availability:
+      - BUILD
+
 scripts:
   # No Sentry source-map upload here (unlike apphosting.yaml): staging skips the
   # debug-ID upload (see the SENTRY_AUTH_TOKEN override above for why the secret

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -40,6 +40,25 @@ env:
     availability:
       - BUILD
 
+  # Nx Cloud read token so the App Hosting build can restore
+  # `web:build:production` from the remote cache instead of rebuilding it.
+  # CI seeds the cache on every main push (`nx affected -t build -c production`
+  # with the write token), and App Hosting only builds commits that already
+  # passed CI (the `deploy` branch is fast-forwarded post-CI), so every rollout
+  # should be a cache hit — turning the ~16-min build that overwhelms the ~8 GB
+  # builder into an artifact download. See docs/ci-cd.md.
+  #
+  # Setup (one-time, requires gcloud + Firebase project owner role; reuse the
+  # read-only token stored as the NX_CLOUD_ACCESS_TOKEN_READ GitHub secret):
+  #   gcloud secrets create NX_CLOUD_ACCESS_TOKEN --replication-policy=automatic
+  #   echo -n "<read-only token>" | gcloud secrets versions add NX_CLOUD_ACCESS_TOKEN --data-file=-
+  #   firebase apphosting:secrets:grantaccess NX_CLOUD_ACCESS_TOKEN \
+  #     --backend pushup-stats-service --project pushup-stats
+  - variable: NX_CLOUD_ACCESS_TOKEN
+    secret: NX_CLOUD_ACCESS_TOKEN
+    availability:
+      - BUILD
+
   # Default Node heap (~2 GB) OOMs during the Angular SSR build's
   # Mark-Compact phase after bundle generation completes. GitHub Actions
   # already bumps to 6144 for the Firebase deploy workflows

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -8,6 +8,31 @@ How code reaches production and staging. AGENTS.md keeps the high-level rule (no
 - **Agent pool:** Nx Cloud dynamic distribution — see `.nx/workflows/distribution-config.yaml`. Details in [`gotchas/build-and-tooling.md`](gotchas/build-and-tooling.md).
 - **Deploy gate:** CI fast-forwards the `deploy` branch from `main` only after all checks pass (`promote-to-deploy` job). Both deployment targets watch this branch.
 
+## App Hosting Build Cache Reuse
+
+The App Hosting builder (~8 GB RAM) cannot reliably run the full production
+web build (9-locale prerender + sourcemaps) — see
+[`gotchas/build-and-tooling.md`](gotchas/build-and-tooling.md). Instead of
+rebuilding, its `buildCommand` restores `web:build:production` from the Nx
+Cloud remote cache:
+
+- **Seeding:** CI runs `nx affected -t=lint,test,build -c=production` with the
+  `NX_CLOUD_ACCESS_TOKEN_WRITE` secret on every main push. If a commit doesn't
+  affect `web`, the previous cache entry still matches (identical input hash).
+- **Ordering guarantee:** App Hosting deploys from the `deploy` branch, which
+  `promote-to-deploy` fast-forwards only after CI is green — the cache entry
+  always exists before the rollout builds.
+- **Restore:** `apphosting.yaml` binds the `NX_CLOUD_ACCESS_TOKEN` Cloud
+  Secret (a read-only Nx Cloud token) at BUILD availability, so
+  `pnpm nx run web:build -c production` in the rollout is a cache download.
+  The task hash matches CI because `web:build` inputs are file-only (no env
+  inputs) and the build reads no env vars at build time.
+- **Staging override:** `apphosting.staging.yaml` replaces the secret binding
+  with a placeholder value (same bind-time-failure pitfall as
+  `SENTRY_AUTH_TOKEN`); an invalid token only degrades to a 401 warning
+  without cache, it never fails the build.
+- Guard tests: `tools/src/apphosting-nx-cloud-guard.spec.js`.
+
 ## Deployment Targets
 
 - **Firebase Hosting** (static, `.github/workflows/firebase-hosting-merge.yml`): Triggers on push to `deploy` branch.

--- a/docs/gotchas/build-and-tooling.md
+++ b/docs/gotchas/build-and-tooling.md
@@ -13,7 +13,16 @@ the log shows one `AbortError ... TimeoutError`, then a cascade of
 collateral, not root causes). The same build takes ~3 minutes on GitHub's
 16 GB runners — the workload only fails on the memory-starved builder.
 
-Two defenses, both locked in by
+Even with the worker cap, the builder remains marginal: after "Application
+bundle generation complete" the Node process can stall for 10+ minutes in the
+finalization phase (writing the multi-locale dist, final GC near the 6 GB heap
+cap), at which point the resident esbuild Go service panics with
+`fatal error: all goroutines are asleep - deadlock!` and fails the build. The
+structural fix is to not build there at all — the App Hosting rollout restores
+`web:build:production` from the Nx Cloud remote cache seeded by CI (see
+[`docs/ci-cd.md`](../ci-cd.md) → "App Hosting Build Cache Reuse").
+
+Defenses for the case the cache misses, locked in by
 `tools/src/prerender-timeout-patch-guard.spec.js`:
 
 1. **`NG_BUILD_MAX_WORKERS=2`** as a BUILD-time env var in `apphosting.yaml`

--- a/tools/project.json
+++ b/tools/project.json
@@ -6,6 +6,15 @@
   "tags": ["scope:tools"],
   "targets": {
     "test": {
+      "inputs": [
+        "default",
+        "^production",
+        "{workspaceRoot}/jest.preset.js",
+        "{workspaceRoot}/apphosting.yaml",
+        "{workspaceRoot}/apphosting.staging.yaml",
+        "{workspaceRoot}/pnpm-workspace.yaml",
+        "{workspaceRoot}/patches/**/*"
+      ],
       "options": {
         "passWithNoTests": true
       },

--- a/tools/src/apphosting-nx-cloud-guard.spec.js
+++ b/tools/src/apphosting-nx-cloud-guard.spec.js
@@ -1,0 +1,57 @@
+const { readFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+const { parse } = require('yaml');
+
+const ROOT = resolve(__dirname, '../..');
+
+function load(file) {
+  return parse(readFileSync(resolve(ROOT, file), 'utf-8'));
+}
+
+function envEntry(config, variable) {
+  return (config.env ?? []).find(
+    (entry) => entry && entry.variable === variable
+  );
+}
+
+/**
+ * Locks in the Nx Cloud remote-cache wiring for App Hosting builds.
+ *
+ * CI seeds `web:build:production` into the remote cache on every main push
+ * (write token), and App Hosting only builds commits that already passed CI —
+ * so with a read token bound at BUILD time, every rollout restores the build
+ * from cache instead of re-running it on the ~8 GB builder that cannot handle
+ * the full 9-locale prerender (see docs/gotchas/build-and-tooling.md).
+ *
+ * Staging must NOT inherit the secret binding: App Hosting merges
+ * apphosting.staging.yaml onto apphosting.yaml by variable name, base-only
+ * entries persist, and a secret reference that doesn't exist in the staging
+ * project fails the rollout at bind time — the same pitfall locked in by
+ * apphosting-sentry-guard.spec.js.
+ */
+describe('App Hosting Nx Cloud cache configuration', () => {
+  it('should bind the NX_CLOUD_ACCESS_TOKEN secret at BUILD time in production', () => {
+    // given the remote cache seeded by CI's main-push run
+    const prod = load('apphosting.yaml');
+    // when App Hosting resolves the build-time environment
+    const tokenEntry = envEntry(prod, 'NX_CLOUD_ACCESS_TOKEN');
+    // then the read token is available to nx during buildCommand
+    expect(tokenEntry).toMatchObject({
+      secret: 'NX_CLOUD_ACCESS_TOKEN',
+      availability: ['BUILD'],
+    });
+  });
+
+  it('should override the inherited secret with a non-empty literal value in staging', () => {
+    // given the staging GCP project has no NX_CLOUD_ACCESS_TOKEN secret
+    const staging = load('apphosting.staging.yaml');
+    // when staging redefines the variable that would otherwise merge in
+    const tokenEntry = envEntry(staging, 'NX_CLOUD_ACCESS_TOKEN');
+    // then the secret resolution is replaced by a plain value ("" is
+    //   reserved by App Hosting and rejected, so it must be non-empty)
+    expect(tokenEntry).toBeDefined();
+    expect(tokenEntry).not.toHaveProperty('secret');
+    expect(typeof tokenEntry.value).toBe('string');
+    expect(tokenEntry.value.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## ⚠️ Deploy gate — do not merge yet

This PR references a Cloud Secret that must exist **before** it reaches the `deploy` branch, or production rollouts fail at bind time (the staging-Sentry lesson). One-time setup, reusing the read-only token already stored as the `NX_CLOUD_ACCESS_TOKEN_READ` GitHub secret:

```bash
gcloud secrets create NX_CLOUD_ACCESS_TOKEN --replication-policy=automatic --project pushup-stats
echo -n "<read-only token>" | gcloud secrets versions add NX_CLOUD_ACCESS_TOKEN --data-file=- --project pushup-stats
firebase apphosting:secrets:grantaccess NX_CLOUD_ACCESS_TOKEN \
  --backend pushup-stats-service --project pushup-stats
```

## Problem

The rollout for `673c85c` confirmed the worker cap from #533 works — prerender of all 2349 routes completed and "Application bundle generation complete" printed after **461 s** (previously 22–29 min of thrash then death). But the build then failed in finalization: Node stalled for **10+ minutes** after completion (writing the multi-locale dist / final GC near the 6 GB heap cap), and the resident esbuild Go service panicked with `fatal error: all goroutines are asleep - deadlock!` (its stacks show goroutines blocked "10 minutes"). The ~8 GB App Hosting builder is structurally too small for this build, and each fix just moves the cliff.

## Fix — stop building there

Everything needed already exists:
- CI seeds `web:build:production` into the Nx Cloud remote cache on every main push (`nx affected -t=lint,test,build -c=production` with `NX_CLOUD_ACCESS_TOKEN_WRITE`). Commits that don't affect `web` still hit the previous entry (identical input hash).
- App Hosting deploys from the `deploy` branch, fast-forwarded by `promote-to-deploy` **only after CI is green** — the cache entry always exists before a rollout builds.
- The rollout's 401 ("You do not have sufficient access to this workspace") in every failing log is the missing piece: no token bound in the App Hosting build env.

Changes:
- **`apphosting.yaml`**: bind `NX_CLOUD_ACCESS_TOKEN` (read-only Nx Cloud token via Cloud Secret Manager) at BUILD availability. `pnpm nx run web:build -c production` in the rollout becomes a cache download.
- **`apphosting.staging.yaml`**: override the inherited secret binding with a placeholder value — App Hosting merges configs by variable name and a dangling secret reference fails staging rollouts at bind time. An invalid token only degrades to a 401 warning with no cache; it never fails the build.
- **`tools/src/apphosting-nx-cloud-guard.spec.js`**: guard spec locking in both bindings (mirrors `apphosting-sentry-guard.spec.js`).
- **`docs/ci-cd.md`** + **`docs/gotchas/build-and-tooling.md`**: document the cache-reuse flow and the esbuild finalization deadlock.

Cache-hit safety: `web:build` inputs are file-only (no env inputs in `nx.json`), and `web/src` reads no env vars at build time (`process.env` usage in `server.ts` executes at runtime) — a CI-built artifact is byte-identical for the same commit. `pnpm sentry:sourcemaps` uploads from the restored `dist/` unchanged.

## Verification

- `pnpm nx test tools` — 93/93 pass, including the 2 new guard tests.
- `pnpm exec eslint` on the new spec — clean.
- After the secret exists and this merges: the rollout log should show `web:build:production` restored from remote cache in ~1–3 min instead of building for 16+ min. The 30/300 s timeout patch and worker cap from #532/#533 remain as defense-in-depth for cache misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HhgdfDoBNLGeSJ71e4gmi

---
_Generated by [Claude Code](https://claude.ai/code/session_012HhgdfDoBNLGeSJ71e4gmi)_