### PR TITLE
Add delete for exercise entries in admin panel

### DIFF
--- a/data-store/firebase.json
+++ b/data-store/firebase.json
@@ -1,7 +1,10 @@
 {
   "functions": {
     "source": "functions-dist",
-    "runtime": "nodejs24"
+    "runtime": "nodejs24",
+    "predeploy": [
+      "node ../tools/src/strip-unused-lockfile-patches.mjs functions-dist/pnpm-lock.yaml"
+    ]
   },
   "emulators": {
     "auth": {

--- a/data-store/functions/src/admin/user-entries-delete.spec.ts
+++ b/data-store/functions/src/admin/user-entries-delete.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  MAX_DELETE_ENTRY_IDS,
+  validateDeleteUserEntriesPayload,
+} from './user-entries-delete';
+
+describe('admin/user-entries-delete', () => {
+  describe('validateDeleteUserEntriesPayload', () => {
+    it('should accept a uid with one or more trimmed entryIds', () => {
+      // given / when
+      const result = validateDeleteUserEntriesPayload({
+        uid: ' user-1 ',
+        entryIds: [' entry-1 ', 'entry-2'],
+      });
+
+      // then
+      expect(result).toEqual({
+        valid: true,
+        uid: 'user-1',
+        entryIds: ['entry-1', 'entry-2'],
+      });
+    });
+
+    it('should reject a missing or empty uid', () => {
+      // given / when / then
+      expect(validateDeleteUserEntriesPayload({ entryIds: ['e'] }).valid).toBe(
+        false
+      );
+      expect(
+        validateDeleteUserEntriesPayload({ uid: '  ', entryIds: ['e'] }).valid
+      ).toBe(false);
+      expect(validateDeleteUserEntriesPayload(null).valid).toBe(false);
+    });
+
+    it('should reject a missing, empty, or non-array entryIds', () => {
+      // given / when / then
+      expect(validateDeleteUserEntriesPayload({ uid: 'u' }).valid).toBe(false);
+      expect(
+        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: [] }).valid
+      ).toBe(false);
+      expect(
+        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: 'e' }).valid
+      ).toBe(false);
+    });
+
+    it('should reject entryIds exceeding the maximum batch size', () => {
+      // given
+      const entryIds = Array.from(
+        { length: MAX_DELETE_ENTRY_IDS + 1 },
+        (_, i) => `e${i}`
+      );
+
+      // when
+      const result = validateDeleteUserEntriesPayload({ uid: 'u', entryIds });
+
+      // then
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject a non-string or blank entryId in the array', () => {
+      // given / when / then
+      expect(
+        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: ['e', 42] })
+          .valid
+      ).toBe(false);
+      expect(
+        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: ['e', '   '] })
+          .valid
+      ).toBe(false);
+    });
+  });
+});

--- a/data-store/functions/src/admin/user-entries-delete.spec.ts
+++ b/data-store/functions/src/admin/user-entries-delete.spec.ts
@@ -57,6 +57,20 @@ describe('admin/user-entries-delete', () => {
       expect(result.valid).toBe(false);
     });
 
+    it('should accept entryIds at exactly the maximum batch size', () => {
+      // given
+      const entryIds = Array.from(
+        { length: MAX_DELETE_ENTRY_IDS },
+        (_, i) => `e${i}`
+      );
+
+      // when
+      const result = validateDeleteUserEntriesPayload({ uid: 'u', entryIds });
+
+      // then
+      expect(result.valid).toBe(true);
+    });
+
     it('should reject a non-string or blank entryId in the array', () => {
       // given / when / then
       expect(

--- a/data-store/functions/src/admin/user-entries-delete.ts
+++ b/data-store/functions/src/admin/user-entries-delete.ts
@@ -1,0 +1,49 @@
+/**
+ * Admin bulk-delete of a user's exercise entries — pure payload validation.
+ * Split out of `user-entries.ts` (list/update payload validation) to keep
+ * that file under the repo's per-file LOC guideline; the callable in
+ * `functions-admin-user-entries.ts` owns the Firestore reads/writes.
+ */
+
+/**
+ * Upper bound for a single `adminDeleteUserEntries` call — a Firestore
+ * `WriteBatch` accepts at most 500 operations.
+ */
+export const MAX_DELETE_ENTRY_IDS = 500;
+
+/**
+ * Validates the `adminDeleteUserEntries` payload: a non-empty `uid` and a
+ * non-empty array of `entryIds` (non-empty strings), capped at
+ * {@link MAX_DELETE_ENTRY_IDS}.
+ */
+export function validateDeleteUserEntriesPayload(
+  data: unknown
+):
+  | { valid: true; uid: string; entryIds: string[] }
+  | { valid: false; error: string } {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, error: 'payload must be an object' };
+  }
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.uid !== 'string' || obj.uid.trim().length === 0) {
+    return { valid: false, error: 'uid missing or empty' };
+  }
+  if (!Array.isArray(obj.entryIds) || obj.entryIds.length === 0) {
+    return { valid: false, error: 'entryIds must be a non-empty array' };
+  }
+  if (obj.entryIds.length > MAX_DELETE_ENTRY_IDS) {
+    return {
+      valid: false,
+      error: `entryIds must not exceed ${MAX_DELETE_ENTRY_IDS}`,
+    };
+  }
+  const entryIds: string[] = [];
+  for (const id of obj.entryIds) {
+    if (typeof id !== 'string' || id.trim().length === 0) {
+      return { valid: false, error: 'entryIds must contain non-empty strings' };
+    }
+    entryIds.push(id.trim());
+  }
+
+  return { valid: true, uid: obj.uid.trim(), entryIds };
+}

--- a/data-store/functions/src/admin/user-entries.spec.ts
+++ b/data-store/functions/src/admin/user-entries.spec.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from '@jest/globals';
 import {
+  MAX_DELETE_ENTRY_IDS,
   MAX_USER_ENTRIES_LIMIT,
   serializeEntry,
   toIsoString,
+  validateDeleteUserEntriesPayload,
   validateListUserEntriesPayload,
   validateUpdateUserEntryPayload,
 } from './user-entries';
@@ -262,6 +264,71 @@ describe('admin/user-entries', () => {
       ).toBe(false);
       expect(
         validateUpdateUserEntryPayload({ uid: 'u', entryId: 'e' }).valid
+      ).toBe(false);
+    });
+  });
+
+  describe('validateDeleteUserEntriesPayload', () => {
+    it('should accept a uid with one or more trimmed entryIds', () => {
+      // given / when
+      const result = validateDeleteUserEntriesPayload({
+        uid: ' user-1 ',
+        entryIds: [' entry-1 ', 'entry-2'],
+      });
+
+      // then
+      expect(result).toEqual({
+        valid: true,
+        uid: 'user-1',
+        entryIds: ['entry-1', 'entry-2'],
+      });
+    });
+
+    it('should reject a missing or empty uid', () => {
+      // given / when / then
+      expect(validateDeleteUserEntriesPayload({ entryIds: ['e'] }).valid).toBe(
+        false
+      );
+      expect(
+        validateDeleteUserEntriesPayload({ uid: '  ', entryIds: ['e'] }).valid
+      ).toBe(false);
+      expect(validateDeleteUserEntriesPayload(null).valid).toBe(false);
+    });
+
+    it('should reject a missing, empty, or non-array entryIds', () => {
+      // given / when / then
+      expect(validateDeleteUserEntriesPayload({ uid: 'u' }).valid).toBe(false);
+      expect(
+        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: [] }).valid
+      ).toBe(false);
+      expect(
+        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: 'e' }).valid
+      ).toBe(false);
+    });
+
+    it('should reject entryIds exceeding the maximum batch size', () => {
+      // given
+      const entryIds = Array.from(
+        { length: MAX_DELETE_ENTRY_IDS + 1 },
+        (_, i) => `e${i}`
+      );
+
+      // when
+      const result = validateDeleteUserEntriesPayload({ uid: 'u', entryIds });
+
+      // then
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject a non-string or blank entryId in the array', () => {
+      // given / when / then
+      expect(
+        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: ['e', 42] })
+          .valid
+      ).toBe(false);
+      expect(
+        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: ['e', '   '] })
+          .valid
       ).toBe(false);
     });
   });

--- a/data-store/functions/src/admin/user-entries.spec.ts
+++ b/data-store/functions/src/admin/user-entries.spec.ts
@@ -1,10 +1,8 @@
 import { describe, it, expect } from '@jest/globals';
 import {
-  MAX_DELETE_ENTRY_IDS,
   MAX_USER_ENTRIES_LIMIT,
   serializeEntry,
   toIsoString,
-  validateDeleteUserEntriesPayload,
   validateListUserEntriesPayload,
   validateUpdateUserEntryPayload,
 } from './user-entries';
@@ -264,71 +262,6 @@ describe('admin/user-entries', () => {
       ).toBe(false);
       expect(
         validateUpdateUserEntryPayload({ uid: 'u', entryId: 'e' }).valid
-      ).toBe(false);
-    });
-  });
-
-  describe('validateDeleteUserEntriesPayload', () => {
-    it('should accept a uid with one or more trimmed entryIds', () => {
-      // given / when
-      const result = validateDeleteUserEntriesPayload({
-        uid: ' user-1 ',
-        entryIds: [' entry-1 ', 'entry-2'],
-      });
-
-      // then
-      expect(result).toEqual({
-        valid: true,
-        uid: 'user-1',
-        entryIds: ['entry-1', 'entry-2'],
-      });
-    });
-
-    it('should reject a missing or empty uid', () => {
-      // given / when / then
-      expect(validateDeleteUserEntriesPayload({ entryIds: ['e'] }).valid).toBe(
-        false
-      );
-      expect(
-        validateDeleteUserEntriesPayload({ uid: '  ', entryIds: ['e'] }).valid
-      ).toBe(false);
-      expect(validateDeleteUserEntriesPayload(null).valid).toBe(false);
-    });
-
-    it('should reject a missing, empty, or non-array entryIds', () => {
-      // given / when / then
-      expect(validateDeleteUserEntriesPayload({ uid: 'u' }).valid).toBe(false);
-      expect(
-        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: [] }).valid
-      ).toBe(false);
-      expect(
-        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: 'e' }).valid
-      ).toBe(false);
-    });
-
-    it('should reject entryIds exceeding the maximum batch size', () => {
-      // given
-      const entryIds = Array.from(
-        { length: MAX_DELETE_ENTRY_IDS + 1 },
-        (_, i) => `e${i}`
-      );
-
-      // when
-      const result = validateDeleteUserEntriesPayload({ uid: 'u', entryIds });
-
-      // then
-      expect(result.valid).toBe(false);
-    });
-
-    it('should reject a non-string or blank entryId in the array', () => {
-      // given / when / then
-      expect(
-        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: ['e', 42] })
-          .valid
-      ).toBe(false);
-      expect(
-        validateDeleteUserEntriesPayload({ uid: 'u', entryIds: ['e', '   '] })
-          .valid
       ).toBe(false);
     });
   });

--- a/data-store/functions/src/admin/user-entries.ts
+++ b/data-store/functions/src/admin/user-entries.ts
@@ -12,6 +12,12 @@
 export const MAX_USER_ENTRIES_LIMIT = 2000;
 const DEFAULT_USER_ENTRIES_LIMIT = 1000;
 
+/**
+ * Upper bound for a single `adminDeleteUserEntries` call — a Firestore
+ * `WriteBatch` accepts at most 500 operations.
+ */
+export const MAX_DELETE_ENTRY_IDS = 500;
+
 export interface AdminEntryPatch {
   timestamp?: string;
   reps?: number;
@@ -294,4 +300,41 @@ export function validateUpdateUserEntryPayload(
     entryId: obj.entryId.trim(),
     patch,
   };
+}
+
+/**
+ * Validates the `adminDeleteUserEntries` payload: a non-empty `uid` and a
+ * non-empty array of `entryIds` (non-empty strings), capped at
+ * {@link MAX_DELETE_ENTRY_IDS}.
+ */
+export function validateDeleteUserEntriesPayload(
+  data: unknown
+):
+  | { valid: true; uid: string; entryIds: string[] }
+  | { valid: false; error: string } {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, error: 'payload must be an object' };
+  }
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.uid !== 'string' || obj.uid.trim().length === 0) {
+    return { valid: false, error: 'uid missing or empty' };
+  }
+  if (!Array.isArray(obj.entryIds) || obj.entryIds.length === 0) {
+    return { valid: false, error: 'entryIds must be a non-empty array' };
+  }
+  if (obj.entryIds.length > MAX_DELETE_ENTRY_IDS) {
+    return {
+      valid: false,
+      error: `entryIds must not exceed ${MAX_DELETE_ENTRY_IDS}`,
+    };
+  }
+  const entryIds: string[] = [];
+  for (const id of obj.entryIds) {
+    if (typeof id !== 'string' || id.trim().length === 0) {
+      return { valid: false, error: 'entryIds must contain non-empty strings' };
+    }
+    entryIds.push(id.trim());
+  }
+
+  return { valid: true, uid: obj.uid.trim(), entryIds };
 }

--- a/data-store/functions/src/admin/user-entries.ts
+++ b/data-store/functions/src/admin/user-entries.ts
@@ -12,12 +12,6 @@
 export const MAX_USER_ENTRIES_LIMIT = 2000;
 const DEFAULT_USER_ENTRIES_LIMIT = 1000;
 
-/**
- * Upper bound for a single `adminDeleteUserEntries` call — a Firestore
- * `WriteBatch` accepts at most 500 operations.
- */
-export const MAX_DELETE_ENTRY_IDS = 500;
-
 export interface AdminEntryPatch {
   timestamp?: string;
   reps?: number;
@@ -300,41 +294,4 @@ export function validateUpdateUserEntryPayload(
     entryId: obj.entryId.trim(),
     patch,
   };
-}
-
-/**
- * Validates the `adminDeleteUserEntries` payload: a non-empty `uid` and a
- * non-empty array of `entryIds` (non-empty strings), capped at
- * {@link MAX_DELETE_ENTRY_IDS}.
- */
-export function validateDeleteUserEntriesPayload(
-  data: unknown
-):
-  | { valid: true; uid: string; entryIds: string[] }
-  | { valid: false; error: string } {
-  if (!data || typeof data !== 'object') {
-    return { valid: false, error: 'payload must be an object' };
-  }
-  const obj = data as Record<string, unknown>;
-  if (typeof obj.uid !== 'string' || obj.uid.trim().length === 0) {
-    return { valid: false, error: 'uid missing or empty' };
-  }
-  if (!Array.isArray(obj.entryIds) || obj.entryIds.length === 0) {
-    return { valid: false, error: 'entryIds must be a non-empty array' };
-  }
-  if (obj.entryIds.length > MAX_DELETE_ENTRY_IDS) {
-    return {
-      valid: false,
-      error: `entryIds must not exceed ${MAX_DELETE_ENTRY_IDS}`,
-    };
-  }
-  const entryIds: string[] = [];
-  for (const id of obj.entryIds) {
-    if (typeof id !== 'string' || id.trim().length === 0) {
-      return { valid: false, error: 'entryIds must contain non-empty strings' };
-    }
-    entryIds.push(id.trim());
-  }
-
-  return { valid: true, uid: obj.uid.trim(), entryIds };
 }

--- a/data-store/functions/src/functions-admin-user-entries.ts
+++ b/data-store/functions/src/functions-admin-user-entries.ts
@@ -9,6 +9,7 @@ import {
 import {
   type AdminEntryPatch,
   serializeEntry,
+  validateDeleteUserEntriesPayload,
   validateListUserEntriesPayload,
   validateUpdateUserEntryPayload,
 } from './admin/user-entries';
@@ -179,5 +180,54 @@ export const adminUpdateUserEntry = onCall(
       by: request.auth?.uid,
     });
     return { ok: true };
+  }
+);
+
+// Admin-only bulk delete of a user's exercise entries (one row or many, from
+// the entries-page table's row/select-all checkboxes). Ownership is
+// re-checked per entry via `db.getAll` — a stale/foreign entryId in the batch
+// is silently skipped rather than aborting the whole request, mirroring
+// `adminBulkDeleteInactiveAnonymous`'s `{ deleted, skipped }` shape. The
+// `updateExerciseStatsOnEntryWrite`, `updateAdminUserActivityOnEntryWrite` and
+// `refreshExerciseLeaderboardsOnEntryWrite` triggers all key off
+// `onDocumentWritten`, which fires on delete too, so aggregates stay current.
+export const adminDeleteUserEntries = onCall(
+  { region: 'europe-west3', timeoutSeconds: 60 },
+  async (request) => {
+    assertAdmin(request);
+
+    const result = validateDeleteUserEntriesPayload(request.data);
+    if (!result.valid) {
+      throw new HttpsError('invalid-argument', result.error);
+    }
+    const { uid, entryIds } = result;
+
+    const refs = entryIds.map((id) =>
+      db.collection(EXERCISE_ENTRIES_COLLECTION).doc(id)
+    );
+    const snaps = await db.getAll(...refs);
+
+    const batch = db.batch();
+    let deleted = 0;
+    let skipped = 0;
+    for (const snap of snaps) {
+      if (snap.exists && snap.data()?.userId === uid) {
+        batch.delete(snap.ref);
+        deleted++;
+      } else {
+        skipped++;
+      }
+    }
+    if (deleted > 0) {
+      await batch.commit();
+    }
+
+    logger.info('adminDeleteUserEntries', {
+      uid,
+      deleted,
+      skipped,
+      by: request.auth?.uid,
+    });
+    return { deleted, skipped };
   }
 );

--- a/data-store/functions/src/functions-admin-user-entries.ts
+++ b/data-store/functions/src/functions-admin-user-entries.ts
@@ -9,10 +9,10 @@ import {
 import {
   type AdminEntryPatch,
   serializeEntry,
-  validateDeleteUserEntriesPayload,
   validateListUserEntriesPayload,
   validateUpdateUserEntryPayload,
 } from './admin/user-entries';
+import { validateDeleteUserEntriesPayload } from './admin/user-entries-delete';
 import { db } from './firebase-app';
 import { assertAdmin } from './functions-admin';
 

--- a/data-store/functions/src/index.ts
+++ b/data-store/functions/src/index.ts
@@ -23,6 +23,7 @@ export {
 } from './functions-admin-user-activity';
 
 export {
+  adminDeleteUserEntries,
   adminListUserEntries,
   adminUpdateUserEntry,
 } from './functions-admin-user-entries';

--- a/docs/gotchas/build-and-tooling.md
+++ b/docs/gotchas/build-and-tooling.md
@@ -38,6 +38,31 @@ Defenses for the case the cache misses, locked in by
    `pnpm patch-commit <edit-dir>`. Delete patch, guard test, and this section
    together only once upstream makes the timeout configurable.
 
+## Cloud Functions deploy: pruned lockfile carries an irrelevant patch entry
+
+`@nx/esbuild`'s `generatePackageJson` (used by `cloud-functions:build`) prunes
+a subset `package.json` + `pnpm-lock.yaml` into `data-store/functions-dist`,
+but copies the workspace's `patchedDependencies` block from the root
+`pnpm-lock.yaml` verbatim — even though `@angular/build` (patched for the
+prerender timeout above) isn't a dependency of the functions codebase at all.
+Firebase's Cloud Build then runs its own `pnpm install --frozen-lockfile`
+against the generated `package.json` (which has no matching
+`pnpm.patchedDependencies` field), and pnpm rejects the mismatch with
+`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.
+
+This only bites when Cloud Build actually rebuilds a function — an
+unchanged-hash deploy is skipped entirely, so the bug can sit latent for a
+long time (it first surfaced only when a brand-new function was deployed,
+well after the `@angular/build` patch had been added). The fix is a
+`predeploy` hook in `data-store/firebase.json` (`functions.predeploy`) that
+runs `tools/src/strip-unused-lockfile-patches.mjs` against the generated
+lockfile before Firebase packages it — it removes the `patchedDependencies`
+block only when none of its packages actually appear in the lockfile's
+`packages:` section, via a targeted text splice (not a full YAML
+parse/stringify round-trip, which would reformat the entire 2000+ line file).
+If a genuinely-used patch and an unused one are ever mixed in the same
+lockfile, the script bails out with a warning instead of guessing.
+
 ## Transient build flakes
 
 **`Inlining of fonts failed ... fonts.googleapis.com/icon?family=Material+Icons`** is a network flake during `web:build`, **not a code bug**. Retry `pnpm nx run web:build -c production` after a few seconds.

--- a/tools/src/strip-unused-lockfile-patches.mjs
+++ b/tools/src/strip-unused-lockfile-patches.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Strip the top-level `patchedDependencies:` block from a generated
+ * per-project pnpm lockfile when none of its patched packages are actually
+ * part of that project's resolved dependency graph.
+ *
+ * `@nx/esbuild`'s `generatePackageJson` prunes a subset `package.json` +
+ * `pnpm-lock.yaml` for a single project (e.g. `data-store/functions-dist`),
+ * but copies the workspace's `patchedDependencies` config verbatim even when
+ * none of the patched packages are dependencies of that project (the
+ * `@angular/build` patch is a web-only devDependency, irrelevant to
+ * cloud-functions). Firebase's Cloud Build then runs its own
+ * `pnpm install --frozen-lockfile` against the generated package.json (which
+ * carries no matching `pnpm.patchedDependencies` field), and pnpm rejects the
+ * mismatch with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.
+ *
+ * Edits the file as plain text (a targeted line splice of the
+ * `patchedDependencies:` block) rather than a full YAML parse/stringify
+ * round-trip, so the rest of a 2000+ line generated lockfile is left
+ * byte-identical.
+ *
+ * Usage: node tools/src/strip-unused-lockfile-patches.mjs <path-to-lockfile>
+ */
+import { promises as fs } from 'node:fs';
+
+/**
+ * Pure transform: removes the `patchedDependencies:` block from lockfile text
+ * when none of its patched package names appear in the rest of the file
+ * (i.e. they're not actually resolved dependencies). Returns the
+ * (possibly unchanged) content plus which names were removed vs. left in
+ * place because they still looked used.
+ */
+export function stripUnusedPatches(raw) {
+  const lines = raw.split('\n');
+
+  const startIdx = lines.findIndex((l) => l === 'patchedDependencies:');
+  if (startIdx === -1) {
+    return { content: raw, removedNames: [], skippedNames: [] };
+  }
+
+  // The block runs until the next top-level (unindented, non-blank) line.
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (lines[i].length > 0 && !lines[i].startsWith(' ')) {
+      endIdx = i;
+      break;
+    }
+  }
+
+  // Patched package names are the block's 2-space-indented `'name':` keys.
+  const nameRe = /^ {2}'?([^':]+)'?:\s*$/;
+  const patchedNames = lines
+    .slice(startIdx + 1, endIdx)
+    .map((l) => l.match(nameRe)?.[1])
+    .filter((name) => name !== undefined);
+
+  const outsideBlock =
+    lines.slice(0, startIdx).join('\n') + lines.slice(endIdx).join('\n');
+  const stillUsed = patchedNames.filter((name) =>
+    outsideBlock.includes(`${name}@`)
+  );
+
+  if (stillUsed.length > 0) {
+    // A mixed case (some patches used, some not) needs real YAML-aware
+    // per-entry removal; bail out rather than risk a malformed splice. The
+    // predeploy step will then surface the original pnpm error clearly.
+    return { content: raw, removedNames: [], skippedNames: stillUsed };
+  }
+
+  // A trailing blank line separates this block from the next section; drop
+  // it along with the block itself so section spacing stays consistent.
+  let spliceEnd = endIdx;
+  if (lines[spliceEnd - 1] === '') spliceEnd -= 1;
+  const nextLines = lines.slice();
+  nextLines.splice(startIdx, spliceEnd - startIdx + 1);
+
+  return {
+    content: nextLines.join('\n'),
+    removedNames: patchedNames,
+    skippedNames: [],
+  };
+}
+
+async function main() {
+  const lockfilePath = process.argv[2];
+  if (!lockfilePath) {
+    console.error(
+      'Usage: strip-unused-lockfile-patches.mjs <path-to-lockfile>'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const raw = await fs.readFile(lockfilePath, 'utf8');
+  const { content, removedNames, skippedNames } = stripUnusedPatches(raw);
+
+  if (skippedNames.length > 0) {
+    console.warn(
+      `strip-unused-lockfile-patches: ${skippedNames.join(
+        ', '
+      )} appear used in ${lockfilePath} — leaving patchedDependencies untouched`
+    );
+    return;
+  }
+
+  if (removedNames.length === 0) {
+    return;
+  }
+
+  await fs.writeFile(lockfilePath, content, 'utf8');
+  console.log(
+    `strip-unused-lockfile-patches: removed unused patchedDependencies (${removedNames.join(
+      ', '
+    )}) from ${lockfilePath}`
+  );
+}
+
+const isMain =
+  process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  await main();
+}

--- a/tools/src/strip-unused-lockfile-patches.mjs
+++ b/tools/src/strip-unused-lockfile-patches.mjs
@@ -30,15 +30,13 @@ import { promises as fs } from 'node:fs';
  * (possibly unchanged) content plus which names were removed vs. left in
  * place because they still looked used.
  */
-export function stripUnusedPatches(raw) {
-  const lines = raw.split('\n');
+// Finds a top-level (column-0) `key:` line and the half-open line range
+// [startIdx, endIdx) of its block — up to the next top-level, non-blank line
+// (or EOF). Returns null if the key isn't present.
+function findTopLevelBlock(lines, key) {
+  const startIdx = lines.findIndex((l) => l === `${key}:`);
+  if (startIdx === -1) return null;
 
-  const startIdx = lines.findIndex((l) => l === 'patchedDependencies:');
-  if (startIdx === -1) {
-    return { content: raw, removedNames: [], skippedNames: [] };
-  }
-
-  // The block runs until the next top-level (unindented, non-blank) line.
   let endIdx = lines.length;
   for (let i = startIdx + 1; i < lines.length; i++) {
     if (lines[i].length > 0 && !lines[i].startsWith(' ')) {
@@ -46,6 +44,17 @@ export function stripUnusedPatches(raw) {
       break;
     }
   }
+  return { startIdx, endIdx };
+}
+
+export function stripUnusedPatches(raw) {
+  const lines = raw.split('\n');
+
+  const patchedBlock = findTopLevelBlock(lines, 'patchedDependencies');
+  if (!patchedBlock) {
+    return { content: raw, removedNames: [], skippedNames: [] };
+  }
+  const { startIdx, endIdx } = patchedBlock;
 
   // Patched package names are the block's 2-space-indented `'name':` keys.
   const nameRe = /^ {2}'?([^':]+)'?:\s*$/;
@@ -54,11 +63,24 @@ export function stripUnusedPatches(raw) {
     .map((l) => l.match(nameRe)?.[1])
     .filter((name) => name !== undefined);
 
-  const outsideBlock =
-    lines.slice(0, startIdx).join('\n') + lines.slice(endIdx).join('\n');
-  const stillUsed = patchedNames.filter((name) =>
-    outsideBlock.includes(`${name}@`)
-  );
+  // A package is "used" only if it's an exact resolved key in `packages:`
+  // (e.g. `'@babel/core@7.0.0':` -> name `@babel/core`) — not a raw
+  // substring match, which would false-positive on e.g. a patch named
+  // `core` against an unrelated `@babel/core@...` entry.
+  const packagesBlock = findTopLevelBlock(lines, 'packages');
+  const resolvedNames = new Set();
+  if (packagesBlock) {
+    const pkgKeyRe = /^ {2}'?(.+)@[^@'\s]+'?:\s*$/;
+    for (const line of lines.slice(
+      packagesBlock.startIdx + 1,
+      packagesBlock.endIdx
+    )) {
+      const match = line.match(pkgKeyRe);
+      if (match) resolvedNames.add(match[1]);
+    }
+  }
+
+  const stillUsed = patchedNames.filter((name) => resolvedNames.has(name));
 
   if (stillUsed.length > 0) {
     // A mixed case (some patches used, some not) needs real YAML-aware
@@ -67,12 +89,12 @@ export function stripUnusedPatches(raw) {
     return { content: raw, removedNames: [], skippedNames: stillUsed };
   }
 
-  // A trailing blank line separates this block from the next section; drop
-  // it along with the block itself so section spacing stays consistent.
-  let spliceEnd = endIdx;
-  if (lines[spliceEnd - 1] === '') spliceEnd -= 1;
+  // [startIdx, endIdx) already spans exactly the block (including any blank
+  // line that separates it from the next section, since that blank line
+  // sits before endIdx) — splicing anything more would eat the next
+  // section's header when there's no blank separator.
   const nextLines = lines.slice();
-  nextLines.splice(startIdx, spliceEnd - startIdx + 1);
+  nextLines.splice(startIdx, endIdx - startIdx);
 
   return {
     content: nextLines.join('\n'),

--- a/tools/src/strip-unused-lockfile-patches.spec.js
+++ b/tools/src/strip-unused-lockfile-patches.spec.js
@@ -19,8 +19,7 @@ function runStripUnusedPatches(raw) {
 }
 
 describe('stripUnusedPatches', () => {
-  it('should leave the content untouched when there is no patchedDependencies block', () => {
-    // given
+  it('leaves the content untouched when there is no patchedDependencies block', () => {
     const raw = [
       "lockfileVersion: '9.0'",
       '',
@@ -29,10 +28,8 @@ describe('stripUnusedPatches', () => {
       '',
     ].join('\n');
 
-    // when
     const result = runStripUnusedPatches(raw);
 
-    // then
     expect(result).toEqual({
       content: raw,
       removedNames: [],
@@ -40,10 +37,10 @@ describe('stripUnusedPatches', () => {
     });
   });
 
-  it('should remove the block when the patched package is not resolved anywhere else', () => {
-    // given — mirrors the real `data-store/functions-dist/pnpm-lock.yaml`
-    // shape: @angular/build is patched workspace-wide but isn't a dependency
-    // of this project, so it never appears as a `packages:` key.
+  it('removes the block when the patched package is not resolved anywhere else', () => {
+    // Mirrors the real `data-store/functions-dist/pnpm-lock.yaml` shape:
+    // @angular/build is patched workspace-wide but isn't a dependency of
+    // this project, so it never appears as a `packages:` key.
     const raw = [
       "lockfileVersion: '9.0'",
       '',
@@ -68,10 +65,8 @@ describe('stripUnusedPatches', () => {
       '',
     ].join('\n');
 
-    // when
     const result = runStripUnusedPatches(raw);
 
-    // then
     expect(result.removedNames).toEqual(['@angular/build']);
     expect(result.skippedNames).toEqual([]);
     expect(result.content).not.toContain('patchedDependencies');
@@ -81,8 +76,7 @@ describe('stripUnusedPatches', () => {
     expect(result.content).toContain('settings:');
   });
 
-  it('should leave the block untouched when the patched package is actually resolved', () => {
-    // given — a patch for a package that IS a real dependency here
+  it('leaves the block untouched when the patched package is actually resolved', () => {
     const raw = [
       "lockfileVersion: '9.0'",
       '',
@@ -97,10 +91,9 @@ describe('stripUnusedPatches', () => {
       '',
     ].join('\n');
 
-    // when
     const result = runStripUnusedPatches(raw);
 
-    // then — bail out rather than risk a malformed partial splice
+    // bail out rather than risk a malformed partial splice
     expect(result).toEqual({
       content: raw,
       removedNames: [],
@@ -108,8 +101,34 @@ describe('stripUnusedPatches', () => {
     });
   });
 
-  it('should remove the trailing blank line along with the block', () => {
-    // given
+  it('does not mistake an unrelated package with a matching suffix for a real match', () => {
+    // Regression: a naive `outsideBlock.includes('${name}@')` substring
+    // check would treat `@babel/core@7.0.0` as "core" being used, since
+    // the substring `core@7.0.0` appears inside it. The exact-key check
+    // must tell these apart.
+    const raw = [
+      "lockfileVersion: '9.0'",
+      '',
+      'patchedDependencies:',
+      "  'core':",
+      '    hash: abc123',
+      '    path: patches/core.patch',
+      '',
+      'packages:',
+      "  '@babel/core@7.0.0':",
+      '    resolution: {integrity: sha512-abc}',
+      '',
+    ].join('\n');
+
+    const result = runStripUnusedPatches(raw);
+
+    expect(result.removedNames).toEqual(['core']);
+    expect(result.skippedNames).toEqual([]);
+    expect(result.content).not.toContain('patchedDependencies');
+    expect(result.content).toContain("'@babel/core@7.0.0':");
+  });
+
+  it('removes the trailing blank line along with the block', () => {
     const raw = [
       "lockfileVersion: '9.0'",
       '',
@@ -123,10 +142,32 @@ describe('stripUnusedPatches', () => {
       '',
     ].join('\n');
 
-    // when
     const result = runStripUnusedPatches(raw);
 
-    // then — no leftover double-blank-line where the block used to be
+    // no leftover double-blank-line where the block used to be
+    expect(result.content).toBe(
+      ["lockfileVersion: '9.0'", '', 'importers:', '  .: {}', ''].join('\n')
+    );
+  });
+
+  it('does not delete the next section header when there is no blank separator', () => {
+    // Regression: an earlier version computed the splice length as
+    // `endIdx - startIdx + 1` whenever there was no trailing blank line,
+    // which ate the very next line — the next section's own `key:` header.
+    const raw = [
+      "lockfileVersion: '9.0'",
+      '',
+      'patchedDependencies:',
+      "  '@angular/build':",
+      '    hash: abc123',
+      '    path: patches/@angular__build.patch',
+      'importers:',
+      '  .: {}',
+      '',
+    ].join('\n');
+
+    const result = runStripUnusedPatches(raw);
+
     expect(result.content).toBe(
       ["lockfileVersion: '9.0'", '', 'importers:', '  .: {}', ''].join('\n')
     );

--- a/tools/src/strip-unused-lockfile-patches.spec.js
+++ b/tools/src/strip-unused-lockfile-patches.spec.js
@@ -1,0 +1,134 @@
+const { execFileSync } = require('node:child_process');
+const { resolve } = require('node:path');
+
+const MODULE_PATH = resolve(__dirname, 'strip-unused-lockfile-patches.mjs');
+
+// `strip-unused-lockfile-patches.mjs` is ESM; run `stripUnusedPatches` in a
+// throwaway node subprocess (mirrors the execFileSync pattern in
+// generate-content.spec.js) rather than importing it into this CommonJS Jest
+// test, since `tools/jest.config.cjs` only transforms `.ts`/`.js`.
+function runStripUnusedPatches(raw) {
+  const script = `
+    import { stripUnusedPatches } from ${JSON.stringify(MODULE_PATH)};
+    process.stdout.write(JSON.stringify(stripUnusedPatches(${JSON.stringify(raw)})));
+  `;
+  const out = execFileSync('node', ['--input-type=module', '-e', script], {
+    encoding: 'utf-8',
+  });
+  return JSON.parse(out);
+}
+
+describe('stripUnusedPatches', () => {
+  it('should leave the content untouched when there is no patchedDependencies block', () => {
+    // given
+    const raw = [
+      "lockfileVersion: '9.0'",
+      '',
+      'importers:',
+      '  .: {}',
+      '',
+    ].join('\n');
+
+    // when
+    const result = runStripUnusedPatches(raw);
+
+    // then
+    expect(result).toEqual({
+      content: raw,
+      removedNames: [],
+      skippedNames: [],
+    });
+  });
+
+  it('should remove the block when the patched package is not resolved anywhere else', () => {
+    // given — mirrors the real `data-store/functions-dist/pnpm-lock.yaml`
+    // shape: @angular/build is patched workspace-wide but isn't a dependency
+    // of this project, so it never appears as a `packages:` key.
+    const raw = [
+      "lockfileVersion: '9.0'",
+      '',
+      'settings:',
+      '  autoInstallPeers: true',
+      '',
+      'patchedDependencies:',
+      "  '@angular/build':",
+      '    hash: abc123',
+      '    path: patches/@angular__build.patch',
+      '',
+      'importers:',
+      '  .:',
+      '    dependencies:',
+      "      '@jest/globals':",
+      '        specifier: 30.4.1',
+      '        version: 30.4.1',
+      '',
+      'packages:',
+      "  '@jest/globals@30.4.1':",
+      '    resolution: {integrity: sha512-abc}',
+      '',
+    ].join('\n');
+
+    // when
+    const result = runStripUnusedPatches(raw);
+
+    // then
+    expect(result.removedNames).toEqual(['@angular/build']);
+    expect(result.skippedNames).toEqual([]);
+    expect(result.content).not.toContain('patchedDependencies');
+    expect(result.content).not.toContain('@angular/build');
+    // the rest of the file (importers/packages) survives byte-for-byte
+    expect(result.content).toContain("'@jest/globals@30.4.1':");
+    expect(result.content).toContain('settings:');
+  });
+
+  it('should leave the block untouched when the patched package is actually resolved', () => {
+    // given — a patch for a package that IS a real dependency here
+    const raw = [
+      "lockfileVersion: '9.0'",
+      '',
+      'patchedDependencies:',
+      "  'some-lib':",
+      '    hash: abc123',
+      '    path: patches/some-lib.patch',
+      '',
+      'packages:',
+      "  'some-lib@1.0.0':",
+      '    resolution: {integrity: sha512-abc}',
+      '',
+    ].join('\n');
+
+    // when
+    const result = runStripUnusedPatches(raw);
+
+    // then — bail out rather than risk a malformed partial splice
+    expect(result).toEqual({
+      content: raw,
+      removedNames: [],
+      skippedNames: ['some-lib'],
+    });
+  });
+
+  it('should remove the trailing blank line along with the block', () => {
+    // given
+    const raw = [
+      "lockfileVersion: '9.0'",
+      '',
+      'patchedDependencies:',
+      "  '@angular/build':",
+      '    hash: abc123',
+      '    path: patches/@angular__build.patch',
+      '',
+      'importers:',
+      '  .: {}',
+      '',
+    ].join('\n');
+
+    // when
+    const result = runStripUnusedPatches(raw);
+
+    // then — no leftover double-blank-line where the block used to be
+    expect(result.content).toBe(
+      ["lockfileVersion: '9.0'", '', 'importers:', '  .: {}', ''].join('\n')
+    );
+  });
+});

--- a/web/src/app/admin/delete-entries-dialog.component.spec.ts
+++ b/web/src/app/admin/delete-entries-dialog.component.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import {
+  DeleteEntriesDialogComponent,
+  DeleteEntriesDialogData,
+} from './delete-entries-dialog.component';
+
+describe('DeleteEntriesDialogComponent', () => {
+  let dialogRefSpy: { close: ReturnType<typeof vi.fn> };
+
+  function setup(data: DeleteEntriesDialogData) {
+    dialogRefSpy = { close: vi.fn() };
+    TestBed.configureTestingModule({
+      imports: [DeleteEntriesDialogComponent, MatDialogModule],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRefSpy },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+      ],
+    });
+    const fixture = TestBed.createComponent(DeleteEntriesDialogComponent);
+    fixture.detectChanges();
+    return { fixture, component: fixture.componentInstance };
+  }
+
+  it('should use the singular confirmation text for a single entry', () => {
+    const { component } = setup({ count: 1 });
+    expect(component.confirmText).toBe(
+      'Möchtest du diesen Eintrag wirklich endgültig löschen?'
+    );
+  });
+
+  it('should use the plural confirmation text and interpolate the count for multiple entries', () => {
+    const { component } = setup({ count: 3 });
+    expect(component.confirmText).toContain('3');
+    expect(component.confirmText).not.toBe(
+      'Möchtest du diesen Eintrag wirklich endgültig löschen?'
+    );
+  });
+
+  it('should close with true when confirm() is called', () => {
+    const { component } = setup({ count: 1 });
+    component.confirm();
+    expect(dialogRefSpy.close).toHaveBeenCalledWith(true);
+  });
+});

--- a/web/src/app/admin/delete-entries-dialog.component.ts
+++ b/web/src/app/admin/delete-entries-dialog.component.ts
@@ -1,0 +1,55 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+
+export interface DeleteEntriesDialogData {
+  count: number;
+}
+
+@Component({
+  selector: 'app-delete-entries-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatButtonModule, MatDialogModule],
+  template: `
+    <h2 mat-dialog-title i18n="@@admin.entries.delete.title">
+      Einträge löschen
+    </h2>
+    <mat-dialog-content>
+      <p>{{ confirmText }}</p>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close i18n="@@admin.entries.delete.cancel">
+        Abbrechen
+      </button>
+      <button
+        mat-flat-button
+        color="warn"
+        (click)="confirm()"
+        i18n="@@admin.entries.delete.button"
+      >
+        Löschen
+      </button>
+    </mat-dialog-actions>
+  `,
+})
+export class DeleteEntriesDialogComponent {
+  readonly data = inject<DeleteEntriesDialogData>(MAT_DIALOG_DATA);
+  private readonly dialogRef = inject(
+    MatDialogRef<DeleteEntriesDialogComponent, boolean>
+  );
+
+  get confirmText(): string {
+    const count = this.data.count;
+    return count === 1
+      ? $localize`:@@admin.entries.delete.confirmOne:Möchtest du diesen Eintrag wirklich endgültig löschen?`
+      : $localize`:@@admin.entries.delete.confirmMany:Möchtest du diese ${count}:count: Einträge wirklich endgültig löschen?`;
+  }
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+}

--- a/web/src/app/admin/user-entries-page.component.html
+++ b/web/src/app/admin/user-entries-page.component.html
@@ -120,68 +120,12 @@
     </p>
   } @else {
     <mat-card>
-      <div class="table-scroll">
-        <mat-table [dataSource]="dataSource" matSort #entriesSort="matSort">
-          <ng-container matColumnDef="timestamp">
-            <mat-header-cell
-              *matHeaderCellDef
-              mat-sort-header
-              i18n="@@admin.entries.col.timestamp"
-              >Zeitpunkt</mat-header-cell
-            >
-            <mat-cell *matCellDef="let e">{{
-              e.timestamp ? (e.timestamp | date: 'short') : '–'
-            }}</mat-cell>
-          </ng-container>
-
-          <ng-container matColumnDef="exercise">
-            <mat-header-cell
-              *matHeaderCellDef
-              mat-sort-header
-              i18n="@@admin.entries.col.exercise"
-              >Übung</mat-header-cell
-            >
-            <mat-cell *matCellDef="let e">{{ exerciseName(e) }}</mat-cell>
-          </ng-container>
-
-          <ng-container matColumnDef="value">
-            <mat-header-cell
-              *matHeaderCellDef
-              mat-sort-header
-              i18n="@@admin.entries.col.value"
-              >Wert</mat-header-cell
-            >
-            <mat-cell *matCellDef="let e">{{ valueDisplay(e) }}</mat-cell>
-          </ng-container>
-
-          <ng-container matColumnDef="source">
-            <mat-header-cell
-              *matHeaderCellDef
-              mat-sort-header
-              i18n="@@admin.entries.col.source"
-              >Quelle</mat-header-cell
-            >
-            <mat-cell *matCellDef="let e">{{ e.source }}</mat-cell>
-          </ng-container>
-
-          <ng-container matColumnDef="actions" stickyEnd>
-            <mat-header-cell *matHeaderCellDef></mat-header-cell>
-            <mat-cell *matCellDef="let e">
-              <button
-                mat-icon-button
-                (click)="openEditDialog(e)"
-                [matTooltip]="editTooltip"
-                [attr.aria-label]="editTooltip"
-              >
-                <mat-icon>edit</mat-icon>
-              </button>
-            </mat-cell>
-          </ng-container>
-
-          <mat-header-row *matHeaderRowDef="displayedColumns" />
-          <mat-row *matRowDef="let row; columns: displayedColumns" />
-        </mat-table>
-      </div>
+      <app-user-entries-table
+        [entries]="entries()"
+        [uid]="uid"
+        (edit)="openEditDialog($event)"
+        (refresh)="loadEntries()"
+      />
     </mat-card>
   }
 </div>

--- a/web/src/app/admin/user-entries-page.component.scss
+++ b/web/src/app/admin/user-entries-page.component.scss
@@ -82,23 +82,6 @@
   color: var(--mat-sys-on-surface-variant);
 }
 
-// Let the table scroll horizontally on narrow viewports instead of clipping
-// inside the card; the actions column is pinned with `stickyEnd` so the edit
-// button stays reachable while the rest scrolls.
-.table-scroll {
-  overflow-x: auto;
-}
-
-mat-cell,
-mat-header-cell {
-  white-space: nowrap;
-}
-
-// A sticky column must be opaque, otherwise scrolled cells show through it.
-.mat-column-actions {
-  background: var(--mat-sys-surface);
-}
-
 .spinner-container {
   display: flex;
   justify-content: center;

--- a/web/src/app/admin/user-entries-page.component.ts
+++ b/web/src/app/admin/user-entries-page.component.ts
@@ -2,10 +2,8 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  effect,
   inject,
   signal,
-  viewChild,
 } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { ActivatedRoute, RouterLink } from '@angular/router';
@@ -16,8 +14,6 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSort, MatSortModule } from '@angular/material/sort';
-import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { type ExerciseEntry, TRAINING_PLANS } from '@pu-stats/models';
 import { TrainingEntryDialogComponent } from '../stats/components/training-entry-dialog/training-entry-dialog.component';
@@ -26,13 +22,8 @@ import { PageHeaderComponent } from '../core/page-header/page-header.component';
 import { CallableFunctionsService } from './callable-functions.service';
 import { errorMessage } from './admin-page.helpers';
 import { AdminUserDetails } from './admin-page.models';
-import {
-  adminEntrySortValue,
-  dialogResultToPatch,
-  entryExerciseName,
-  entryToDialogData,
-  entryValueDisplay,
-} from './user-entries.helpers';
+import { UserEntriesTableComponent } from './user-entries-table.component';
+import { dialogResultToPatch, entryToDialogData } from './user-entries.helpers';
 
 /**
  * Admin drill-down into one user's exercise entries, as a routed page
@@ -54,10 +45,9 @@ import {
     MatDialogModule,
     MatIconModule,
     MatProgressSpinnerModule,
-    MatSortModule,
-    MatTableModule,
     MatTooltipModule,
     PageHeaderComponent,
+    UserEntriesTableComponent,
   ],
   templateUrl: './user-entries-page.component.html',
   styleUrl: './user-entries-page.component.scss',
@@ -76,14 +66,6 @@ export class UserEntriesPageComponent {
       (history.state as { label?: string } | null)?.label) ||
     this.uid;
 
-  readonly displayedColumns = [
-    'timestamp',
-    'exercise',
-    'value',
-    'source',
-    'actions',
-  ];
-  readonly editTooltip = $localize`:@@admin.entry.editTooltip:Eintrag bearbeiten`;
   readonly refreshTooltip = $localize`:@@admin.entries.refresh:Neu laden`;
   readonly copyUidTooltip = $localize`:@@admin.entries.copyUid:UID kopieren`;
   readonly adminBadge = $localize`:@@admin.entries.roleAdmin:Admin`;
@@ -116,21 +98,7 @@ export class UserEntriesPageComponent {
     );
   });
 
-  readonly dataSource = new MatTableDataSource<ExerciseEntry>([]);
-  private readonly sort = viewChild<MatSort>('entriesSort');
-
-  readonly exerciseName = entryExerciseName;
-  readonly valueDisplay = entryValueDisplay;
-
   constructor() {
-    this.dataSource.sortingDataAccessor = adminEntrySortValue;
-    effect(() => {
-      this.dataSource.data = this.entries();
-    });
-    effect(() => {
-      const s = this.sort();
-      if (s) this.dataSource.sort = s;
-    });
     void this.loadEntries();
     void this.loadDetails();
   }

--- a/web/src/app/admin/user-entries-table.component.html
+++ b/web/src/app/admin/user-entries-table.component.html
@@ -1,0 +1,110 @@
+@if (error()) {
+  <p class="error-text">{{ error() }}</p>
+}
+
+@if (hasSelection()) {
+  <div class="selection-bar">
+    <span i18n="@@admin.entries.selection.count"
+      >{{ selectedIds().size }} ausgewählt</span
+    >
+    <button
+      mat-button
+      color="warn"
+      [disabled]="deleting()"
+      (click)="deleteSelected()"
+    >
+      <mat-icon>delete</mat-icon>
+      <span i18n="@@admin.entries.deleteSelected">Ausgewählte löschen</span>
+    </button>
+  </div>
+}
+
+<div class="table-scroll">
+  <mat-table [dataSource]="dataSource" matSort #entriesSort="matSort">
+    <ng-container matColumnDef="select">
+      <mat-header-cell *matHeaderCellDef>
+        <mat-checkbox
+          [checked]="allSelected()"
+          [indeterminate]="someSelected()"
+          [attr.aria-label]="selectAllLabel"
+          (change)="toggleAll($event.checked)"
+        />
+      </mat-header-cell>
+      <mat-cell *matCellDef="let e">
+        <mat-checkbox
+          [checked]="isSelected(e)"
+          [attr.aria-label]="selectRowLabel"
+          (change)="toggleRow(e, $event.checked)"
+        />
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="timestamp">
+      <mat-header-cell
+        *matHeaderCellDef
+        mat-sort-header
+        i18n="@@admin.entries.col.timestamp"
+        >Zeitpunkt</mat-header-cell
+      >
+      <mat-cell *matCellDef="let e">{{
+        e.timestamp ? (e.timestamp | date: 'short') : '–'
+      }}</mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="exercise">
+      <mat-header-cell
+        *matHeaderCellDef
+        mat-sort-header
+        i18n="@@admin.entries.col.exercise"
+        >Übung</mat-header-cell
+      >
+      <mat-cell *matCellDef="let e">{{ exerciseName(e) }}</mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="value">
+      <mat-header-cell
+        *matHeaderCellDef
+        mat-sort-header
+        i18n="@@admin.entries.col.value"
+        >Wert</mat-header-cell
+      >
+      <mat-cell *matCellDef="let e">{{ valueDisplay(e) }}</mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="source">
+      <mat-header-cell
+        *matHeaderCellDef
+        mat-sort-header
+        i18n="@@admin.entries.col.source"
+        >Quelle</mat-header-cell
+      >
+      <mat-cell *matCellDef="let e">{{ e.source }}</mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="actions" stickyEnd>
+      <mat-header-cell *matHeaderCellDef></mat-header-cell>
+      <mat-cell *matCellDef="let e">
+        <button
+          mat-icon-button
+          (click)="edit.emit(e)"
+          [matTooltip]="editTooltip"
+          [attr.aria-label]="editTooltip"
+        >
+          <mat-icon>edit</mat-icon>
+        </button>
+        <button
+          mat-icon-button
+          [disabled]="deleting()"
+          (click)="deleteOne(e)"
+          [matTooltip]="deleteTooltip"
+          [attr.aria-label]="deleteTooltip"
+        >
+          <mat-icon>delete</mat-icon>
+        </button>
+      </mat-cell>
+    </ng-container>
+
+    <mat-header-row *matHeaderRowDef="displayedColumns" />
+    <mat-row *matRowDef="let row; columns: displayedColumns" />
+  </mat-table>
+</div>

--- a/web/src/app/admin/user-entries-table.component.scss
+++ b/web/src/app/admin/user-entries-table.component.scss
@@ -1,0 +1,28 @@
+// Let the table scroll horizontally on narrow viewports instead of clipping
+// inside the card; the actions column is pinned with `stickyEnd` so the edit
+// button stays reachable while the rest scrolls.
+.table-scroll {
+  overflow-x: auto;
+}
+
+mat-cell,
+mat-header-cell {
+  white-space: nowrap;
+}
+
+// A sticky column must be opaque, otherwise scrolled cells show through it.
+.mat-column-actions {
+  background: var(--mat-sys-surface);
+}
+
+.selection-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 8px 12px;
+}
+
+.error-text {
+  color: var(--mat-sys-error);
+}

--- a/web/src/app/admin/user-entries-table.component.spec.ts
+++ b/web/src/app/admin/user-entries-table.component.spec.ts
@@ -257,5 +257,73 @@ describe('UserEntriesTableComponent', () => {
       // then
       expect(dialogOpenSpy).not.toHaveBeenCalled();
     });
+
+    it('should chunk a selection larger than the 500-entry delete batch cap', async () => {
+      // given — the page can load up to 1000 entries, above the server's
+      // per-call limit, so a full select-all must split into multiple calls
+      const manyEntries: ExerciseEntry[] = Array.from(
+        { length: 600 },
+        (_, i) => ({
+          _id: `entry-${i}`,
+          userId: 'user-1',
+          exerciseId: 'pushup',
+          timestamp: '2026-04-09T10:00:00.000Z',
+          reps: 10,
+          source: 'web',
+        })
+      );
+      const deleteCallable = vi.fn(async (_req: unknown) => ({
+        data: { deleted: 500, skipped: 0 },
+      }));
+      await createComponent(manyEntries, [
+        { name: 'adminDeleteUserEntries', impl: deleteCallable },
+      ]);
+      component.toggleAll(true);
+      dialogOpenSpy.mockReturnValue(stubDialogRef(true));
+
+      // when
+      await component.deleteSelected();
+
+      // then
+      expect(deleteCallable).toHaveBeenCalledTimes(2);
+      const [firstCall, secondCall] = deleteCallable.mock.calls as [
+        { entryIds: string[] },
+      ][];
+      expect(firstCall[0].entryIds.length).toBe(500);
+      expect(secondCall[0].entryIds.length).toBe(100);
+    });
+
+    it('should still emit refresh after a later chunk fails, so earlier deletions are reflected', async () => {
+      // given
+      const manyEntries: ExerciseEntry[] = Array.from(
+        { length: 600 },
+        (_, i) => ({
+          _id: `entry-${i}`,
+          userId: 'user-1',
+          exerciseId: 'pushup',
+          timestamp: '2026-04-09T10:00:00.000Z',
+          reps: 10,
+          source: 'web',
+        })
+      );
+      const deleteCallable = vi
+        .fn()
+        .mockResolvedValueOnce({ data: { deleted: 500, skipped: 0 } })
+        .mockRejectedValueOnce(new Error('internal'));
+      await createComponent(manyEntries, [
+        { name: 'adminDeleteUserEntries', impl: deleteCallable },
+      ]);
+      component.toggleAll(true);
+      dialogOpenSpy.mockReturnValue(stubDialogRef(true));
+      const refreshSpy = vi.fn();
+      component.refresh.subscribe(refreshSpy);
+
+      // when
+      await component.deleteSelected();
+
+      // then
+      expect(component.error()).toBe('internal');
+      expect(refreshSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/web/src/app/admin/user-entries-table.component.spec.ts
+++ b/web/src/app/admin/user-entries-table.component.spec.ts
@@ -286,11 +286,16 @@ describe('UserEntriesTableComponent', () => {
 
       // then
       expect(deleteCallable).toHaveBeenCalledTimes(2);
-      const [firstCall, secondCall] = deleteCallable.mock.calls as [
-        { entryIds: string[] },
+      const requests = deleteCallable.mock.calls as [
+        { uid: string; entryIds: string[] },
       ][];
+      const [firstCall, secondCall] = requests;
       expect(firstCall[0].entryIds.length).toBe(500);
       expect(secondCall[0].entryIds.length).toBe(100);
+      expect(requests.every(([{ uid }]) => uid === 'user-1')).toBe(true);
+      expect(requests.flatMap(([{ entryIds }]) => entryIds).sort()).toEqual(
+        manyEntries.map(({ _id }) => _id).sort()
+      );
     });
 
     it('should still emit refresh after a later chunk fails, so earlier deletions are reflected', async () => {

--- a/web/src/app/admin/user-entries-table.component.spec.ts
+++ b/web/src/app/admin/user-entries-table.component.spec.ts
@@ -1,0 +1,261 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  MatDialog,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { type ExerciseEntry } from '@pu-stats/models';
+import { UserEntriesTableComponent } from './user-entries-table.component';
+import { CallableFunctionsService } from './callable-functions.service';
+import {
+  CallableRecord,
+  createCallablesMock,
+} from './callable-functions.testing';
+import { DeleteEntriesDialogComponent } from './delete-entries-dialog.component';
+
+const { callablesMock, setupCallables } = createCallablesMock();
+
+describe('UserEntriesTableComponent', () => {
+  let fixture: ComponentFixture<UserEntriesTableComponent>;
+  let component: UserEntriesTableComponent;
+  let dialogOpenSpy: ReturnType<typeof vi.spyOn>;
+
+  function stubDialogRef<T>(result: T): MatDialogRef<unknown, T> {
+    return { afterClosed: () => of(result) } as MatDialogRef<unknown, T>;
+  }
+
+  const entryOne: ExerciseEntry = {
+    _id: 'entry-1',
+    userId: 'user-1',
+    exerciseId: 'pushup',
+    timestamp: '2026-04-09T10:00:00.000Z',
+    reps: 30,
+    source: 'web',
+  };
+  const entryTwo: ExerciseEntry = {
+    _id: 'entry-2',
+    userId: 'user-1',
+    exerciseId: 'pushup',
+    timestamp: '2026-04-08T10:00:00.000Z',
+    reps: 20,
+    source: 'web',
+  };
+
+  async function createComponent(
+    entries: ExerciseEntry[] = [entryOne, entryTwo],
+    extraCallables: CallableRecord[] = []
+  ): Promise<void> {
+    setupCallables(extraCallables);
+
+    await TestBed.configureTestingModule({
+      imports: [UserEntriesTableComponent, MatDialogModule],
+      providers: [
+        { provide: CallableFunctionsService, useValue: callablesMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserEntriesTableComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('entries', entries);
+    fixture.componentRef.setInput('uid', 'user-1');
+    dialogOpenSpy = vi.spyOn(
+      fixture.debugElement.injector.get(MatDialog),
+      'open'
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render one row per entry', async () => {
+    // given / when
+    await createComponent();
+
+    // then
+    const rows = fixture.nativeElement.querySelectorAll('mat-row');
+    expect(rows.length).toBe(2);
+  });
+
+  it('should emit edit with the clicked entry', async () => {
+    // given
+    await createComponent();
+    const editSpy = vi.fn();
+    component.edit.subscribe(editSpy);
+
+    // when
+    const editButton = fixture.nativeElement.querySelector(
+      'mat-cell.mat-column-actions button'
+    ) as HTMLButtonElement;
+    editButton.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true })
+    );
+    fixture.detectChanges();
+
+    // then
+    expect(editSpy).toHaveBeenCalledWith(entryOne);
+  });
+
+  describe('row selection', () => {
+    it('should select all rows when the header checkbox is toggled on', async () => {
+      // given
+      await createComponent();
+
+      // when
+      component.toggleAll(true);
+
+      // then
+      expect(component.isSelected(entryOne)).toBe(true);
+      expect(component.isSelected(entryTwo)).toBe(true);
+      expect(component.allSelected()).toBe(true);
+    });
+
+    it('should mark someSelected (indeterminate) when only some rows are checked', async () => {
+      // given
+      await createComponent();
+
+      // when
+      component.toggleRow(entryOne, true);
+
+      // then
+      expect(component.someSelected()).toBe(true);
+      expect(component.allSelected()).toBe(false);
+    });
+
+    it('should clear the selection when the header checkbox is toggled off', async () => {
+      // given
+      await createComponent();
+      component.toggleAll(true);
+
+      // when
+      component.toggleAll(false);
+
+      // then
+      expect(component.hasSelection()).toBe(false);
+    });
+  });
+
+  describe('deleteOne', () => {
+    it('should open the confirmation dialog for a single entry', async () => {
+      // given
+      await createComponent();
+      dialogOpenSpy.mockReturnValue(stubDialogRef(false));
+
+      // when
+      await component.deleteOne(entryOne);
+
+      // then
+      expect(dialogOpenSpy).toHaveBeenCalledWith(
+        DeleteEntriesDialogComponent,
+        expect.objectContaining({ data: { count: 1 } })
+      );
+    });
+
+    it('should NOT call adminDeleteUserEntries when the user cancels', async () => {
+      // given
+      const deleteCallable = vi.fn(async () => ({
+        data: { deleted: 1, skipped: 0 },
+      }));
+      await createComponent(
+        [entryOne, entryTwo],
+        [{ name: 'adminDeleteUserEntries', impl: deleteCallable }]
+      );
+      dialogOpenSpy.mockReturnValue(stubDialogRef(false));
+
+      // when
+      await component.deleteOne(entryOne);
+
+      // then
+      expect(deleteCallable).not.toHaveBeenCalled();
+    });
+
+    it('should call adminDeleteUserEntries and emit refresh when the user confirms', async () => {
+      // given
+      const deleteCallable = vi.fn(async () => ({
+        data: { deleted: 1, skipped: 0 },
+      }));
+      await createComponent(
+        [entryOne, entryTwo],
+        [{ name: 'adminDeleteUserEntries', impl: deleteCallable }]
+      );
+      dialogOpenSpy.mockReturnValue(stubDialogRef(true));
+      const refreshSpy = vi.fn();
+      component.refresh.subscribe(refreshSpy);
+
+      // when
+      await component.deleteOne(entryOne);
+
+      // then
+      expect(deleteCallable).toHaveBeenCalledWith({
+        uid: 'user-1',
+        entryIds: ['entry-1'],
+      });
+      expect(refreshSpy).toHaveBeenCalled();
+      expect(component.error()).toBeNull();
+    });
+
+    it('should show an error and NOT emit refresh when the Cloud Function fails', async () => {
+      // given
+      const deleteCallable = vi.fn(async () => {
+        throw new Error('permission-denied');
+      });
+      await createComponent(
+        [entryOne, entryTwo],
+        [{ name: 'adminDeleteUserEntries', impl: deleteCallable }]
+      );
+      dialogOpenSpy.mockReturnValue(stubDialogRef(true));
+      const refreshSpy = vi.fn();
+      component.refresh.subscribe(refreshSpy);
+
+      // when
+      await component.deleteOne(entryOne);
+
+      // then
+      expect(component.error()).toBe('permission-denied');
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteSelected', () => {
+    it('should call adminDeleteUserEntries with all selected ids', async () => {
+      // given
+      const deleteCallable = vi.fn(async () => ({
+        data: { deleted: 2, skipped: 0 },
+      }));
+      await createComponent(
+        [entryOne, entryTwo],
+        [{ name: 'adminDeleteUserEntries', impl: deleteCallable }]
+      );
+      component.toggleAll(true);
+      dialogOpenSpy.mockReturnValue(stubDialogRef(true));
+
+      // when
+      await component.deleteSelected();
+
+      // then
+      expect(dialogOpenSpy).toHaveBeenCalledWith(
+        DeleteEntriesDialogComponent,
+        expect.objectContaining({ data: { count: 2 } })
+      );
+      expect(deleteCallable).toHaveBeenCalledWith({
+        uid: 'user-1',
+        entryIds: ['entry-1', 'entry-2'],
+      });
+    });
+
+    it('should do nothing when nothing is selected', async () => {
+      // given
+      await createComponent();
+
+      // when
+      await component.deleteSelected();
+
+      // then
+      expect(dialogOpenSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/app/admin/user-entries-table.component.ts
+++ b/web/src/app/admin/user-entries-table.component.ts
@@ -1,0 +1,165 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { firstValueFrom } from 'rxjs';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { type ExerciseEntry } from '@pu-stats/models';
+import { CallableFunctionsService } from './callable-functions.service';
+import { errorMessage, toggleSetMember } from './admin-page.helpers';
+import { type BulkDeleteResult } from './admin-page.models';
+import {
+  DeleteEntriesDialogComponent,
+  type DeleteEntriesDialogData,
+} from './delete-entries-dialog.component';
+import {
+  adminEntrySortValue,
+  entryExerciseName,
+  entryValueDisplay,
+} from './user-entries.helpers';
+
+/**
+ * Sortable, selectable table for one user's exercise entries — the drill-down
+ * body of `UserEntriesPageComponent`. Owns row/select-all checkboxes and the
+ * `adminDeleteUserEntries` delete flow (single row or the current selection).
+ * The parent still owns loading the list (it needs it for the header stats)
+ * and the shared edit dialog, so an edit click is emitted via `edit`, and a
+ * successful delete via `refresh` so the parent reloads — mirroring how
+ * `openEditDialog` reloads rather than optimistic-merges.
+ */
+@Component({
+  selector: 'app-user-entries-table',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DatePipe,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatDialogModule,
+    MatIconModule,
+    MatSortModule,
+    MatTableModule,
+    MatTooltipModule,
+  ],
+  templateUrl: './user-entries-table.component.html',
+  styleUrl: './user-entries-table.component.scss',
+})
+export class UserEntriesTableComponent {
+  private readonly dialog = inject(MatDialog);
+  private readonly callables = inject(CallableFunctionsService);
+
+  readonly entries = input.required<ExerciseEntry[]>();
+  readonly uid = input.required<string>();
+
+  readonly edit = output<ExerciseEntry>();
+  readonly refresh = output<void>();
+
+  readonly displayedColumns = [
+    'select',
+    'timestamp',
+    'exercise',
+    'value',
+    'source',
+    'actions',
+  ];
+  readonly editTooltip = $localize`:@@admin.entry.editTooltip:Eintrag bearbeiten`;
+  readonly deleteTooltip = $localize`:@@admin.entry.deleteTooltip:Eintrag löschen`;
+  readonly selectAllLabel = $localize`:@@admin.entries.selectAll:Alle Einträge auswählen`;
+  readonly selectRowLabel = $localize`:@@admin.entries.selectRow:Eintrag auswählen`;
+
+  readonly exerciseName = entryExerciseName;
+  readonly valueDisplay = entryValueDisplay;
+
+  readonly selectedIds = signal<ReadonlySet<string>>(new Set());
+  readonly deleting = signal(false);
+  readonly error = signal<string | null>(null);
+
+  readonly hasSelection = computed(() => this.selectedIds().size > 0);
+  readonly allSelected = computed(() => {
+    const list = this.entries();
+    const selected = this.selectedIds();
+    return list.length > 0 && list.every((e) => selected.has(e._id));
+  });
+  readonly someSelected = computed(
+    () => this.hasSelection() && !this.allSelected()
+  );
+
+  readonly dataSource = new MatTableDataSource<ExerciseEntry>([]);
+  private readonly sort = viewChild<MatSort>('entriesSort');
+
+  constructor() {
+    this.dataSource.sortingDataAccessor = adminEntrySortValue;
+    effect(() => {
+      this.dataSource.data = this.entries();
+    });
+    effect(() => {
+      const s = this.sort();
+      if (s) this.dataSource.sort = s;
+    });
+  }
+
+  isSelected(entry: ExerciseEntry): boolean {
+    return this.selectedIds().has(entry._id);
+  }
+
+  toggleRow(entry: ExerciseEntry, checked: boolean): void {
+    this.selectedIds.update((s) => toggleSetMember(s, entry._id, checked));
+  }
+
+  toggleAll(checked: boolean): void {
+    this.selectedIds.set(
+      checked ? new Set(this.entries().map((e) => e._id)) : new Set()
+    );
+  }
+
+  async deleteOne(entry: ExerciseEntry): Promise<void> {
+    await this.confirmAndDelete([entry._id]);
+  }
+
+  async deleteSelected(): Promise<void> {
+    await this.confirmAndDelete([...this.selectedIds()]);
+  }
+
+  private async confirmAndDelete(entryIds: string[]): Promise<void> {
+    if (entryIds.length === 0) return;
+
+    const ref = this.dialog.open<
+      DeleteEntriesDialogComponent,
+      DeleteEntriesDialogData,
+      boolean
+    >(DeleteEntriesDialogComponent, {
+      data: { count: entryIds.length },
+      width: '420px',
+    });
+    const confirmed = await firstValueFrom(ref.afterClosed());
+    if (!confirmed) return;
+
+    this.deleting.set(true);
+    this.error.set(null);
+    try {
+      const fn = this.callables.call<
+        { uid: string; entryIds: string[] },
+        BulkDeleteResult
+      >('adminDeleteUserEntries');
+      await fn({ uid: this.uid(), entryIds });
+      this.refresh.emit();
+    } catch (err) {
+      this.error.set(errorMessage(err));
+    } finally {
+      this.deleting.set(false);
+    }
+  }
+}

--- a/web/src/app/admin/user-entries-table.component.ts
+++ b/web/src/app/admin/user-entries-table.component.ts
@@ -32,6 +32,12 @@ import {
   entryValueDisplay,
 } from './user-entries.helpers';
 
+// Must match `MAX_DELETE_ENTRY_IDS` in
+// `data-store/functions/src/admin/user-entries.ts` (a Firestore `WriteBatch`
+// caps at 500 operations). The entries page loads up to 1000 rows, so
+// "select all" can exceed this — chunk the request rather than fail.
+const MAX_DELETE_BATCH_SIZE = 500;
+
 /**
  * Sortable, selectable table for one user's exercise entries — the drill-down
  * body of `UserEntriesPageComponent`. Owns row/select-all checkboxes and the
@@ -149,17 +155,24 @@ export class UserEntriesTableComponent {
 
     this.deleting.set(true);
     this.error.set(null);
+    const fn = this.callables.call<
+      { uid: string; entryIds: string[] },
+      BulkDeleteResult
+    >('adminDeleteUserEntries');
+    let anyDeleted = false;
     try {
-      const fn = this.callables.call<
-        { uid: string; entryIds: string[] },
-        BulkDeleteResult
-      >('adminDeleteUserEntries');
-      await fn({ uid: this.uid(), entryIds });
-      this.refresh.emit();
+      for (let i = 0; i < entryIds.length; i += MAX_DELETE_BATCH_SIZE) {
+        const chunk = entryIds.slice(i, i + MAX_DELETE_BATCH_SIZE);
+        await fn({ uid: this.uid(), entryIds: chunk });
+        anyDeleted = true;
+      }
     } catch (err) {
       this.error.set(errorMessage(err));
     } finally {
       this.deleting.set(false);
+      // Refresh even on a partial failure so rows deleted by earlier chunks
+      // don't linger stale in the table until a manual reload.
+      if (anyDeleted) this.refresh.emit();
     }
   }
 }

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10372,5 +10372,65 @@
         <target>Δημόσιο προφίλ</target>
       </segment>
     </unit>
+    <unit id="admin.entries.delete.title">
+      <segment state="initial">
+        <source> Einträge löschen </source>
+        <target> Einträge löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.button">
+      <segment state="initial">
+        <source> Löschen </source>
+        <target> Löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmOne">
+      <segment state="initial">
+        <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
+        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmMany">
+      <segment state="initial">
+        <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
+        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selection.count">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.deleteSelected">
+      <segment state="initial">
+        <source>Ausgewählte löschen</source>
+        <target>Ausgewählte löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.deleteTooltip">
+      <segment state="initial">
+        <source>Eintrag löschen</source>
+        <target>Eintrag löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectAll">
+      <segment state="initial">
+        <source>Alle Einträge auswählen</source>
+        <target>Alle Einträge auswählen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectRow">
+      <segment state="initial">
+        <source>Eintrag auswählen</source>
+        <target>Eintrag auswählen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10571,5 +10571,65 @@ Deine Position: # ·  Reps        </source>
         <target>Public profile</target>
       </segment>
     </unit>
+    <unit id="admin.entries.delete.title">
+      <segment state="initial">
+        <source> Einträge löschen </source>
+        <target> Einträge löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.button">
+      <segment state="initial">
+        <source> Löschen </source>
+        <target> Löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmOne">
+      <segment state="initial">
+        <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
+        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmMany">
+      <segment state="initial">
+        <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
+        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selection.count">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.deleteSelected">
+      <segment state="initial">
+        <source>Ausgewählte löschen</source>
+        <target>Ausgewählte löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.deleteTooltip">
+      <segment state="initial">
+        <source>Eintrag löschen</source>
+        <target>Eintrag löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectAll">
+      <segment state="initial">
+        <source>Alle Einträge auswählen</source>
+        <target>Alle Einträge auswählen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectRow">
+      <segment state="initial">
+        <source>Eintrag auswählen</source>
+        <target>Eintrag auswählen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10368,5 +10368,65 @@
         <target>Perfil público</target>
       </segment>
     </unit>
+    <unit id="admin.entries.delete.title">
+      <segment state="initial">
+        <source> Einträge löschen </source>
+        <target> Einträge löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.button">
+      <segment state="initial">
+        <source> Löschen </source>
+        <target> Löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmOne">
+      <segment state="initial">
+        <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
+        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmMany">
+      <segment state="initial">
+        <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
+        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selection.count">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.deleteSelected">
+      <segment state="initial">
+        <source>Ausgewählte löschen</source>
+        <target>Ausgewählte löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.deleteTooltip">
+      <segment state="initial">
+        <source>Eintrag löschen</source>
+        <target>Eintrag löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectAll">
+      <segment state="initial">
+        <source>Alle Einträge auswählen</source>
+        <target>Alle Einträge auswählen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectRow">
+      <segment state="initial">
+        <source>Eintrag auswählen</source>
+        <target>Eintrag auswählen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10244,5 +10244,65 @@
         <target>Profil public</target>
       </segment>
     </unit>
+    <unit id="admin.entries.delete.title">
+      <segment state="initial">
+        <source> Einträge löschen </source>
+        <target> Einträge löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.button">
+      <segment state="initial">
+        <source> Löschen </source>
+        <target> Löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmOne">
+      <segment state="initial">
+        <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
+        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmMany">
+      <segment state="initial">
+        <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
+        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selection.count">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.deleteSelected">
+      <segment state="initial">
+        <source>Ausgewählte löschen</source>
+        <target>Ausgewählte löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.deleteTooltip">
+      <segment state="initial">
+        <source>Eintrag löschen</source>
+        <target>Eintrag löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectAll">
+      <segment state="initial">
+        <source>Alle Einträge auswählen</source>
+        <target>Alle Einträge auswählen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectRow">
+      <segment state="initial">
+        <source>Eintrag auswählen</source>
+        <target>Eintrag auswählen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10372,5 +10372,65 @@
         <target>Profilo pubblico</target>
       </segment>
     </unit>
+    <unit id="admin.entries.delete.title">
+      <segment state="initial">
+        <source> Einträge löschen </source>
+        <target> Einträge löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.button">
+      <segment state="initial">
+        <source> Löschen </source>
+        <target> Löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmOne">
+      <segment state="initial">
+        <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
+        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmMany">
+      <segment state="initial">
+        <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
+        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selection.count">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.deleteSelected">
+      <segment state="initial">
+        <source>Ausgewählte löschen</source>
+        <target>Ausgewählte löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.deleteTooltip">
+      <segment state="initial">
+        <source>Eintrag löschen</source>
+        <target>Eintrag löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectAll">
+      <segment state="initial">
+        <source>Alle Einträge auswählen</source>
+        <target>Alle Einträge auswählen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectRow">
+      <segment state="initial">
+        <source>Eintrag auswählen</source>
+        <target>Eintrag auswählen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10372,5 +10372,65 @@
         <target>Openbaar profiel</target>
       </segment>
     </unit>
+    <unit id="admin.entries.delete.title">
+      <segment state="initial">
+        <source> Einträge löschen </source>
+        <target> Einträge löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.button">
+      <segment state="initial">
+        <source> Löschen </source>
+        <target> Löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmOne">
+      <segment state="initial">
+        <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
+        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmMany">
+      <segment state="initial">
+        <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
+        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selection.count">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.deleteSelected">
+      <segment state="initial">
+        <source>Ausgewählte löschen</source>
+        <target>Ausgewählte löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.deleteTooltip">
+      <segment state="initial">
+        <source>Eintrag löschen</source>
+        <target>Eintrag löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectAll">
+      <segment state="initial">
+        <source>Alle Einträge auswählen</source>
+        <target>Alle Einträge auswählen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectRow">
+      <segment state="initial">
+        <source>Eintrag auswählen</source>
+        <target>Eintrag auswählen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9665,5 +9665,65 @@ Deine Position: # ·  Reps        </source>
         <target>Offentlig profil</target>
       </segment>
     </unit>
+    <unit id="admin.entries.delete.title">
+      <segment state="initial">
+        <source> Einträge löschen </source>
+        <target> Einträge löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.button">
+      <segment state="initial">
+        <source> Löschen </source>
+        <target> Löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmOne">
+      <segment state="initial">
+        <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
+        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmMany">
+      <segment state="initial">
+        <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
+        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selection.count">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.deleteSelected">
+      <segment state="initial">
+        <source>Ausgewählte löschen</source>
+        <target>Ausgewählte löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.deleteTooltip">
+      <segment state="initial">
+        <source>Eintrag löschen</source>
+        <target>Eintrag löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectAll">
+      <segment state="initial">
+        <source>Alle Einträge auswählen</source>
+        <target>Alle Einträge auswählen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectRow">
+      <segment state="initial">
+        <source>Eintrag auswählen</source>
+        <target>Eintrag auswählen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2959,6 +2959,46 @@
         <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier"/></source>
       </segment>
     </unit>
+    <unit id="admin.entries.delete.title">
+      <notes>
+        <note category="location">web/src/app/admin/delete-entries-dialog.component.ts:19,22</note>
+      </notes>
+      <segment>
+        <source> Einträge löschen </source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.cancel">
+      <notes>
+        <note category="location">web/src/app/admin/delete-entries-dialog.component.ts:26,29</note>
+      </notes>
+      <segment>
+        <source> Abbrechen </source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.button">
+      <notes>
+        <note category="location">web/src/app/admin/delete-entries-dialog.component.ts:34,36</note>
+      </notes>
+      <segment>
+        <source> Löschen </source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmOne">
+      <notes>
+        <note category="location">web/src/app/admin/delete-entries-dialog.component.ts:48</note>
+      </notes>
+      <segment>
+        <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmMany">
+      <notes>
+        <note category="location">web/src/app/admin/delete-entries-dialog.component.ts:49</note>
+      </notes>
+      <segment>
+        <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
+      </segment>
+    </unit>
     <unit id="admin.feedback.delete.title">
       <notes>
         <note category="location">web/src/app/admin/delete-feedback-dialog.component.ts:20,23</note>
@@ -3283,7 +3323,7 @@
     </unit>
     <unit id="admin.entries.meta.lastEntry">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.html:74,76</note>
+        <note category="location">web/src/app/admin/user-entries-page.component.html:74,77</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -3291,7 +3331,7 @@
     </unit>
     <unit id="admin.entries.meta.createdAt">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.html:81,83</note>
+        <note category="location">web/src/app/admin/user-entries-page.component.html:85,88</note>
       </notes>
       <segment>
         <source>Registriert</source>
@@ -3299,7 +3339,7 @@
     </unit>
     <unit id="admin.entries.meta.activePlan">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.html:88,90</note>
+        <note category="location">web/src/app/admin/user-entries-page.component.html:96,98</note>
       </notes>
       <segment>
         <source>Aktiver Plan</source>
@@ -3307,7 +3347,7 @@
     </unit>
     <unit id="admin.entries.meta.noPlan">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.html:94,97</note>
+        <note category="location">web/src/app/admin/user-entries-page.component.html:102,105</note>
       </notes>
       <segment>
         <source>Kein aktiver Plan</source>
@@ -3315,55 +3355,15 @@
     </unit>
     <unit id="admin.entries.empty">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.html:111,114</note>
+        <note category="location">web/src/app/admin/user-entries-page.component.html:119,122</note>
       </notes>
       <segment>
         <source> Keine Einträge vorhanden. </source>
       </segment>
     </unit>
-    <unit id="admin.entries.col.timestamp">
-      <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.html:122,124</note>
-      </notes>
-      <segment>
-        <source>Zeitpunkt</source>
-      </segment>
-    </unit>
-    <unit id="admin.entries.col.exercise">
-      <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.html:134,136</note>
-      </notes>
-      <segment>
-        <source>Übung</source>
-      </segment>
-    </unit>
-    <unit id="admin.entries.col.value">
-      <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.html:144,146</note>
-      </notes>
-      <segment>
-        <source>Wert</source>
-      </segment>
-    </unit>
-    <unit id="admin.entries.col.source">
-      <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.html:154,156</note>
-      </notes>
-      <segment>
-        <source>Quelle</source>
-      </segment>
-    </unit>
-    <unit id="admin.entry.editTooltip">
-      <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.ts:86</note>
-      </notes>
-      <segment>
-        <source>Eintrag bearbeiten</source>
-      </segment>
-    </unit>
     <unit id="admin.entries.refresh">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.ts:87</note>
+        <note category="location">web/src/app/admin/user-entries-page.component.ts:69</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -3371,7 +3371,7 @@
     </unit>
     <unit id="admin.entries.copyUid">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.ts:88</note>
+        <note category="location">web/src/app/admin/user-entries-page.component.ts:70</note>
       </notes>
       <segment>
         <source>UID kopieren</source>
@@ -3379,7 +3379,7 @@
     </unit>
     <unit id="admin.entries.roleAdmin">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.ts:89</note>
+        <note category="location">web/src/app/admin/user-entries-page.component.ts:71</note>
       </notes>
       <segment>
         <source>Admin</source>
@@ -3387,7 +3387,7 @@
     </unit>
     <unit id="admin.entries.anonymous">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.ts:90</note>
+        <note category="location">web/src/app/admin/user-entries-page.component.ts:72</note>
       </notes>
       <segment>
         <source>Anonym</source>
@@ -3395,10 +3395,90 @@
     </unit>
     <unit id="admin.entries.publicProfile">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-page.component.ts:91</note>
+        <note category="location">web/src/app/admin/user-entries-page.component.ts:73</note>
       </notes>
       <segment>
         <source>Öffentliches Profil</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selection.count">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-table.component.html:8,10</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.deleteSelected">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-table.component.html:17,22</note>
+      </notes>
+      <segment>
+        <source>Ausgewählte löschen</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.timestamp">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-table.component.html:47,49</note>
+      </notes>
+      <segment>
+        <source>Zeitpunkt</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.exercise">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-table.component.html:59,61</note>
+      </notes>
+      <segment>
+        <source>Übung</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.value">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-table.component.html:69,71</note>
+      </notes>
+      <segment>
+        <source>Wert</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.col.source">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-table.component.html:79,81</note>
+      </notes>
+      <segment>
+        <source>Quelle</source>
+      </segment>
+    </unit>
+    <unit id="admin.entry.editTooltip">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-table.component.ts:78</note>
+      </notes>
+      <segment>
+        <source>Eintrag bearbeiten</source>
+      </segment>
+    </unit>
+    <unit id="admin.entry.deleteTooltip">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-table.component.ts:79</note>
+      </notes>
+      <segment>
+        <source>Eintrag löschen</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectAll">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-table.component.ts:80</note>
+      </notes>
+      <segment>
+        <source>Alle Einträge auswählen</source>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectRow">
+      <notes>
+        <note category="location">web/src/app/admin/user-entries-table.component.ts:81</note>
+      </notes>
+      <segment>
+        <source>Eintrag auswählen</source>
       </segment>
     </unit>
     <unit id="app.title">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9878,5 +9878,65 @@
         <target>公开资料</target>
       </segment>
     </unit>
+    <unit id="admin.entries.delete.title">
+      <segment state="initial">
+        <source> Einträge löschen </source>
+        <target> Einträge löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.cancel">
+      <segment state="initial">
+        <source> Abbrechen </source>
+        <target> Abbrechen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.button">
+      <segment state="initial">
+        <source> Löschen </source>
+        <target> Löschen </target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmOne">
+      <segment state="initial">
+        <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
+        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.delete.confirmMany">
+      <segment state="initial">
+        <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
+        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selection.count">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.deleteSelected">
+      <segment state="initial">
+        <source>Ausgewählte löschen</source>
+        <target>Ausgewählte löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entry.deleteTooltip">
+      <segment state="initial">
+        <source>Eintrag löschen</source>
+        <target>Eintrag löschen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectAll">
+      <segment state="initial">
+        <source>Alle Einträge auswählen</source>
+        <target>Alle Einträge auswählen</target>
+      </segment>
+    </unit>
+    <unit id="admin.entries.selectRow">
+      <segment state="initial">
+        <source>Eintrag auswählen</source>
+        <target>Eintrag auswählen</target>
+      </segment>
+    </unit>
 </file>
 </xliff>


### PR DESCRIPTION
## Summary
- The admin per-user entries table (`/admin/users/:uid/entries`) now supports deleting a single entry (row action) or a multi-selected batch (row checkboxes + select-all + "Ausgewählte löschen").
- New `adminDeleteUserEntries` Cloud Function callable does the actual deletion: it re-checks ownership (`userId === uid`) for every requested `entryId` via `db.getAll`, batch-deletes only the ones that match, and returns `{ deleted, skipped }` (silently skipping stale/foreign ids rather than aborting the whole request). Existing `onDocumentWritten` triggers (`updateExerciseStatsOnEntryWrite`, `updateAdminUserActivityOnEntryWrite`, `refreshExerciseLeaderboardsOnEntryWrite`) fire on delete too, so aggregates/leaderboards stay current automatically.
- A confirmation dialog (`DeleteEntriesDialogComponent`) guards both the single- and multi-delete paths, with singular/plural German confirmation text.
- Extracted the entries table (rendering, sorting, selection, delete flow) out of `UserEntriesPageComponent` into a new `UserEntriesTableComponent` to keep both files under the repo's ~250 LOC guideline. The page still owns loading entries/details and the shared edit dialog; the table emits `edit` and `refresh` events back up.
- Added/synced i18n strings for the new UI (`web:extract-i18n` + `sync-xliff-locales.mjs`), German source only — other locales get real translations from the daily translations routine.

## Test plan
- [x] `pnpm nx run cloud-functions:test --testPathPatterns=user-entries` — 36 tests pass, including new `validateDeleteUserEntriesPayload` coverage
- [x] `pnpm nx run web:test --include="web/src/app/admin/**/*.spec.ts"` — 92 tests pass, including new specs for `UserEntriesTableComponent` and `DeleteEntriesDialogComponent`
- [x] `pnpm nx run cloud-functions:build` and `pnpm nx run cloud-functions:eslint:lint`
- [x] `pnpm nx run web:lint`
- [x] `pnpm nx build web --configuration=development` (full prerender build)


---
_Generated by [Claude Code](https://claude.ai/code/session_017g4gW7WFuJ4rHQs6sj9AyA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can delete individual or multiple exercise entries from the user entries table.
  * Select individual entries or use “select all,” with confirmation dialogs showing the number selected.
  * Large selections are processed automatically in manageable batches.
  * The table refreshes after deletion and reports errors when an operation fails.
* **Improvements**
  * User entry tables now provide clearer reusable sorting, selection, and action controls.
  * Added interface text for the deletion workflow across supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->