### PR TITLE
chore(i18n): fill missing translations (80 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10373,63 +10373,63 @@
       </segment>
     </unit>
     <unit id="admin.entries.delete.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einträge löschen </source>
-        <target> Einträge löschen </target>
+        <target> Διαγραφή καταχωρήσεων </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Ακύρωση </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.button">
-      <segment state="initial">
+      <segment state="translated">
         <source> Löschen </source>
-        <target> Löschen </target>
+        <target> Διαγραφή </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmOne">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
-        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+        <target>Θέλετε πραγματικά να διαγράψετε οριστικά αυτή την καταχώρηση;</target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmMany">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
-        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+        <target>Θέλετε πραγματικά να διαγράψετε οριστικά αυτές τις <ph id="0" equiv="count" disp="count"/> καταχωρήσεις;</target>
       </segment>
     </unit>
     <unit id="admin.entries.selection.count">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> επιλεγμένες</target>
       </segment>
     </unit>
     <unit id="admin.entries.deleteSelected">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausgewählte löschen</source>
-        <target>Ausgewählte löschen</target>
+        <target>Διαγραφή επιλεγμένων</target>
       </segment>
     </unit>
     <unit id="admin.entry.deleteTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag löschen</source>
-        <target>Eintrag löschen</target>
+        <target>Διαγραφή καταχώρησης</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectAll">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Einträge auswählen</source>
-        <target>Alle Einträge auswählen</target>
+        <target>Επιλογή όλων των καταχωρήσεων</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectRow">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag auswählen</source>
-        <target>Eintrag auswählen</target>
+        <target>Επιλογή καταχώρησης</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10572,63 +10572,63 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.entries.delete.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einträge löschen </source>
-        <target> Einträge löschen </target>
+        <target> Delete entries </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Cancel </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.button">
-      <segment state="initial">
+      <segment state="translated">
         <source> Löschen </source>
-        <target> Löschen </target>
+        <target> Delete </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmOne">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
-        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+        <target>Do you really want to permanently delete this entry?</target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmMany">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
-        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+        <target>Do you really want to permanently delete these <ph id="0" equiv="count" disp="count"/> entries?</target>
       </segment>
     </unit>
     <unit id="admin.entries.selection.count">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> selected</target>
       </segment>
     </unit>
     <unit id="admin.entries.deleteSelected">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausgewählte löschen</source>
-        <target>Ausgewählte löschen</target>
+        <target>Delete selected</target>
       </segment>
     </unit>
     <unit id="admin.entry.deleteTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag löschen</source>
-        <target>Eintrag löschen</target>
+        <target>Delete entry</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectAll">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Einträge auswählen</source>
-        <target>Alle Einträge auswählen</target>
+        <target>Select all entries</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectRow">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag auswählen</source>
-        <target>Eintrag auswählen</target>
+        <target>Select entry</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10369,63 +10369,63 @@
       </segment>
     </unit>
     <unit id="admin.entries.delete.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einträge löschen </source>
-        <target> Einträge löschen </target>
+        <target> Eliminar entradas </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Cancelar </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.button">
-      <segment state="initial">
+      <segment state="translated">
         <source> Löschen </source>
-        <target> Löschen </target>
+        <target> Eliminar </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmOne">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
-        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+        <target>¿Realmente deseas eliminar permanentemente esta entrada?</target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmMany">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
-        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+        <target>¿Realmente deseas eliminar permanentemente estas <ph id="0" equiv="count" disp="count"/> entradas?</target>
       </segment>
     </unit>
     <unit id="admin.entries.selection.count">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> seleccionada(s)</target>
       </segment>
     </unit>
     <unit id="admin.entries.deleteSelected">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausgewählte löschen</source>
-        <target>Ausgewählte löschen</target>
+        <target>Eliminar seleccionadas</target>
       </segment>
     </unit>
     <unit id="admin.entry.deleteTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag löschen</source>
-        <target>Eintrag löschen</target>
+        <target>Eliminar entrada</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectAll">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Einträge auswählen</source>
-        <target>Alle Einträge auswählen</target>
+        <target>Seleccionar todas las entradas</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectRow">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag auswählen</source>
-        <target>Eintrag auswählen</target>
+        <target>Seleccionar entrada</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10245,63 +10245,63 @@
       </segment>
     </unit>
     <unit id="admin.entries.delete.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einträge löschen </source>
-        <target> Einträge löschen </target>
+        <target> Supprimer les entrées </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Annuler </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.button">
-      <segment state="initial">
+      <segment state="translated">
         <source> Löschen </source>
-        <target> Löschen </target>
+        <target> Supprimer </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmOne">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
-        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+        <target>Souhaitez-vous vraiment supprimer définitivement cette entrée?</target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmMany">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
-        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+        <target>Souhaitez-vous vraiment supprimer définitivement ces <ph id="0" equiv="count" disp="count"/> entrées?</target>
       </segment>
     </unit>
     <unit id="admin.entries.selection.count">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> sélectionné(s)</target>
       </segment>
     </unit>
     <unit id="admin.entries.deleteSelected">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausgewählte löschen</source>
-        <target>Ausgewählte löschen</target>
+        <target>Supprimer la sélection</target>
       </segment>
     </unit>
     <unit id="admin.entry.deleteTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag löschen</source>
-        <target>Eintrag löschen</target>
+        <target>Supprimer l'entrée</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectAll">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Einträge auswählen</source>
-        <target>Alle Einträge auswählen</target>
+        <target>Sélectionner toutes les entrées</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectRow">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag auswählen</source>
-        <target>Eintrag auswählen</target>
+        <target>Sélectionner l'entrée</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10373,63 +10373,63 @@
       </segment>
     </unit>
     <unit id="admin.entries.delete.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einträge löschen </source>
-        <target> Einträge löschen </target>
+        <target> Elimina voci </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Annulla </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.button">
-      <segment state="initial">
+      <segment state="translated">
         <source> Löschen </source>
-        <target> Löschen </target>
+        <target> Elimina </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmOne">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
-        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+        <target>Vuoi davvero eliminare definitivamente questa voce?</target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmMany">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
-        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+        <target>Vuoi davvero eliminare definitivamente queste <ph id="0" equiv="count" disp="count"/> voci?</target>
       </segment>
     </unit>
     <unit id="admin.entries.selection.count">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> selezionate</target>
       </segment>
     </unit>
     <unit id="admin.entries.deleteSelected">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausgewählte löschen</source>
-        <target>Ausgewählte löschen</target>
+        <target>Elimina selezionate</target>
       </segment>
     </unit>
     <unit id="admin.entry.deleteTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag löschen</source>
-        <target>Eintrag löschen</target>
+        <target>Elimina voce</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectAll">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Einträge auswählen</source>
-        <target>Alle Einträge auswählen</target>
+        <target>Seleziona tutte le voci</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectRow">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag auswählen</source>
-        <target>Eintrag auswählen</target>
+        <target>Seleziona voce</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10373,63 +10373,63 @@
       </segment>
     </unit>
     <unit id="admin.entries.delete.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einträge löschen </source>
-        <target> Einträge löschen </target>
+        <target> Invoeren verwijderen </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Annuleren </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.button">
-      <segment state="initial">
+      <segment state="translated">
         <source> Löschen </source>
-        <target> Löschen </target>
+        <target> Verwijderen </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmOne">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
-        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+        <target>Wil je deze invoer echt definitief verwijderen?</target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmMany">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
-        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+        <target>Wil je deze <ph id="0" equiv="count" disp="count"/> invoeren echt definitief verwijderen?</target>
       </segment>
     </unit>
     <unit id="admin.entries.selection.count">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> geselecteerd</target>
       </segment>
     </unit>
     <unit id="admin.entries.deleteSelected">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausgewählte löschen</source>
-        <target>Ausgewählte löschen</target>
+        <target>Geselecteerde verwijderen</target>
       </segment>
     </unit>
     <unit id="admin.entry.deleteTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag löschen</source>
-        <target>Eintrag löschen</target>
+        <target>Invoer verwijderen</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectAll">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Einträge auswählen</source>
-        <target>Alle Einträge auswählen</target>
+        <target>Alle invoeren selecteren</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectRow">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag auswählen</source>
-        <target>Eintrag auswählen</target>
+        <target>Invoer selecteren</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9666,63 +9666,63 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.entries.delete.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einträge löschen </source>
-        <target> Einträge löschen </target>
+        <target> Slett oppføringer </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> Avbryt </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.button">
-      <segment state="initial">
+      <segment state="translated">
         <source> Löschen </source>
-        <target> Löschen </target>
+        <target> Slett </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmOne">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
-        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+        <target>Vil du virkelig slette denne oppføringen permanent?</target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmMany">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
-        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+        <target>Vil du virkelig slette disse <ph id="0" equiv="count" disp="count"/> oppføringene permanent?</target>
       </segment>
     </unit>
     <unit id="admin.entries.selection.count">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> valgt</target>
       </segment>
     </unit>
     <unit id="admin.entries.deleteSelected">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausgewählte löschen</source>
-        <target>Ausgewählte löschen</target>
+        <target>Slett valgte</target>
       </segment>
     </unit>
     <unit id="admin.entry.deleteTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag löschen</source>
-        <target>Eintrag löschen</target>
+        <target>Slett oppføring</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectAll">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Einträge auswählen</source>
-        <target>Alle Einträge auswählen</target>
+        <target>Velg alle oppføringer</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectRow">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag auswählen</source>
-        <target>Eintrag auswählen</target>
+        <target>Velg oppføring</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9879,63 +9879,63 @@
       </segment>
     </unit>
     <unit id="admin.entries.delete.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einträge löschen </source>
-        <target> Einträge löschen </target>
+        <target> 删除记录 </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.cancel">
-      <segment state="initial">
+      <segment state="translated">
         <source> Abbrechen </source>
-        <target> Abbrechen </target>
+        <target> 取消 </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.button">
-      <segment state="initial">
+      <segment state="translated">
         <source> Löschen </source>
-        <target> Löschen </target>
+        <target> 删除 </target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmOne">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diesen Eintrag wirklich endgültig löschen?</source>
-        <target>Möchtest du diesen Eintrag wirklich endgültig löschen?</target>
+        <target>确定要永久删除此记录吗？</target>
       </segment>
     </unit>
     <unit id="admin.entries.delete.confirmMany">
-      <segment state="initial">
+      <segment state="translated">
         <source>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</source>
-        <target>Möchtest du diese <ph id="0" equiv="count" disp="count"/> Einträge wirklich endgültig löschen?</target>
+        <target>确定要永久删除这 <ph id="0" equiv="count" disp="count"/> 条记录吗？</target>
       </segment>
     </unit>
     <unit id="admin.entries.selection.count">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> ausgewählt</target>
+        <target>已选择 <ph id="0" equiv="INTERPOLATION" disp="{{ selectedIds().size }}"/> 项</target>
       </segment>
     </unit>
     <unit id="admin.entries.deleteSelected">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ausgewählte löschen</source>
-        <target>Ausgewählte löschen</target>
+        <target>删除所选</target>
       </segment>
     </unit>
     <unit id="admin.entry.deleteTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag löschen</source>
-        <target>Eintrag löschen</target>
+        <target>删除记录</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectAll">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Einträge auswählen</source>
-        <target>Alle Einträge auswählen</target>
+        <target>全选记录</target>
       </segment>
     </unit>
     <unit id="admin.entries.selectRow">
-      <segment state="initial">
+      <segment state="translated">
         <source>Eintrag auswählen</source>
-        <target>Eintrag auswählen</target>
+        <target>选择记录</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
Fills XLIFF translation gaps detected by `tools/src/detect-translation-gaps.mjs`. All 80 gaps were seeded-fallback units for the new admin "delete entries" feature (dialog title/cancel/confirm button, single/bulk confirm text, bulk-selection count/select-all/select-row/tooltip strings) — 10 units × 8 target locales, all with `state="initial"` and `<target>` equal to `<source>`.

## Touched locales

- `en`: 10 unit(s), 0 blog post(s), 0 wiki entry/entries
- `fr`: 10 unit(s), 0 blog post(s), 0 wiki entry/entries
- `es`: 10 unit(s), 0 blog post(s), 0 wiki entry/entries
- `it`: 10 unit(s), 0 blog post(s), 0 wiki entry/entries
- `nl`: 10 unit(s), 0 blog post(s), 0 wiki entry/entries
- `el`: 10 unit(s), 0 blog post(s), 0 wiki entry/entries
- `no`: 10 unit(s), 0 blog post(s), 0 wiki entry/entries
- `zh`: 10 unit(s), 0 blog post(s), 0 wiki entry/entries

Terminology was cross-checked against existing translated units in the same files (e.g. `admin.feedback.delete.*`, `admin.entry.editTooltip`, `admin.entries.title` / `admin.col.entries`) to keep wording consistent with the rest of the admin UI. All 80 units flipped from `state="initial"` to `state="translated"`; XLIFF placeholders (`<ph id="0" equiv="count" .../>`, `<ph id="0" equiv="INTERPOLATION" .../>`) preserved verbatim.

## Skipped

None — all 80 detected gaps were translated.

## Detector summary

```
Detected 80 gap(s) — xliff:80 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh
```

Re-running the detector after this change reports `has_gaps=false` (0 gaps).

## Notes

- `web/src/locale/messages.xlf` (auto-generated extraction source) was **not** committed — only line-number drift from re-running `extract-i18n`, no content changes.
- `libs/stats/src/lib/models/exercise-wiki-content.generated.ts` showed unrelated pre-existing drift from `content/wiki` on `main` (triggered by the build's `tools:generate-content` dependency) — left untouched since this PR makes no content/markdown changes.
- Pre-push checks (`pnpm nx affected -t=lint,test,build -c=production --parallel=3`) pass.
- The prior `claude/translations` branch only contained history already merged into `main` (last PR #530, merged 2026-07-20) with no open PR, so this run restarted the branch fresh from `main`'s tip rather than building on stale merged history.

🤖 Generated by an autonomous Claude Code translation routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_019jKRzFqExTDHqGZrV35Wwn)_