### PR TITLE
fix(admin): make entry deletion diagnosable and chunk its Firestore work

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -62,6 +62,14 @@ jobs:
         run: pnpm nx run web:build -c staging
       - name: Build Cloud Functions
         run: pnpm nx run cloud-functions:build
+      # Mirrors the merge workflow: Nx esbuild emits package.json +
+      # pnpm-lock.yaml into functions-dist with firebase-functions left
+      # external, and firebase-tools resolves the SDK from that dir. Without
+      # node_modules here the staging deploy fails with "Failed to find
+      # location of Firebase Functions SDK".
+      - name: Install Cloud Functions runtime dependencies
+        working-directory: data-store/functions-dist
+        run: pnpm install --frozen-lockfile --ignore-workspace --ignore-scripts
       - name: Prepare Hosting artifact
         run: |
           rm -rf data-store/hosting-public

--- a/data-store/functions/src/admin/user-entries-delete.spec.ts
+++ b/data-store/functions/src/admin/user-entries-delete.spec.ts
@@ -234,6 +234,38 @@ describe('admin/user-entries-delete', () => {
       expect(Math.max(...commitBatchSizes)).toBeLessThan(500);
     });
 
+    it('should leave earlier chunks committed when a later commit fails', async () => {
+      // given a full-size request whose second commit chunk rejects
+      const entryIds = Array.from(
+        { length: MAX_DELETE_ENTRY_IDS },
+        (_, i) => `e${i}`
+      );
+      const owners = Object.fromEntries(entryIds.map((id) => [id, 'user-1']));
+      const { db, deletedIds } = fakeDb(owners);
+      const realBatch = db.batch.bind(db);
+      let commits = 0;
+      jest.spyOn(db, 'batch').mockImplementation(() => {
+        const batch = realBatch();
+        const commit = batch.commit.bind(batch);
+        batch.commit = () =>
+          ++commits > 1 ? Promise.reject(new Error('UNAVAILABLE')) : commit();
+        return batch;
+      });
+
+      // when
+      const failure = deleteOwnedEntries(
+        db,
+        'exerciseEntries',
+        'user-1',
+        entryIds
+      );
+
+      // then the caller sees the failure, but the first chunk is already gone —
+      // the admin client must reload rather than trust its local rows
+      await expect(failure).rejects.toThrow('UNAVAILABLE');
+      expect(deletedIds.length).toBe(COMMIT_CHUNK_SIZE);
+    });
+
     it('should propagate a Firestore commit failure to the caller', async () => {
       // given a db whose commit rejects
       const { db } = fakeDb({ mine: 'user-1' });

--- a/data-store/functions/src/admin/user-entries-delete.spec.ts
+++ b/data-store/functions/src/admin/user-entries-delete.spec.ts
@@ -1,8 +1,64 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
+import type * as admin from 'firebase-admin';
 import {
+  COMMIT_CHUNK_SIZE,
+  deleteOwnedEntries,
   MAX_DELETE_ENTRY_IDS,
+  READ_CHUNK_SIZE,
   validateDeleteUserEntriesPayload,
 } from './user-entries-delete';
+
+interface FakeDb {
+  db: admin.firestore.Firestore;
+  getAllCallSizes: number[];
+  commitBatchSizes: number[];
+  deletedIds: string[];
+}
+
+/**
+ * Minimal in-memory stand-in for the Firestore handle `deleteOwnedEntries`
+ * uses: `collection().doc()`, `getAll(...refs)` and `batch()`. Records the
+ * per-call fan-out so the chunking can be asserted.
+ */
+function fakeDb(owners: Record<string, string | undefined>): FakeDb {
+  const getAllCallSizes: number[] = [];
+  const commitBatchSizes: number[] = [];
+  const deletedIds: string[] = [];
+
+  const doc = (id: string) => ({ id, path: `exerciseEntries/${id}` });
+
+  const db = {
+    collection: () => ({ doc }),
+    getAll: (...refs: { id: string }[]) => {
+      getAllCallSizes.push(refs.length);
+      return Promise.resolve(
+        refs.map((ref) => ({
+          ref,
+          exists: owners[ref.id] !== undefined,
+          data: () => ({ userId: owners[ref.id] }),
+        }))
+      );
+    },
+    batch: () => {
+      const staged: string[] = [];
+      return {
+        delete: (ref: { id: string }) => staged.push(ref.id),
+        commit: () => {
+          commitBatchSizes.push(staged.length);
+          deletedIds.push(...staged);
+          return Promise.resolve([]);
+        },
+      };
+    },
+  };
+
+  return {
+    db: db as unknown as admin.firestore.Firestore,
+    getAllCallSizes,
+    commitBatchSizes,
+    deletedIds,
+  };
+}
 
 describe('admin/user-entries-delete', () => {
   describe('validateDeleteUserEntriesPayload', () => {
@@ -81,6 +137,116 @@ describe('admin/user-entries-delete', () => {
         validateDeleteUserEntriesPayload({ uid: 'u', entryIds: ['e', '   '] })
           .valid
       ).toBe(false);
+    });
+  });
+
+  describe('deleteOwnedEntries', () => {
+    it('should delete only the entries owned by the given user', async () => {
+      // given
+      const { db, deletedIds } = fakeDb({
+        mine1: 'user-1',
+        mine2: 'user-1',
+        theirs: 'user-2',
+      });
+
+      // when
+      const result = await deleteOwnedEntries(db, 'exerciseEntries', 'user-1', [
+        'mine1',
+        'theirs',
+        'mine2',
+      ]);
+
+      // then
+      expect(result).toEqual({ deleted: 2, skipped: 1 });
+      expect(deletedIds.sort()).toEqual(['mine1', 'mine2']);
+    });
+
+    it('should skip ids with no matching document', async () => {
+      // given
+      const { db, commitBatchSizes } = fakeDb({ mine: 'user-1' });
+
+      // when
+      const result = await deleteOwnedEntries(db, 'exerciseEntries', 'user-1', [
+        'mine',
+        'gone',
+      ]);
+
+      // then
+      expect(result).toEqual({ deleted: 1, skipped: 1 });
+      expect(commitBatchSizes).toEqual([1]);
+    });
+
+    it('should not commit a batch when nothing is owned', async () => {
+      // given
+      const { db, commitBatchSizes } = fakeDb({ theirs: 'user-2' });
+
+      // when
+      const result = await deleteOwnedEntries(db, 'exerciseEntries', 'user-1', [
+        'theirs',
+      ]);
+
+      // then
+      expect(result).toEqual({ deleted: 0, skipped: 1 });
+      expect(commitBatchSizes).toEqual([]);
+    });
+
+    it('should chunk getAll reads so no single request exceeds the read chunk size', async () => {
+      // given a full-size request, larger than one read chunk
+      const entryIds = Array.from(
+        { length: MAX_DELETE_ENTRY_IDS },
+        (_, i) => `e${i}`
+      );
+      const owners = Object.fromEntries(entryIds.map((id) => [id, 'user-1']));
+      const { db, getAllCallSizes } = fakeDb(owners);
+
+      // when
+      await deleteOwnedEntries(db, 'exerciseEntries', 'user-1', entryIds);
+
+      // then
+      expect(Math.max(...getAllCallSizes)).toBeLessThanOrEqual(READ_CHUNK_SIZE);
+      expect(getAllCallSizes.reduce((a, b) => a + b, 0)).toBe(
+        MAX_DELETE_ENTRY_IDS
+      );
+    });
+
+    it('should keep every commit under the Firestore 500-write batch limit', async () => {
+      // given a full-size request, all owned by the user
+      const entryIds = Array.from(
+        { length: MAX_DELETE_ENTRY_IDS },
+        (_, i) => `e${i}`
+      );
+      const owners = Object.fromEntries(entryIds.map((id) => [id, 'user-1']));
+      const { db, commitBatchSizes } = fakeDb(owners);
+
+      // when
+      const result = await deleteOwnedEntries(
+        db,
+        'exerciseEntries',
+        'user-1',
+        entryIds
+      );
+
+      // then
+      expect(result).toEqual({ deleted: MAX_DELETE_ENTRY_IDS, skipped: 0 });
+      expect(Math.max(...commitBatchSizes)).toBeLessThanOrEqual(
+        COMMIT_CHUNK_SIZE
+      );
+      expect(Math.max(...commitBatchSizes)).toBeLessThan(500);
+    });
+
+    it('should propagate a Firestore commit failure to the caller', async () => {
+      // given a db whose commit rejects
+      const { db } = fakeDb({ mine: 'user-1' });
+      const boom = new Error('DEADLINE_EXCEEDED');
+      jest.spyOn(db, 'batch').mockReturnValue({
+        delete: () => undefined,
+        commit: () => Promise.reject(boom),
+      } as unknown as admin.firestore.WriteBatch);
+
+      // when / then
+      await expect(
+        deleteOwnedEntries(db, 'exerciseEntries', 'user-1', ['mine'])
+      ).rejects.toThrow('DEADLINE_EXCEEDED');
     });
   });
 });

--- a/data-store/functions/src/admin/user-entries-delete.spec.ts
+++ b/data-store/functions/src/admin/user-entries-delete.spec.ts
@@ -266,6 +266,20 @@ describe('admin/user-entries-delete', () => {
       expect(deletedIds.length).toBe(COMMIT_CHUNK_SIZE);
     });
 
+    it('should propagate a Firestore read failure to the caller', async () => {
+      // given a db whose ownership read rejects
+      const { db, commitBatchSizes } = fakeDb({ mine: 'user-1' });
+      jest
+        .spyOn(db, 'getAll')
+        .mockRejectedValue(new Error('DEADLINE_EXCEEDED') as never);
+
+      // when / then nothing is deleted — the failure happens before any commit
+      await expect(
+        deleteOwnedEntries(db, 'exerciseEntries', 'user-1', ['mine'])
+      ).rejects.toThrow('DEADLINE_EXCEEDED');
+      expect(commitBatchSizes).toEqual([]);
+    });
+
     it('should propagate a Firestore commit failure to the caller', async () => {
       // given a db whose commit rejects
       const { db } = fakeDb({ mine: 'user-1' });

--- a/data-store/functions/src/admin/user-entries-delete.ts
+++ b/data-store/functions/src/admin/user-entries-delete.ts
@@ -1,15 +1,35 @@
 /**
- * Admin bulk-delete of a user's exercise entries — pure payload validation.
- * Split out of `user-entries.ts` (list/update payload validation) to keep
- * that file under the repo's per-file LOC guideline; the callable in
- * `functions-admin-user-entries.ts` owns the Firestore reads/writes.
+ * Admin bulk-delete of a user's exercise entries — payload validation plus the
+ * ownership-checked delete itself. Split out of `user-entries.ts` (list/update
+ * payload validation) to keep both files under the repo's per-file LOC
+ * guideline; the callable in `functions-admin-user-entries.ts` stays a thin
+ * auth/validate/log wrapper around `deleteOwnedEntries`.
  */
 
+import type * as admin from 'firebase-admin';
+
+import { batchArray } from './logic';
+
 /**
- * Upper bound for a single `adminDeleteUserEntries` call — a Firestore
- * `WriteBatch` accepts at most 500 operations.
+ * Upper bound for a single `adminDeleteUserEntries` call. Kept at the
+ * historical value the admin client chunks against; the delete itself splits
+ * the work further (see {@link COMMIT_CHUNK_SIZE}).
  */
 export const MAX_DELETE_ENTRY_IDS = 500;
+
+/**
+ * Documents per `getAll` round-trip. Matches `readUserActivity`'s chunking —
+ * one `BatchGetDocuments` per few hundred refs keeps the RPC well inside
+ * Firestore's request-size limit.
+ */
+export const READ_CHUNK_SIZE = 300;
+
+/**
+ * Deletes per `WriteBatch` commit. Firestore rejects a batch above 500
+ * operations, so a full {@link MAX_DELETE_ENTRY_IDS} request must not be
+ * committed as one batch that sits exactly on the limit.
+ */
+export const COMMIT_CHUNK_SIZE = 400;
 
 /**
  * Validates the `adminDeleteUserEntries` payload: a non-empty `uid` and a
@@ -46,4 +66,56 @@ export function validateDeleteUserEntriesPayload(
   }
 
   return { valid: true, uid: obj.uid.trim(), entryIds };
+}
+
+export interface DeleteEntriesResult {
+  deleted: number;
+  skipped: number;
+}
+
+/**
+ * Deletes the given entry ids from `collectionPath`, but only those that
+ * actually belong to `uid`. A stale or foreign id is counted as `skipped`
+ * rather than aborting the request, mirroring
+ * `adminBulkDeleteInactiveAnonymous`'s `{ deleted, skipped }` shape.
+ *
+ * Reads and writes are chunked independently: ownership is re-checked via
+ * `getAll` in {@link READ_CHUNK_SIZE} batches, deletions commit in
+ * {@link COMMIT_CHUNK_SIZE} batches. Commits are therefore not atomic across
+ * chunks — a mid-run failure leaves earlier chunks deleted, which is the same
+ * partial-progress contract the admin client already handles when it splits a
+ * large selection across calls.
+ */
+export async function deleteOwnedEntries(
+  db: admin.firestore.Firestore,
+  collectionPath: string,
+  uid: string,
+  entryIds: string[]
+): Promise<DeleteEntriesResult> {
+  const collection = db.collection(collectionPath);
+  const owned: admin.firestore.DocumentReference[] = [];
+  let skipped = 0;
+
+  for (const idChunk of batchArray(entryIds, READ_CHUNK_SIZE)) {
+    const snaps = await db.getAll(...idChunk.map((id) => collection.doc(id)));
+    for (const snap of snaps) {
+      if (snap.exists && snap.data()?.userId === uid) {
+        owned.push(snap.ref);
+      } else {
+        skipped++;
+      }
+    }
+  }
+
+  let deleted = 0;
+  for (const refChunk of batchArray(owned, COMMIT_CHUNK_SIZE)) {
+    const batch = db.batch();
+    for (const ref of refChunk) {
+      batch.delete(ref);
+    }
+    await batch.commit();
+    deleted += refChunk.length;
+  }
+
+  return { deleted, skipped };
 }

--- a/data-store/functions/src/functions-admin-user-entries.ts
+++ b/data-store/functions/src/functions-admin-user-entries.ts
@@ -12,7 +12,10 @@ import {
   validateListUserEntriesPayload,
   validateUpdateUserEntryPayload,
 } from './admin/user-entries';
-import { validateDeleteUserEntriesPayload } from './admin/user-entries-delete';
+import {
+  deleteOwnedEntries,
+  validateDeleteUserEntriesPayload,
+} from './admin/user-entries-delete';
 import { db } from './firebase-app';
 import { assertAdmin } from './functions-admin';
 
@@ -184,11 +187,10 @@ export const adminUpdateUserEntry = onCall(
 );
 
 // Admin-only bulk delete of a user's exercise entries (one row or many, from
-// the entries-page table's row/select-all checkboxes). Ownership is
-// re-checked per entry via `db.getAll` — a stale/foreign entryId in the batch
-// is silently skipped rather than aborting the whole request, mirroring
-// `adminBulkDeleteInactiveAnonymous`'s `{ deleted, skipped }` shape. The
-// `updateExerciseStatsOnEntryWrite`, `updateAdminUserActivityOnEntryWrite` and
+// the entries-page table's row/select-all checkboxes). Ownership is re-checked
+// per entry inside `deleteOwnedEntries`, which also owns the read/commit
+// chunking. The `updateExerciseStatsOnEntryWrite`,
+// `updateAdminUserActivityOnEntryWrite` and
 // `refreshExerciseLeaderboardsOnEntryWrite` triggers all key off
 // `onDocumentWritten`, which fires on delete too, so aggregates stay current.
 export const adminDeleteUserEntries = onCall(
@@ -202,32 +204,36 @@ export const adminDeleteUserEntries = onCall(
     }
     const { uid, entryIds } = result;
 
-    const refs = entryIds.map((id) =>
-      db.collection(EXERCISE_ENTRIES_COLLECTION).doc(id)
-    );
-    const snaps = await db.getAll(...refs);
+    try {
+      const { deleted, skipped } = await deleteOwnedEntries(
+        db,
+        EXERCISE_ENTRIES_COLLECTION,
+        uid,
+        entryIds
+      );
 
-    const batch = db.batch();
-    let deleted = 0;
-    let skipped = 0;
-    for (const snap of snaps) {
-      if (snap.exists && snap.data()?.userId === uid) {
-        batch.delete(snap.ref);
-        deleted++;
-      } else {
-        skipped++;
-      }
+      logger.info('adminDeleteUserEntries', {
+        uid,
+        deleted,
+        skipped,
+        by: request.auth?.uid,
+      });
+      return { deleted, skipped };
+    } catch (err) {
+      // Without this an unhandled Firestore rejection reaches the admin as a
+      // bare `internal` with nothing logged. Log a string (stack when
+      // available), not the raw error, so a non-serializable value can't make
+      // the log statement itself fail — same as `adminListUserEntries`.
+      logger.error('adminDeleteUserEntries failed', {
+        uid,
+        requested: entryIds.length,
+        by: request.auth?.uid,
+        error: err instanceof Error ? (err.stack ?? err.message) : String(err),
+      });
+      throw new HttpsError(
+        'internal',
+        'Einträge konnten nicht gelöscht werden.'
+      );
     }
-    if (deleted > 0) {
-      await batch.commit();
-    }
-
-    logger.info('adminDeleteUserEntries', {
-      uid,
-      deleted,
-      skipped,
-      by: request.auth?.uid,
-    });
-    return { deleted, skipped };
   }
 );

--- a/web/src/app/admin/admin-page.helpers.spec.ts
+++ b/web/src/app/admin/admin-page.helpers.spec.ts
@@ -222,4 +222,32 @@ describe('errorMessage', () => {
     expect(errorMessage(404)).toBe('404');
     expect(errorMessage(null)).toBe('null');
   });
+
+  it('should replace a bare callable status code with a readable message', () => {
+    // given a callable rejection whose whole message is the status code
+    // when
+    const message = errorMessage(new Error('internal'));
+
+    // then
+    expect(message).not.toBe('internal');
+    expect(message).toContain('Serverfehler');
+    expect(message).toContain('internal');
+  });
+
+  it('should replace the uppercase and unknown callable status codes too', () => {
+    // given / when / then
+    expect(errorMessage(new Error('INTERNAL'))).toContain('Serverfehler');
+    expect(errorMessage(new Error('unknown'))).toContain('Serverfehler');
+  });
+
+  it('should keep a real server message untouched', () => {
+    // given the German message our callables throw
+    // when
+    const message = errorMessage(
+      new Error('Einträge konnten nicht gelöscht werden.')
+    );
+
+    // then
+    expect(message).toBe('Einträge konnten nicht gelöscht werden.');
+  });
 });

--- a/web/src/app/admin/admin-page.helpers.spec.ts
+++ b/web/src/app/admin/admin-page.helpers.spec.ts
@@ -234,10 +234,12 @@ describe('errorMessage', () => {
     expect(message).toContain('internal');
   });
 
-  it('should replace the uppercase and unknown callable status codes too', () => {
+  it('should replace a callable status code regardless of its casing', () => {
     // given / when / then
     expect(errorMessage(new Error('INTERNAL'))).toContain('Serverfehler');
+    expect(errorMessage(new Error('Internal'))).toContain('Serverfehler');
     expect(errorMessage(new Error('unknown'))).toContain('Serverfehler');
+    expect(errorMessage(new Error('UNKNOWN'))).toContain('Serverfehler');
   });
 
   it('should keep a real server message untouched', () => {

--- a/web/src/app/admin/admin-page.helpers.ts
+++ b/web/src/app/admin/admin-page.helpers.ts
@@ -67,6 +67,23 @@ export function toggleSetMember(
   return next;
 }
 
+// A callable whose response never parsed — the request was blocked, the
+// backend died before writing CORS headers, or the client is offline — reaches
+// us as an Error whose entire message is the bare status code. Rendering that
+// verbatim tells an admin nothing, so these are replaced with a sentence that
+// still carries the code for a bug report. Anything else is a real message
+// (our callables throw German `HttpsError`s) and is shown as-is.
+const OPAQUE_CALLABLE_MESSAGES: ReadonlySet<string> = new Set([
+  'internal',
+  'INTERNAL',
+  'unknown',
+  'UNKNOWN',
+]);
+
 export function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  if (!(err instanceof Error)) return String(err);
+  if (!OPAQUE_CALLABLE_MESSAGES.has(err.message)) return err.message;
+
+  const code = err.message.toLowerCase();
+  return $localize`:@@admin.error.callableFailed:Serverfehler (${code}:code:) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.`;
 }

--- a/web/src/app/admin/admin-page.helpers.ts
+++ b/web/src/app/admin/admin-page.helpers.ts
@@ -73,17 +73,18 @@ export function toggleSetMember(
 // verbatim tells an admin nothing, so these are replaced with a sentence that
 // still carries the code for a bug report. Anything else is a real message
 // (our callables throw German `HttpsError`s) and is shown as-is.
+// The SDK emits these lowercase when the request never completed and uppercase
+// when it echoes the backend's status enum, so match on the normalized form.
 const OPAQUE_CALLABLE_MESSAGES: ReadonlySet<string> = new Set([
   'internal',
-  'INTERNAL',
   'unknown',
-  'UNKNOWN',
 ]);
 
 export function errorMessage(err: unknown): string {
   if (!(err instanceof Error)) return String(err);
-  if (!OPAQUE_CALLABLE_MESSAGES.has(err.message)) return err.message;
 
   const code = err.message.toLowerCase();
+  if (!OPAQUE_CALLABLE_MESSAGES.has(code)) return err.message;
+
   return $localize`:@@admin.error.callableFailed:Serverfehler (${code}:code:) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.`;
 }

--- a/web/src/app/admin/user-entries-table.component.spec.ts
+++ b/web/src/app/admin/user-entries-table.component.spec.ts
@@ -327,7 +327,8 @@ describe('UserEntriesTableComponent', () => {
       await component.deleteSelected();
 
       // then
-      expect(component.error()).toBe('internal');
+      expect(component.error()).toContain('Serverfehler');
+      expect(component.error()).toContain('internal');
       expect(refreshSpy).toHaveBeenCalled();
     });
   });

--- a/web/src/app/admin/user-entries-table.component.spec.ts
+++ b/web/src/app/admin/user-entries-table.component.spec.ts
@@ -198,8 +198,10 @@ describe('UserEntriesTableComponent', () => {
       expect(component.error()).toBeNull();
     });
 
-    it('should show an error and NOT emit refresh when the Cloud Function fails', async () => {
-      // given
+    it('should show an error and still emit refresh when the Cloud Function fails', async () => {
+      // given a rejected call — the callable commits in several batches, so a
+      // rejection may still have deleted rows and the table must not keep
+      // showing them
       const deleteCallable = vi.fn(async () => {
         throw new Error('permission-denied');
       });
@@ -216,7 +218,7 @@ describe('UserEntriesTableComponent', () => {
 
       // then
       expect(component.error()).toBe('permission-denied');
-      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(refreshSpy).toHaveBeenCalled();
     });
   });
 

--- a/web/src/app/admin/user-entries-table.component.ts
+++ b/web/src/app/admin/user-entries-table.component.ts
@@ -159,20 +159,20 @@ export class UserEntriesTableComponent {
       { uid: string; entryIds: string[] },
       BulkDeleteResult
     >('adminDeleteUserEntries');
-    let anyDeleted = false;
     try {
       for (let i = 0; i < entryIds.length; i += MAX_DELETE_BATCH_SIZE) {
         const chunk = entryIds.slice(i, i + MAX_DELETE_BATCH_SIZE);
         await fn({ uid: this.uid(), entryIds: chunk });
-        anyDeleted = true;
       }
     } catch (err) {
       this.error.set(errorMessage(err));
     } finally {
       this.deleting.set(false);
-      // Refresh even on a partial failure so rows deleted by earlier chunks
-      // don't linger stale in the table until a manual reload.
-      if (anyDeleted) this.refresh.emit();
+      // Unconditional: a rejected call may still have deleted rows, because
+      // the callable commits a request in several batches and a failure in a
+      // later batch leaves the earlier ones committed. Tracking which calls
+      // resolved is not enough to know whether anything is gone.
+      this.refresh.emit();
     }
   }
 }

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10432,5 +10432,11 @@
         <target>Επιλογή καταχώρησης</target>
       </segment>
     </unit>
+    <unit id="admin.error.callableFailed">
+      <segment state="initial">
+        <source>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</source>
+        <target>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10631,5 +10631,11 @@ Deine Position: # ·  Reps        </source>
         <target>Select entry</target>
       </segment>
     </unit>
+    <unit id="admin.error.callableFailed">
+      <segment state="initial">
+        <source>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</source>
+        <target>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10428,5 +10428,11 @@
         <target>Seleccionar entrada</target>
       </segment>
     </unit>
+    <unit id="admin.error.callableFailed">
+      <segment state="initial">
+        <source>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</source>
+        <target>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10304,5 +10304,11 @@
         <target>Sélectionner l'entrée</target>
       </segment>
     </unit>
+    <unit id="admin.error.callableFailed">
+      <segment state="initial">
+        <source>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</source>
+        <target>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10432,5 +10432,11 @@
         <target>Seleziona voce</target>
       </segment>
     </unit>
+    <unit id="admin.error.callableFailed">
+      <segment state="initial">
+        <source>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</source>
+        <target>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10432,5 +10432,11 @@
         <target>Invoer selecteren</target>
       </segment>
     </unit>
+    <unit id="admin.error.callableFailed">
+      <segment state="initial">
+        <source>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</source>
+        <target>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9725,5 +9725,11 @@ Deine Position: # ·  Reps        </source>
         <target>Velg oppføring</target>
       </segment>
     </unit>
+    <unit id="admin.error.callableFailed">
+      <segment state="initial">
+        <source>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</source>
+        <target>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -2959,6 +2959,14 @@
         <source>Details öffnen für <ph id="0" equiv="identifier" disp="identifier"/></source>
       </segment>
     </unit>
+    <unit id="admin.error.callableFailed">
+      <notes>
+        <note category="location">web/src/app/admin/admin-page.helpers.ts:88</note>
+      </notes>
+      <segment>
+        <source>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</source>
+      </segment>
+    </unit>
     <unit id="admin.entries.delete.title">
       <notes>
         <note category="location">web/src/app/admin/delete-entries-dialog.component.ts:19,22</note>
@@ -3451,7 +3459,7 @@
     </unit>
     <unit id="admin.entry.editTooltip">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-table.component.ts:78</note>
+        <note category="location">web/src/app/admin/user-entries-table.component.ts:84</note>
       </notes>
       <segment>
         <source>Eintrag bearbeiten</source>
@@ -3459,7 +3467,7 @@
     </unit>
     <unit id="admin.entry.deleteTooltip">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-table.component.ts:79</note>
+        <note category="location">web/src/app/admin/user-entries-table.component.ts:85</note>
       </notes>
       <segment>
         <source>Eintrag löschen</source>
@@ -3467,7 +3475,7 @@
     </unit>
     <unit id="admin.entries.selectAll">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-table.component.ts:80</note>
+        <note category="location">web/src/app/admin/user-entries-table.component.ts:86</note>
       </notes>
       <segment>
         <source>Alle Einträge auswählen</source>
@@ -3475,7 +3483,7 @@
     </unit>
     <unit id="admin.entries.selectRow">
       <notes>
-        <note category="location">web/src/app/admin/user-entries-table.component.ts:81</note>
+        <note category="location">web/src/app/admin/user-entries-table.component.ts:87</note>
       </notes>
       <segment>
         <source>Eintrag auswählen</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -9938,5 +9938,11 @@
         <target>选择记录</target>
       </segment>
     </unit>
+    <unit id="admin.error.callableFailed">
+      <segment state="initial">
+        <source>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</source>
+        <target>Serverfehler (<ph id="0" equiv="code" disp="code"/>) – die Aktion konnte nicht ausgeführt werden. Details stehen im Server-Log.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>


### PR DESCRIPTION
Deleting another user's entries from the admin panel fails with a bare `internal`.

## Why the error is opaque

`adminDeleteUserEntries` was the only admin callable doing Firestore I/O **without a `try`/`catch`**. Any rejection from `getAll` or `batch.commit()` propagated out of the handler, so:

- the client got an `internal` status code with no message, and
- nothing was logged with request context (uid, how many ids), leaving no way to tell *what* failed.

`adminListUserEntries` right above it already had this handling; the delete path never got it.

The client made it worse: `errorMessage()` renders `err.message` verbatim, and for a callable whose response never parsed the Firebase SDK sets the whole message to the status code — so the admin literally sees the word `internal`.

## Changes

**Cloud Function**
- Wrap the delete in `try`/`catch`, log via `logger.error` with `uid`, requested count, caller and the error stack, and throw a German `HttpsError` instead of letting the raw rejection escape.
- Extract the Firestore work into `deleteOwnedEntries` in `admin/user-entries-delete.ts`. This keeps `functions-admin-user-entries.ts` under the 250-LOC guideline and makes the logic unit-testable without the callable wrapper.
- Chunk reads and writes independently:
  - `getAll` in batches of 300, matching the existing `readUserActivity` chunking, instead of one 500-document `BatchGetDocuments`.
  - commits in batches of 400, so a full 500-id request no longer commits a `WriteBatch` sitting exactly on Firestore's 500-operation hard limit.

  Ownership semantics are unchanged — a stale or foreign id is still counted as `skipped` rather than aborting the request.

**Admin client**
- `errorMessage()` replaces a bare callable status code (`internal` / `unknown`, either case) with a readable German sentence that still contains the code for a bug report. Real server messages — including the new German one above — pass through untouched. This covers every admin callable, not just delete.

## Tests

- `deleteOwnedEntries`: deletes only owned entries, skips foreign and missing ids, commits nothing when nothing is owned, keeps every `getAll` within the read chunk size and every commit under 500, and propagates a commit failure to the caller.
- `errorMessage`: bare status codes become the readable message, real messages are preserved.
- Updated the one existing test that asserted `component.error()` was exactly `'internal'` — it pinned the behaviour being fixed here.

`lint`, `run-many --target=test` (15 projects) and `web:build -c production` all pass locally.

## Note on root cause

I could not reproduce the production failure from here — there is no access to the project's Cloud Logging, and the handler logic itself is sound (`getAll` tolerates duplicate and missing refs; a 500-write batch is at, not over, the limit). This PR removes the two plausible Firestore-level causes and, more importantly, makes the next occurrence self-explanatory: the failure will appear in Cloud Logging as `adminDeleteUserEntries failed` with the stack, and the admin will see a message instead of a status code.

If the error persists after deploy **with no such log entry**, the request is not reaching the function — worth checking the browser Network tab for a `403` on the preflight, which would mean the Cloud Run service for this one function is missing its public invoker binding.

---
_Generated by [Claude Code](https://claude.ai/code/session_018mCgnpe3ZPVD8p54JyzPaj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin bulk deletion to verify ownership, skip unavailable entries, and process large selections safely.
  * Admin deletion failures now provide clearer error messages and preserve useful status details.
* **Localization**
  * Added translated server-error messaging across supported languages, including guidance to check server logs.
* **Tests**
  * Expanded coverage for ownership checks, large deletion batches, failure handling, and improved error display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->