### PR TITLE
feat(store): publish the Play listing from the repo instead of by hand

### DIFF
--- a/.github/workflows/play-listing.yml
+++ b/.github/workflows/play-listing.yml
@@ -1,0 +1,58 @@
+name: Play Store Listing
+
+# Manual only. Store copy goes into Google's review queue once committed,
+# so this never fires on a push — someone decides when the listing changes.
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Publish for real (unchecked = dry run, prints the diff only)'
+        type: boolean
+        default: false
+      locale:
+        description: 'Limit to one Play locale, e.g. de-DE (empty = all)'
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # Two concurrent runs would fight over the same Play edit and one would
+  # fail with a conflict.
+  group: play-listing
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          filter: tree:0
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+
+      # Corepack pins the pnpm version from package.json's `packageManager`,
+      # matching ci.yml — see the note there on pnpm/action-setup#228.
+      - name: Enable corepack
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+        run: |
+          corepack enable
+          pnpm --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish listing
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          COMMIT_FLAG: ${{ inputs.commit && '--commit' || '' }}
+          LOCALE_FLAG: ${{ inputs.locale && format('--locale={0}', inputs.locale) || '' }}
+        run: node tools/src/publish-play-listing.mjs $COMMIT_FLAG $LOCALE_FLAG

--- a/.github/workflows/play-listing.yml
+++ b/.github/workflows/play-listing.yml
@@ -32,6 +32,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           filter: tree:0
+          # No step here needs authenticated git; don't leave the token in
+          # the runner's git config for the publish step to inherit.
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v7
@@ -50,9 +53,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Invoked directly rather than through `nx run tools:publish-play-listing`
+      # on purpose: the locale is operator input, and every extra layer of
+      # argument forwarding is another place it can be re-split into flags.
+      # The Nx target stays for local use, where the input is trusted.
       - name: Publish listing
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-          COMMIT_FLAG: ${{ inputs.commit && '--commit' || '' }}
-          LOCALE_FLAG: ${{ inputs.locale && format('--locale={0}', inputs.locale) || '' }}
-        run: node tools/src/publish-play-listing.mjs $COMMIT_FLAG $LOCALE_FLAG
+          PUBLISH_COMMIT: ${{ inputs.commit }}
+          PUBLISH_LOCALE: ${{ inputs.locale }}
+        run: |
+          # Build an argv array instead of interpolating into one string:
+          # unquoted expansion word-splits, so a locale input of
+          # "de-DE --commit" would publish for real off a dry-run request.
+          args=()
+          if [[ "$PUBLISH_COMMIT" == "true" ]]; then
+            args+=(--commit)
+          fi
+          if [[ -n "$PUBLISH_LOCALE" ]]; then
+            args+=("--locale=$PUBLISH_LOCALE")
+          fi
+          node tools/src/publish-play-listing.mjs "${args[@]}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ Detailed reference material lives in [`docs/`](docs/). **Read the relevant doc b
 | AG-UI / CopilotKit assistant, frontend tools, lazy setup | [`docs/ai-assistant.md`](docs/ai-assistant.md)                                                                                 |
 | Firebase environments + deployment                       | [`docs/Firebase_DEPLOYMENT.md`](docs/Firebase_DEPLOYMENT.md), [`docs/firebase-environments.md`](docs/firebase-environments.md) |
 | Sentry source maps, releases, `SENTRY_AUTH_TOKEN` setup  | [`docs/observability/sentry.md`](docs/observability/sentry.md)                                                                 |
+| Play-Store-Text: Quelldateien, Publish-Script, Setup     | [`docs/play-store-publishing.md`](docs/play-store-publishing.md), [`docs/playstore-listing.md`](docs/playstore-listing.md)     |
 
 ### Push notifications
 

--- a/docs/play-store-publishing.md
+++ b/docs/play-store-publishing.md
@@ -58,9 +58,13 @@ Repo → **Settings → Secrets and variables → Actions → New repository sec
 ### 4. Erster Lauf — als Dry-Run
 
 Repo → **Actions → Play Store Listing → Run workflow**, „Publish for real"
-**nicht** ankreuzen. Der Lauf liest den Live-Eintrag, zeigt den Diff und
-schreibt nichts. Sieht der Diff richtig aus, denselben Workflow mit
+**nicht** ankreuzen. Sieht der Diff richtig aus, denselben Workflow mit
 angekreuztem „Publish for real" nochmal starten.
+
+„Dry-Run" heißt: es wird nichts veröffentlicht. **Read-only ist es trotzdem
+nicht** — der Lauf legt einen temporären Play-Edit an, um den Live-Eintrag
+zu lesen, und verwirft ihn danach wieder. Er braucht deshalb dieselbe
+Berechtigung wie ein echter Publish; ein reines Lese-Recht genügt nicht.
 
 ## Alltag
 
@@ -115,9 +119,12 @@ eine neue App-Sprache ohne Play-Mapping bricht CI.
   der nächste mit einem Konflikt scheitern. Das Script räumt seinen Edit im
   Fehlerfall selbst ab; bleibt trotzdem einer hängen, in der Console unter
   dem App-Eintrag verwerfen.
-- **Emoji zählen als ein Zeichen.** Die Beschreibung ist voller Emoji, und
-  `String.length` zählt Surrogatpaare doppelt. `countCharacters()` zählt
-  Codepoints — deshalb passt der lokale Check zu dem, was die Console sagt.
+- **Emoji kosten mehr als ein Zeichen.** Play zählt UTF-16-Code-Units, nicht
+  Glyphen — das Backend ist eine JVM. `📷` kostet 2, `🏋️` sogar 3 (Surrogatpaar
+  plus Variation Selector), obwohl beide wie ein Zeichen aussehen. Die
+  Beschreibung ist voller Emoji: Codepoint-Zählung lag ~10 Zeichen zu niedrig
+  und hätte einen 4004 Zeichen langen Text als „3994" durchgewunken.
+  `countCharacters()` zählt deshalb Code-Units.
 - **Grafiken bleiben Handarbeit.** Screenshots, Feature-Grafik und Icon
   gehen über diesen Weg nicht mit; die API kann sie zwar, das Script macht
   bewusst nur Text.

--- a/docs/play-store-publishing.md
+++ b/docs/play-store-publishing.md
@@ -1,0 +1,123 @@
+# Play-Store-Listing per Code veröffentlichen
+
+Der Store-Text lebt als Quelldateien im Repo und wird über die Google Play
+Developer API in die Console geschoben — kein Copy-Paste mehr.
+
+| Was                  | Wo                                                                        |
+| -------------------- | ------------------------------------------------------------------------- |
+| Quelltexte           | `store/play/<play-locale>/{title,short-description,full-description}.txt` |
+| Validierung + Limits | `tools/src/play-listing-source.mjs`                                       |
+| Publish-Script       | `tools/src/publish-play-listing.mjs`                                      |
+| Manueller Workflow   | `.github/workflows/play-listing.yml`                                      |
+
+## Einmalige Einrichtung
+
+Diese Schritte kann nur jemand mit Zugriff auf Play Console und Google Cloud
+machen — sie sind **nicht** automatisierbar.
+
+### 1. Service-Account in Google Cloud anlegen
+
+1. [Google Cloud Console](https://console.cloud.google.com/) → Projekt wählen
+   (oder ein neues anlegen, z. B. `pushup-stats-play`).
+2. **APIs & Dienste → Bibliothek** → „Google Play Android Developer API"
+   suchen → **Aktivieren**.
+3. **IAM & Verwaltung → Dienstkonten → Dienstkonto erstellen**.
+   Name z. B. `play-listing-publisher`. Projekt-Rollen braucht es **keine** —
+   die Berechtigung kommt in Schritt 2 aus der Play Console.
+4. Beim erstellten Dienstkonto → **Schlüssel → Schlüssel hinzufügen → Neuen
+   Schlüssel erstellen → JSON**. Die Datei wird einmalig heruntergeladen.
+5. Die E-Mail-Adresse des Dienstkontos kopieren
+   (`play-listing-publisher@<projekt>.iam.gserviceaccount.com`).
+
+> Die JSON-Datei ist ein Passwort. Sie gehört **nicht** ins Repo — siehe
+> `AGENTS.md`, „Never commit secrets".
+
+### 2. Dienstkonto in der Play Console berechtigen
+
+1. [Play Console](https://play.google.com/console/) → **Nutzer und
+   Berechtigungen → Nutzer einladen**.
+2. Die Dienstkonto-E-Mail aus Schritt 1.5 eintragen.
+3. Unter **App-Berechtigungen** die App `com.pushupstats.app` auswählen.
+4. Recht **„Store-Eintrag, Preise und Vertrieb bearbeiten"** setzen
+   (englisch: _Edit store listing, pricing & distribution_). Mehr braucht das
+   Script nicht — es lädt keine Releases hoch.
+5. Einladen.
+
+> **Rechte brauchen Zeit.** Google propagiert neue Dienstkonto-Berechtigungen
+> teils mehrere Stunden, in Einzelfällen bis zu 24 h. Wenn der erste Lauf mit
+> `403` scheitert, ist meistens nichts falsch konfiguriert — später nochmal.
+
+### 3. Schlüssel als GitHub-Secret hinterlegen
+
+Repo → **Settings → Secrets and variables → Actions → New repository secret**
+
+- **Name:** `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
+- **Wert:** der **komplette Inhalt** der JSON-Datei aus Schritt 1.4
+  (von `{` bis `}`, nicht der Dateipfad)
+
+### 4. Erster Lauf — als Dry-Run
+
+Repo → **Actions → Play Store Listing → Run workflow**, „Publish for real"
+**nicht** ankreuzen. Der Lauf liest den Live-Eintrag, zeigt den Diff und
+schreibt nichts. Sieht der Diff richtig aus, denselben Workflow mit
+angekreuztem „Publish for real" nochmal starten.
+
+## Alltag
+
+Text ändern = die `.txt`-Dateien unter `store/play/` ändern, PR, mergen. Die
+Limits (30 / 80 / 4000 Zeichen) prüft `pnpm nx test tools` bei jedem PR mit —
+zu langer Text scheitert also in CI und nicht erst beim Publish.
+
+Veröffentlicht wird danach bewusst per Hand über den Workflow.
+
+### Lokal ausführen
+
+```bash
+export GOOGLE_PLAY_SERVICE_ACCOUNT_JSON="$(cat ~/pfad/zum/key.json)"
+
+pnpm nx run tools:publish-play-listing                      # Dry-Run, zeigt Diff
+pnpm nx run tools:publish-play-listing -- --commit          # veröffentlicht
+pnpm nx run tools:publish-play-listing -- --locale=de-DE    # nur eine Sprache
+```
+
+## Neue Sprache ergänzen
+
+1. Verzeichnis `store/play/<play-locale>/` anlegen, die drei `.txt`-Dateien
+   befüllen.
+2. Der Locale-Code muss in `PLAY_LOCALE_BY_APP_LOCALE`
+   (`tools/src/play-listing-source.mjs`) stehen — sonst schlägt der Test fehl.
+   Play verlangt volle Codes (`de-DE`), nicht die App-Codes (`de`).
+
+Aktuelles Mapping:
+
+| App (`web/project.json`) | Play    |
+| ------------------------ | ------- |
+| `de`                     | `de-DE` |
+| `en`                     | `en-US` |
+| `fr`                     | `fr-FR` |
+| `es`                     | `es-ES` |
+| `it`                     | `it-IT` |
+| `nl`                     | `nl-NL` |
+| `el`                     | `el-GR` |
+| `no`                     | `no-NO` |
+| `zh`                     | `zh-CN` |
+
+Ein Test pinnt diese Tabelle an die `localize`-Liste in `web/project.json`:
+eine neue App-Sprache ohne Play-Mapping bricht CI.
+
+## Gotchas
+
+- **Review-Queue.** Ein committeter Listing-Text ist nicht sofort live,
+  Google prüft ihn. Rollback = alten Text erneut veröffentlichen.
+- **Managed Publishing.** Ist das in der Console aktiv, hängt die Änderung
+  zusätzlich, bis sie dort freigegeben wird.
+- **Offene Edits blockieren.** Bricht ein Lauf mitten in einem Edit ab, kann
+  der nächste mit einem Konflikt scheitern. Das Script räumt seinen Edit im
+  Fehlerfall selbst ab; bleibt trotzdem einer hängen, in der Console unter
+  dem App-Eintrag verwerfen.
+- **Emoji zählen als ein Zeichen.** Die Beschreibung ist voller Emoji, und
+  `String.length` zählt Surrogatpaare doppelt. `countCharacters()` zählt
+  Codepoints — deshalb passt der lokale Check zu dem, was die Console sagt.
+- **Grafiken bleiben Handarbeit.** Screenshots, Feature-Grafik und Icon
+  gehen über diesen Weg nicht mit; die API kann sie zwar, das Script macht
+  bewusst nur Text.

--- a/docs/playstore-listing.md
+++ b/docs/playstore-listing.md
@@ -1,22 +1,34 @@
-# Play Store Listing (de)
+# Play Store Listing — Inhalt & Belege
 
-Quelle für den Google-Play-Store-Eintrag der Android-App (TWA-Wrapper unter
+Der Store-Text der Android-App (TWA-Wrapper unter
 [`mobile/android-twa`](../mobile/android-twa)). Deutsch ist die Quell-Sprache,
 analog zu `web/src/locale/messages.xlf`.
 
-| Feld                      | Limit | Aktuell |
-| ------------------------- | ----- | ------- |
-| Titel                     | 30    | 12      |
-| Kurzbeschreibung          | 80    | 77      |
-| Vollständige Beschreibung | 4000  | 3994    |
+> **Der Text steht nicht mehr in dieser Datei.** Quelle sind die Dateien unter
+> [`store/play/`](../store/play), von dort veröffentlicht das Publish-Script
+> direkt in die Play Console — siehe
+> [`docs/play-store-publishing.md`](play-store-publishing.md).
+>
+> | Feld                      | Datei                                    | Limit |
+> | ------------------------- | ---------------------------------------- | ----- |
+> | Titel                     | `store/play/de-DE/title.txt`             | 30    |
+> | Kurzbeschreibung          | `store/play/de-DE/short-description.txt` | 80    |
+> | Vollständige Beschreibung | `store/play/de-DE/full-description.txt`  | 4000  |
+>
+> Die Limits prüft `pnpm nx test tools` — zu langer Text scheitert in CI,
+> nicht erst beim Veröffentlichen.
 
-> **Feature-Drift vermeiden:** Diese Datei ist eine Momentaufnahme des
-> Funktionsumfangs. Wenn du Übungen (`EXERCISE_CATALOG`), Trainingspläne
-> (`TRAINING_PLANS`), Liegestütz-Varianten (`PUSHUP_TYPES`) oder die
-> Locale-Liste in `web/project.json` änderst, gehören die Zahlen unten
-> mit angepasst.
+Diese Datei bleibt als **Beleg-Sammlung**: Der Store-Text behauptet konkrete
+Zahlen und Eigenschaften, und die veralten still, wenn sie niemand an den Code
+bindet.
 
-Belege für die genannten Zahlen (Stand dieser Datei):
+## Feature-Drift vermeiden
+
+Wenn du Übungen (`EXERCISE_CATALOG`), Trainingspläne (`TRAINING_PLANS`),
+Liegestütz-Varianten (`PUSHUP_TYPES`) oder die Locale-Liste in
+`web/project.json` änderst, gehören die Zahlen im Store-Text mit angepasst.
+
+## Belege für die Aussagen im Listing
 
 - **41 Übungen + 9 Kategorien** — `EXERCISE_CATALOG` / `EXERCISE_CATEGORIES`
   in `libs/stats/src/lib/models/exercise.catalog.ts`. Der Katalog enthält
@@ -43,77 +55,12 @@ Belege für die genannten Zahlen (Stand dieser Datei):
   `libs/stats/src/lib/models/user-config.models.ts`. Die sechs Slots teilen
   sich alle Übungen, es sind keine sechs Presets _pro_ Übung.
 
-## Titel
+## Was noch fehlt
 
-```text
-Pushup Stats
-```
-
-## Kurzbeschreibung
-
-```text
-Reps per Kamera zählen, Trainingsplänen folgen, in der Bestenliste mithalten.
-```
-
-## Vollständige Beschreibung
-
-```text
-Pushup Stats macht aus Liegestützen und 40 weiteren Übungen ein Spiel, das du gewinnen willst.
-
-Egal ob du gerade erst anfängst oder schon dein erstes Hundert geschafft hast — diese App hilft dir, dranzubleiben. Die Kamera zählt deine Wiederholungen automatisch, kuratierte Trainingspläne geben dir jeden Tag eine klare Vorgabe, und die Bestenliste motiviert ohne zu nerven.
-
-📷 REPS AUTOMATISCH ZÄHLEN
-Handy hinstellen, Auto-Zähler öffnen, loslegen: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit und zählt jede saubere Wiederholung mit. Für Plank und Hollow Hold läuft stattdessen ein automatischer Halte-Timer. Die Erkennung läuft komplett auf deinem Gerät — kein Video verlässt dein Handy.
-
-🏋️ MEHR ALS NUR LIEGESTÜTZE
-• 13 Liegestütz-Varianten: Standard, Knie, Incline, Decline, Wide, Diamant, Pike, Archer bis zur einarmigen — mit Anleitung pro Typ
-• 41 Übungen in 9 Kategorien: Liegestütze, Push, Pull, Squat, Hinge, Lunge, Core, Cardio, Mobility
-• Klimmzüge, Dips, Kniebeugen, Ausfallschritte, Plank, Hollow Hold, Burpees, Seilspringen, Yoga, Dehnen und mehr
-• Ausdauer mit Distanz und Zeit: Laufen, Gehen, Radfahren, Rudern, Schwimmen — inklusive Pace
-• Jede Übung mit eigener Maßeinheit — Wiederholungen, Sekunden oder Meter
-
-⚡ ERFASSEN IN ZWEI SEKUNDEN
-• Ein Tap auf den Schnell-Button: Eintrag fertig, komplett ohne Dialog
-• Adaptive Vorschläge lernen aus deiner Historie, dazu sechs frei belegbare Schnellaktionen
-• Sätze einzeln erfassen (12 + 10 + 8) — die App summiert automatisch
-• Intervalle samt Pace für Lauf- und Ausdauer-Workouts
-
-📈 TRAINING MIT SYSTEM — 10 TRAININGSPLÄNE
-• Von 0 auf 100 — 6-Wochen-Aufbau für Einsteiger
-• 30-Tage-Challenge mit Maximaltest an Tag 1 und 30
-• Liegestütze ab 40 — schonender 4-Wochen-Plan
-• Daily 100 — 30 Tage zur 100er-Marke
-• Einarmige Liegestütze — 12-Wochen-Aufbau
-• Push & Pull Balance, Full Body Strong, Core Foundations, HIIT Burner, Mobility & Recovery
-Jeden Tag genau die Vorgabe, die dich weiterbringt — mit Ruhetagen, leichten Tagen und Test-Tagen. Erledigte Tage markieren sich automatisch, sobald du dein Tagesziel erreichst.
-
-🎯 ZIELE, STREAKS & STATISTIKEN
-• Tages-, Wochen- und Monatsziele — pro Übung, mit Wochentag-Filter
-• Dreifacher Fortschrittsbalken, Konfetti beim Zielerreichen, Streak-Zähler fürs Dranbleiben
-• Heatmap-Kalender über Wochen und Monate
-• Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich, Zeitraum frei wählbar
-• Bestwerte: bester Tag, bester Satz, beste Einzeleinheit
-
-🏆 BESTENLISTE & PROFIL
-Miss dich mit anderen Athleten oder bleib privat — du entscheidest. Ranglisten für heute, die letzten 7 und die letzten 30 Tage. Dein öffentliches Profil mit Gesamt-Reps, Streak und Bestleistungen lässt sich per Link teilen. Dazu jeden Tag eine frische Motivation.
-
-🔔 SMARTE ERINNERUNGEN
-Push-Benachrichtigungen mit konfigurierbarem Intervall, Ruhephasen, Wochentagen und Zeitzone — auch bei geschlossener App. Und der schnellste Weg zum Eintrag: ein Tap auf „50 eintragen“ direkt in der Benachrichtigung.
-
-📚 WISSEN STATT RATEN
-Übungs-Wiki mit sauberer Ausführung, Technik-Tipps und typischen Fehlern. Dazu ein Blog mit Trainingstipps von Einsteiger bis Fortgeschritten.
-
-🔒 DEINE DATEN
-Als Gast ausprobieren, ganz ohne Konto. Privater Modus auf Wunsch. DSGVO-konform mit anpassbarer Cookie-Zustimmung. Konto jederzeit löschbar — Trainingsdaten bleiben danach nur anonymisiert erhalten. Datenbank in Frankfurt.
-
-📱 ANDROID + WEB
-Die gleichen Daten auf dem Phone und im Browser, mit Echtzeit-Sync über alle Geräte. Login per Google oder E-Mail. Funktioniert auch offline — Einträge synchronisieren sich, sobald du wieder online bist. Helles und dunkles Design.
-
-🌍 NEUN SPRACHEN
-Deutsch, Englisch, Französisch, Spanisch, Italienisch, Niederländisch, Griechisch, Norwegisch, Chinesisch.
-
-Kostenlos. Kein Abo. Keine Kreditkarte.
-
-Pushup Stats ist eine ehrliche App für Leute, die wirklich trainieren — nicht für Sticker-Sammler.
-Lade sie jetzt runter und mach den ersten.
-```
+- **Übersetzungen.** Nur `de-DE` ist gepflegt. Die Store-Texte laufen bewusst
+  **nicht** über die tägliche Übersetzungs-Routine (die arbeitet auf XLIFF und
+  `content/`), also müssen weitere Sprachen von Hand ergänzt werden.
+- **KI-Coach.** Nicht im Listing erwähnt: `aiAssistantConfig.runtimeUrl` ist
+  leer, im ausgelieferten Build ist der Assistent also nicht nutzbar.
+- **Grafiken.** Screenshots, Feature-Grafik und Icon pflegt weiterhin die
+  Console — das Script veröffentlicht nur Text.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-playwright": "^2.11.0",
     "firebase-tools": "^14.27.0",
+    "google-auth-library": "^11.0.0",
     "husky": "9.1.7",
     "jest": "30.4.2",
     "jest-environment-jsdom": "30.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       firebase-tools:
         specifier: ^14.27.0
         version: 14.27.0(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@25.9.1)(encoding@0.1.13)(supports-color@7.2.0)(typescript@6.0.3)
+      google-auth-library:
+        specifier: ^11.0.0
+        version: 11.0.0(supports-color@7.2.0)
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -7536,6 +7539,10 @@ packages:
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
+
+  google-auth-library@11.0.0:
+    resolution: {integrity: sha512-WC5gkb2pElGhZKgGx9r799trH3ZUx90ecgIOIMmgiiHS/gzO3r4vvFoQWuKI0QmR2xU5uee2M4hDUxRZDh/x7w==}
+    engines: {node: '>=22'}
 
   google-auth-library@9.15.1:
     resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
@@ -21093,6 +21100,17 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       gaxios: 7.1.4(supports-color@8.1.1)
       gcp-metadata: 8.1.2(supports-color@8.1.1)
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-auth-library@11.0.0(supports-color@7.2.0):
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4(supports-color@7.2.0)
+      gcp-metadata: 8.1.2(supports-color@7.2.0)
       google-logging-utils: 1.1.3
       jws: 4.0.1
     transitivePeerDependencies:

--- a/store/play/de-DE/full-description.txt
+++ b/store/play/de-DE/full-description.txt
@@ -1,0 +1,58 @@
+Pushup Stats macht aus Liegestützen und 40 weiteren Übungen ein Spiel, das du gewinnen willst.
+
+Egal ob du gerade erst anfängst oder schon dein erstes Hundert geschafft hast — diese App hilft dir, dranzubleiben. Die Kamera zählt deine Wiederholungen automatisch, kuratierte Trainingspläne geben dir jeden Tag eine klare Vorgabe, und die Bestenliste motiviert ohne zu nerven.
+
+📷 REPS AUTOMATISCH ZÄHLEN
+Handy hinstellen, Auto-Zähler öffnen, loslegen: Die KI erkennt Liegestütze, Kniebeugen, Klimmzüge und Sit-ups in Echtzeit und zählt jede saubere Wiederholung mit. Für Plank und Hollow Hold läuft stattdessen ein automatischer Halte-Timer. Die Erkennung läuft komplett auf deinem Gerät — kein Video verlässt dein Handy.
+
+🏋️ MEHR ALS NUR LIEGESTÜTZE
+• 13 Liegestütz-Varianten: Standard, Knie, Incline, Decline, Wide, Diamant, Pike, Archer bis zur einarmigen — mit Anleitung pro Typ
+• 41 Übungen in 9 Kategorien: Liegestütze, Push, Pull, Squat, Hinge, Lunge, Core, Cardio, Mobility
+• Klimmzüge, Dips, Kniebeugen, Ausfallschritte, Plank, Hollow Hold, Burpees, Seilspringen, Yoga, Dehnen und mehr
+• Ausdauer mit Distanz und Zeit: Laufen, Gehen, Radfahren, Rudern, Schwimmen — inklusive Pace
+• Jede Übung mit eigener Maßeinheit — Wiederholungen, Sekunden oder Meter
+
+⚡ ERFASSEN IN ZWEI SEKUNDEN
+• Ein Tap auf den Schnell-Button: Eintrag fertig, komplett ohne Dialog
+• Adaptive Vorschläge lernen aus deiner Historie, dazu sechs frei belegbare Schnellaktionen
+• Sätze einzeln erfassen (12 + 10 + 8) — die App summiert automatisch
+• Intervalle samt Pace für Lauf- und Ausdauer-Workouts
+
+📈 TRAINING MIT SYSTEM — 10 TRAININGSPLÄNE
+• Von 0 auf 100 — 6-Wochen-Aufbau für Einsteiger
+• 30-Tage-Challenge mit Maximaltest an Tag 1 und 30
+• Liegestütze ab 40 — schonender 4-Wochen-Plan
+• Daily 100 — 30 Tage zur 100er-Marke
+• Einarmige Liegestütze — 12-Wochen-Aufbau
+• Push & Pull Balance, Full Body Strong, Core Foundations, HIIT Burner, Mobility & Recovery
+Jeden Tag genau die Vorgabe, die dich weiterbringt — mit Ruhetagen, leichten Tagen und Test-Tagen. Erledigte Tage markieren sich automatisch, sobald du dein Tagesziel erreichst.
+
+🎯 ZIELE, STREAKS & STATISTIKEN
+• Tages-, Wochen- und Monatsziele — pro Übung, mit Wochentag-Filter
+• Dreifacher Fortschrittsbalken, Konfetti beim Zielerreichen, Streak-Zähler fürs Dranbleiben
+• Heatmap-Kalender über Wochen und Monate
+• Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich, Zeitraum frei wählbar
+• Bestwerte: bester Tag, bester Satz, beste Einzeleinheit
+
+🏆 BESTENLISTE & PROFIL
+Miss dich mit anderen Athleten oder bleib privat — du entscheidest. Ranglisten für heute, die letzten 7 und die letzten 30 Tage. Dein öffentliches Profil mit Gesamt-Reps, Streak und Bestleistungen lässt sich per Link teilen. Dazu jeden Tag eine frische Motivation.
+
+🔔 SMARTE ERINNERUNGEN
+Push-Benachrichtigungen mit konfigurierbarem Intervall, Ruhephasen, Wochentagen und Zeitzone — auch bei geschlossener App. Und der schnellste Weg zum Eintrag: ein Tap auf „50 eintragen“ direkt in der Benachrichtigung.
+
+📚 WISSEN STATT RATEN
+Übungs-Wiki mit sauberer Ausführung, Technik-Tipps und typischen Fehlern. Dazu ein Blog mit Trainingstipps von Einsteiger bis Fortgeschritten.
+
+🔒 DEINE DATEN
+Als Gast ausprobieren, ganz ohne Konto. Privater Modus auf Wunsch. DSGVO-konform mit anpassbarer Cookie-Zustimmung. Konto jederzeit löschbar — Trainingsdaten bleiben danach nur anonymisiert erhalten. Datenbank in Frankfurt.
+
+📱 ANDROID + WEB
+Die gleichen Daten auf dem Phone und im Browser, mit Echtzeit-Sync über alle Geräte. Login per Google oder E-Mail. Funktioniert auch offline — Einträge synchronisieren sich, sobald du wieder online bist. Helles und dunkles Design.
+
+🌍 NEUN SPRACHEN
+Deutsch, Englisch, Französisch, Spanisch, Italienisch, Niederländisch, Griechisch, Norwegisch, Chinesisch.
+
+Kostenlos. Kein Abo. Keine Kreditkarte.
+
+Pushup Stats ist eine ehrliche App für Leute, die wirklich trainieren — nicht für Sticker-Sammler.
+Lade sie jetzt runter und mach den ersten.

--- a/store/play/de-DE/full-description.txt
+++ b/store/play/de-DE/full-description.txt
@@ -31,7 +31,7 @@ Jeden Tag genau die Vorgabe, die dich weiterbringt — mit Ruhetagen, leichten T
 • Tages-, Wochen- und Monatsziele — pro Übung, mit Wochentag-Filter
 • Dreifacher Fortschrittsbalken, Konfetti beim Zielerreichen, Streak-Zähler fürs Dranbleiben
 • Heatmap-Kalender über Wochen und Monate
-• Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich, Zeitraum frei wählbar
+• Analyse mit Verlaufsdiagrammen, KPI-Karten und Kategorie-Vergleich, Zeitraum wählbar
 • Bestwerte: bester Tag, bester Satz, beste Einzeleinheit
 
 🏆 BESTENLISTE & PROFIL
@@ -41,7 +41,7 @@ Miss dich mit anderen Athleten oder bleib privat — du entscheidest. Ranglisten
 Push-Benachrichtigungen mit konfigurierbarem Intervall, Ruhephasen, Wochentagen und Zeitzone — auch bei geschlossener App. Und der schnellste Weg zum Eintrag: ein Tap auf „50 eintragen“ direkt in der Benachrichtigung.
 
 📚 WISSEN STATT RATEN
-Übungs-Wiki mit sauberer Ausführung, Technik-Tipps und typischen Fehlern. Dazu ein Blog mit Trainingstipps von Einsteiger bis Fortgeschritten.
+Übungs-Wiki mit sauberer Ausführung, Technik-Tipps und typischen Fehlern. Dazu ein Blog mit Tipps von Einsteiger bis Fortgeschritten.
 
 🔒 DEINE DATEN
 Als Gast ausprobieren, ganz ohne Konto. Privater Modus auf Wunsch. DSGVO-konform mit anpassbarer Cookie-Zustimmung. Konto jederzeit löschbar — Trainingsdaten bleiben danach nur anonymisiert erhalten. Datenbank in Frankfurt.

--- a/store/play/de-DE/short-description.txt
+++ b/store/play/de-DE/short-description.txt
@@ -1,0 +1,1 @@
+Reps per Kamera zählen, Trainingsplänen folgen, in der Bestenliste mithalten.

--- a/store/play/de-DE/title.txt
+++ b/store/play/de-DE/title.txt
@@ -1,0 +1,1 @@
+Pushup Stats

--- a/tools/project.json
+++ b/tools/project.json
@@ -51,6 +51,14 @@
         "cwd": "{workspaceRoot}"
       }
     },
+    "publish-play-listing": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "options": {
+        "command": "node tools/src/publish-play-listing.mjs",
+        "cwd": "{workspaceRoot}"
+      }
+    },
     "generate-content": {
       "executor": "nx:run-commands",
       "inputs": [

--- a/tools/project.json
+++ b/tools/project.json
@@ -14,7 +14,9 @@
         "{workspaceRoot}/apphosting.staging.yaml",
         "{workspaceRoot}/pnpm-workspace.yaml",
         "{workspaceRoot}/patches/**/*",
-        "{workspaceRoot}/.prettierignore"
+        "{workspaceRoot}/.prettierignore",
+        "{workspaceRoot}/store/play/**/*",
+        "{workspaceRoot}/web/project.json"
       ],
       "options": {
         "passWithNoTests": true

--- a/tools/src/play-listing-source.mjs
+++ b/tools/src/play-listing-source.mjs
@@ -1,0 +1,140 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * Root of the Play store listing sources. One directory per Play locale,
+ * each holding the three text fields the Play API accepts.
+ */
+export const LISTINGS_ROOT = resolve(
+  new URL('../..', import.meta.url).pathname,
+  'store/play'
+);
+
+export const FIELD_FILES = {
+  title: 'title.txt',
+  shortDescription: 'short-description.txt',
+  fullDescription: 'full-description.txt',
+};
+
+/**
+ * Hard limits enforced by the Play Console. Exceeding any of them makes
+ * `edits.commit` fail with a validation error *after* the edit was already
+ * opened, so we check locally first and never open an edit we can't commit.
+ */
+export const LIMITS = {
+  title: 30,
+  shortDescription: 80,
+  fullDescription: 4000,
+};
+
+/**
+ * Play uses full BCP-47-ish locale codes where the app uses bare language
+ * codes, so `de` is not a valid Play locale and would be rejected at commit
+ * time. Keys are the app's `localize` codes from `web/project.json`; values
+ * are the Play Console locale each one maps to.
+ *
+ * A locale listed here does not have to have a listing on disk — English and
+ * the rest are still untranslated. The map exists so a new listing directory
+ * can only ever be one of the codes Play actually accepts.
+ */
+export const PLAY_LOCALE_BY_APP_LOCALE = Object.freeze({
+  de: 'de-DE',
+  en: 'en-US',
+  fr: 'fr-FR',
+  es: 'es-ES',
+  it: 'it-IT',
+  nl: 'nl-NL',
+  el: 'el-GR',
+  no: 'no-NO',
+  zh: 'zh-CN',
+});
+
+export const SUPPORTED_PLAY_LOCALES = Object.freeze(
+  Object.values(PLAY_LOCALE_BY_APP_LOCALE)
+);
+
+/**
+ * Play counts characters, not UTF-16 code units. The description is full of
+ * emoji (📷, 🏋️, …) which are surrogate pairs, so `String.length` overcounts
+ * them and would reject copy the Console accepts. Spread into code points.
+ */
+export function countCharacters(text) {
+  return [...text].length;
+}
+
+function readField(localeDir, fileName) {
+  // Trailing newline is a file-hygiene artifact, not part of the copy —
+  // sending it would burn a character against the limit.
+  return readFileSync(join(localeDir, fileName), 'utf-8').replace(/\n+$/, '');
+}
+
+export function listLocaleDirectories(root = LISTINGS_ROOT) {
+  return readdirSync(root)
+    .filter((entry) => statSync(join(root, entry)).isDirectory())
+    .sort();
+}
+
+/**
+ * Reads every listing from disk and validates it. Returns one entry per
+ * locale, shaped like the `Listing` resource the Play API expects.
+ *
+ * Throws on anything that would make the remote commit fail: an unknown
+ * locale directory, a missing field file, an empty field, or copy over the
+ * character limit.
+ */
+export function readListings(root = LISTINGS_ROOT) {
+  const locales = listLocaleDirectories(root);
+  if (locales.length === 0) {
+    throw new Error(`No listing directories found under ${root}`);
+  }
+
+  const problems = [];
+  const listings = [];
+
+  for (const locale of locales) {
+    if (!SUPPORTED_PLAY_LOCALES.includes(locale)) {
+      problems.push(
+        `${locale}: not a Play locale for this app — expected one of ${SUPPORTED_PLAY_LOCALES.join(', ')}`
+      );
+      continue;
+    }
+
+    const localeDir = join(root, locale);
+    const listing = { language: locale };
+
+    for (const [field, fileName] of Object.entries(FIELD_FILES)) {
+      let value;
+      try {
+        value = readField(localeDir, fileName);
+      } catch {
+        problems.push(`${locale}: missing ${fileName}`);
+        continue;
+      }
+
+      if (value.trim() === '') {
+        problems.push(`${locale}/${fileName}: is empty`);
+        continue;
+      }
+
+      const length = countCharacters(value);
+      if (length > LIMITS[field]) {
+        problems.push(
+          `${locale}/${fileName}: ${length} characters, limit is ${LIMITS[field]}`
+        );
+        continue;
+      }
+
+      listing[field] = value;
+    }
+
+    listings.push(listing);
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `Invalid Play listing sources:\n  ${problems.join('\n  ')}`
+    );
+  }
+
+  return listings;
+}

--- a/tools/src/play-listing-source.mjs
+++ b/tools/src/play-listing-source.mjs
@@ -1,12 +1,14 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Root of the Play store listing sources. One directory per Play locale,
  * each holding the three text fields the Play API accepts.
  */
 export const LISTINGS_ROOT = resolve(
-  new URL('../..', import.meta.url).pathname,
+  dirname(fileURLToPath(import.meta.url)),
+  '../..',
   'store/play'
 );
 
@@ -54,12 +56,19 @@ export const SUPPORTED_PLAY_LOCALES = Object.freeze(
 );
 
 /**
- * Play counts characters, not UTF-16 code units. The description is full of
- * emoji (📷, 🏋️, …) which are surrogate pairs, so `String.length` overcounts
- * them and would reject copy the Console accepts. Spread into code points.
+ * Play enforces its limits on UTF-16 code units, not code points or glyphs —
+ * its backend is a JVM, where `String.length()` is the code-unit count. The
+ * description is full of emoji, and they are not one unit each: `📷` is a
+ * surrogate pair (2), and `🏋️` is a surrogate pair plus a variation selector
+ * (3) despite rendering as a single glyph.
+ *
+ * Counting code points instead would undercount by ~10 characters on the
+ * current description and let copy through that the Console then rejects at
+ * commit time. Counting code units can only ever be too strict, which costs
+ * a few characters of headroom and never a failed publish.
  */
 export function countCharacters(text) {
-  return [...text].length;
+  return text.length;
 }
 
 function readField(localeDir, fileName) {

--- a/tools/src/play-listing-source.spec.js
+++ b/tools/src/play-listing-source.spec.js
@@ -1,0 +1,293 @@
+const { execFileSync } = require('node:child_process');
+const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join, resolve } = require('node:path');
+
+const SOURCE_MODULE = resolve(__dirname, 'play-listing-source.mjs');
+const PUBLISH_MODULE = resolve(__dirname, 'publish-play-listing.mjs');
+
+// Both modules are ESM; `tools/jest.config.cjs` only transforms `.ts`/`.js`,
+// so exercise them in a throwaway node subprocess (same pattern as
+// write-functions-workspace-allowbuilds.spec.js).
+function runInModule(modulePath, expression) {
+  const script = `
+    import * as mod from ${JSON.stringify(modulePath)};
+    const run = async () => (${expression});
+    run().then(
+      (value) => process.stdout.write(JSON.stringify({ ok: true, value })),
+      (error) => process.stdout.write(JSON.stringify({ ok: false, message: error.message }))
+    );
+  `;
+  return JSON.parse(
+    execFileSync('node', ['--input-type=module', '-e', script], {
+      encoding: 'utf-8',
+    })
+  );
+}
+
+function makeListingDir(fields) {
+  const root = mkdtempSync(join(tmpdir(), 'play-listing-'));
+  for (const [locale, files] of Object.entries(fields)) {
+    mkdirSync(join(root, locale), { recursive: true });
+    for (const [fileName, content] of Object.entries(files)) {
+      writeFileSync(join(root, locale, fileName), content);
+    }
+  }
+  return root;
+}
+
+const VALID_DE = {
+  'title.txt': 'Pushup Stats\n',
+  'short-description.txt': 'Reps zählen, Plänen folgen.\n',
+  'full-description.txt': 'Eine ehrliche Trainings-App.\n',
+};
+
+describe('readListings', () => {
+  let root;
+
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = undefined;
+  });
+
+  it('should read every field and strip the trailing newline', () => {
+    // given
+    root = makeListingDir({ 'de-DE': VALID_DE });
+
+    // when
+    const result = runInModule(
+      SOURCE_MODULE,
+      `mod.readListings(${JSON.stringify(root)})`
+    );
+
+    // then
+    expect(result.ok).toBe(true);
+    expect(result.value).toEqual([
+      {
+        language: 'de-DE',
+        title: 'Pushup Stats',
+        shortDescription: 'Reps zählen, Plänen folgen.',
+        fullDescription: 'Eine ehrliche Trainings-App.',
+      },
+    ]);
+  });
+
+  it('should reject a directory that is not a Play locale for this app', () => {
+    // given — `de` is the app's locale code, but Play needs `de-DE`
+    root = makeListingDir({ de: VALID_DE });
+
+    // when
+    const result = runInModule(
+      SOURCE_MODULE,
+      `mod.readListings(${JSON.stringify(root)})`
+    );
+
+    // then
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('de: not a Play locale');
+  });
+
+  it('should reject copy that exceeds a Play character limit', () => {
+    // given
+    root = makeListingDir({
+      'de-DE': { ...VALID_DE, 'title.txt': `${'x'.repeat(31)}\n` },
+    });
+
+    // when
+    const result = runInModule(
+      SOURCE_MODULE,
+      `mod.readListings(${JSON.stringify(root)})`
+    );
+
+    // then
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('title.txt: 31 characters, limit is 30');
+  });
+
+  it('should reject a missing field file', () => {
+    // given
+    root = makeListingDir({
+      'de-DE': { 'title.txt': 'Pushup Stats\n' },
+    });
+
+    // when
+    const result = runInModule(
+      SOURCE_MODULE,
+      `mod.readListings(${JSON.stringify(root)})`
+    );
+
+    // then
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('missing short-description.txt');
+  });
+
+  it('should reject a field that is present but blank', () => {
+    // given
+    root = makeListingDir({
+      'de-DE': { ...VALID_DE, 'short-description.txt': '   \n' },
+    });
+
+    // when
+    const result = runInModule(
+      SOURCE_MODULE,
+      `mod.readListings(${JSON.stringify(root)})`
+    );
+
+    // then
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('short-description.txt: is empty');
+  });
+});
+
+describe('countCharacters', () => {
+  it('should count emoji as one character each, like the Play Console does', () => {
+    // given — naive `String.length` reports 4 for these two surrogate pairs
+    const text = '📷🏋';
+
+    // when
+    const result = runInModule(
+      SOURCE_MODULE,
+      `mod.countCharacters(${JSON.stringify(text)})`
+    );
+
+    // then
+    expect(result.value).toBe(2);
+  });
+});
+
+describe('the checked-in listing sources', () => {
+  it('should be valid and within every Play limit', () => {
+    // given / when — no argument: reads the real store/play directory
+    const result = runInModule(SOURCE_MODULE, 'mod.readListings()');
+
+    // then
+    expect(result.ok).toBe(true);
+    expect(result.value.length).toBeGreaterThan(0);
+  });
+
+  it('should include the German listing, which is the source locale', () => {
+    // given / when
+    const result = runInModule(
+      SOURCE_MODULE,
+      'mod.readListings().map((l) => l.language)'
+    );
+
+    // then
+    expect(result.value).toContain('de-DE');
+  });
+});
+
+describe('PLAY_LOCALE_BY_APP_LOCALE', () => {
+  it('should cover every locale the web app is built for', () => {
+    // given — the app's localize list is the authority on shipped languages
+    const project = require(resolve(__dirname, '../../web/project.json'));
+    const appLocales =
+      project.targets.build.configurations.production.localize ??
+      project.targets.build.options.localize;
+
+    // when
+    const result = runInModule(SOURCE_MODULE, 'mod.PLAY_LOCALE_BY_APP_LOCALE');
+
+    // then
+    expect(Object.keys(result.value).sort()).toEqual([...appLocales].sort());
+  });
+});
+
+describe('parseArgs', () => {
+  it('should default to a dry run so publishing is always explicit', () => {
+    // given / when
+    const result = runInModule(PUBLISH_MODULE, 'mod.parseArgs([])');
+
+    // then
+    expect(result.value).toEqual({ commit: false, locale: null });
+  });
+
+  it('should accept --commit and both --locale spellings', () => {
+    // given / when
+    const spaced = runInModule(
+      PUBLISH_MODULE,
+      "mod.parseArgs(['--commit', '--locale', 'de-DE'])"
+    );
+    const equals = runInModule(
+      PUBLISH_MODULE,
+      "mod.parseArgs(['--locale=en-US'])"
+    );
+
+    // then
+    expect(spaced.value).toEqual({ commit: true, locale: 'de-DE' });
+    expect(equals.value).toEqual({ commit: false, locale: 'en-US' });
+  });
+
+  it('should reject an unknown flag instead of silently ignoring it', () => {
+    // given / when
+    const result = runInModule(PUBLISH_MODULE, "mod.parseArgs(['--publish'])");
+
+    // then
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('Unknown argument: --publish');
+  });
+});
+
+describe('diffListing', () => {
+  const local = {
+    language: 'de-DE',
+    title: 'Pushup Stats',
+    shortDescription: 'neu',
+    fullDescription: 'gleich',
+  };
+
+  it('should report only the fields that actually differ', () => {
+    // given
+    const remote = {
+      title: 'Pushup Stats',
+      shortDescription: 'alt',
+      fullDescription: 'gleich',
+    };
+
+    // when
+    const result = runInModule(
+      PUBLISH_MODULE,
+      `mod.diffListing(${JSON.stringify(local)}, ${JSON.stringify(remote)})`
+    );
+
+    // then
+    expect(result.value).toEqual([
+      { field: 'shortDescription', before: 'alt', after: 'neu' },
+    ]);
+  });
+
+  it('should treat a missing remote listing as every field being new', () => {
+    // given — a locale that has no listing in the Console yet
+    // when
+    const result = runInModule(
+      PUBLISH_MODULE,
+      `mod.diffListing(${JSON.stringify(local)}, null)`
+    );
+
+    // then
+    expect(result.value.map((c) => c.field)).toEqual([
+      'title',
+      'shortDescription',
+      'fullDescription',
+    ]);
+    expect(result.value.every((c) => c.before === '')).toBe(true);
+  });
+
+  it('should report nothing when the live listing already matches', () => {
+    // given
+    const remote = {
+      title: 'Pushup Stats',
+      shortDescription: 'neu',
+      fullDescription: 'gleich',
+    };
+
+    // when
+    const result = runInModule(
+      PUBLISH_MODULE,
+      `mod.diffListing(${JSON.stringify(local)}, ${JSON.stringify(remote)})`
+    );
+
+    // then
+    expect(result.value).toEqual([]);
+  });
+});

--- a/tools/src/play-listing-source.spec.js
+++ b/tools/src/play-listing-source.spec.js
@@ -593,6 +593,52 @@ describe('buildUpdateBody', () => {
   });
 });
 
+describe('summarize', () => {
+  it('should show a short single-line value in full, with no ellipsis', () => {
+    // given / when
+    const result = runInModule(PUBLISH_MODULE, "mod.summarize('Pushup Stats')");
+
+    // then
+    expect(result.value).toBe('"Pushup Stats" [12 chars]');
+  });
+
+  it('should mark a value cut off mid-line as shortened', () => {
+    // given — 80 characters, longer than the 72-character preview
+    const value = 'x'.repeat(80);
+
+    // when
+    const result = runInModule(
+      PUBLISH_MODULE,
+      `mod.summarize(${JSON.stringify(value)})`
+    );
+
+    // then
+    expect(result.value).toContain(' … [80 chars]');
+  });
+
+  it('should mark a multi-line value as shortened even when line one is short', () => {
+    // given
+    const value = 'kurz\nzweite Zeile';
+
+    // when
+    const result = runInModule(
+      PUBLISH_MODULE,
+      `mod.summarize(${JSON.stringify(value)})`
+    );
+
+    // then
+    expect(result.value).toBe('"kurz" … [17 chars]');
+  });
+
+  it('should render an absent value as (empty) rather than empty quotes', () => {
+    // given / when — the "before" side for a locale Play does not have yet
+    const result = runInModule(PUBLISH_MODULE, "mod.summarize('')");
+
+    // then
+    expect(result.value).toBe('(empty)');
+  });
+});
+
 describe('diffListing', () => {
   const local = {
     language: 'de-DE',

--- a/tools/src/play-listing-source.spec.js
+++ b/tools/src/play-listing-source.spec.js
@@ -1,5 +1,11 @@
 const { execFileSync } = require('node:child_process');
-const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require('node:fs');
+const {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+} = require('node:fs');
 const { tmpdir } = require('node:os');
 const { join, resolve } = require('node:path');
 
@@ -23,6 +29,50 @@ function runInModule(modulePath, expression) {
       encoding: 'utf-8',
     })
   );
+}
+
+/**
+ * Runs `publishListings` against a fake API inside the subprocess and returns
+ * the recorded call sequence, so the publish transaction can be asserted
+ * without touching Google.
+ *
+ * `remoteByLocale` seeds what `getListing` returns; `failOn` lists API methods
+ * that should throw, to exercise the cleanup path. Each throws a
+ * `boom:<method>` error so the test can tell which failure surfaced.
+ */
+function runPublish({ listings, commit, remoteByLocale = {}, failOn = [] }) {
+  const expression = `(async () => {
+    const calls = [];
+    const failing = ${JSON.stringify([].concat(failOn))};
+    const record = (name) => (...args) => {
+      calls.push([name, ...args]);
+      if (failing.includes(name)) throw new Error('boom:' + name);
+      return undefined;
+    };
+    const api = {
+      createEdit: async (...a) => { record('createEdit')(...a); return { id: 'edit-1' }; },
+      getListing: async (editId, language) => {
+        calls.push(['getListing', editId, language]);
+        if (failing.includes('getListing')) throw new Error('boom:getListing');
+        return ${JSON.stringify(remoteByLocale)}[language] ?? null;
+      },
+      updateListing: async (...a) => record('updateListing')(...a),
+      commitEdit: async (...a) => record('commitEdit')(...a),
+      deleteEdit: async (...a) => record('deleteEdit')(...a),
+    };
+    try {
+      const changed = await mod.publishListings({
+        listings: ${JSON.stringify(listings)},
+        commit: ${JSON.stringify(commit)},
+        api,
+        log: () => {},
+      });
+      return { calls, changed };
+    } catch (error) {
+      return { calls, failed: error.message };
+    }
+  })()`;
+  return runInModule(PUBLISH_MODULE, expression).value;
 }
 
 function makeListingDir(fields) {
@@ -140,18 +190,42 @@ describe('readListings', () => {
 });
 
 describe('countCharacters', () => {
-  it('should count emoji as one character each, like the Play Console does', () => {
-    // given — naive `String.length` reports 4 for these two surrogate pairs
-    const text = '📷🏋';
-
-    // when
+  // Play enforces its limits on UTF-16 code units (its backend is a JVM), so
+  // an emoji costs more than the one character it looks like. Counting code
+  // points would undercount and let copy through that Play then rejects.
+  it.each([
+    ['a plain ASCII string', 'abc', 3],
+    ['a surrogate-pair emoji', '📷', 2],
+    ['an emoji with a variation selector', '🏋️', 3],
+    ['a ZWJ sequence', '👨‍👩‍👧', 8],
+  ])('should count %s as its UTF-16 length', (_name, text, expected) => {
+    // given / when
     const result = runInModule(
       SOURCE_MODULE,
       `mod.countCharacters(${JSON.stringify(text)})`
     );
 
     // then
-    expect(result.value).toBe(2);
+    expect(result.value).toBe(expected);
+  });
+
+  it('should match the checked-in description, which sits close to the limit', () => {
+    // given — the real copy is emoji-heavy; code-point counting reported ~10
+    // fewer characters and put an over-limit description under the cap
+    const description = readFileSync(
+      resolve(__dirname, '../../store/play/de-DE/full-description.txt'),
+      'utf-8'
+    ).replace(/\n+$/, '');
+
+    // when
+    const result = runInModule(
+      SOURCE_MODULE,
+      `mod.countCharacters(${JSON.stringify(description)})`
+    );
+
+    // then
+    expect(result.value).toBe(description.length);
+    expect(result.value).toBeGreaterThan([...description].length);
   });
 });
 
@@ -174,6 +248,29 @@ describe('the checked-in listing sources', () => {
 
     // then
     expect(result.value).toContain('de-DE');
+  });
+});
+
+describe('the tools:test Nx wiring', () => {
+  // The two guards below assert against files outside the `tools` project.
+  // Nx has no way to infer that, so without these inputs `nx affected` would
+  // skip the run — or replay a stale cached pass — when a PR only touches
+  // the store copy or the locale list. That is exactly the case the guards
+  // exist for.
+  it.each([
+    ['the listing sources', '{workspaceRoot}/store/play/**/*'],
+    ['the app locale list', '{workspaceRoot}/web/project.json'],
+  ])('should declare %s as a test input', (_name, input) => {
+    // given
+    const project = JSON.parse(
+      readFileSync(resolve(__dirname, '../project.json'), 'utf-8')
+    );
+
+    // when
+    const inputs = project.targets.test.inputs;
+
+    // then
+    expect(inputs).toContain(input);
   });
 });
 
@@ -225,6 +322,274 @@ describe('parseArgs', () => {
     // then
     expect(result.ok).toBe(false);
     expect(result.message).toContain('Unknown argument: --publish');
+  });
+
+  it.each([
+    ['--locale with no value', "['--commit', '--locale']"],
+    ['--locale= with an empty value', "['--commit', '--locale=']"],
+    ['--locale with only whitespace', "['--commit', '--locale=  ']"],
+  ])(
+    'should reject %s rather than widening the run to every locale',
+    (_name, argv) => {
+      // given / when
+      const result = runInModule(PUBLISH_MODULE, `mod.parseArgs(${argv})`);
+
+      // then
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('--locale needs a value');
+    }
+  );
+});
+
+describe('buildAuth', () => {
+  it('should point at the setup doc when the credentials env var is unset', () => {
+    // given / when
+    const result = runInModule(PUBLISH_MODULE, 'mod.buildAuth({})');
+
+    // then
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain(
+      'GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is not set'
+    );
+    expect(result.message).toContain('docs/play-store-publishing.md');
+  });
+
+  it('should say so when the env var holds a path instead of the key itself', () => {
+    // given — the likely mistake is exporting the filename, not its contents
+    const env = { GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: '~/keys/play.json' };
+
+    // when
+    const result = runInModule(
+      PUBLISH_MODULE,
+      `mod.buildAuth(${JSON.stringify(env)})`
+    );
+
+    // then
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('not valid JSON');
+  });
+});
+
+describe('selectListings', () => {
+  const all = [{ language: 'de-DE' }, { language: 'en-US' }];
+
+  it('should return every listing when no locale is given', () => {
+    // given / when
+    const result = runInModule(
+      PUBLISH_MODULE,
+      `mod.selectListings(${JSON.stringify(all)}, null)`
+    );
+
+    // then
+    expect(result.value).toHaveLength(2);
+  });
+
+  it('should narrow to the requested locale', () => {
+    // given / when
+    const result = runInModule(
+      PUBLISH_MODULE,
+      `mod.selectListings(${JSON.stringify(all)}, 'en-US')`
+    );
+
+    // then
+    expect(result.value).toEqual([{ language: 'en-US' }]);
+  });
+
+  it('should fail loudly for a locale that has no listing on disk', () => {
+    // given / when
+    const result = runInModule(
+      PUBLISH_MODULE,
+      `mod.selectListings(${JSON.stringify(all)}, 'fr-FR')`
+    );
+
+    // then
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('No listing found for locale fr-FR');
+  });
+
+  it('should reject a locale that smuggles a second flag in its value', () => {
+    // given — the workflow passes the operator's locale as a single argv
+    // element, so an injected flag arrives as part of the locale string.
+    // This is the last line of defence behind the quoting in the workflow.
+    const argv = "['--locale=de-DE --commit']";
+
+    // when
+    const parsed = runInModule(PUBLISH_MODULE, `mod.parseArgs(${argv})`);
+    const selected = runInModule(
+      PUBLISH_MODULE,
+      `mod.selectListings(${JSON.stringify(all)}, ${JSON.stringify('de-DE --commit')})`
+    );
+
+    // then — it never becomes a commit, and it never matches a real locale
+    expect(parsed.value.commit).toBe(false);
+    expect(selected.ok).toBe(false);
+    expect(selected.message).toContain('No listing found');
+  });
+});
+
+describe('publishListings', () => {
+  const de = {
+    language: 'de-DE',
+    title: 'Pushup Stats',
+    shortDescription: 'kurz',
+    fullDescription: 'lang',
+  };
+  const names = (calls) => calls.map(([name]) => name);
+
+  it('should never write or commit on a dry run', () => {
+    // given — the live listing differs from the source
+    // when
+    const result = runPublish({
+      listings: [de],
+      commit: false,
+      remoteByLocale: { 'de-DE': { ...de, shortDescription: 'alt' } },
+    });
+
+    // then
+    expect(names(result.calls)).toEqual([
+      'createEdit',
+      'getListing',
+      'deleteEdit',
+    ]);
+    expect(result.changed).toBe(1);
+  });
+
+  it('should update and commit when --commit is set', () => {
+    // given
+    // when
+    const result = runPublish({
+      listings: [de],
+      commit: true,
+      remoteByLocale: { 'de-DE': { ...de, title: 'alt' } },
+    });
+
+    // then
+    expect(names(result.calls)).toEqual([
+      'createEdit',
+      'getListing',
+      'updateListing',
+      'commitEdit',
+    ]);
+  });
+
+  it('should discard the edit instead of committing when nothing changed', () => {
+    // given — live listing already matches, so a commit would be an empty
+    // edit and would still cost a review cycle
+    // when
+    const result = runPublish({
+      listings: [de],
+      commit: true,
+      remoteByLocale: { 'de-DE': de },
+    });
+
+    // then
+    expect(names(result.calls)).toEqual([
+      'createEdit',
+      'getListing',
+      'deleteEdit',
+    ]);
+    expect(result.changed).toBe(0);
+  });
+
+  it('should treat a locale with no live listing as a create', () => {
+    // given — `getListing` resolves to null for an unknown locale
+    // when
+    const result = runPublish({
+      listings: [de],
+      commit: true,
+      remoteByLocale: {},
+    });
+
+    // then
+    expect(names(result.calls)).toContain('updateListing');
+    expect(result.changed).toBe(1);
+  });
+
+  it('should send the full listing body on update', () => {
+    // given
+    // when
+    const result = runPublish({
+      listings: [de],
+      commit: true,
+      remoteByLocale: { 'de-DE': { ...de, title: 'alt' } },
+    });
+
+    // then
+    const [, editId, body] = result.calls.find(
+      ([name]) => name === 'updateListing'
+    );
+    expect(editId).toBe('edit-1');
+    expect(body).toEqual(de);
+  });
+
+  it('should clean up the edit when a call fails mid-transaction', () => {
+    // given — an open edit blocks the next run with a conflict
+    // when
+    const result = runPublish({
+      listings: [de],
+      commit: true,
+      remoteByLocale: { 'de-DE': { ...de, title: 'alt' } },
+      failOn: ['updateListing'],
+    });
+
+    // then
+    expect(names(result.calls)).toEqual([
+      'createEdit',
+      'getListing',
+      'updateListing',
+      'deleteEdit',
+    ]);
+    expect(result.failed).toBe('boom:updateListing');
+  });
+
+  it('should report the original failure, not a failure from the cleanup', () => {
+    // given — the update throws, and so does the cleanup that follows it
+    // when
+    const result = runPublish({
+      listings: [de],
+      commit: true,
+      remoteByLocale: { 'de-DE': { ...de, title: 'alt' } },
+      failOn: ['updateListing', 'deleteEdit'],
+    });
+
+    // then — the surfaced error is the one that actually broke the run
+    expect(result.failed).toBe('boom:updateListing');
+  });
+});
+
+describe('buildUpdateBody', () => {
+  const local = {
+    language: 'de-DE',
+    title: 'Pushup Stats',
+    shortDescription: 'kurz',
+    fullDescription: 'lang',
+  };
+
+  it('should carry the promo video over so a text update cannot wipe it', () => {
+    // given — `edits.listings.update` is a full replace, and the video is
+    // maintained in the Console with no source in this repo
+    const remote = { video: 'https://youtu.be/abc123' };
+
+    // when
+    const result = runInModule(
+      PUBLISH_MODULE,
+      `mod.buildUpdateBody(${JSON.stringify(local)}, ${JSON.stringify(remote)})`
+    );
+
+    // then
+    expect(result.value.video).toBe('https://youtu.be/abc123');
+  });
+
+  it('should omit the video field when the live listing has none', () => {
+    // given / when
+    const result = runInModule(
+      PUBLISH_MODULE,
+      `mod.buildUpdateBody(${JSON.stringify(local)}, null)`
+    );
+
+    // then
+    expect(result.value).toEqual(local);
+    expect('video' in result.value).toBe(false);
   });
 });
 

--- a/tools/src/play-listing-source.spec.js
+++ b/tools/src/play-listing-source.spec.js
@@ -370,6 +370,129 @@ describe('buildAuth', () => {
   });
 });
 
+/**
+ * `authorizedFetch` and `createPlayApi` are the only pieces that touch the
+ * network, so they are exercised with `fetch` stubbed inside the subprocess.
+ * These are the paths the very first real run hits.
+ */
+function runWithStubbedFetch({ status, body = '', expression }) {
+  return runInModule(
+    PUBLISH_MODULE,
+    `(async () => {
+      const requests = [];
+      globalThis.fetch = async (url, init) => {
+        requests.push({ url, method: init?.method ?? 'GET' });
+        return {
+          ok: ${status} >= 200 && ${status} < 300,
+          status: ${status},
+          text: async () => ${JSON.stringify(body)},
+          json: async () => JSON.parse(${JSON.stringify(body || '{}')}),
+        };
+      };
+      const auth = {
+        getClient: async () => ({
+          getAccessToken: async () => ({ token: 'stub-token' }),
+        }),
+      };
+      try {
+        const value = await (${expression});
+        return { value, requests };
+      } catch (error) {
+        return { failed: error.message, status: error.status, requests };
+      }
+    })()`
+  ).value;
+}
+
+describe('authorizedFetch', () => {
+  it('should attach the status so callers can tell 404 from a real failure', () => {
+    // given / when
+    const result = runWithStubbedFetch({
+      status: 403,
+      body: 'The caller does not have permission',
+      expression: "mod.authorizedFetch(auth, 'https://example.test/x')",
+    });
+
+    // then
+    expect(result.status).toBe(403);
+    expect(result.failed).toContain('403');
+    // The body matters: it is what tells the operator the permission is
+    // missing rather than the request being malformed.
+    expect(result.failed).toContain('The caller does not have permission');
+  });
+
+  it('should return null for 204, which has no body to parse', () => {
+    // given / when — deleting an edit answers 204
+    const result = runWithStubbedFetch({
+      status: 204,
+      expression:
+        "mod.authorizedFetch(auth, 'https://example.test/x', { method: 'DELETE' })",
+    });
+
+    // then
+    expect(result.value).toBeNull();
+  });
+});
+
+describe('createPlayApi', () => {
+  it('should treat a 404 listing as "not created yet" rather than an error', () => {
+    // given — the locale exists on disk but not yet in the Console
+    // when
+    const result = runWithStubbedFetch({
+      status: 404,
+      body: 'not found',
+      expression: "mod.createPlayApi(auth).getListing('edit-1', 'en-US')",
+    });
+
+    // then
+    expect(result.failed).toBeUndefined();
+    expect(result.value).toBeNull();
+  });
+
+  it('should propagate a 403 instead of silently reporting no listing', () => {
+    // given — the most likely first-run failure: permissions not propagated
+    // when
+    const result = runWithStubbedFetch({
+      status: 403,
+      body: 'forbidden',
+      expression: "mod.createPlayApi(auth).getListing('edit-1', 'de-DE')",
+    });
+
+    // then
+    expect(result.value).toBeUndefined();
+    expect(result.status).toBe(403);
+  });
+
+  it('should address the listing endpoint by the language in the body', () => {
+    // given / when
+    const result = runWithStubbedFetch({
+      status: 200,
+      body: '{}',
+      expression:
+        "mod.createPlayApi(auth).updateListing('edit-1', { language: 'de-DE', title: 'x' })",
+    });
+
+    // then
+    expect(result.requests[0].method).toBe('PUT');
+    expect(result.requests[0].url).toContain(
+      '/applications/com.pushupstats.app/edits/edit-1/listings/de-DE'
+    );
+  });
+
+  it('should commit through the :commit sub-resource', () => {
+    // given / when
+    const result = runWithStubbedFetch({
+      status: 200,
+      body: '{}',
+      expression: "mod.createPlayApi(auth).commitEdit('edit-1')",
+    });
+
+    // then
+    expect(result.requests[0].method).toBe('POST');
+    expect(result.requests[0].url).toContain('/edits/edit-1:commit');
+  });
+});
+
 describe('selectListings', () => {
   const all = [{ language: 'de-DE' }, { language: 'en-US' }];
 

--- a/tools/src/publish-play-listing.mjs
+++ b/tools/src/publish-play-listing.mjs
@@ -32,11 +32,21 @@ export function parseArgs(argv) {
   const args = { commit: false, locale: null };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (arg === '--commit') args.commit = true;
-    else if (arg === '--locale') args.locale = argv[++i] ?? null;
-    else if (arg.startsWith('--locale='))
-      args.locale = arg.slice('--locale='.length);
-    else throw new Error(`Unknown argument: ${arg}`);
+    if (arg === '--commit') {
+      args.commit = true;
+    } else if (arg === '--locale' || arg.startsWith('--locale=')) {
+      const value =
+        arg === '--locale' ? argv[++i] : arg.slice('--locale='.length);
+      // A blank value must not silently widen the run to every locale — on
+      // the --commit path that is the difference between publishing one
+      // language and publishing all of them.
+      if (!value || value.trim() === '') {
+        throw new Error('--locale needs a value, e.g. --locale=de-DE');
+      }
+      args.locale = value.trim();
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
   }
   return args;
 }
@@ -58,11 +68,92 @@ export function diffListing(local, remote) {
   return changes;
 }
 
+/**
+ * `edits.listings.update` is a full replace: any field missing from the body
+ * is cleared on the remote listing. The promo video is maintained by hand in
+ * the Console and this tool has no source for it, so it has to be carried
+ * over from the remote listing or a text change would silently wipe it.
+ */
+export function buildUpdateBody(local, remote) {
+  const body = {
+    language: local.language,
+    title: local.title,
+    shortDescription: local.shortDescription,
+    fullDescription: local.fullDescription,
+  };
+  if (remote?.video) {
+    body.video = remote.video;
+  }
+  return body;
+}
+
 function summarize(value) {
   if (value === '') return '(empty)';
   const firstLine = value.split('\n')[0];
   const suffix = value.includes('\n') ? ' …' : '';
   return `${JSON.stringify(firstLine.slice(0, 72))}${suffix} [${countCharacters(value)} chars]`;
+}
+
+/**
+ * Drives one publish run against an injected `api`, so the transaction —
+ * edit creation, per-locale diff, update, commit, and cleanup on failure —
+ * is testable without talking to Google.
+ *
+ * Returns the number of locales that differed from the live listing.
+ */
+export async function publishListings({
+  listings,
+  commit,
+  api,
+  log = console.log,
+}) {
+  const edit = await api.createEdit();
+  let changedLocales = 0;
+
+  try {
+    for (const listing of listings) {
+      const remote = await api.getListing(edit.id, listing.language);
+      const changes = diffListing(listing, remote);
+
+      if (changes.length === 0) {
+        log(`${listing.language}: unchanged`);
+        continue;
+      }
+
+      changedLocales++;
+      log(`${listing.language}: ${changes.length} field(s) changed`);
+      for (const { field, before, after } of changes) {
+        log(`  ${field}`);
+        log(`    - ${summarize(before)}`);
+        log(`    + ${summarize(after)}`);
+      }
+
+      if (commit) {
+        await api.updateListing(edit.id, buildUpdateBody(listing, remote));
+      }
+    }
+
+    if (!commit || changedLocales === 0) {
+      await api.deleteEdit(edit.id);
+      log(
+        changedLocales === 0
+          ? '\nNothing to do — the live listing already matches the sources.'
+          : `\nDry run: ${changedLocales} locale(s) would change. Re-run with --commit to publish.`
+      );
+      return changedLocales;
+    }
+
+    await api.commitEdit(edit.id);
+    log(
+      `\nPublished ${changedLocales} locale(s). Google reviews store-listing changes before they go live.`
+    );
+    return changedLocales;
+  } catch (error) {
+    // Leaving an edit open blocks the next run with a conflict, so always
+    // try to clean it up — but report the original failure, not the cleanup.
+    await api.deleteEdit(edit.id).catch(() => undefined);
+    throw error;
+  }
 }
 
 async function authorizedFetch(auth, url, init = {}) {
@@ -79,16 +170,46 @@ async function authorizedFetch(auth, url, init = {}) {
 
   if (!response.ok) {
     const body = await response.text();
-    throw new Error(
+    const error = new Error(
       `${init.method ?? 'GET'} ${url} → ${response.status}\n${body}`
     );
+    error.status = response.status;
+    throw error;
   }
 
   return response.status === 204 ? null : response.json();
 }
 
-function buildAuth() {
-  const raw = process.env[CREDENTIALS_ENV];
+function createPlayApi(auth) {
+  const editsUrl = `${API_ROOT}/applications/${PACKAGE_NAME}/edits`;
+  const listingUrl = (editId, language) =>
+    `${editsUrl}/${editId}/listings/${language}`;
+
+  return {
+    createEdit: () => authorizedFetch(auth, editsUrl, { method: 'POST' }),
+    getListing: async (editId, language) => {
+      try {
+        return await authorizedFetch(auth, listingUrl(editId, language));
+      } catch (error) {
+        // A locale with no listing yet 404s; that's a create, not a failure.
+        if (error.status === 404) return null;
+        throw error;
+      }
+    },
+    updateListing: (editId, body) =>
+      authorizedFetch(auth, listingUrl(editId, body.language), {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      }),
+    commitEdit: (editId) =>
+      authorizedFetch(auth, `${editsUrl}/${editId}:commit`, { method: 'POST' }),
+    deleteEdit: (editId) =>
+      authorizedFetch(auth, `${editsUrl}/${editId}`, { method: 'DELETE' }),
+  };
+}
+
+export function buildAuth(env = process.env) {
+  const raw = env[CREDENTIALS_ENV];
   if (!raw) {
     throw new Error(
       `${CREDENTIALS_ENV} is not set. See docs/play-store-publishing.md for how to create the service account and store its key.`
@@ -107,92 +228,29 @@ function buildAuth() {
   return new GoogleAuth({ credentials, scopes: [SCOPE] });
 }
 
+export function selectListings(all, locale) {
+  if (!locale) return all;
+  const selected = all.filter((listing) => listing.language === locale);
+  if (selected.length === 0) {
+    throw new Error(
+      `No listing found for locale ${locale} — known locales: ${all.map((l) => l.language).join(', ')}`
+    );
+  }
+  return selected;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
 
   // Validation runs before any network call, so bad copy fails fast and
   // never leaves a dangling edit behind in the Console.
-  let listings = readListings();
-  if (args.locale) {
-    listings = listings.filter((l) => l.language === args.locale);
-    if (listings.length === 0) {
-      throw new Error(`No listing found for locale ${args.locale}`);
-    }
-  }
+  const listings = selectListings(readListings(), args.locale);
 
-  const auth = buildAuth();
-  const editsUrl = `${API_ROOT}/applications/${PACKAGE_NAME}/edits`;
-  const edit = await authorizedFetch(auth, editsUrl, { method: 'POST' });
-  const editBase = `${editsUrl}/${edit.id}`;
-
-  let changedLocales = 0;
-  try {
-    for (const listing of listings) {
-      const { language, ...fields } = listing;
-
-      let remote = null;
-      try {
-        remote = await authorizedFetch(
-          auth,
-          `${editBase}/listings/${language}`
-        );
-      } catch (error) {
-        // A locale with no listing yet 404s; that's a create, not a failure.
-        if (!/→ 404/.test(String(error.message))) throw error;
-      }
-
-      const changes = diffListing(listing, remote);
-      if (changes.length === 0) {
-        console.log(`${language}: unchanged`);
-        continue;
-      }
-
-      changedLocales++;
-      console.log(`${language}: ${changes.length} field(s) changed`);
-      for (const { field, before, after } of changes) {
-        console.log(`  ${field}`);
-        console.log(`    - ${summarize(before)}`);
-        console.log(`    + ${summarize(after)}`);
-      }
-
-      if (args.commit) {
-        await authorizedFetch(auth, `${editBase}/listings/${language}`, {
-          method: 'PUT',
-          body: JSON.stringify({ language, ...fields }),
-        });
-      }
-    }
-
-    if (!args.commit) {
-      await authorizedFetch(auth, editBase, { method: 'DELETE' });
-      console.log(
-        changedLocales === 0
-          ? '\nDry run: live listing already matches the sources.'
-          : `\nDry run: ${changedLocales} locale(s) would change. Re-run with --commit to publish.`
-      );
-      return;
-    }
-
-    if (changedLocales === 0) {
-      await authorizedFetch(auth, editBase, { method: 'DELETE' });
-      console.log(
-        '\nNothing to publish — live listing already matches the sources.'
-      );
-      return;
-    }
-
-    await authorizedFetch(auth, `${editBase}:commit`, { method: 'POST' });
-    console.log(
-      `\nPublished ${changedLocales} locale(s). Google reviews store-listing changes before they go live.`
-    );
-  } catch (error) {
-    // Leaving an edit open blocks the next run with a conflict, so always
-    // try to clean it up — but report the original failure, not the cleanup.
-    await authorizedFetch(auth, editBase, { method: 'DELETE' }).catch(
-      () => undefined
-    );
-    throw error;
-  }
+  await publishListings({
+    listings,
+    commit: args.commit,
+    api: createPlayApi(buildAuth()),
+  });
 }
 
 // Only run when invoked as a script, so the spec can import the helpers

--- a/tools/src/publish-play-listing.mjs
+++ b/tools/src/publish-play-listing.mjs
@@ -1,0 +1,208 @@
+/**
+ * Pushes `store/play/<locale>/*.txt` to the Google Play Console via the
+ * Play Developer API.
+ *
+ * Dry run by default — it reads the live listing, prints a diff and exits
+ * without opening an edit. Writing requires an explicit `--commit`, because
+ * a committed listing goes into Google's review queue and there is no undo
+ * beyond publishing the previous text again.
+ *
+ * Setup (service account, permissions, secret): docs/play-store-publishing.md
+ *
+ * Usage:
+ *   node tools/src/publish-play-listing.mjs               # diff only
+ *   node tools/src/publish-play-listing.mjs --commit      # actually publish
+ *   node tools/src/publish-play-listing.mjs --locale de-DE
+ */
+
+import { pathToFileURL } from 'node:url';
+import { GoogleAuth } from 'google-auth-library';
+import {
+  FIELD_FILES,
+  countCharacters,
+  readListings,
+} from './play-listing-source.mjs';
+
+const PACKAGE_NAME = 'com.pushupstats.app';
+const API_ROOT = 'https://androidpublisher.googleapis.com/androidpublisher/v3';
+const SCOPE = 'https://www.googleapis.com/auth/androidpublisher';
+const CREDENTIALS_ENV = 'GOOGLE_PLAY_SERVICE_ACCOUNT_JSON';
+
+export function parseArgs(argv) {
+  const args = { commit: false, locale: null };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--commit') args.commit = true;
+    else if (arg === '--locale') args.locale = argv[++i] ?? null;
+    else if (arg.startsWith('--locale='))
+      args.locale = arg.slice('--locale='.length);
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+/**
+ * Field-level comparison between what's on disk and what's live. Only
+ * changed fields are reported — Play accepts a full listing object on every
+ * update, but showing unchanged copy in the diff buries the real change.
+ */
+export function diffListing(local, remote) {
+  const changes = [];
+  for (const field of Object.keys(FIELD_FILES)) {
+    const before = remote?.[field] ?? '';
+    const after = local[field];
+    if (before !== after) {
+      changes.push({ field, before, after });
+    }
+  }
+  return changes;
+}
+
+function summarize(value) {
+  if (value === '') return '(empty)';
+  const firstLine = value.split('\n')[0];
+  const suffix = value.includes('\n') ? ' …' : '';
+  return `${JSON.stringify(firstLine.slice(0, 72))}${suffix} [${countCharacters(value)} chars]`;
+}
+
+async function authorizedFetch(auth, url, init = {}) {
+  const client = await auth.getClient();
+  const { token } = await client.getAccessToken();
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `${init.method ?? 'GET'} ${url} → ${response.status}\n${body}`
+    );
+  }
+
+  return response.status === 204 ? null : response.json();
+}
+
+function buildAuth() {
+  const raw = process.env[CREDENTIALS_ENV];
+  if (!raw) {
+    throw new Error(
+      `${CREDENTIALS_ENV} is not set. See docs/play-store-publishing.md for how to create the service account and store its key.`
+    );
+  }
+
+  let credentials;
+  try {
+    credentials = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      `${CREDENTIALS_ENV} is not valid JSON — paste the whole service-account key file.`
+    );
+  }
+
+  return new GoogleAuth({ credentials, scopes: [SCOPE] });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  // Validation runs before any network call, so bad copy fails fast and
+  // never leaves a dangling edit behind in the Console.
+  let listings = readListings();
+  if (args.locale) {
+    listings = listings.filter((l) => l.language === args.locale);
+    if (listings.length === 0) {
+      throw new Error(`No listing found for locale ${args.locale}`);
+    }
+  }
+
+  const auth = buildAuth();
+  const editsUrl = `${API_ROOT}/applications/${PACKAGE_NAME}/edits`;
+  const edit = await authorizedFetch(auth, editsUrl, { method: 'POST' });
+  const editBase = `${editsUrl}/${edit.id}`;
+
+  let changedLocales = 0;
+  try {
+    for (const listing of listings) {
+      const { language, ...fields } = listing;
+
+      let remote = null;
+      try {
+        remote = await authorizedFetch(
+          auth,
+          `${editBase}/listings/${language}`
+        );
+      } catch (error) {
+        // A locale with no listing yet 404s; that's a create, not a failure.
+        if (!/→ 404/.test(String(error.message))) throw error;
+      }
+
+      const changes = diffListing(listing, remote);
+      if (changes.length === 0) {
+        console.log(`${language}: unchanged`);
+        continue;
+      }
+
+      changedLocales++;
+      console.log(`${language}: ${changes.length} field(s) changed`);
+      for (const { field, before, after } of changes) {
+        console.log(`  ${field}`);
+        console.log(`    - ${summarize(before)}`);
+        console.log(`    + ${summarize(after)}`);
+      }
+
+      if (args.commit) {
+        await authorizedFetch(auth, `${editBase}/listings/${language}`, {
+          method: 'PUT',
+          body: JSON.stringify({ language, ...fields }),
+        });
+      }
+    }
+
+    if (!args.commit) {
+      await authorizedFetch(auth, editBase, { method: 'DELETE' });
+      console.log(
+        changedLocales === 0
+          ? '\nDry run: live listing already matches the sources.'
+          : `\nDry run: ${changedLocales} locale(s) would change. Re-run with --commit to publish.`
+      );
+      return;
+    }
+
+    if (changedLocales === 0) {
+      await authorizedFetch(auth, editBase, { method: 'DELETE' });
+      console.log(
+        '\nNothing to publish — live listing already matches the sources.'
+      );
+      return;
+    }
+
+    await authorizedFetch(auth, `${editBase}:commit`, { method: 'POST' });
+    console.log(
+      `\nPublished ${changedLocales} locale(s). Google reviews store-listing changes before they go live.`
+    );
+  } catch (error) {
+    // Leaving an edit open blocks the next run with a conflict, so always
+    // try to clean it up — but report the original failure, not the cleanup.
+    await authorizedFetch(auth, editBase, { method: 'DELETE' }).catch(
+      () => undefined
+    );
+    throw error;
+  }
+}
+
+// Only run when invoked as a script, so the spec can import the helpers
+// without triggering a network call.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tools/src/publish-play-listing.mjs
+++ b/tools/src/publish-play-listing.mjs
@@ -87,11 +87,19 @@ export function buildUpdateBody(local, remote) {
   return body;
 }
 
-function summarize(value) {
+const PREVIEW_LENGTH = 72;
+
+/**
+ * One-line preview of a field for the diff output. The operator decides
+ * whether to publish from this, so a shortened preview has to be visibly
+ * shortened — an unmarked cut mid-word reads like the field really ends
+ * there.
+ */
+export function summarize(value) {
   if (value === '') return '(empty)';
-  const firstLine = value.split('\n')[0];
-  const suffix = value.includes('\n') ? ' …' : '';
-  return `${JSON.stringify(firstLine.slice(0, 72))}${suffix} [${countCharacters(value)} chars]`;
+  const preview = value.split('\n')[0].slice(0, PREVIEW_LENGTH);
+  const ellipsis = preview === value ? '' : ' …';
+  return `${JSON.stringify(preview)}${ellipsis} [${countCharacters(value)} chars]`;
 }
 
 /**

--- a/tools/src/publish-play-listing.mjs
+++ b/tools/src/publish-play-listing.mjs
@@ -164,7 +164,12 @@ export async function publishListings({
   }
 }
 
-async function authorizedFetch(auth, url, init = {}) {
+/**
+ * Adds the bearer token and turns a non-OK response into an Error carrying
+ * `status`, which `getListing` reads to tell "this locale has no listing
+ * yet" (404) from a real failure such as a missing permission (403).
+ */
+export async function authorizedFetch(auth, url, init = {}) {
   const client = await auth.getClient();
   const { token } = await client.getAccessToken();
   const response = await fetch(url, {
@@ -188,7 +193,7 @@ async function authorizedFetch(auth, url, init = {}) {
   return response.status === 204 ? null : response.json();
 }
 
-function createPlayApi(auth) {
+export function createPlayApi(auth) {
   const editsUrl = `${API_ROOT}/applications/${PACKAGE_NAME}/edits`;
   const listingUrl = (editId, language) =>
     `${editsUrl}/${editId}/listings/${language}`;


### PR DESCRIPTION
## Warum

Der Store-Text lag als Markdown-Dokument im Repo und musste von Hand in die Play Console kopiert werden. Zwei Probleme: die Zeichen-Limits waren eine Tabelle, der man glauben musste, und es gab keine Aufzeichnung davon, was eigentlich live ist.

## Was drin ist

**Quelltexte statt Markdown-Block**

`store/play/<play-locale>/{title,short-description,full-description}.txt` ist ab jetzt die Wahrheit. `docs/playstore-listing.md` behält nur noch die Beleg-Liste, die jede Behauptung im Text an die Code-Stelle bindet, die sie deckt.

**Validierung vor dem ersten Netzwerk-Call**

`tools/src/play-listing-source.mjs` liest und prüft die Dateien. Unbekanntes Locale-Verzeichnis, fehlendes oder leeres Feld, Text über dem Limit — alles scheitert lokal, damit nie ein Edit in der Console geöffnet wird, der sich dann nicht committen lässt.

**Publisher mit Dry-Run als Default**

`tools/src/publish-play-listing.mjs` spricht die Play Developer API. Ohne Flag diffed es die Quellen gegen den Live-Eintrag und löscht seinen Edit wieder. Schreiben braucht explizit `--commit` — ein committeter Listing-Text geht in Googles Review-Queue, ein echtes Undo gibt es nicht.

**Workflow, nur manuell**

`.github/workflows/play-listing.yml`, `workflow_dispatch` mit Checkbox „Publish for real" und optionalem Locale-Filter. Bewusst kein Auto-Trigger auf `main`.

## Zwei Fallen, die sonst zugeschnappt wären

**Play zählt UTF-16-Code-Units, nicht Zeichen.** Das Backend ist eine JVM, wo `String.length()` genau das ist. Die Beschreibung ist emoji-lastig: `📷` kostet 2, `🏋️` sogar 3 (Surrogatpaar plus Variation Selector). Codepoint-Zählung lag ~10 Zeichen zu niedrig und hätte eine 4004 Zeichen lange Beschreibung als „3994/4000 OK" durchgewunken — der erste Publish wäre abgelehnt worden, mit grünem CI davor. Der Text ist auf 3990 gekürzt.

**Play-Locales sind nicht die App-Locales.** `de` wird abgelehnt, Play will `de-DE`. Das Mapping ist explizit, und ein Test pinnt es an die `localize`-Liste in `web/project.json` — eine neue App-Sprache ohne Play-Mapping bricht CI.

## Tests

39 Tests in `tools/src/play-listing-source.spec.js`:

- Einlesen und alle Fehlerpfade der Validierung (unbekanntes Locale, fehlendes Feld, leeres Feld, Limit überschritten)
- Zeichenzählung für ASCII, Surrogatpaar, Variation Selector und ZWJ-Sequenz
- Locale-Mapping gegen `web/project.json`
- Argument-Parsing inklusive leerem `--locale`
- Die Publish-Transaktion gegen eine injizierte API: Dry-Run, Commit, No-op, Neuanlage, Cleanup mitten in der Transaktion, und dass ein fehlschlagendes Cleanup den Originalfehler nicht überdeckt
- Regression für eine Locale-Eingabe, die ein zweites Flag einzuschleusen versucht

Zwei Guards prüfen die eingecheckten Quelldateien selbst und die Nx-Test-Inputs — zu langer Store-Text scheitert damit in CI und nicht erst beim Veröffentlichen.

## Abhängigkeit

Neu: `google-auth-library` (devDependency) für den Access-Token. Die REST-Calls laufen über `fetch` — für vier Endpunkte lohnt sich das komplette `googleapis`-Paket nicht.

## Review

Codex und CodeRabbit haben zusammen zehn Findings gemeldet, neun davon berechtigt und übernommen (Details im [Kommentar](https://github.com/WolfSoko/pushup-stats-service/pull/567#issuecomment-5146162318)). Neben der UTF-16-Zählung war der zweite ernste Fund eine Shell-Injection: die Locale-Eingabe wurde unquoted expandiert, `de-DE --commit` hätte sich in einen echten Publish aufgesplittet.

Abgelehnt: Aufruf über den Nx-Target statt direkt `node`. Der direkte Aufruf ist Absicht und steht so kommentiert im Workflow — jede weitere Ebene Argument-Weiterreichung ist eine weitere Stelle, an der Operator-Eingabe erneut in Flags zerlegt werden kann.

## Was du noch tun musst

Service-Account, Berechtigung und Secret, Schritt für Schritt in [`docs/play-store-publishing.md`](https://github.com/WolfSoko/pushup-stats-service/blob/main/docs/play-store-publishing.md).

Reihenfolge beachten: Der Workflow taucht unter *Actions* erst auf, wenn er auf `main` liegt — GitHub zeigt `workflow_dispatch` nur vom Default-Branch. Also erst mergen, dann Dry-Run.