### PR TITLE
chore(i18n): fill missing translations (176 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10643,21 +10643,21 @@
       </segment>
     </unit>
     <unit id="sw.update.buttonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neue Version verfügbar – jetzt neu laden</source>
-        <target>Neue Version verfügbar – jetzt neu laden</target>
+        <target>Διατίθεται νέα έκδοση – επαναφόρτωση τώρα</target>
       </segment>
     </unit>
     <unit id="sw.update.unrecoverable">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – bitte neu laden</source>
-        <target>App-Daten beschädigt – bitte neu laden</target>
+        <target>Τα δεδομένα της εφαρμογής καταστράφηκαν – παρακαλώ κάντε επαναφόρτωση</target>
       </segment>
     </unit>
     <unit id="sw.update.recoverButtonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – jetzt neu laden</source>
-        <target>App-Daten beschädigt – jetzt neu laden</target>
+        <target>Τα δεδομένα της εφαρμογής καταστράφηκαν – επαναφόρτωση τώρα</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10571,75 +10571,75 @@
       </segment>
     </unit>
     <unit id="quickAdd.fab.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Ημερήσιοι στόχοι</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele zum Abhaken anzeigen</source>
-        <target>Tagesziele zum Abhaken anzeigen</target>
+        <target>Εμφάνιση ημερήσιων στόχων για επισήμανση</target>
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.checkHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
-        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+        <target> Μπορείς να επισημάνεις τους επιμέρους στόχους στον πίνακα ελέγχου. </target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.reached">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel erreicht</source>
-        <target>Ziel erreicht</target>
+        <target>Ο στόχος επιτεύχθηκε</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.manual">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dieses Ziel braucht einen manuellen Eintrag</source>
-        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+        <target>Αυτός ο στόχος χρειάζεται χειροκίνητη καταχώρηση</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.fill">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
-        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+        <target>Καταχώρησε το υπόλοιπο και επισήμανε: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+        <target>Επισήμανση <ph id="0" equiv="EXERCISE" disp="item.exerciseName"/></target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemReachedAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> ήδη επιτεύχθηκε</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
-        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+        <target>Προσθήκη <ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> στον ημερήσιο στόχο</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurücksetzen</source>
-        <target>Übung zurücksetzen</target>
+        <target>Επαναφορά άσκησης</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurückgesetzt.</source>
-        <target>Übung zurückgesetzt.</target>
+        <target>Η άσκηση επαναφέρθηκε.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetKept">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
-        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+        <target>Η επισήμανση αφαιρέθηκε — οι δικές σου καταχωρήσεις παραμένουν.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10529,45 +10529,45 @@
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.unquantified">
-      <segment state="initial">
+      <segment state="translated">
         <source>nach Vorgabe</source>
-        <target>nach Vorgabe</target>
+        <target>όπως προβλέπεται</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.auto">
-      <segment state="initial">
+      <segment state="translated">
         <source>Automatisch erfüllt — durch deine Einträge an diesem Tag.</source>
-        <target>Automatisch erfüllt — durch deine Einträge an diesem Tag.</target>
+        <target>Ολοκληρώθηκε αυτόματα — από τις καταχωρήσεις σου αυτή την ημέρα.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.check">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung abhaken (ohne Eintrag)</source>
-        <target>Übung abhaken (ohne Eintrag)</target>
+        <target>Επισήμανση άσκησης (χωρίς καταχώρηση)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.undo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernen</source>
-        <target>Haken entfernen</target>
+        <target>Αφαίρεση επισήμανσης</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.log">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorgabe eintragen</source>
-        <target>Vorgabe eintragen</target>
+        <target>Καταχώρηση προβλεπόμενης τιμής</target>
       </segment>
     </unit>
     <unit id="trainingPlans.checkoffHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Tag — Übungen einzeln abhaken.</source>
-        <target>Intervall-Tag — Übungen einzeln abhaken.</target>
+        <target>Ημέρα διαλειμμάτων — επισήμανε τις ασκήσεις μεμονωμένα.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logAllDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen &amp; abhaken</source>
-        <target>Alle Übungen eintragen &amp; abhaken</target>
+        <target>Καταχώρηση &amp; επισήμανση όλων των ασκήσεων</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10770,75 +10770,75 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Daily goals</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele zum Abhaken anzeigen</source>
-        <target>Tagesziele zum Abhaken anzeigen</target>
+        <target>Show daily goals to check off</target>
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.checkHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
-        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+        <target> You can check off partial goals on the dashboard. </target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.reached">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel erreicht</source>
-        <target>Ziel erreicht</target>
+        <target>Goal reached</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.manual">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dieses Ziel braucht einen manuellen Eintrag</source>
-        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+        <target>This goal needs a manual entry</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.fill">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
-        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+        <target>Log the rest and check off: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+        <target>Check off <ph id="0" equiv="EXERCISE" disp="item.exerciseName"/></target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemReachedAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> already reached</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
-        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+        <target>Add <ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> to daily goal</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurücksetzen</source>
-        <target>Übung zurücksetzen</target>
+        <target>Reset exercise</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurückgesetzt.</source>
-        <target>Übung zurückgesetzt.</target>
+        <target>Exercise reset.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetKept">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
-        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+        <target>Checkmark removed — your own entries remain.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10842,21 +10842,21 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="sw.update.buttonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neue Version verfügbar – jetzt neu laden</source>
-        <target>Neue Version verfügbar – jetzt neu laden</target>
+        <target>New version available – reload now</target>
       </segment>
     </unit>
     <unit id="sw.update.unrecoverable">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – bitte neu laden</source>
-        <target>App-Daten beschädigt – bitte neu laden</target>
+        <target>App data corrupted – please reload</target>
       </segment>
     </unit>
     <unit id="sw.update.recoverButtonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – jetzt neu laden</source>
-        <target>App-Daten beschädigt – jetzt neu laden</target>
+        <target>App data corrupted – reload now</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10728,45 +10728,45 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.unquantified">
-      <segment state="initial">
+      <segment state="translated">
         <source>nach Vorgabe</source>
-        <target>nach Vorgabe</target>
+        <target>as prescribed</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.auto">
-      <segment state="initial">
+      <segment state="translated">
         <source>Automatisch erfüllt — durch deine Einträge an diesem Tag.</source>
-        <target>Automatisch erfüllt — durch deine Einträge an diesem Tag.</target>
+        <target>Automatically completed — from your entries on this day.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.check">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung abhaken (ohne Eintrag)</source>
-        <target>Übung abhaken (ohne Eintrag)</target>
+        <target>Check off exercise (without entry)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.undo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernen</source>
-        <target>Haken entfernen</target>
+        <target>Remove checkmark</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.log">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorgabe eintragen</source>
-        <target>Vorgabe eintragen</target>
+        <target>Log prescribed amount</target>
       </segment>
     </unit>
     <unit id="trainingPlans.checkoffHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Tag — Übungen einzeln abhaken.</source>
-        <target>Intervall-Tag — Übungen einzeln abhaken.</target>
+        <target>Interval day — check off exercises individually.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logAllDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen &amp; abhaken</source>
-        <target>Alle Übungen eintragen &amp; abhaken</target>
+        <target>Log &amp; check off all exercises</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10639,21 +10639,21 @@
       </segment>
     </unit>
     <unit id="sw.update.buttonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neue Version verfügbar – jetzt neu laden</source>
-        <target>Neue Version verfügbar – jetzt neu laden</target>
+        <target>Nueva versión disponible – recargar ahora</target>
       </segment>
     </unit>
     <unit id="sw.update.unrecoverable">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – bitte neu laden</source>
-        <target>App-Daten beschädigt – bitte neu laden</target>
+        <target>Datos de la aplicación dañados – recarga la página</target>
       </segment>
     </unit>
     <unit id="sw.update.recoverButtonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – jetzt neu laden</source>
-        <target>App-Daten beschädigt – jetzt neu laden</target>
+        <target>Datos de la aplicación dañados – recargar ahora</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10567,75 +10567,75 @@
       </segment>
     </unit>
     <unit id="quickAdd.fab.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Objetivos diarios</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele zum Abhaken anzeigen</source>
-        <target>Tagesziele zum Abhaken anzeigen</target>
+        <target>Mostrar objetivos diarios para marcar</target>
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.checkHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
-        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+        <target> Puedes marcar los objetivos parciales en el panel. </target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.reached">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel erreicht</source>
-        <target>Ziel erreicht</target>
+        <target>Objetivo alcanzado</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.manual">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dieses Ziel braucht einen manuellen Eintrag</source>
-        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+        <target>Este objetivo necesita un registro manual</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.fill">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
-        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+        <target>Registra el resto y marca: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+        <target>Marcar <ph id="0" equiv="EXERCISE" disp="item.exerciseName"/></target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemReachedAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> ya alcanzado</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
-        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+        <target>Añadir <ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> al objetivo diario</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurücksetzen</source>
-        <target>Übung zurücksetzen</target>
+        <target>Restablecer ejercicio</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurückgesetzt.</source>
-        <target>Übung zurückgesetzt.</target>
+        <target>Ejercicio restablecido.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetKept">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
-        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+        <target>Marca eliminada — tus propios registros se conservan.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10525,45 +10525,45 @@
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.unquantified">
-      <segment state="initial">
+      <segment state="translated">
         <source>nach Vorgabe</source>
-        <target>nach Vorgabe</target>
+        <target>según lo indicado</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.auto">
-      <segment state="initial">
+      <segment state="translated">
         <source>Automatisch erfüllt — durch deine Einträge an diesem Tag.</source>
-        <target>Automatisch erfüllt — durch deine Einträge an diesem Tag.</target>
+        <target>Completado automáticamente — mediante tus entradas de este día.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.check">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung abhaken (ohne Eintrag)</source>
-        <target>Übung abhaken (ohne Eintrag)</target>
+        <target>Marcar ejercicio (sin registro)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.undo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernen</source>
-        <target>Haken entfernen</target>
+        <target>Quitar marca</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.log">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorgabe eintragen</source>
-        <target>Vorgabe eintragen</target>
+        <target>Registrar cantidad indicada</target>
       </segment>
     </unit>
     <unit id="trainingPlans.checkoffHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Tag — Übungen einzeln abhaken.</source>
-        <target>Intervall-Tag — Übungen einzeln abhaken.</target>
+        <target>Día de intervalos — marca los ejercicios uno por uno.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logAllDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen &amp; abhaken</source>
-        <target>Alle Übungen eintragen &amp; abhaken</target>
+        <target>Registrar y marcar todos los ejercicios</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10443,75 +10443,75 @@
       </segment>
     </unit>
     <unit id="quickAdd.fab.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Objectifs quotidiens</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele zum Abhaken anzeigen</source>
-        <target>Tagesziele zum Abhaken anzeigen</target>
+        <target>Afficher les objectifs quotidiens à cocher</target>
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.checkHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
-        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+        <target> Tu peux cocher les objectifs partiels sur le tableau de bord. </target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.reached">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel erreicht</source>
-        <target>Ziel erreicht</target>
+        <target>Objectif atteint</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.manual">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dieses Ziel braucht einen manuellen Eintrag</source>
-        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+        <target>Cet objectif nécessite une saisie manuelle</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.fill">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
-        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+        <target>Saisir le reste et cocher : +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+        <target>Cocher <ph id="0" equiv="EXERCISE" disp="item.exerciseName"/></target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemReachedAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> déjà atteint</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
-        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+        <target>Ajouter <ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> à l'objectif quotidien</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurücksetzen</source>
-        <target>Übung zurücksetzen</target>
+        <target>Réinitialiser l'exercice</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurückgesetzt.</source>
-        <target>Übung zurückgesetzt.</target>
+        <target>Exercice réinitialisé.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetKept">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
-        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+        <target>Coche retirée — tes propres saisies restent conservées.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10401,45 +10401,45 @@
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.unquantified">
-      <segment state="initial">
+      <segment state="translated">
         <source>nach Vorgabe</source>
-        <target>nach Vorgabe</target>
+        <target>selon la consigne</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.auto">
-      <segment state="initial">
+      <segment state="translated">
         <source>Automatisch erfüllt — durch deine Einträge an diesem Tag.</source>
-        <target>Automatisch erfüllt — durch deine Einträge an diesem Tag.</target>
+        <target>Automatiquement complété — grâce à tes entrées de ce jour.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.check">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung abhaken (ohne Eintrag)</source>
-        <target>Übung abhaken (ohne Eintrag)</target>
+        <target>Cocher l'exercice (sans entrée)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.undo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernen</source>
-        <target>Haken entfernen</target>
+        <target>Retirer la coche</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.log">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorgabe eintragen</source>
-        <target>Vorgabe eintragen</target>
+        <target>Saisir la consigne</target>
       </segment>
     </unit>
     <unit id="trainingPlans.checkoffHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Tag — Übungen einzeln abhaken.</source>
-        <target>Intervall-Tag — Übungen einzeln abhaken.</target>
+        <target>Jour d'intervalle — coche les exercices un par un.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logAllDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen &amp; abhaken</source>
-        <target>Alle Übungen eintragen &amp; abhaken</target>
+        <target>Saisir et cocher tous les exercices</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10515,21 +10515,21 @@
       </segment>
     </unit>
     <unit id="sw.update.buttonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neue Version verfügbar – jetzt neu laden</source>
-        <target>Neue Version verfügbar – jetzt neu laden</target>
+        <target>Nouvelle version disponible – recharger maintenant</target>
       </segment>
     </unit>
     <unit id="sw.update.unrecoverable">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – bitte neu laden</source>
-        <target>App-Daten beschädigt – bitte neu laden</target>
+        <target>Données de l'application corrompues – veuillez recharger</target>
       </segment>
     </unit>
     <unit id="sw.update.recoverButtonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – jetzt neu laden</source>
-        <target>App-Daten beschädigt – jetzt neu laden</target>
+        <target>Données de l'application corrompues – recharger maintenant</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10529,45 +10529,45 @@
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.unquantified">
-      <segment state="initial">
+      <segment state="translated">
         <source>nach Vorgabe</source>
-        <target>nach Vorgabe</target>
+        <target>come da programma</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.auto">
-      <segment state="initial">
+      <segment state="translated">
         <source>Automatisch erfüllt — durch deine Einträge an diesem Tag.</source>
-        <target>Automatisch erfüllt — durch deine Einträge an diesem Tag.</target>
+        <target>Completato automaticamente — dalle tue voci di oggi.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.check">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung abhaken (ohne Eintrag)</source>
-        <target>Übung abhaken (ohne Eintrag)</target>
+        <target>Spunta esercizio (senza registrazione)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.undo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernen</source>
-        <target>Haken entfernen</target>
+        <target>Rimuovi spunta</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.log">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorgabe eintragen</source>
-        <target>Vorgabe eintragen</target>
+        <target>Registra quantità prevista</target>
       </segment>
     </unit>
     <unit id="trainingPlans.checkoffHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Tag — Übungen einzeln abhaken.</source>
-        <target>Intervall-Tag — Übungen einzeln abhaken.</target>
+        <target>Giorno a intervalli — spunta gli esercizi singolarmente.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logAllDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen &amp; abhaken</source>
-        <target>Alle Übungen eintragen &amp; abhaken</target>
+        <target>Registra e spunta tutti gli esercizi</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10571,75 +10571,75 @@
       </segment>
     </unit>
     <unit id="quickAdd.fab.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Obiettivi giornalieri</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele zum Abhaken anzeigen</source>
-        <target>Tagesziele zum Abhaken anzeigen</target>
+        <target>Mostra gli obiettivi giornalieri da spuntare</target>
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.checkHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
-        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+        <target> Puoi spuntare gli obiettivi parziali nella dashboard. </target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.reached">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel erreicht</source>
-        <target>Ziel erreicht</target>
+        <target>Obiettivo raggiunto</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.manual">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dieses Ziel braucht einen manuellen Eintrag</source>
-        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+        <target>Questo obiettivo richiede una registrazione manuale</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.fill">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
-        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+        <target>Registra il resto e spunta: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+        <target>Spunta <ph id="0" equiv="EXERCISE" disp="item.exerciseName"/></target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemReachedAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> già raggiunto</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
-        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+        <target>Aggiungi <ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> all'obiettivo giornaliero</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurücksetzen</source>
-        <target>Übung zurücksetzen</target>
+        <target>Ripristina esercizio</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurückgesetzt.</source>
-        <target>Übung zurückgesetzt.</target>
+        <target>Esercizio ripristinato.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetKept">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
-        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+        <target>Spunta rimossa — le tue registrazioni personali restano.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10643,21 +10643,21 @@
       </segment>
     </unit>
     <unit id="sw.update.buttonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neue Version verfügbar – jetzt neu laden</source>
-        <target>Neue Version verfügbar – jetzt neu laden</target>
+        <target>Nuova versione disponibile – ricarica ora</target>
       </segment>
     </unit>
     <unit id="sw.update.unrecoverable">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – bitte neu laden</source>
-        <target>App-Daten beschädigt – bitte neu laden</target>
+        <target>Dati dell'app danneggiati – ricarica la pagina</target>
       </segment>
     </unit>
     <unit id="sw.update.recoverButtonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – jetzt neu laden</source>
-        <target>App-Daten beschädigt – jetzt neu laden</target>
+        <target>Dati dell'app danneggiati – ricarica ora</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10571,75 +10571,75 @@
       </segment>
     </unit>
     <unit id="quickAdd.fab.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Dagelijkse doelen</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele zum Abhaken anzeigen</source>
-        <target>Tagesziele zum Abhaken anzeigen</target>
+        <target>Dagelijkse doelen tonen om af te vinken</target>
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.checkHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
-        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+        <target> Deeldoelen kun je afvinken op het dashboard. </target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.reached">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel erreicht</source>
-        <target>Ziel erreicht</target>
+        <target>Doel bereikt</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.manual">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dieses Ziel braucht einen manuellen Eintrag</source>
-        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+        <target>Dit doel vereist een handmatige invoer</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.fill">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
-        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+        <target>Rest invoeren en afvinken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> afvinken</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemReachedAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> al bereikt</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
-        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> toevoegen aan dagelijks doel</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurücksetzen</source>
-        <target>Übung zurücksetzen</target>
+        <target>Oefening resetten</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurückgesetzt.</source>
-        <target>Übung zurückgesetzt.</target>
+        <target>Oefening gereset.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetKept">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
-        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+        <target>Vinkje verwijderd — je eigen invoer blijft behouden.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10529,45 +10529,45 @@
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.unquantified">
-      <segment state="initial">
+      <segment state="translated">
         <source>nach Vorgabe</source>
-        <target>nach Vorgabe</target>
+        <target>volgens voorschrift</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.auto">
-      <segment state="initial">
+      <segment state="translated">
         <source>Automatisch erfüllt — durch deine Einträge an diesem Tag.</source>
-        <target>Automatisch erfüllt — durch deine Einträge an diesem Tag.</target>
+        <target>Automatisch voltooid — door je invoer op deze dag.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.check">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung abhaken (ohne Eintrag)</source>
-        <target>Übung abhaken (ohne Eintrag)</target>
+        <target>Oefening afvinken (zonder invoer)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.undo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernen</source>
-        <target>Haken entfernen</target>
+        <target>Vinkje verwijderen</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.log">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorgabe eintragen</source>
-        <target>Vorgabe eintragen</target>
+        <target>Voorschrift invoeren</target>
       </segment>
     </unit>
     <unit id="trainingPlans.checkoffHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Tag — Übungen einzeln abhaken.</source>
-        <target>Intervall-Tag — Übungen einzeln abhaken.</target>
+        <target>Intervaldag — vink oefeningen afzonderlijk af.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logAllDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen &amp; abhaken</source>
-        <target>Alle Übungen eintragen &amp; abhaken</target>
+        <target>Alle oefeningen invoeren &amp; afvinken</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10643,21 +10643,21 @@
       </segment>
     </unit>
     <unit id="sw.update.buttonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neue Version verfügbar – jetzt neu laden</source>
-        <target>Neue Version verfügbar – jetzt neu laden</target>
+        <target>Nieuwe versie beschikbaar – nu herladen</target>
       </segment>
     </unit>
     <unit id="sw.update.unrecoverable">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – bitte neu laden</source>
-        <target>App-Daten beschädigt – bitte neu laden</target>
+        <target>App-gegevens beschadigd – herlaad de pagina</target>
       </segment>
     </unit>
     <unit id="sw.update.recoverButtonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – jetzt neu laden</source>
-        <target>App-Daten beschädigt – jetzt neu laden</target>
+        <target>App-gegevens beschadigd – nu herladen</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9936,21 +9936,21 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="sw.update.buttonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neue Version verfügbar – jetzt neu laden</source>
-        <target>Neue Version verfügbar – jetzt neu laden</target>
+        <target>Ny versjon tilgjengelig – last inn på nytt nå</target>
       </segment>
     </unit>
     <unit id="sw.update.unrecoverable">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – bitte neu laden</source>
-        <target>App-Daten beschädigt – bitte neu laden</target>
+        <target>App-data skadet – last inn siden på nytt</target>
       </segment>
     </unit>
     <unit id="sw.update.recoverButtonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – jetzt neu laden</source>
-        <target>App-Daten beschädigt – jetzt neu laden</target>
+        <target>App-data skadet – last inn på nytt nå</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9864,75 +9864,75 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>Daglige mål</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele zum Abhaken anzeigen</source>
-        <target>Tagesziele zum Abhaken anzeigen</target>
+        <target>Vis daglige mål for avkrysning</target>
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.checkHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
-        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+        <target> Du kan krysse av delmål på dashbordet. </target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.reached">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel erreicht</source>
-        <target>Ziel erreicht</target>
+        <target>Mål nådd</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.manual">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dieses Ziel braucht einen manuellen Eintrag</source>
-        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+        <target>Dette målet krever en manuell registrering</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.fill">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
-        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+        <target>Registrer resten og kryss av: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+        <target>Kryss av <ph id="0" equiv="EXERCISE" disp="item.exerciseName"/></target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemReachedAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> allerede nådd</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
-        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+        <target>Legg til <ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> i dagsmålet</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurücksetzen</source>
-        <target>Übung zurücksetzen</target>
+        <target>Tilbakestill øvelse</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurückgesetzt.</source>
-        <target>Übung zurückgesetzt.</target>
+        <target>Øvelse tilbakestilt.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetKept">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
-        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+        <target>Hake fjernet — dine egne registreringer beholdes.</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9822,45 +9822,45 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.unquantified">
-      <segment state="initial">
+      <segment state="translated">
         <source>nach Vorgabe</source>
-        <target>nach Vorgabe</target>
+        <target>som foreskrevet</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.auto">
-      <segment state="initial">
+      <segment state="translated">
         <source>Automatisch erfüllt — durch deine Einträge an diesem Tag.</source>
-        <target>Automatisch erfüllt — durch deine Einträge an diesem Tag.</target>
+        <target>Automatisk fullført — basert på oppføringene dine denne dagen.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.check">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung abhaken (ohne Eintrag)</source>
-        <target>Übung abhaken (ohne Eintrag)</target>
+        <target>Kryss av øvelse (uten oppføring)</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.undo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernen</source>
-        <target>Haken entfernen</target>
+        <target>Fjern hake</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.log">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorgabe eintragen</source>
-        <target>Vorgabe eintragen</target>
+        <target>Registrer foreskrevet mengde</target>
       </segment>
     </unit>
     <unit id="trainingPlans.checkoffHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Tag — Übungen einzeln abhaken.</source>
-        <target>Intervall-Tag — Übungen einzeln abhaken.</target>
+        <target>Intervalldag — kryss av øvelser enkeltvis.</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logAllDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen &amp; abhaken</source>
-        <target>Alle Übungen eintragen &amp; abhaken</target>
+        <target>Registrer og kryss av alle øvelser</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -10149,21 +10149,21 @@
       </segment>
     </unit>
     <unit id="sw.update.buttonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Neue Version verfügbar – jetzt neu laden</source>
-        <target>Neue Version verfügbar – jetzt neu laden</target>
+        <target>新版本可用 – 立即重新加载</target>
       </segment>
     </unit>
     <unit id="sw.update.unrecoverable">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – bitte neu laden</source>
-        <target>App-Daten beschädigt – bitte neu laden</target>
+        <target>应用数据已损坏 – 请重新加载</target>
       </segment>
     </unit>
     <unit id="sw.update.recoverButtonAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>App-Daten beschädigt – jetzt neu laden</source>
-        <target>App-Daten beschädigt – jetzt neu laden</target>
+        <target>应用数据已损坏 – 立即重新加载</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -10077,75 +10077,75 @@
       </segment>
     </unit>
     <unit id="quickAdd.fab.goals">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele</source>
-        <target>Tagesziele</target>
+        <target>每日目标</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalsAria">
-      <segment state="initial">
+      <segment state="translated">
         <source>Tagesziele zum Abhaken anzeigen</source>
-        <target>Tagesziele zum Abhaken anzeigen</target>
+        <target>显示每日目标以勾选</target>
       </segment>
     </unit>
     <unit id="toolbarDailyGoal.checkHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
-        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+        <target> 你可以在仪表盘上勾选部分目标。 </target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.reached">
-      <segment state="initial">
+      <segment state="translated">
         <source>Ziel erreicht</source>
-        <target>Ziel erreicht</target>
+        <target>已达成目标</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.manual">
-      <segment state="initial">
+      <segment state="translated">
         <source>Dieses Ziel braucht einen manuellen Eintrag</source>
-        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+        <target>此目标需要手动录入</target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.fill">
-      <segment state="initial">
+      <segment state="translated">
         <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
-        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+        <target>录入剩余部分并勾选：+<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
       </segment>
     </unit>
     <unit id="dailyGoal.check.aria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+        <target>勾选<ph id="0" equiv="EXERCISE" disp="item.exerciseName"/></target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemReachedAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
-        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/>已达成</target>
       </segment>
     </unit>
     <unit id="quickAdd.fab.goalItemAria">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
-        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+        <target>将<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/>添加到每日目标</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.reset">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurücksetzen</source>
-        <target>Übung zurücksetzen</target>
+        <target>重置动作</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung zurückgesetzt.</source>
-        <target>Übung zurückgesetzt.</target>
+        <target>动作已重置。</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.resetKept">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
-        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+        <target>已取消勾选 — 你自己的记录仍会保留。</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -10035,45 +10035,45 @@
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.unquantified">
-      <segment state="initial">
+      <segment state="translated">
         <source>nach Vorgabe</source>
-        <target>nach Vorgabe</target>
+        <target>按计划</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.auto">
-      <segment state="initial">
+      <segment state="translated">
         <source>Automatisch erfüllt — durch deine Einträge an diesem Tag.</source>
-        <target>Automatisch erfüllt — durch deine Einträge an diesem Tag.</target>
+        <target>自动完成 — 根据你当天的记录。</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.check">
-      <segment state="initial">
+      <segment state="translated">
         <source>Übung abhaken (ohne Eintrag)</source>
-        <target>Übung abhaken (ohne Eintrag)</target>
+        <target>勾选动作（无需记录）</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.undo">
-      <segment state="initial">
+      <segment state="translated">
         <source>Haken entfernen</source>
-        <target>Haken entfernen</target>
+        <target>取消勾选</target>
       </segment>
     </unit>
     <unit id="trainingPlans.exercise.log">
-      <segment state="initial">
+      <segment state="translated">
         <source>Vorgabe eintragen</source>
-        <target>Vorgabe eintragen</target>
+        <target>记录计划量</target>
       </segment>
     </unit>
     <unit id="trainingPlans.checkoffHint">
-      <segment state="initial">
+      <segment state="translated">
         <source>Intervall-Tag — Übungen einzeln abhaken.</source>
-        <target>Intervall-Tag — Übungen einzeln abhaken.</target>
+        <target>间歇日 — 逐项勾选动作。</target>
       </segment>
     </unit>
     <unit id="trainingPlans.menu.logAllDone">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen &amp; abhaken</source>
-        <target>Alle Übungen eintragen &amp; abhaken</target>
+        <target>记录并勾选所有动作</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
Fills gaps detected by `tools/src/detect-translation-gaps.mjs`. This PR accumulates translation work across multiple automated runs; the count reflects the total diff against `main`, not just the latest run.

## Latest run (2026-08-03)

24 XLIFF units were seeded as gaps across 8 locales (service-worker update available / unrecoverable-corruption aria labels and snackbar message):

- `en`: 3 unit(s)
- `fr`: 3 unit(s)
- `es`: 3 unit(s)
- `it`: 3 unit(s)
- `nl`: 3 unit(s)
- `no`: 3 unit(s)
- `el`: 3 unit(s)
- `zh`: 3 unit(s)

Detector summary: `Detected 24 gap(s) — xliff:24 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh`

Translated `sw.update.buttonAria`, `sw.update.unrecoverable`, and `sw.update.recoverButtonAria`, grounded in the existing "Neue Version verfügbar" / "Neu laden" terminology already used elsewhere per locale (e.g. "New version available" / "Reload" for `en`, "Nouvelle version disponible" / "Recharger" for `fr`, "Nuova versione disponibile" / "Ricarica" for `it`).

## Skipped

None — all 24 units in this run were translated and flipped to `state="translated"`.

## Cumulative total

`176` translated XLIFF units now differ from `main` on this branch (152 from prior runs + 24 from this run). No blog or wiki locale files were touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added and updated translations in Greek, English, Spanish, French, Italian, Dutch, Norwegian, and Chinese.
  * Improved localized labels for training-plan exercise actions, daily-goal controls, quick-add actions, and exercise reset feedback.
  * Added translated service-worker update and recovery messages for a more consistent multilingual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->