### PR TITLE
feat(goals): Teilziele auf Dashboard, Topleiste, Quick-Add und Plan abhaken

### DIFF
--- a/libs/quick-add/src/lib/quick-add-fab.component.html
+++ b/libs/quick-add/src/lib/quick-add-fab.component.html
@@ -85,6 +85,20 @@
               fabState.goalMenu() ? 'expand_more' : 'expand_less'
             }}</mat-icon>
           </button>
+        } @else if (item.type === 'goal' && singleGoal(); as goal) {
+          <button
+            mat-fab
+            extended
+            class="goal-fab"
+            [class.reached]="goal.reached"
+            [disabled]="goal.disabled"
+            [attr.aria-label]="goal.ariaLabel"
+            data-testid="quick-add-goal-single"
+            (click)="onFillGoalItem(goal)"
+          >
+            <mat-icon>{{ goal.reached ? 'check' : 'flag' }}</mat-icon>
+            <span>{{ goal.label }}</span>
+          </button>
         } @else if (item.type === 'goal') {
           <button
             mat-fab

--- a/libs/quick-add/src/lib/quick-add-fab.component.html
+++ b/libs/quick-add/src/lib/quick-add-fab.component.html
@@ -50,6 +50,41 @@
             <mat-icon>{{ item.icon }}</mat-icon>
             <span i18n="@@quickAdd.fab.customValue">Eigener Wert</span>
           </button>
+        } @else if (item.type === 'goal' && hasGoalSubmenu()) {
+          @if (fabState.goalMenu()) {
+            <div class="goal-submenu" data-testid="quick-add-goal-submenu">
+              @for (goal of goalItems(); track goal.id) {
+                <button
+                  mat-fab
+                  extended
+                  class="goal-sub-fab"
+                  [class.reached]="goal.reached"
+                  [disabled]="goal.disabled"
+                  [attr.aria-label]="goal.ariaLabel"
+                  data-testid="quick-add-goal-submenu-item"
+                  (click)="onFillGoalItem(goal)"
+                >
+                  <mat-icon>{{ goal.reached ? 'check' : 'flag' }}</mat-icon>
+                  <span>{{ goal.label }}</span>
+                </button>
+              }
+            </div>
+          }
+          <button
+            mat-fab
+            extended
+            class="goal-fab"
+            [attr.aria-expanded]="fabState.goalMenu()"
+            [attr.aria-label]="goalsAria"
+            data-testid="quick-add-goal-menu-toggle"
+            (click)="toggleGoalMenu()"
+          >
+            <mat-icon>{{ item.icon }}</mat-icon>
+            <span>{{ goalsLabel }} ({{ goalItems().length }})</span>
+            <mat-icon>{{
+              fabState.goalMenu() ? 'expand_more' : 'expand_less'
+            }}</mat-icon>
+          </button>
         } @else if (item.type === 'goal') {
           <button
             mat-fab

--- a/libs/quick-add/src/lib/quick-add-fab.component.scss
+++ b/libs/quick-add/src/lib/quick-add-fab.component.scss
@@ -137,6 +137,7 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 6px;
+
   // Indented so the submenu reads as belonging to the goal button below
   // it rather than as another top-level dial action.
   padding-right: 12px;

--- a/libs/quick-add/src/lib/quick-add-fab.component.scss
+++ b/libs/quick-add/src/lib/quick-add-fab.component.scss
@@ -131,3 +131,30 @@
     opacity: 0.7;
   }
 }
+
+.goal-submenu {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  // Indented so the submenu reads as belonging to the goal button below
+  // it rather than as another top-level dial action.
+  padding-right: 12px;
+  animation: dial-item-in 160ms cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+
+.goal-sub-fab {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 205, 96, 0.92),
+    rgba(226, 148, 40, 0.92)
+  ) !important;
+  color: #fff8ea !important;
+  transform: scale(0.92);
+  transform-origin: right center;
+
+  &.reached,
+  &[disabled] {
+    opacity: 0.7;
+  }
+}

--- a/libs/quick-add/src/lib/quick-add-fab.component.spec.ts
+++ b/libs/quick-add/src/lib/quick-add-fab.component.spec.ts
@@ -351,7 +351,37 @@ describe('QuickAddFabComponent — goal submenu', () => {
     expect(fillGoalItem).not.toHaveBeenCalled();
   });
 
-  it('should keep the single fill button when only one goal applies', async () => {
+  it("should fill the day's only goal in its own measurement", async () => {
+    // given exactly one goal, and no pushup gap of its own
+    const fillGoalItem = jest.fn();
+    const fillToGoal = jest.fn();
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+    await render(QuickAddFabComponent, {
+      inputs: {
+        suggestions: [],
+        remainingToGoal: 0,
+        goalReached: false,
+        fillToGoalInFlight: false,
+        autoCountEnabled: false,
+        goalItems: [goal({ id: 'squats', label: 'Kniebeugen +20' })],
+      },
+      on: { fillGoalItem, fillToGoal },
+    });
+    await user.click(
+      screen.getByRole('button', { name: /Schnellerfassung öffnen/i })
+    );
+
+    // when the goal entry is used
+    await user.click(screen.getByTestId('quick-add-goal-single'));
+
+    // then the goal itself is filled, not the legacy pushup gap
+    expect(fillGoalItem).toHaveBeenCalledWith('squats');
+    expect(fillToGoal).not.toHaveBeenCalled();
+  });
+
+  it('should keep the legacy fill button when no goal breakdown is available', async () => {
     // given a single goal and an open pushup gap
     const fillToGoal = jest.fn();
     const user = userEvent.setup({
@@ -364,7 +394,7 @@ describe('QuickAddFabComponent — goal submenu', () => {
         goalReached: false,
         fillToGoalInFlight: false,
         autoCountEnabled: false,
-        goalItems: [goal()],
+        goalItems: [],
       },
       on: { fillToGoal },
     });

--- a/libs/quick-add/src/lib/quick-add-fab.component.spec.ts
+++ b/libs/quick-add/src/lib/quick-add-fab.component.spec.ts
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { PointerEventsCheckLevel } from '@testing-library/user-event';
 import {
   QuickAddFabComponent,
+  type QuickAddGoalItem,
   type QuickAddSuggestion,
 } from './quick-add-fab.component';
 
@@ -23,6 +24,7 @@ describe('QuickAddFabComponent — goal dial item', () => {
     goalReached?: boolean;
     fillToGoalInFlight?: boolean;
     autoCountEnabled?: boolean;
+    goalItems?: QuickAddGoalItem[];
   }) {
     const quickAdd = jest.fn();
     const openDialog = jest.fn();
@@ -30,6 +32,7 @@ describe('QuickAddFabComponent — goal dial item', () => {
     const fillToGoal = jest.fn();
     const openAutoCount = jest.fn();
     const openExerciseTimer = jest.fn();
+    const fillGoalItem = jest.fn();
     const opened = jest.fn();
 
     // Material disabled buttons set pointer-events:none; skip that check so
@@ -46,6 +49,7 @@ describe('QuickAddFabComponent — goal dial item', () => {
         goalReached: inputs.goalReached ?? false,
         fillToGoalInFlight: inputs.fillToGoalInFlight ?? false,
         autoCountEnabled: inputs.autoCountEnabled ?? false,
+        goalItems: inputs.goalItems ?? [],
       },
       on: {
         quickAdd,
@@ -54,6 +58,7 @@ describe('QuickAddFabComponent — goal dial item', () => {
         fillToGoal,
         openAutoCount,
         openExerciseTimer,
+        fillGoalItem,
         opened,
       },
     });
@@ -72,6 +77,7 @@ describe('QuickAddFabComponent — goal dial item', () => {
       fillToGoal,
       openAutoCount,
       openExerciseTimer,
+      fillGoalItem,
       opened,
     };
   }
@@ -254,5 +260,125 @@ describe('QuickAddFabComponent — goal dial item', () => {
     );
 
     expect(opened).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('QuickAddFabComponent — goal submenu', () => {
+  async function renderWithGoals(goalItems: QuickAddGoalItem[]) {
+    const fillGoalItem = jest.fn();
+    const fillToGoal = jest.fn();
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+    await render(QuickAddFabComponent, {
+      inputs: {
+        suggestions: [],
+        remainingToGoal: 0,
+        goalReached: false,
+        fillToGoalInFlight: false,
+        autoCountEnabled: false,
+        goalItems,
+      },
+      on: { fillGoalItem, fillToGoal },
+    });
+    await user.click(
+      screen.getByRole('button', { name: /Schnellerfassung öffnen/i })
+    );
+    return { user, fillGoalItem, fillToGoal };
+  }
+
+  function goal(overrides: Partial<QuickAddGoalItem> = {}): QuickAddGoalItem {
+    return {
+      id: 'g1',
+      label: 'Liegestütze +40',
+      ariaLabel: '40 Liegestütze bis zum Tagesziel hinzufügen',
+      reached: false,
+      disabled: false,
+      ...overrides,
+    };
+  }
+
+  it('should offer a submenu instead of a single fill button when several goals apply', async () => {
+    // given two daily goals
+    const { user } = await renderWithGoals([
+      goal(),
+      goal({ id: 'g2', label: 'Kniebeugen +20', ariaLabel: '20 Kniebeugen' }),
+    ]);
+
+    // when the goal entry is opened
+    expect(screen.queryByTestId('quick-add-goal-submenu')).toBeNull();
+    await user.click(screen.getByTestId('quick-add-goal-menu-toggle'));
+
+    // then every goal is listed
+    expect(screen.getByTestId('quick-add-goal-submenu')).toBeTruthy();
+    expect(screen.getAllByTestId('quick-add-goal-submenu-item').length).toBe(2);
+    expect(screen.getByText('Liegestütze +40')).toBeTruthy();
+    expect(screen.getByText('Kniebeugen +20')).toBeTruthy();
+  });
+
+  it('should emit the picked goal id and close the dial', async () => {
+    // given an open submenu
+    const { user, fillGoalItem } = await renderWithGoals([
+      goal(),
+      goal({ id: 'g2', label: 'Kniebeugen +20', ariaLabel: '20 Kniebeugen' }),
+    ]);
+    await user.click(screen.getByTestId('quick-add-goal-menu-toggle'));
+
+    // when a goal is picked
+    await user.click(screen.getByText('Kniebeugen +20'));
+
+    // then the id round-trips back and the dial closes
+    expect(fillGoalItem).toHaveBeenCalledWith('g2');
+    expect(screen.queryByTestId('quick-add-goal-submenu')).toBeNull();
+  });
+
+  it('should render a goal that cannot be filled as disabled', async () => {
+    // given one reached and one manual-entry-only goal
+    const { user, fillGoalItem } = await renderWithGoals([
+      goal({ reached: true, disabled: true }),
+      goal({ id: 'g2', label: 'Laufen +2.00 km', disabled: true }),
+    ]);
+    await user.click(screen.getByTestId('quick-add-goal-menu-toggle'));
+
+    // when a disabled goal is clicked
+    const items = screen.getAllByTestId(
+      'quick-add-goal-submenu-item'
+    ) as HTMLButtonElement[];
+    expect(items.every((b) => b.disabled)).toBe(true);
+    await user.click(items[1]);
+
+    // then nothing is emitted
+    expect(fillGoalItem).not.toHaveBeenCalled();
+  });
+
+  it('should keep the single fill button when only one goal applies', async () => {
+    // given a single goal and an open pushup gap
+    const fillToGoal = jest.fn();
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+    await render(QuickAddFabComponent, {
+      inputs: {
+        suggestions: [],
+        remainingToGoal: 42,
+        goalReached: false,
+        fillToGoalInFlight: false,
+        autoCountEnabled: false,
+        goalItems: [goal()],
+      },
+      on: { fillToGoal },
+    });
+    await user.click(
+      screen.getByRole('button', { name: /Schnellerfassung öffnen/i })
+    );
+
+    // when the goal entry is clicked
+    await user.click(
+      screen.getByRole('button', { name: /Liegestütze bis zum Tagesziel/i })
+    );
+
+    // then the legacy one-tap fill still runs
+    expect(fillToGoal).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('quick-add-goal-submenu')).toBeNull();
   });
 });

--- a/libs/quick-add/src/lib/quick-add-fab.component.ts
+++ b/libs/quick-add/src/lib/quick-add-fab.component.ts
@@ -86,6 +86,16 @@ export class QuickAddFabComponent {
     () => this.goalItems().length > 1
   );
 
+  /**
+   * The day's only goal, when there is exactly one. It replaces the legacy
+   * "+X bis zum Ziel" button so a single non-pushup goal is filled in its
+   * own measurement instead of writing pushups against it.
+   */
+  protected readonly singleGoal = computed<QuickAddGoalItem | null>(() => {
+    const items = this.goalItems();
+    return items.length === 1 ? items[0] : null;
+  });
+
   protected readonly dialItems = computed<DialItem[]>(() => {
     if (!this.fabState.open()) return [];
     const quickItems: DialItem[] = this.suggestions()
@@ -102,9 +112,9 @@ export class QuickAddFabComponent {
 
     const remaining = this.remainingToGoal();
     const reached = this.goalReached();
-    // With a submenu the dial entry stays even when the pushup-based
-    // `remainingToGoal` is 0 — the other goals of the day may still be open.
-    if (this.hasGoalSubmenu() || remaining > 0 || reached) {
+    // Goals of the day keep the dial entry alive even when the pushup-based
+    // `remainingToGoal` is 0 — a squats or plank goal may still be open.
+    if (this.goalItems().length > 0 || remaining > 0 || reached) {
       items.push({
         value: remaining,
         type: 'goal',
@@ -148,40 +158,44 @@ export class QuickAddFabComponent {
     patchState(this.fabState, { goalMenu: !this.fabState.goalMenu() });
   }
 
+  private closeDial(): void {
+    patchState(this.fabState, { open: false, goalMenu: false });
+  }
+
   protected onFillGoalItem(goal: QuickAddGoalItem): void {
     if (goal.disabled) return;
-    patchState(this.fabState, { open: false, goalMenu: false });
+    this.closeDial();
     this.fillGoalItem.emit(goal.id);
   }
 
   protected onQuickAdd(suggestion: QuickAddSuggestion): void {
-    patchState(this.fabState, { open: false, goalMenu: false });
+    this.closeDial();
     this.quickAdd.emit(suggestion);
   }
 
   protected onOpenDialog(): void {
-    patchState(this.fabState, { open: false, goalMenu: false });
+    this.closeDial();
     this.openDialog.emit();
   }
 
   protected onOpenAutoCount(): void {
-    patchState(this.fabState, { open: false, goalMenu: false });
+    this.closeDial();
     this.openAutoCount.emit();
   }
 
   protected onOpenExerciseTimer(): void {
-    patchState(this.fabState, { open: false, goalMenu: false });
+    this.closeDial();
     this.openExerciseTimer.emit();
   }
 
   protected onOpenFeedback(): void {
-    patchState(this.fabState, { open: false, goalMenu: false });
+    this.closeDial();
     this.openFeedback.emit();
   }
 
   protected onFillToGoal(): void {
     if (this.goalDisabled()) return;
-    patchState(this.fabState, { open: false, goalMenu: false });
+    this.closeDial();
     this.fillToGoal.emit();
   }
 }

--- a/libs/quick-add/src/lib/quick-add-fab.component.ts
+++ b/libs/quick-add/src/lib/quick-add-fab.component.ts
@@ -24,15 +24,24 @@ export interface QuickAddSuggestion {
   readonly exerciseId: string;
 }
 
+/**
+ * One daily goal in the speed dial's goal submenu. The FAB stays
+ * presentation-only: producers localise the label and decide whether a
+ * goal can be closed with one tap, the id round-trips back through
+ * `fillGoalItem`.
+ */
+export interface QuickAddGoalItem {
+  readonly id: string;
+  readonly label: string;
+  readonly ariaLabel: string;
+  readonly reached: boolean;
+  readonly disabled: boolean;
+}
+
 interface DialItem {
   readonly value: number;
   readonly type:
-    | 'quick'
-    | 'custom'
-    | 'feedback'
-    | 'goal'
-    | 'auto-count'
-    | 'exercise-timer';
+    'quick' | 'custom' | 'feedback' | 'goal' | 'auto-count' | 'exercise-timer';
   /** Functional glyph for the fixed dial items; quick-add items render label-only. */
   readonly icon?: string;
   readonly label?: string;
@@ -54,36 +63,48 @@ export class QuickAddFabComponent {
   readonly goalReached = input<boolean>(false);
   readonly fillToGoalInFlight = input<boolean>(false);
   readonly autoCountEnabled = input<boolean>(false);
+  /**
+   * Today's daily goals. With more than one the goal dial entry becomes a
+   * submenu — a single "bis zum Ziel" button can only ever fill one of
+   * them, which would silently pick a goal for the user.
+   */
+  readonly goalItems = input<QuickAddGoalItem[]>([]);
 
   readonly quickAdd = output<QuickAddSuggestion>();
   readonly openDialog = output<void>();
   readonly openFeedback = output<void>();
   readonly fillToGoal = output<void>();
+  /** Id of the goal the user picked from the submenu. */
+  readonly fillGoalItem = output<string>();
   readonly openAutoCount = output<void>();
   readonly openExerciseTimer = output<void>();
   readonly opened = output<void>();
 
-  protected readonly fabState = signalState({ open: false });
+  protected readonly fabState = signalState({ open: false, goalMenu: false });
+
+  protected readonly hasGoalSubmenu = computed(
+    () => this.goalItems().length > 1
+  );
 
   protected readonly dialItems = computed<DialItem[]>(() => {
     if (!this.fabState.open()) return [];
     const quickItems: DialItem[] = this.suggestions()
       .slice(0, 3)
-      .map(
-        (s): DialItem => ({
-          value: s.reps,
-          type: 'quick',
-          label: s.label,
-          ariaLabel: s.ariaLabel,
-          suggestion: s,
-        })
-      );
+      .map((s): DialItem => ({
+        value: s.reps,
+        type: 'quick',
+        label: s.label,
+        ariaLabel: s.ariaLabel,
+        suggestion: s,
+      }));
 
     const items: DialItem[] = [...quickItems];
 
     const remaining = this.remainingToGoal();
     const reached = this.goalReached();
-    if (remaining > 0 || reached) {
+    // With a submenu the dial entry stays even when the pushup-based
+    // `remainingToGoal` is 0 — the other goals of the day may still be open.
+    if (this.hasGoalSubmenu() || remaining > 0 || reached) {
       items.push({
         value: remaining,
         type: 'goal',
@@ -114,40 +135,53 @@ export class QuickAddFabComponent {
     return this.goalReached() || this.fillToGoalInFlight();
   }
 
+  protected readonly goalsLabel = $localize`:@@quickAdd.fab.goals:Tagesziele`;
+  protected readonly goalsAria = $localize`:@@quickAdd.fab.goalsAria:Tagesziele zum Abhaken anzeigen`;
+
   protected toggle(): void {
     const nextOpen = !this.fabState.open();
-    patchState(this.fabState, { open: nextOpen });
+    patchState(this.fabState, { open: nextOpen, goalMenu: false });
     if (nextOpen) this.opened.emit();
   }
 
+  protected toggleGoalMenu(): void {
+    patchState(this.fabState, { goalMenu: !this.fabState.goalMenu() });
+  }
+
+  protected onFillGoalItem(goal: QuickAddGoalItem): void {
+    if (goal.disabled) return;
+    patchState(this.fabState, { open: false, goalMenu: false });
+    this.fillGoalItem.emit(goal.id);
+  }
+
   protected onQuickAdd(suggestion: QuickAddSuggestion): void {
-    patchState(this.fabState, { open: false });
+    patchState(this.fabState, { open: false, goalMenu: false });
     this.quickAdd.emit(suggestion);
   }
 
   protected onOpenDialog(): void {
-    patchState(this.fabState, { open: false });
+    patchState(this.fabState, { open: false, goalMenu: false });
     this.openDialog.emit();
   }
 
   protected onOpenAutoCount(): void {
-    patchState(this.fabState, { open: false });
+    patchState(this.fabState, { open: false, goalMenu: false });
     this.openAutoCount.emit();
   }
 
   protected onOpenExerciseTimer(): void {
-    patchState(this.fabState, { open: false });
+    patchState(this.fabState, { open: false, goalMenu: false });
     this.openExerciseTimer.emit();
   }
 
   protected onOpenFeedback(): void {
-    patchState(this.fabState, { open: false });
+    patchState(this.fabState, { open: false, goalMenu: false });
     this.openFeedback.emit();
   }
 
   protected onFillToGoal(): void {
     if (this.goalDisabled()) return;
-    patchState(this.fabState, { open: false });
+    patchState(this.fabState, { open: false, goalMenu: false });
     this.fillToGoal.emit();
   }
 }

--- a/web/src/app/app.html
+++ b/web/src/app/app.html
@@ -172,11 +172,13 @@
         (focusout)="scheduleCloseGoalDetails()"
       >
         <span
-          class="goal-pill"
-          [class.is-clickable]="goalReached()"
-          [attr.role]="goalReached() ? 'button' : null"
-          [attr.tabindex]="goalReached() ? 0 : null"
-          [attr.aria-label]="goalReached() ? reopenDailyAriaLabel : null"
+          class="goal-pill is-clickable"
+          role="button"
+          tabindex="0"
+          [attr.aria-label]="
+            goalReached() ? reopenDailyAriaLabel : goalDetailsAriaLabel
+          "
+          [attr.aria-expanded]="goalReached() ? null : goalDetailsOpen()"
           data-testid="toolbar-goal-pill"
           (click)="handleGoalPillClick()"
           (keydown.enter)="handleGoalPillKeydown($event)"
@@ -209,24 +211,13 @@
           (mouseenter)="openGoalDetails()"
           (mouseleave)="scheduleCloseGoalDetails()"
         >
-          @for (item of dailyGoalBreakdown(); track item.id) {
-          <div
-            class="goal-dropdown-item"
-            data-testid="toolbar-goal-dropdown-item"
-          >
-            <div class="goal-dropdown-line">
-              <span class="goal-dropdown-name">{{ item.exerciseName }}</span>
-              <span class="goal-dropdown-val"
-                >{{ item.progressDisplay }} / {{ item.targetDisplay }} · {{
-                item.percent }}%</span
-              >
-            </div>
-            <mat-progress-bar
-              mode="determinate"
-              [value]="item.percent"
-            ></mat-progress-bar>
-          </div>
-          }
+          <app-daily-goal-checklist
+            [items]="dailyGoalBreakdown()"
+            testId="toolbar-goal-dropdown-item"
+          />
+          <p class="goal-dropdown-hint" i18n="@@toolbarDailyGoal.checkHint">
+            Teilziele abhaken kannst du auf dem Dashboard.
+          </p>
         </div>
       </ng-template>
       <app-theme-toggle />
@@ -347,7 +338,9 @@
   [goalReached]="goalReached()"
   [fillToGoalInFlight]="fillToGoalInFlight()"
   [autoCountEnabled]="autoCountEnabled()"
+  [goalItems]="goalDialItems()"
   (quickAdd)="handleQuickAdd($event)"
+  (fillGoalItem)="handleFillGoalItem($event)"
   (openDialog)="handleOpenDialog()"
   (openAutoCount)="handleOpenAutoCount()"
   (openExerciseTimer)="handleOpenExerciseTimer()"

--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -442,7 +442,7 @@ describe('App (testing-library)', () => {
       );
     });
 
-    it('omits role/tabindex/aria-label on the pill while the daily goal is not yet reached', async () => {
+    it('labels the pill as the goal-details toggle while the daily goal is not yet reached', async () => {
       // Given
       userConfigApiMock.getConfig.mockReturnValue(of({ dailyGoal: 100 }));
       const notifierMock = makeNotifierMock();
@@ -465,10 +465,39 @@ describe('App (testing-library)', () => {
         '[data-testid="toolbar-goal-pill"]'
       );
       expect(pill).toBeTruthy();
-      expect(pill?.classList.contains('is-clickable')).toBe(false);
-      expect(pill?.getAttribute('role')).toBeNull();
-      expect(pill?.getAttribute('tabindex')).toBeNull();
-      expect(pill?.getAttribute('aria-label')).toBeNull();
+      expect(pill?.getAttribute('role')).toBe('button');
+      expect(pill?.getAttribute('tabindex')).toBe('0');
+      expect(pill?.getAttribute('aria-label')).toBe(
+        'Tagesziel-Einzelpositionen anzeigen'
+      );
+      expect(pill?.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('opens the goal details on a pill tap while the daily goal is not yet reached', async () => {
+      // given a goal that is still open (no hover on touch devices)
+      userConfigApiMock.getConfig.mockReturnValue(of({ dailyGoal: 100 }));
+      const notifierMock = makeNotifierMock();
+      const today = new Date().toISOString().slice(0, 10);
+      liveEntriesSignal.set([
+        {
+          _id: 'e1',
+          exerciseId: 'pushup',
+          timestamp: `${today}T10:00:00`,
+          reps: 10,
+          source: 'web',
+        },
+      ]);
+      liveConnectedSignal.set(true);
+      await render(App, { providers: commonProviders(notifierMock) });
+      await screen.findAllByText((content) => content.includes('10 / 100'));
+
+      // when the pill is tapped
+      await userEvent.click(screen.getByTestId('toolbar-goal-pill'));
+
+      // then the breakdown opens instead of replaying the celebration
+      const dropdown = await screen.findByTestId('toolbar-goal-dropdown');
+      expect(dropdown.textContent).toContain('Liegestütze');
+      expect(notifierMock.reopenPrimaryGoal).not.toHaveBeenCalled();
     });
 
     it('replays the celebration when Enter is pressed on the pill after the goal is reached', async () => {

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { type ConnectedPosition, OverlayModule } from '@angular/cdk/overlay';
+import { OverlayModule } from '@angular/cdk/overlay';
 import { Analytics, logEvent } from '@angular/fire/analytics';
 import { Auth } from '@angular/fire/auth';
 import { MatButtonModule } from '@angular/material/button';
@@ -22,7 +22,6 @@ import { MatListModule } from '@angular/material/list';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 
@@ -53,6 +52,10 @@ import {
   type QuickAddSuggestion,
 } from '@pu-stats/quick-add';
 import { UserConfigStore } from './core/user-config.store';
+import { DailyGoalActionsService } from './core/daily-goal-actions.service';
+import { DailyGoalChecklistComponent } from './core/daily-goal/daily-goal-checklist.component';
+import { toGoalDialItems } from './core/daily-goal/goal-dial-items';
+import { createGoalPillOverlay } from './core/daily-goal/goal-pill-overlay';
 import { ThemeToggleComponent } from './core/theme';
 import { ReminderOrchestrationService } from './core/reminder-orchestration.service';
 import { AppDataFacade } from './core/app-data.facade';
@@ -125,9 +128,9 @@ function resolveCurrentLocale(localeId: string): SupportedLocale {
     QuickAddFabCoachmarkComponent,
     ThemeToggleComponent,
     AiAssistantNavButtonComponent,
+    DailyGoalChecklistComponent,
     MatDialogModule,
     MatFormFieldModule,
-    MatProgressBarModule,
     MatSelectModule,
     OverlayModule,
   ],
@@ -278,59 +281,38 @@ export class App {
   readonly dailyGoalBreakdown = this.appData.dailyGoalBreakdown;
   protected readonly goalDetailsAriaLabel = $localize`:@@toolbarDailyGoal.detailsAria:Tagesziel-Einzelpositionen anzeigen`;
 
-  // The dropdown renders through a CDK overlay (body-level) instead of as a
-  // toolbar descendant: `.top-nav` carries a `mask-image` edge-fade, and a
-  // CSS mask clips descendant painting to the toolbar box, so an in-toolbar
-  // panel below the bar would be masked away.
-  protected readonly goalDetailsOpen = signal(false);
-  protected readonly goalOverlayPositions: ConnectedPosition[] = [
-    {
-      originX: 'end',
-      originY: 'bottom',
-      overlayX: 'end',
-      overlayY: 'top',
-      offsetY: 6,
-    },
-    {
-      originX: 'end',
-      originY: 'top',
-      overlayX: 'end',
-      overlayY: 'bottom',
-      offsetY: -6,
-    },
-  ];
-  // Bridges the gap between the pill and the detached panel so moving the
-  // pointer across it (or a focus bounce between origin and overlay) doesn't
-  // flicker the menu closed.
-  private goalDetailsCloseTimer: ReturnType<typeof setTimeout> | null = null;
-  private readonly _clearGoalTimerOnDestroy = this.destroyRef.onDestroy(() => {
-    if (this.goalDetailsCloseTimer) clearTimeout(this.goalDetailsCloseTimer);
-  });
+  private readonly goalOverlay = createGoalPillOverlay(
+    () => this.dailyGoalBreakdown().length > 0
+  );
+  protected readonly goalDetailsOpen = this.goalOverlay.open;
+  protected readonly goalOverlayPositions = this.goalOverlay.positions;
 
   openGoalDetails(): void {
-    if (this.goalDetailsCloseTimer) {
-      clearTimeout(this.goalDetailsCloseTimer);
-      this.goalDetailsCloseTimer = null;
-    }
-    if (this.dailyGoalBreakdown().length > 0) this.goalDetailsOpen.set(true);
+    this.goalOverlay.show();
   }
 
   scheduleCloseGoalDetails(): void {
-    if (this.goalDetailsCloseTimer) clearTimeout(this.goalDetailsCloseTimer);
-    this.goalDetailsCloseTimer = setTimeout(
-      () => this.goalDetailsOpen.set(false),
-      120
-    );
+    this.goalOverlay.scheduleHide();
   }
 
   closeGoalDetails(): void {
-    if (this.goalDetailsCloseTimer) {
-      clearTimeout(this.goalDetailsCloseTimer);
-      this.goalDetailsCloseTimer = null;
-    }
-    this.goalDetailsOpen.set(false);
+    this.goalOverlay.hide();
   }
   readonly fillToGoalInFlight = this.quickAdd.fillToGoalInFlight;
+
+  private readonly goalActions = inject(DailyGoalActionsService);
+  /** Daily goals rendered as the speed dial's goal submenu. */
+  readonly goalDialItems = computed(() =>
+    toGoalDialItems(this.dailyGoalBreakdown(), (id) =>
+      this.goalActions.isPending(id)
+    )
+  );
+
+  handleFillGoalItem(goalId: string): void {
+    const item = this.dailyGoalBreakdown().find((i) => i.id === goalId);
+    if (!item) return;
+    void this.goalActions.complete(item);
+  }
 
   private readonly tcfConsent = inject(TcfConsentService);
 
@@ -472,7 +454,12 @@ export class App {
    * is showing. No-op while the pill is still counting up to the goal.
    */
   handleGoalPillClick(): void {
-    if (!this.goalReached()) return;
+    if (!this.goalReached()) {
+      // Touch devices never fire the hover that opens the dropdown, so a tap
+      // on the pill has to open the goal details itself.
+      this.goalOverlay.show();
+      return;
+    }
     this._goalReachedNotifier.reopenPrimaryGoal();
   }
 

--- a/web/src/app/core/app-data.facade.ts
+++ b/web/src/app/core/app-data.facade.ts
@@ -5,7 +5,6 @@ import { LiveDataStore } from '@pu-stats/data-access-state';
 import {
   type ComplexGoalEntry,
   complexGoalAppliesOnWeekday,
-  formatExerciseValue,
   PUSHUP_QUICK_ADD_EXERCISE_ID,
   type QuickAddConfig,
 } from '@pu-stats/models';
@@ -17,21 +16,13 @@ import {
 import { TrainingPlanStore } from '../training-plans/training-plan.store';
 import { UserConfigStore } from './user-config.store';
 import { exerciseDisplayName } from '../stats/i18n/exercise-display-names';
-
-/**
- * Per-exercise view of a single daily goal — exercise name, formatted
- * target and progress in the goal's native unit, and the completion share.
- * Shared by the dashboard goal card and the toolbar pill dropdown so both
- * surfaces render "Anzahl/Zeitziel + Übung + Anteil geschafft" identically.
- */
-export interface DailyGoalItemView {
-  readonly id: string;
-  readonly exerciseName: string;
-  readonly targetDisplay: string;
-  readonly progressDisplay: string;
-  readonly percent: number;
-  readonly reached: boolean;
-}
+import {
+  aggregateGoalPercent,
+  allGoalsReached,
+  type DailyGoalItemView,
+  dailyGoalItemViews,
+  goalProgressValues,
+} from './daily-goal.helpers';
 
 function configuredSuggestion(
   cfg: QuickAddConfig,
@@ -216,36 +207,15 @@ export class AppDataFacade {
         e.exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID ? pushupRepsToday : 0
       );
     }
-    const exerciseEntries = this.live
-      .exerciseEntries()
-      .filter((e) => e.timestamp.slice(0, 10) === berlinToday);
-    return entries.map((entry) => {
-      // Post-cutover pushups live in `exerciseEntries` (`exerciseId:'pushup'`)
-      // like every other exercise, so the generic matching below handles
-      // them — no pushup short-circuit needed.
-      //
-      // When the goal pins a specific variant, count only entries of that
-      // variant. Otherwise match every entry for the exercise across all
-      // its variants — the goals page deliberately does not expose a
-      // variant picker yet (so most entries here will have no
-      // `variantId`), and a user logging "decline sit-ups" against a
-      // generic "Sit-ups" goal should still increment the progress.
-      const matching = exerciseEntries.filter((e) => {
-        if (e.exerciseId !== entry.exerciseId) return false;
-        if (!entry.variantId) return true;
-        return e.variantId === entry.variantId;
-      });
-      switch (entry.measurement) {
-        case 'reps':
-        case 'weight':
-          return matching.reduce((sum, e) => sum + (e.reps ?? 0), 0);
-        case 'time':
-          return matching.reduce((sum, e) => sum + (e.durationSec ?? 0), 0);
-        case 'distance':
-        case 'distance-time':
-          return matching.reduce((sum, e) => sum + (e.distanceM ?? 0), 0);
-      }
-    });
+    // Post-cutover pushups live in `exerciseEntries` (`exerciseId:'pushup'`)
+    // like every other exercise, so the generic scoring handles them —
+    // no pushup short-circuit needed.
+    return goalProgressValues(
+      entries,
+      this.live
+        .exerciseEntries()
+        .filter((e) => e.timestamp.slice(0, 10) === berlinToday)
+    );
   });
 
   /**
@@ -263,37 +233,17 @@ export class AppDataFacade {
    * blown-out single goal can't mask the others). Returns 0 when no
    * goals apply today.
    */
-  readonly dailyGoalAggregatedPercent = computed(() => {
-    const entries = this.todayGoalEntries();
-    if (entries.length === 0) return 0;
-    const progress = this.todayGoalProgress();
-    let pctSum = 0;
-    let counted = 0;
-    for (let i = 0; i < entries.length; i++) {
-      const target = entries[i].target;
-      if (!target || target <= 0) continue;
-      const ratio = Math.min(1, progress[i] / target);
-      pctSum += ratio * 100;
-      counted += 1;
-    }
-    if (counted === 0) return 0;
-    return Math.round(pctSum / counted);
-  });
+  readonly dailyGoalAggregatedPercent = computed(() =>
+    aggregateGoalPercent(this.todayGoalEntries(), this.todayGoalProgress())
+  );
 
   /**
    * True iff every configured exercise reached its target today. Used by
    * the toolbar pill to flag "click to replay snap animation".
    */
-  readonly dailyGoalsAllReached = computed(() => {
-    const entries = this.todayGoalEntries();
-    if (entries.length === 0) return false;
-    const progress = this.todayGoalProgress();
-    for (let i = 0; i < entries.length; i++) {
-      if (entries[i].target <= 0) continue;
-      if (progress[i] < entries[i].target) return false;
-    }
-    return true;
-  });
+  readonly dailyGoalsAllReached = computed(() =>
+    allGoalsReached(this.todayGoalEntries(), this.todayGoalProgress())
+  );
 
   /**
    * Per-exercise breakdown of today's daily goals for the dashboard card
@@ -304,33 +254,9 @@ export class AppDataFacade {
    * same way as a manually configured goal. Empty when no goal applies
    * today (callers fall back to their legacy single-line display).
    */
-  readonly dailyGoalBreakdown = computed<readonly DailyGoalItemView[]>(() => {
-    const entries = this.todayGoalEntries();
-    if (entries.length === 0) return [];
-    const progress = this.todayGoalProgress();
-    return entries.map((entry, i) => {
-      const value = progress[i] ?? 0;
-      const target = entry.target;
-      const hasTarget = target > 0;
-      // The pushup sentinel isn't in the exercise-name catalog (legacy
-      // pushups live in their own collection) — resolve it to the same
-      // "Liegestütze" label the analysis page uses.
-      const exerciseName =
-        entry.exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID
-          ? $localize`:@@exercise.category.pushup:Liegestütze`
-          : exerciseDisplayName(entry.exerciseId);
-      return {
-        id: entry.id,
-        exerciseName,
-        targetDisplay: formatExerciseValue(target, entry.unit),
-        progressDisplay: formatExerciseValue(value, entry.unit),
-        percent: hasTarget
-          ? Math.min(100, Math.round((value / target) * 100))
-          : 0,
-        reached: hasTarget && value >= target,
-      };
-    });
-  });
+  readonly dailyGoalBreakdown = computed<readonly DailyGoalItemView[]>(() =>
+    dailyGoalItemViews(this.todayGoalEntries(), this.todayGoalProgress())
+  );
 
   /**
    * Refreshes the SSR / cold-start fallback resources. In the browser, live

--- a/web/src/app/core/daily-goal-actions.service.spec.ts
+++ b/web/src/app/core/daily-goal-actions.service.spec.ts
@@ -1,0 +1,170 @@
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { signal } from '@angular/core';
+import { UserContextService } from '@pu-auth/auth';
+import { ExerciseFirestoreService } from '@pu-stats/data-access';
+import { of, Subject, throwError } from 'rxjs';
+
+import { AppDataFacade } from './app-data.facade';
+import { DailyGoalActionsService } from './daily-goal-actions.service';
+import type { DailyGoalItemView } from './daily-goal.helpers';
+
+function item(overrides: Partial<DailyGoalItemView> = {}): DailyGoalItemView {
+  return {
+    id: 'g1',
+    exerciseId: 'pushup',
+    exerciseName: 'Liegestütze',
+    measurement: 'reps',
+    unit: 'reps',
+    target: 100,
+    value: 40,
+    remaining: 60,
+    targetDisplay: '100',
+    progressDisplay: '40',
+    remainingDisplay: '60',
+    percent: 40,
+    reached: false,
+    fillable: true,
+    ...overrides,
+  };
+}
+
+describe('DailyGoalActionsService', () => {
+  const createEntry = vitest.fn();
+  const snackBarOpen = vitest.fn();
+  const reloadAfterMutation = vitest.fn();
+  const userId = signal<string>('u1');
+
+  function setup(): DailyGoalActionsService {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ExerciseFirestoreService, useValue: { createEntry } },
+        { provide: MatSnackBar, useValue: { open: snackBarOpen } },
+        {
+          provide: UserContextService,
+          useValue: { userIdSafe: () => userId() },
+        },
+        {
+          provide: AppDataFacade,
+          useValue: {
+            reloadAfterMutation,
+            dailyGoalBreakdown: signal<readonly DailyGoalItemView[]>([]),
+          },
+        },
+      ],
+    });
+    return TestBed.inject(DailyGoalActionsService);
+  }
+
+  beforeEach(() => {
+    createEntry.mockReset().mockReturnValue(of({ _id: 'e1' }));
+    snackBarOpen.mockReset();
+    reloadAfterMutation.mockReset();
+    userId.set('u1');
+  });
+
+  it('should log the missing amount for the checked goal', async () => {
+    // given a goal that is 60 reps short
+    const service = setup();
+
+    // when
+    const result = await service.complete(item());
+
+    // then
+    expect(result).toBe('logged');
+    expect(createEntry).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({
+        exerciseId: 'pushup',
+        reps: 60,
+        sets: [60],
+        source: 'goal-fill',
+      })
+    );
+    expect(reloadAfterMutation).toHaveBeenCalled();
+  });
+
+  it('should write the time field for a hold goal', async () => {
+    // given a plank goal 45 s short
+    const service = setup();
+
+    // when
+    await service.complete(
+      item({
+        id: 'plank',
+        exerciseId: 'plank.standard',
+        measurement: 'time',
+        unit: 's',
+        target: 120,
+        value: 75,
+        remaining: 45,
+      })
+    );
+
+    // then
+    expect(createEntry).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ durationSec: 45, intervals: [45] })
+    );
+  });
+
+  it('should not write anything for a goal that is already reached', async () => {
+    // given / when
+    const service = setup();
+    const result = await service.complete(
+      item({ value: 100, remaining: 0, reached: true })
+    );
+
+    // then
+    expect(result).toBe('already-reached');
+    expect(createEntry).not.toHaveBeenCalled();
+  });
+
+  it('should refuse a goal that needs a manual entry', async () => {
+    // given a run goal (distance needs a duration companion)
+    const service = setup();
+
+    // when
+    const result = await service.complete(
+      item({ exerciseId: 'cardio.running', fillable: false })
+    );
+
+    // then
+    expect(result).toBe('noop');
+    expect(createEntry).not.toHaveBeenCalled();
+    expect(snackBarOpen).toHaveBeenCalled();
+  });
+
+  it('should surface a failed write and clear the pending flag', async () => {
+    // given a failing Firestore write
+    const service = setup();
+    createEntry.mockReturnValue(throwError(() => new Error('offline')));
+
+    // when
+    const result = await service.complete(item());
+
+    // then
+    expect(result).toBe('error');
+    expect(service.isPending('g1')).toBe(false);
+    expect(snackBarOpen).toHaveBeenCalled();
+  });
+
+  it('should mark the goal pending while its write is in flight', async () => {
+    // given a write that only completes when we let it
+    const service = setup();
+    const write = new Subject<{ _id: string }>();
+    createEntry.mockReturnValue(write.asObservable());
+
+    // when
+    const pending = service.complete(item());
+    expect(service.isPending('g1')).toBe(true);
+    expect(service.anyPending()).toBe(true);
+    write.next({ _id: 'e1' });
+    write.complete();
+    await pending;
+
+    // then
+    expect(service.isPending('g1')).toBe(false);
+  });
+});

--- a/web/src/app/core/daily-goal-actions.service.ts
+++ b/web/src/app/core/daily-goal-actions.service.ts
@@ -1,0 +1,85 @@
+import { computed, inject, Injectable, signal } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { UserContextService } from '@pu-auth/auth';
+import { ExerciseFirestoreService } from '@pu-stats/data-access';
+import { nowLocalIsoTimestamp } from '@pu-stats/date';
+import { firstValueFrom } from 'rxjs';
+
+import { AppDataFacade } from './app-data.facade';
+import {
+  type DailyGoalItemView,
+  dailyGoalFillPayload,
+} from './daily-goal.helpers';
+import { notifyEntrySaved, notifyError } from './quick-add-notify';
+
+/** Outcome of a single check-off, for callers that report it. */
+export type CompleteGoalResult =
+  'logged' | 'already-reached' | 'noop' | 'error';
+
+/**
+ * Checking a daily goal off writes the entry that closes its gap — goals
+ * have no completion flag of their own, they are scored from entries, so
+ * "abhaken" has to mean "log what's missing". Shared by the dashboard
+ * checklist and the Quick-Add goal submenu.
+ */
+@Injectable({ providedIn: 'root' })
+export class DailyGoalActionsService {
+  private readonly exerciseApi = inject(ExerciseFirestoreService, {
+    optional: true,
+  });
+  private readonly userContext = inject(UserContextService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly appData = inject(AppDataFacade);
+
+  private readonly _pending = signal<ReadonlySet<string>>(new Set());
+
+  /** Goal ids with an in-flight check-off write. */
+  readonly pending = this._pending.asReadonly();
+  readonly anyPending = computed(() => this._pending().size > 0);
+
+  isPending(goalId: string): boolean {
+    return this._pending().has(goalId);
+  }
+
+  /** Today's goals, ready to be rendered as a checklist. */
+  readonly items = this.appData.dailyGoalBreakdown;
+
+  async complete(item: DailyGoalItemView): Promise<CompleteGoalResult> {
+    if (item.reached) return 'already-reached';
+    if (this.isPending(item.id)) return 'noop';
+    const payload = dailyGoalFillPayload(item);
+    const userId = this.userContext.userIdSafe();
+    if (!payload || !userId || !this.exerciseApi) {
+      notifyError(this.snackBar);
+      return payload ? 'error' : 'noop';
+    }
+    this.markPending(item.id, true);
+    try {
+      await firstValueFrom(
+        this.exerciseApi.createEntry(userId, {
+          exerciseId: payload.exerciseId,
+          ...(payload.variantId ? { variantId: payload.variantId } : {}),
+          timestamp: nowLocalIsoTimestamp(),
+          [payload.valueField]: payload.value,
+          [payload.breakdownField]: payload.breakdown,
+          source: 'goal-fill',
+        })
+      );
+      notifyEntrySaved(this.snackBar);
+      this.appData.reloadAfterMutation();
+      return 'logged';
+    } catch (err) {
+      notifyError(this.snackBar, err);
+      return 'error';
+    } finally {
+      this.markPending(item.id, false);
+    }
+  }
+
+  private markPending(goalId: string, pending: boolean): void {
+    const next = new Set(this._pending());
+    if (pending) next.add(goalId);
+    else next.delete(goalId);
+    this._pending.set(next);
+  }
+}

--- a/web/src/app/core/daily-goal-actions.service.ts
+++ b/web/src/app/core/daily-goal-actions.service.ts
@@ -48,10 +48,21 @@ export class DailyGoalActionsService {
     if (item.reached) return 'already-reached';
     if (this.isPending(item.id)) return 'noop';
     const payload = dailyGoalFillPayload(item);
+    if (!payload) {
+      // Not a failure: the goal needs a companion value only a real entry
+      // can carry, so point the user at the entry dialog instead of
+      // flashing a generic error.
+      this.snackBar.open(
+        $localize`:@@dailyGoal.check.manual:Dieses Ziel braucht einen manuellen Eintrag`,
+        '',
+        { duration: 3000 }
+      );
+      return 'noop';
+    }
     const userId = this.userContext.userIdSafe();
-    if (!payload || !userId || !this.exerciseApi) {
+    if (!userId || !this.exerciseApi) {
       notifyError(this.snackBar);
-      return payload ? 'error' : 'noop';
+      return 'error';
     }
     this.markPending(item.id, true);
     try {

--- a/web/src/app/core/daily-goal.helpers.spec.ts
+++ b/web/src/app/core/daily-goal.helpers.spec.ts
@@ -220,6 +220,28 @@ describe('dailyGoalFillPayload', () => {
     expect(payload?.value).toBe(500);
   });
 
+  it('should raise a sub-minimum gap to the exercise minimum', () => {
+    // given a plank goal that is 1 second short (catalog min is 1 s, and
+    // a rounded-down gap of 0 would not be writable at all)
+    const [item] = dailyGoalItemViews(
+      [
+        goal({
+          exerciseId: 'plank.standard',
+          target: 120,
+          measurement: 'time',
+          unit: 's',
+        }),
+      ],
+      [119.6]
+    );
+
+    // when
+    const payload = dailyGoalFillPayload(item);
+
+    // then the smallest entry the catalog allows is written
+    expect(payload?.value).toBe(1);
+  });
+
   it('should return null for a reached goal', () => {
     // given / when
     const [item] = dailyGoalItemViews([goal()], [100]);

--- a/web/src/app/core/daily-goal.helpers.spec.ts
+++ b/web/src/app/core/daily-goal.helpers.spec.ts
@@ -1,0 +1,263 @@
+import type { ComplexGoalEntry } from '@pu-stats/models';
+import {
+  aggregateGoalPercent,
+  allGoalsReached,
+  dailyGoalFillPayload,
+  dailyGoalItemViews,
+  goalProgressValues,
+} from './daily-goal.helpers';
+
+function goal(overrides: Partial<ComplexGoalEntry> = {}): ComplexGoalEntry {
+  return {
+    id: 'g1',
+    exerciseId: 'pushup',
+    target: 100,
+    measurement: 'reps',
+    unit: 'reps',
+    ...overrides,
+  };
+}
+
+describe('dailyGoalItemViews', () => {
+  it('should format progress, target and remaining in the goal unit', () => {
+    // given a time goal that is half done
+    const entries = [
+      goal({
+        id: 'plank',
+        exerciseId: 'plank.standard',
+        target: 120,
+        measurement: 'time',
+        unit: 's',
+      }),
+    ];
+
+    // when
+    const [item] = dailyGoalItemViews(entries, [60]);
+
+    // then
+    expect(item.targetDisplay).toBe('2:00');
+    expect(item.progressDisplay).toBe('1:00');
+    expect(item.remainingDisplay).toBe('1:00');
+    expect(item.remaining).toBe(60);
+    expect(item.percent).toBe(50);
+    expect(item.reached).toBe(false);
+  });
+
+  it('should cap a blown-out goal at 100% and flag it reached', () => {
+    // given / when
+    const [item] = dailyGoalItemViews([goal()], [250]);
+
+    // then
+    expect(item.percent).toBe(100);
+    expect(item.reached).toBe(true);
+    expect(item.remaining).toBe(0);
+  });
+
+  it('should mark a goal whose entry needs a companion value as not fillable', () => {
+    // given a run (distance + duration) and a plain rep goal
+    const entries = [
+      goal({
+        id: 'run',
+        exerciseId: 'cardio.running',
+        target: 2000,
+        measurement: 'distance-time',
+        unit: 'm',
+      }),
+      goal({ id: 'pu' }),
+    ];
+
+    // when
+    const items = dailyGoalItemViews(entries, [0, 0]);
+
+    // then only the rep goal can be closed with a one-click entry
+    expect(items[0].fillable).toBe(false);
+    expect(items[1].fillable).toBe(true);
+  });
+
+  it('should carry the exercise name of the pushup sentinel', () => {
+    // given / when
+    const [item] = dailyGoalItemViews([goal()], [0]);
+
+    // then
+    expect(item.exerciseName).toBe('Liegestütze');
+    expect(item.exerciseId).toBe('pushup');
+  });
+});
+
+describe('goalProgressValues', () => {
+  it('should read the entry field that matches each goal measurement', () => {
+    // given one rep goal and one time goal
+    const entries = [
+      goal(),
+      goal({
+        id: 'plank',
+        exerciseId: 'plank.standard',
+        target: 120,
+        measurement: 'time',
+        unit: 's',
+      }),
+    ];
+
+    // when
+    const progress = goalProgressValues(entries, [
+      { exerciseId: 'pushup', reps: 20 },
+      { exerciseId: 'pushup', reps: 15 },
+      { exerciseId: 'plank.standard', durationSec: 45 },
+    ]);
+
+    // then
+    expect(progress).toEqual([35, 45]);
+  });
+
+  it('should count only the pinned variant when the goal names one', () => {
+    // given a goal pinned to one variant
+    const entries = [goal({ exerciseId: 'abs.situps', variantId: 'decline' })];
+
+    // when
+    const progress = goalProgressValues(entries, [
+      { exerciseId: 'abs.situps', variantId: 'decline', reps: 10 },
+      { exerciseId: 'abs.situps', reps: 30 },
+    ]);
+
+    // then
+    expect(progress).toEqual([10]);
+  });
+
+  it('should count every variant when the goal pins none', () => {
+    // given / when
+    const progress = goalProgressValues(
+      [goal({ exerciseId: 'abs.situps' })],
+      [
+        { exerciseId: 'abs.situps', variantId: 'decline', reps: 10 },
+        { exerciseId: 'abs.situps', reps: 30 },
+      ]
+    );
+
+    // then
+    expect(progress).toEqual([40]);
+  });
+});
+
+describe('aggregateGoalPercent', () => {
+  it('should average the per-goal shares with each capped at 100%', () => {
+    // given one goal massively overshot, one untouched
+    // when
+    const percent = aggregateGoalPercent(
+      [goal(), goal({ id: 'g2' })],
+      [500, 0]
+    );
+
+    // then the overshoot cannot mask the open goal
+    expect(percent).toBe(50);
+  });
+
+  it('should ignore goals without a positive target', () => {
+    // given / when
+    const percent = aggregateGoalPercent(
+      [goal(), goal({ id: 'g2', target: 0 })],
+      [50, 0]
+    );
+
+    // then
+    expect(percent).toBe(50);
+  });
+});
+
+describe('allGoalsReached', () => {
+  it('should be false while any goal is short', () => {
+    expect(allGoalsReached([goal(), goal({ id: 'g2' })], [100, 99])).toBe(
+      false
+    );
+  });
+
+  it('should be true once every goal is covered', () => {
+    expect(allGoalsReached([goal(), goal({ id: 'g2' })], [100, 120])).toBe(
+      true
+    );
+  });
+
+  it('should be false when no goal applies', () => {
+    expect(allGoalsReached([], [])).toBe(false);
+  });
+});
+
+describe('dailyGoalFillPayload', () => {
+  it('should write the missing amount into the measurement field', () => {
+    // given a plank goal 45 s short
+    const [item] = dailyGoalItemViews(
+      [
+        goal({
+          exerciseId: 'plank.standard',
+          target: 120,
+          measurement: 'time',
+          unit: 's',
+        }),
+      ],
+      [75]
+    );
+
+    // when
+    const payload = dailyGoalFillPayload(item);
+
+    // then
+    expect(payload).toEqual({
+      exerciseId: 'plank.standard',
+      valueField: 'durationSec',
+      value: 45,
+      breakdownField: 'intervals',
+      breakdown: [45],
+    });
+  });
+
+  it('should clamp a gap larger than the exercise maximum', () => {
+    // given a 900-rep pushup goal (catalog max is 500)
+    const [item] = dailyGoalItemViews([goal({ target: 900 })], [0]);
+
+    // when
+    const payload = dailyGoalFillPayload(item);
+
+    // then the entry stays writable; the rest closes on a second tick
+    expect(payload?.value).toBe(500);
+  });
+
+  it('should return null for a reached goal', () => {
+    // given / when
+    const [item] = dailyGoalItemViews([goal()], [100]);
+
+    // then
+    expect(dailyGoalFillPayload(item)).toBeNull();
+  });
+
+  it('should return null for a goal that needs a companion value', () => {
+    // given a running goal
+    const [item] = dailyGoalItemViews(
+      [
+        goal({
+          exerciseId: 'cardio.running',
+          target: 2000,
+          measurement: 'distance-time',
+          unit: 'm',
+        }),
+      ],
+      [0]
+    );
+
+    // then
+    expect(dailyGoalFillPayload(item)).toBeNull();
+  });
+
+  it('should keep the pinned variant on the written entry', () => {
+    // given / when
+    const [item] = dailyGoalItemViews(
+      [goal({ exerciseId: 'abs.situps', variantId: 'decline', target: 40 })],
+      [10]
+    );
+
+    // then
+    expect(dailyGoalFillPayload(item)).toMatchObject({
+      exerciseId: 'abs.situps',
+      variantId: 'decline',
+      value: 30,
+    });
+  });
+});

--- a/web/src/app/core/daily-goal.helpers.ts
+++ b/web/src/app/core/daily-goal.helpers.ts
@@ -96,6 +96,19 @@ export function dailyGoalItemViews(
   });
 }
 
+/**
+ * Whether a one-click check-off is unavailable for this goal: already
+ * reached, not fillable at all, or a write is still in flight. Shared so
+ * the dashboard checklist and the Quick-Add submenu can never disagree
+ * about which rows are actionable.
+ */
+export function goalCheckDisabled(
+  item: Pick<DailyGoalItemView, 'id' | 'reached' | 'fillable'>,
+  isPending: (goalId: string) => boolean
+): boolean {
+  return item.reached || !item.fillable || isPending(item.id);
+}
+
 function goalIsFillable(entry: ComplexGoalEntry): boolean {
   if (entry.target <= 0) return false;
   const def = findExerciseDefinition(entry.exerciseId);

--- a/web/src/app/core/daily-goal.helpers.ts
+++ b/web/src/app/core/daily-goal.helpers.ts
@@ -1,0 +1,209 @@
+import {
+  type ComplexGoalEntry,
+  entryBreakdownField,
+  type ExerciseEntry,
+  findExerciseDefinition,
+  formatExerciseValue,
+  type MeasurementType,
+  measurementValueField,
+  PUSHUP_QUICK_ADD_EXERCISE_ID,
+  requiredCompanionFields,
+} from '@pu-stats/models';
+import { exerciseDisplayName } from '../stats/i18n/exercise-display-names';
+
+/**
+ * Per-exercise view of a single daily goal — exercise name, formatted
+ * target and progress in the goal's native unit, and the completion share.
+ * Shared by the dashboard goal checklist, the toolbar pill dropdown and
+ * the Quick-Add goal submenu so all three render the same numbers.
+ */
+export interface DailyGoalItemView {
+  readonly id: string;
+  readonly exerciseId: string;
+  readonly variantId?: string;
+  readonly exerciseName: string;
+  readonly measurement: MeasurementType;
+  readonly unit: string;
+  readonly target: number;
+  readonly value: number;
+  /** Missing amount in the goal's native unit; 0 once the goal is reached. */
+  readonly remaining: number;
+  readonly targetDisplay: string;
+  readonly progressDisplay: string;
+  readonly remainingDisplay: string;
+  readonly percent: number;
+  readonly reached: boolean;
+  /**
+   * Whether a one-click check-off can write a filling entry. False for
+   * measurements whose entries need a companion value the goal doesn't
+   * carry (`weight` needs a load, `distance-time` needs a duration) —
+   * those stay manual-entry only.
+   */
+  readonly fillable: boolean;
+}
+
+/** Entry payload that closes the gap of a single daily goal. */
+export interface DailyGoalFillPayload {
+  readonly exerciseId: string;
+  readonly variantId?: string;
+  readonly valueField: ReturnType<typeof measurementValueField>;
+  readonly value: number;
+  readonly breakdownField: 'sets' | 'intervals';
+  readonly breakdown: number[];
+}
+
+function goalExerciseName(exerciseId: string): string {
+  // The pushup sentinel predates the display-name registry's catalog
+  // coverage; resolve it to the same label the analysis page uses.
+  return exerciseId === PUSHUP_QUICK_ADD_EXERCISE_ID
+    ? $localize`:@@exercise.category.pushup:Liegestütze`
+    : exerciseDisplayName(exerciseId);
+}
+
+/**
+ * Per-exercise breakdown of the given goals with today's progress folded
+ * in. `progress` is positional — index `i` is the amount logged for
+ * `entries[i]`, in that entry's native unit.
+ */
+export function dailyGoalItemViews(
+  entries: readonly ComplexGoalEntry[],
+  progress: readonly number[]
+): readonly DailyGoalItemView[] {
+  return entries.map((entry, i) => {
+    const value = progress[i] ?? 0;
+    const target = entry.target;
+    const hasTarget = target > 0;
+    const remaining = hasTarget ? Math.max(0, target - value) : 0;
+    return {
+      id: entry.id,
+      exerciseId: entry.exerciseId,
+      ...(entry.variantId ? { variantId: entry.variantId } : {}),
+      exerciseName: goalExerciseName(entry.exerciseId),
+      measurement: entry.measurement,
+      unit: entry.unit,
+      target,
+      value,
+      remaining,
+      targetDisplay: formatExerciseValue(target, entry.unit),
+      progressDisplay: formatExerciseValue(value, entry.unit),
+      remainingDisplay: formatExerciseValue(remaining, entry.unit),
+      percent: hasTarget
+        ? Math.min(100, Math.round((value / target) * 100))
+        : 0,
+      reached: hasTarget && value >= target,
+      fillable: goalIsFillable(entry),
+    };
+  });
+}
+
+function goalIsFillable(entry: ComplexGoalEntry): boolean {
+  if (entry.target <= 0) return false;
+  const def = findExerciseDefinition(entry.exerciseId);
+  if (!def) return false;
+  return requiredCompanionFields(def.measurement).length === 0;
+}
+
+/** Minimal shape of a logged entry needed to score a goal. */
+export type GoalProgressEntry = Pick<ExerciseEntry, 'exerciseId'> &
+  Partial<
+    Pick<ExerciseEntry, 'variantId' | 'reps' | 'durationSec' | 'distanceM'>
+  >;
+
+/**
+ * Amount logged towards each goal, positionally aligned with `entries`
+ * and expressed in each goal's native unit. `todaysEntries` must already
+ * be narrowed to the day the goals are scored against.
+ *
+ * When a goal pins a variant only that variant counts; otherwise every
+ * entry for the exercise does — the goals page has no variant picker, so
+ * "decline sit-ups" must still fill a generic "Sit-ups" goal.
+ */
+export function goalProgressValues(
+  entries: readonly ComplexGoalEntry[],
+  todaysEntries: readonly GoalProgressEntry[]
+): readonly number[] {
+  return entries.map((entry) => {
+    const matching = todaysEntries.filter((e) => {
+      if (e.exerciseId !== entry.exerciseId) return false;
+      if (!entry.variantId) return true;
+      return e.variantId === entry.variantId;
+    });
+    switch (entry.measurement) {
+      case 'reps':
+      case 'weight':
+        return matching.reduce((sum, e) => sum + (e.reps ?? 0), 0);
+      case 'time':
+        return matching.reduce((sum, e) => sum + (e.durationSec ?? 0), 0);
+      case 'distance':
+      case 'distance-time':
+        return matching.reduce((sum, e) => sum + (e.distanceM ?? 0), 0);
+    }
+  });
+}
+
+/**
+ * Aggregated 0–100 completion across all goals (averaged, capped per
+ * entry at 100% so one blown-out goal can't mask the others). Returns 0
+ * when nothing with a positive target applies.
+ */
+export function aggregateGoalPercent(
+  entries: readonly ComplexGoalEntry[],
+  progress: readonly number[]
+): number {
+  let pctSum = 0;
+  let counted = 0;
+  for (let i = 0; i < entries.length; i++) {
+    const target = entries[i].target;
+    if (!target || target <= 0) continue;
+    pctSum += Math.min(1, (progress[i] ?? 0) / target) * 100;
+    counted += 1;
+  }
+  if (counted === 0) return 0;
+  return Math.round(pctSum / counted);
+}
+
+/** True iff every goal with a positive target is covered. Empty ⇒ false. */
+export function allGoalsReached(
+  entries: readonly ComplexGoalEntry[],
+  progress: readonly number[]
+): boolean {
+  if (entries.length === 0) return false;
+  for (let i = 0; i < entries.length; i++) {
+    if (entries[i].target <= 0) continue;
+    if ((progress[i] ?? 0) < entries[i].target) return false;
+  }
+  return true;
+}
+
+/**
+ * Entry payload that brings a goal up to its target, or null when the
+ * goal is already covered or can't be written in one shot (unknown
+ * exercise, or a measurement needing a companion value).
+ *
+ * The written amount is clamped into the exercise's catalog bounds:
+ * a gap larger than `def.max` closes over several check-offs rather
+ * than being rejected by validation, and a sub-minimum gap rounds up to
+ * `def.min` (the smallest entry the catalog allows at all).
+ */
+export function dailyGoalFillPayload(
+  item: Pick<
+    DailyGoalItemView,
+    'exerciseId' | 'variantId' | 'remaining' | 'fillable'
+  >
+): DailyGoalFillPayload | null {
+  if (!item.fillable || item.remaining <= 0) return null;
+  const def = findExerciseDefinition(item.exerciseId);
+  if (!def) return null;
+  const value = Math.max(
+    def.min,
+    Math.min(def.max, Math.round(item.remaining))
+  );
+  return {
+    exerciseId: item.exerciseId,
+    ...(item.variantId ? { variantId: item.variantId } : {}),
+    valueField: measurementValueField(def.measurement),
+    value,
+    breakdownField: entryBreakdownField(def.measurement),
+    breakdown: [value],
+  };
+}

--- a/web/src/app/core/daily-goal/daily-goal-checklist.component.html
+++ b/web/src/app/core/daily-goal/daily-goal-checklist.component.html
@@ -11,6 +11,7 @@
             class="goal-check"
             [checked]="item.reached"
             [disabled]="checkDisabled(item)"
+            [disabledInteractive]="true"
             [matTooltip]="tooltipFor(item)"
             [attr.aria-label]="ariaFor(item)"
             data-testid="daily-goal-check"

--- a/web/src/app/core/daily-goal/daily-goal-checklist.component.html
+++ b/web/src/app/core/daily-goal/daily-goal-checklist.component.html
@@ -1,0 +1,41 @@
+<ul class="goal-checklist">
+  @for (item of items(); track item.id) {
+    <li
+      class="goal-item"
+      [class.reached]="item.reached"
+      [attr.data-testid]="testId()"
+    >
+      <div class="goal-line">
+        @if (interactive()) {
+          <mat-checkbox
+            class="goal-check"
+            [checked]="item.reached"
+            [disabled]="checkDisabled(item)"
+            [matTooltip]="tooltipFor(item)"
+            [attr.aria-label]="ariaFor(item)"
+            data-testid="daily-goal-check"
+            (change)="onToggle(item, $event.checked)"
+          >
+            <span class="goal-name">{{ item.exerciseName }}</span>
+          </mat-checkbox>
+        } @else {
+          <span class="goal-name">
+            @if (item.reached) {
+              <mat-icon class="goal-done-icon" aria-hidden="true"
+                >check_circle</mat-icon
+              >
+            }
+            {{ item.exerciseName }}
+          </span>
+        }
+
+        <span class="goal-value">
+          {{ item.progressDisplay }} / {{ item.targetDisplay }}
+          <span class="goal-percent">· {{ item.percent }}%</span>
+        </span>
+      </div>
+
+      <mat-progress-bar mode="determinate" [value]="item.percent" />
+    </li>
+  }
+</ul>

--- a/web/src/app/core/daily-goal/daily-goal-checklist.component.scss
+++ b/web/src/app/core/daily-goal/daily-goal-checklist.component.scss
@@ -1,0 +1,63 @@
+.goal-checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.goal-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+.goal-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--mat-sys-on-surface, inherit);
+}
+
+.goal-value {
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.goal-percent {
+  color: #9fb3de;
+}
+
+.goal-done-icon {
+  font-size: 1rem;
+  width: 1rem;
+  height: 1rem;
+  color: #4ade80;
+}
+
+.goal-check {
+  // The checkbox owns the row's leading edge; its label carries the
+  // exercise name so the whole name stays a click target.
+  margin-right: auto;
+}
+
+.reached .goal-name {
+  opacity: 0.85;
+}
+
+:host-context(html.light-theme) {
+  .goal-percent {
+    color: #64748b;
+  }
+
+  .goal-done-icon {
+    color: #16a34a;
+  }
+}

--- a/web/src/app/core/daily-goal/daily-goal-checklist.component.spec.ts
+++ b/web/src/app/core/daily-goal/daily-goal-checklist.component.spec.ts
@@ -72,36 +72,59 @@ describe('DailyGoalChecklistComponent', () => {
     );
   });
 
+  it('should not emit when a row is un-ticked', async () => {
+    // given an interactive row
+    const { complete } = await setup([item()]);
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+
+    // when a change event arrives with checked=false
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+
+    // then nothing is logged — un-ticking cannot un-log an entry
+    expect(complete).not.toHaveBeenCalled();
+  });
+
   it('should lock a reached goal as checked', async () => {
     // given / when
-    await setup([
+    const { complete } = await setup([
       item({ value: 100, remaining: 0, percent: 100, reached: true }),
     ]);
 
-    // then — goals are scored from entries, un-ticking would not stick
+    // then — goals are scored from entries, un-ticking would not stick.
+    // The row stays focusable (`disabledInteractive`) so its tooltip is
+    // reachable, so the guard is asserted through the emit, not the DOM.
     const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
     expect(checkbox.checked).toBe(true);
-    expect(checkbox.disabled).toBe(true);
+    expect(checkbox.getAttribute('aria-disabled')).toBe('true');
+    await userEvent.click(checkbox);
+    expect(complete).not.toHaveBeenCalled();
   });
 
-  it('should disable the check-off of a goal that needs a manual entry', async () => {
-    // given / when
-    await setup([item({ fillable: false })]);
+  it('should refuse the check-off of a goal that needs a manual entry', async () => {
+    // given a goal that cannot be filled with one click
+    const { complete } = await setup([item({ fillable: false })]);
+
+    // when
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.getAttribute('aria-disabled')).toBe('true');
+    await userEvent.click(checkbox);
 
     // then
-    expect((screen.getByRole('checkbox') as HTMLInputElement).disabled).toBe(
-      true
-    );
+    expect(complete).not.toHaveBeenCalled();
   });
 
-  it('should disable a goal whose check-off write is in flight', async () => {
-    // given / when
-    await setup([item()], true, new Set(['g1']));
+  it('should refuse a goal whose check-off write is in flight', async () => {
+    // given a pending write for this goal
+    const { complete } = await setup([item()], true, new Set(['g1']));
 
-    // then
-    expect((screen.getByRole('checkbox') as HTMLInputElement).disabled).toBe(
-      true
-    );
+    // when
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.getAttribute('aria-disabled')).toBe('true');
+    await userEvent.click(checkbox);
+
+    // then a double tap cannot write the gap twice
+    expect(complete).not.toHaveBeenCalled();
   });
 
   it('should render a read-only list without checkboxes', async () => {

--- a/web/src/app/core/daily-goal/daily-goal-checklist.component.spec.ts
+++ b/web/src/app/core/daily-goal/daily-goal-checklist.component.spec.ts
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
+import type { DailyGoalItemView } from '../daily-goal.helpers';
+import { DailyGoalChecklistComponent } from './daily-goal-checklist.component';
+
+function item(overrides: Partial<DailyGoalItemView> = {}): DailyGoalItemView {
+  return {
+    id: 'g1',
+    exerciseId: 'pushup',
+    exerciseName: 'Liegestütze',
+    measurement: 'reps',
+    unit: 'reps',
+    target: 100,
+    value: 40,
+    remaining: 60,
+    targetDisplay: '100',
+    progressDisplay: '40',
+    remainingDisplay: '60',
+    percent: 40,
+    reached: false,
+    fillable: true,
+    ...overrides,
+  };
+}
+
+async function setup(
+  items: DailyGoalItemView[],
+  interactive = true,
+  pending: ReadonlySet<string> = new Set()
+) {
+  const complete = vitest.fn();
+  await render(DailyGoalChecklistComponent, {
+    inputs: { items, interactive, pending },
+    on: { complete },
+  });
+  return { complete };
+}
+
+describe('DailyGoalChecklistComponent', () => {
+  it('should render one row per goal with progress, target and share', async () => {
+    // given / when
+    await setup([
+      item(),
+      item({
+        id: 'g2',
+        exerciseName: 'Plank',
+        progressDisplay: '1:00',
+        targetDisplay: '2:00',
+        percent: 50,
+      }),
+    ]);
+
+    // then
+    const rows = document.querySelectorAll('[data-testid="daily-goal-item"]');
+    expect(rows.length).toBe(2);
+    expect(screen.getByText('Liegestütze')).toBeTruthy();
+    expect(document.body.textContent).toContain('40 / 100');
+    expect(document.body.textContent).toContain('· 40%');
+  });
+
+  it('should emit the goal when its checkbox is ticked', async () => {
+    // given
+    const { complete } = await setup([item({ id: 'squats' })]);
+
+    // when
+    await userEvent.click(screen.getByRole('checkbox'));
+
+    // then
+    expect(complete).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'squats' })
+    );
+  });
+
+  it('should lock a reached goal as checked', async () => {
+    // given / when
+    await setup([
+      item({ value: 100, remaining: 0, percent: 100, reached: true }),
+    ]);
+
+    // then — goals are scored from entries, un-ticking would not stick
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(checkbox.disabled).toBe(true);
+  });
+
+  it('should disable the check-off of a goal that needs a manual entry', async () => {
+    // given / when
+    await setup([item({ fillable: false })]);
+
+    // then
+    expect((screen.getByRole('checkbox') as HTMLInputElement).disabled).toBe(
+      true
+    );
+  });
+
+  it('should disable a goal whose check-off write is in flight', async () => {
+    // given / when
+    await setup([item()], true, new Set(['g1']));
+
+    // then
+    expect((screen.getByRole('checkbox') as HTMLInputElement).disabled).toBe(
+      true
+    );
+  });
+
+  it('should render a read-only list without checkboxes', async () => {
+    // given / when
+    await setup([item()], false);
+
+    // then
+    expect(screen.queryByRole('checkbox')).toBeNull();
+    expect(screen.getByText('Liegestütze')).toBeTruthy();
+  });
+});

--- a/web/src/app/core/daily-goal/daily-goal-checklist.component.ts
+++ b/web/src/app/core/daily-goal/daily-goal-checklist.component.ts
@@ -1,0 +1,69 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+} from '@angular/core';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+import type { DailyGoalItemView } from '../daily-goal.helpers';
+
+/**
+ * Detailed daily-goal list: one row per goal with its exercise, progress
+ * in the goal's native unit, completion share and bar. Purely
+ * presentational — the parent owns the write.
+ *
+ * `interactive` turns the rows into check-offs. A goal has no completion
+ * flag of its own (it is scored from entries), so ticking one means
+ * logging the missing amount and a reached goal stays locked: un-ticking
+ * would be a lie the next entry update would immediately undo.
+ */
+@Component({
+  selector: 'app-daily-goal-checklist',
+  imports: [
+    MatCheckboxModule,
+    MatIconModule,
+    MatProgressBarModule,
+    MatTooltipModule,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './daily-goal-checklist.component.html',
+  styleUrl: './daily-goal-checklist.component.scss',
+})
+export class DailyGoalChecklistComponent {
+  readonly items = input.required<readonly DailyGoalItemView[]>();
+  /** False renders a read-only list (toolbar dropdown, preview surfaces). */
+  readonly interactive = input(false);
+  /** Goal ids with an in-flight check-off write. */
+  readonly pending = input<ReadonlySet<string>>(new Set<string>());
+  /** Lets each host keep its own row test id. */
+  readonly testId = input('daily-goal-item');
+
+  readonly complete = output<DailyGoalItemView>();
+
+  protected checkDisabled(item: DailyGoalItemView): boolean {
+    return item.reached || !item.fillable || this.pending().has(item.id);
+  }
+
+  protected tooltipFor(item: DailyGoalItemView): string {
+    if (item.reached) {
+      return $localize`:@@dailyGoal.check.reached:Ziel erreicht`;
+    }
+    if (!item.fillable) {
+      return $localize`:@@dailyGoal.check.manual:Dieses Ziel braucht einen manuellen Eintrag`;
+    }
+    return $localize`:@@dailyGoal.check.fill:Rest eintragen und abhaken: +${item.remainingDisplay}:REMAINING:`;
+  }
+
+  protected ariaFor(item: DailyGoalItemView): string {
+    return $localize`:@@dailyGoal.check.aria:${item.exerciseName}:EXERCISE: abhaken`;
+  }
+
+  protected onToggle(item: DailyGoalItemView, checked: boolean): void {
+    if (!checked) return;
+    this.complete.emit(item);
+  }
+}

--- a/web/src/app/core/daily-goal/daily-goal-checklist.component.ts
+++ b/web/src/app/core/daily-goal/daily-goal-checklist.component.ts
@@ -9,7 +9,10 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
-import type { DailyGoalItemView } from '../daily-goal.helpers';
+import {
+  type DailyGoalItemView,
+  goalCheckDisabled,
+} from '../daily-goal.helpers';
 
 /**
  * Detailed daily-goal list: one row per goal with its exercise, progress
@@ -45,7 +48,7 @@ export class DailyGoalChecklistComponent {
   readonly complete = output<DailyGoalItemView>();
 
   protected checkDisabled(item: DailyGoalItemView): boolean {
-    return item.reached || !item.fillable || this.pending().has(item.id);
+    return goalCheckDisabled(item, (id) => this.pending().has(id));
   }
 
   protected tooltipFor(item: DailyGoalItemView): string {
@@ -63,7 +66,10 @@ export class DailyGoalChecklistComponent {
   }
 
   protected onToggle(item: DailyGoalItemView, checked: boolean): void {
-    if (!checked) return;
+    // `disabledInteractive` keeps a locked row focusable so its tooltip
+    // explains why — which also means the change event can still reach
+    // us, so the guard has to live here rather than in the template.
+    if (!checked || this.checkDisabled(item)) return;
     this.complete.emit(item);
   }
 }

--- a/web/src/app/core/daily-goal/goal-dial-items.spec.ts
+++ b/web/src/app/core/daily-goal/goal-dial-items.spec.ts
@@ -1,0 +1,64 @@
+import type { DailyGoalItemView } from '../daily-goal.helpers';
+import { toGoalDialItems } from './goal-dial-items';
+
+function item(overrides: Partial<DailyGoalItemView> = {}): DailyGoalItemView {
+  return {
+    id: 'g1',
+    exerciseId: 'pushup',
+    exerciseName: 'Liegestütze',
+    measurement: 'reps',
+    unit: 'reps',
+    target: 100,
+    value: 40,
+    remaining: 60,
+    targetDisplay: '100',
+    progressDisplay: '40',
+    remainingDisplay: '60',
+    percent: 40,
+    reached: false,
+    fillable: true,
+    ...overrides,
+  };
+}
+
+const nothingPending = () => false;
+
+describe('toGoalDialItems', () => {
+  it('should label an open goal with the amount still missing', () => {
+    // given / when
+    const [dial] = toGoalDialItems([item()], nothingPending);
+
+    // then
+    expect(dial.label).toBe('Liegestütze +60');
+    expect(dial.disabled).toBe(false);
+  });
+
+  it('should render a reached goal as a disabled, label-only entry', () => {
+    // given / when
+    const [dial] = toGoalDialItems(
+      [item({ value: 100, remaining: 0, reached: true })],
+      nothingPending
+    );
+
+    // then
+    expect(dial.label).toBe('Liegestütze');
+    expect(dial.reached).toBe(true);
+    expect(dial.disabled).toBe(true);
+  });
+
+  it('should disable a goal that needs a manual entry', () => {
+    // given / when
+    const [dial] = toGoalDialItems([item({ fillable: false })], nothingPending);
+
+    // then
+    expect(dial.disabled).toBe(true);
+  });
+
+  it('should disable a goal whose write is in flight', () => {
+    // given / when
+    const [dial] = toGoalDialItems([item()], (id) => id === 'g1');
+
+    // then
+    expect(dial.disabled).toBe(true);
+  });
+});

--- a/web/src/app/core/daily-goal/goal-dial-items.ts
+++ b/web/src/app/core/daily-goal/goal-dial-items.ts
@@ -1,0 +1,26 @@
+import type { QuickAddGoalItem } from '@pu-stats/quick-add';
+
+import type { DailyGoalItemView } from '../daily-goal.helpers';
+
+/**
+ * Maps today's goals onto the speed dial's goal submenu. A goal that is
+ * already reached, needs a manual entry (weight / distance-time), or has
+ * a write in flight renders disabled rather than being hidden — the dial
+ * doubles as today's goal overview.
+ */
+export function toGoalDialItems(
+  items: readonly DailyGoalItemView[],
+  isPending: (goalId: string) => boolean
+): QuickAddGoalItem[] {
+  return items.map((item) => ({
+    id: item.id,
+    label: item.reached
+      ? item.exerciseName
+      : `${item.exerciseName} +${item.remainingDisplay}`,
+    ariaLabel: item.reached
+      ? $localize`:@@quickAdd.fab.goalItemReachedAria:${item.exerciseName}:EXERCISE: bereits erreicht`
+      : $localize`:@@quickAdd.fab.goalItemAria:${item.remainingDisplay}:REMAINING: ${item.exerciseName}:EXERCISE: bis zum Tagesziel hinzufügen`,
+    reached: item.reached,
+    disabled: item.reached || !item.fillable || isPending(item.id),
+  }));
+}

--- a/web/src/app/core/daily-goal/goal-dial-items.ts
+++ b/web/src/app/core/daily-goal/goal-dial-items.ts
@@ -1,6 +1,9 @@
 import type { QuickAddGoalItem } from '@pu-stats/quick-add';
 
-import type { DailyGoalItemView } from '../daily-goal.helpers';
+import {
+  type DailyGoalItemView,
+  goalCheckDisabled,
+} from '../daily-goal.helpers';
 
 /**
  * Maps today's goals onto the speed dial's goal submenu. A goal that is
@@ -21,6 +24,6 @@ export function toGoalDialItems(
       ? $localize`:@@quickAdd.fab.goalItemReachedAria:${item.exerciseName}:EXERCISE: bereits erreicht`
       : $localize`:@@quickAdd.fab.goalItemAria:${item.remainingDisplay}:REMAINING: ${item.exerciseName}:EXERCISE: bis zum Tagesziel hinzufügen`,
     reached: item.reached,
-    disabled: item.reached || !item.fillable || isPending(item.id),
+    disabled: goalCheckDisabled(item, isPending),
   }));
 }

--- a/web/src/app/core/daily-goal/goal-pill-overlay.ts
+++ b/web/src/app/core/daily-goal/goal-pill-overlay.ts
@@ -1,0 +1,79 @@
+import { DestroyRef, inject, signal, type Signal } from '@angular/core';
+import type { ConnectedPosition } from '@angular/cdk/overlay';
+
+/**
+ * Open/close state for the toolbar goal pill's detail dropdown. Must be
+ * created from an injection context (the shell component's field
+ * initialiser) so the close timer is cleared on destroy.
+ *
+ * The dropdown renders through a CDK overlay (body-level) instead of as a
+ * toolbar descendant: `.top-nav` carries a `mask-image` edge-fade, and a
+ * CSS mask clips descendant painting to the toolbar box, so an in-toolbar
+ * panel below the bar would be masked away.
+ */
+export interface GoalPillOverlay {
+  readonly open: Signal<boolean>;
+  readonly positions: ConnectedPosition[];
+  show(): void;
+  hide(): void;
+  /**
+   * Close after a short grace period. Bridges the gap between the pill and
+   * the detached panel so moving the pointer across it (or a focus bounce
+   * between origin and overlay) doesn't flicker the menu closed.
+   */
+  scheduleHide(): void;
+}
+
+const CLOSE_GRACE_MS = 120;
+
+export function createGoalPillOverlay(
+  hasItems: () => boolean
+): GoalPillOverlay {
+  const open = signal(false);
+  let closeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearTimer = (): void => {
+    if (closeTimer) {
+      clearTimeout(closeTimer);
+      closeTimer = null;
+    }
+  };
+
+  inject(DestroyRef).onDestroy(clearTimer);
+
+  const show = (): void => {
+    clearTimer();
+    if (hasItems()) open.set(true);
+  };
+
+  const hide = (): void => {
+    clearTimer();
+    open.set(false);
+  };
+
+  return {
+    open: open.asReadonly(),
+    positions: [
+      {
+        originX: 'end',
+        originY: 'bottom',
+        overlayX: 'end',
+        overlayY: 'top',
+        offsetY: 6,
+      },
+      {
+        originX: 'end',
+        originY: 'top',
+        overlayX: 'end',
+        overlayY: 'bottom',
+        offsetY: -6,
+      },
+    ],
+    show,
+    hide,
+    scheduleHide: () => {
+      clearTimer();
+      closeTimer = setTimeout(() => open.set(false), CLOSE_GRACE_MS);
+    },
+  };
+}

--- a/web/src/app/stats/shell/stats-dashboard.component.html
+++ b/web/src/app/stats/shell/stats-dashboard.component.html
@@ -278,23 +278,13 @@
           }
         } @else if (dailyGoalBreakdown().length > 0) {
           <p class="goal-subhead" i18n="@@dashboard.dailyGoalLabel">Tag</p>
-          @for (item of dailyGoalBreakdown(); track item.id) {
-            <div class="goal-item" data-testid="dashboard-daily-goal-item">
-              <div class="goal-row">
-                <small class="goal-item-exercise">{{
-                  item.exerciseName
-                }}</small>
-                <span class="goal-item-value">
-                  {{ item.progressDisplay }} / {{ item.targetDisplay }}
-                  <span class="goal-item-percent">· {{ item.percent }}%</span>
-                </span>
-              </div>
-              <mat-progress-bar
-                mode="determinate"
-                [value]="item.percent"
-              ></mat-progress-bar>
-            </div>
-          }
+          <app-daily-goal-checklist
+            [items]="dailyGoalBreakdown()"
+            [interactive]="true"
+            [pending]="dailyGoalPending()"
+            testId="dashboard-daily-goal-item"
+            (complete)="completeDailyGoal($event)"
+          />
         } @else {
           <div class="goal-row">
             <small i18n="@@dashboard.dailyGoalLabel">Tag</small>

--- a/web/src/app/stats/shell/stats-dashboard.component.scss
+++ b/web/src/app/stats/shell/stats-dashboard.component.scss
@@ -353,31 +353,6 @@ h1 {
   }
 }
 
-.goal-item {
-  margin-top: 4px;
-
-  .goal-row {
-    margin-top: 6px;
-    justify-content: space-between;
-  }
-
-  .goal-item-exercise {
-    color: var(--mat-sys-on-surface, rgba(255, 255, 255, 0.87));
-    text-transform: none;
-    letter-spacing: 0;
-    font-size: 0.85rem;
-    font-weight: 600;
-  }
-
-  .goal-item-value {
-    font-size: 0.85rem;
-  }
-
-  .goal-item-percent {
-    color: #9fb3de;
-  }
-}
-
 .motivational-quote {
   display: flex;
   align-items: center;

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -22,13 +22,33 @@ import {
   provideRouter,
 } from '@angular/router';
 import { QuickAddOrchestrationService } from '../../core/quick-add-orchestration.service';
-import {
-  AppDataFacade,
-  type DailyGoalItemView,
-} from '../../core/app-data.facade';
+import { AppDataFacade } from '../../core/app-data.facade';
+import type { DailyGoalItemView } from '../../core/daily-goal.helpers';
 import { ShareService } from '../../core/share.service';
 import { UserConfigStore } from '../../core/user-config.store';
 import { TrainingPlanStore } from '../../training-plans/training-plan.store';
+
+function goalItem(
+  overrides: Partial<DailyGoalItemView> = {}
+): DailyGoalItemView {
+  return {
+    id: 'g1',
+    exerciseId: 'pushup',
+    exerciseName: 'Liegestütze',
+    measurement: 'reps',
+    unit: 'reps',
+    target: 100,
+    value: 40,
+    remaining: 60,
+    targetDisplay: '100',
+    progressDisplay: '40',
+    remainingDisplay: '60',
+    percent: 40,
+    reached: false,
+    fillable: true,
+    ...overrides,
+  };
+}
 
 describe('StatsDashboardComponent', () => {
   let fixture: ComponentFixture<StatsDashboardComponent>;
@@ -319,22 +339,21 @@ describe('StatsDashboardComponent', () => {
       it('Then it renders each daily goal with exercise, progress/target and percent', async () => {
         // Given a multi-exercise daily goal breakdown
         dailyGoalBreakdown.set([
-          {
-            id: 'g1',
-            exerciseName: 'Liegestütze',
-            progressDisplay: '40',
-            targetDisplay: '100',
-            percent: 40,
-            reached: false,
-          },
-          {
+          goalItem(),
+          goalItem({
             id: 'g2',
+            exerciseId: 'plank.standard',
             exerciseName: 'Plank',
-            progressDisplay: '1:00',
+            measurement: 'time',
+            unit: 's',
+            target: 120,
+            value: 60,
+            remaining: 60,
             targetDisplay: '2:00',
+            progressDisplay: '1:00',
+            remainingDisplay: '1:00',
             percent: 50,
-            reached: false,
-          },
+          }),
         ]);
         fixture.detectChanges();
         await fixture.whenStable();
@@ -351,6 +370,48 @@ describe('StatsDashboardComponent', () => {
         expect(text).toContain('40%');
         expect(text).toContain('Plank');
         expect(text).toContain('1:00 / 2:00');
+      });
+
+      it('Then ticking a sub-goal logs the amount still missing for it', async () => {
+        // given a daily goal that is 60 reps short
+        dailyGoalBreakdown.set([goalItem()]);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        exerciseCreateSpy.mockClear();
+
+        // when the user ticks it off
+        const checkbox = (fixture.nativeElement as HTMLElement).querySelector(
+          '[data-testid="daily-goal-check"] input'
+        ) as HTMLInputElement;
+        checkbox.click();
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        // then the gap is written as an entry for that exercise
+        expect(exerciseCreateSpy).toHaveBeenCalledWith(
+          'u1',
+          expect.objectContaining({
+            exerciseId: 'pushup',
+            reps: 60,
+            source: 'goal-fill',
+          })
+        );
+      });
+
+      it('Then a reached sub-goal renders checked and locked', async () => {
+        // given a goal that is already covered
+        dailyGoalBreakdown.set([
+          goalItem({ value: 100, remaining: 0, percent: 100, reached: true }),
+        ]);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        // then un-ticking it is not offered — goals are scored from entries
+        const checkbox = (fixture.nativeElement as HTMLElement).querySelector(
+          '[data-testid="daily-goal-check"] input'
+        ) as HTMLInputElement;
+        expect(checkbox.checked).toBe(true);
+        expect(checkbox.disabled).toBe(true);
       });
 
       it('Then it should offer quick add buttons for 10, 20 and 30 reps', () => {

--- a/web/src/app/stats/shell/stats-dashboard.component.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.spec.ts
@@ -406,12 +406,18 @@ describe('StatsDashboardComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        // then un-ticking it is not offered — goals are scored from entries
+        // then un-ticking it is not offered — goals are scored from entries.
+        // The row stays focusable so its "Ziel erreicht" tooltip is reachable.
         const checkbox = (fixture.nativeElement as HTMLElement).querySelector(
           '[data-testid="daily-goal-check"] input'
         ) as HTMLInputElement;
         expect(checkbox.checked).toBe(true);
-        expect(checkbox.disabled).toBe(true);
+        expect(checkbox.getAttribute('aria-disabled')).toBe('true');
+        exerciseCreateSpy.mockClear();
+        checkbox.click();
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(exerciseCreateSpy).not.toHaveBeenCalled();
       });
 
       it('Then it should offer quick add buttons for 10, 20 and 30 reps', () => {

--- a/web/src/app/stats/shell/stats-dashboard.component.ts
+++ b/web/src/app/stats/shell/stats-dashboard.component.ts
@@ -25,8 +25,6 @@ import {
   findExerciseDefinition,
   formatEntryDisplay,
   PUSHUP_QUICK_ADD_EXERCISE_ID,
-  QUICK_LOG_REPS_MAX,
-  QUICK_LOG_REPS_MIN,
   UnifiedEntry,
 } from '@pu-stats/models';
 import { nowLocalIsoTimestamp } from '@pu-stats/date';
@@ -36,6 +34,10 @@ import { QuickAddBridgeService } from '@pu-stats/quick-add';
 import { QuickAddOrchestrationService } from '../../core/quick-add-orchestration.service';
 import { autoCountProfileForCatalogId } from '../../core/quick-add-orchestration.helpers';
 import { AppDataFacade } from '../../core/app-data.facade';
+import { DailyGoalActionsService } from '../../core/daily-goal-actions.service';
+import type { DailyGoalItemView } from '../../core/daily-goal.helpers';
+import { DailyGoalChecklistComponent } from '../../core/daily-goal/daily-goal-checklist.component';
+import { registerDashboardDeepLinks } from './stats-dashboard.deep-links';
 import { AdSlotComponent } from '@pu-stats/ads';
 import { AnalysisTeaserCardComponent } from '../components/analysis-teaser-card/analysis-teaser-card.component';
 import { PreviewBannerComponent } from '../components/preview-banner/preview-banner.component';
@@ -57,6 +59,7 @@ import type { QuickAddButtonViewModel } from '../dashboard/quick-add-view-model'
     MatProgressBarModule,
     DatePipe,
     AnalysisTeaserCardComponent,
+    DailyGoalChecklistComponent,
     PreviewBannerComponent,
     AdSlotComponent,
     RouterLink,
@@ -138,6 +141,9 @@ export class StatsDashboardComponent {
   readonly userConfiguredDailyGoal = this.store.userConfiguredDailyGoal;
   /** Per-exercise daily goal breakdown shared with the toolbar pill. */
   readonly dailyGoalBreakdown = this.appData.dailyGoalBreakdown;
+  private readonly goalActions = inject(DailyGoalActionsService);
+  /** Goal ids whose check-off write is still in flight. */
+  readonly dailyGoalPending = this.goalActions.pending;
   private readonly trainingPlans = inject(TrainingPlanStore);
   /**
    * Only render the "no active plan" banner once the plan resource has
@@ -192,11 +198,28 @@ export class StatsDashboardComponent {
       this.refreshCounter.update((c) => c + 1);
     });
 
+    registerDashboardDeepLinks({
+      route: this.route,
+      router: this.router,
+      openCreateDialog: () => this.openCreateDialog(),
+      // Attribute deep-link entries to the reminder so source-based analytics
+      // match the in-tab `QUICK_LOG_PUSHUPS` path (CodeRabbit/Copilot P2).
+      quickLog: (reps) => void this.addQuickEntry(reps, 'reminder'),
+    });
+
     this.store.loadQuote();
   }
 
   fillToGoal(): void {
     this.quickAdd.fillToGoal();
+  }
+
+  /** Ticking a sub-goal logs the amount still missing for it. */
+  async completeDailyGoal(item: DailyGoalItemView): Promise<void> {
+    const result = await this.goalActions.complete(item);
+    if (result !== 'logged') return;
+    this.store.refreshAll();
+    this.refreshCounter.update((c) => c + 1);
   }
 
   openCreateDialog(): void {
@@ -229,52 +252,6 @@ export class StatsDashboardComponent {
   shareDay(): void {
     void this.store.shareDay();
   }
-
-  /**
-   * Called after render — handles two notification deep-links:
-   *   - `?log=1`     → open create-entry dialog (existing behavior)
-   *   - `?quickLog=N` → silently log N pushups (notification button click
-   *                     when no app tab was open — see sw-push handlers).
-   *
-   * `quickLog` arrives via URL and is therefore untrusted: clamp into the
-   * configured `[QUICK_LOG_REPS_MIN, QUICK_LOG_REPS_MAX]` range so a tampered
-   * link can't persist absurd entries (CodeRabbit/Copilot/Codex P1, PR #249).
-   *
-   * Snooze always wins: if `?snooze=N` is also present, the user explicitly
-   * snoozed and did NOT want to log push-ups in this navigation. Skip both
-   * deep-links so a combined or stale URL can never silently create an entry
-   * alongside the snooze — App.ts consumes the snooze param separately.
-   */
-  private readonly _handleLogParam = afterNextRender(() => {
-    const params = this.route.snapshot.queryParamMap;
-    if (params.has('snooze')) return;
-    const quickLog = params.get('quickLog');
-    const quickReps = quickLog != null ? Number(quickLog) : NaN;
-    if (Number.isFinite(quickReps) && quickReps >= QUICK_LOG_REPS_MIN) {
-      const clamped = Math.min(Math.floor(quickReps), QUICK_LOG_REPS_MAX);
-      void this.router.navigate([], {
-        relativeTo: this.route,
-        queryParams: { quickLog: null },
-        queryParamsHandling: 'merge',
-        replaceUrl: true,
-      });
-      // Attribute deep-link entries to the reminder so source-based analytics
-      // match the in-tab `QUICK_LOG_PUSHUPS` path (CodeRabbit/Copilot P2).
-      void this.addQuickEntry(clamped, 'reminder');
-      return;
-    }
-    const log = params.get('log');
-    if (log === '1') {
-      // Clean up URL without re-navigating
-      void this.router.navigate([], {
-        relativeTo: this.route,
-        queryParams: { log: null },
-        queryParamsHandling: 'merge',
-        replaceUrl: true,
-      });
-      this.openCreateDialog();
-    }
-  });
 
   async createEntry(result: TrainingEntryDialogResult) {
     const userId = this.userContext.userIdSafe();

--- a/web/src/app/stats/shell/stats-dashboard.deep-links.spec.ts
+++ b/web/src/app/stats/shell/stats-dashboard.deep-links.spec.ts
@@ -1,0 +1,103 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ActivatedRoute,
+  convertToParamMap,
+  type Params,
+  Router,
+} from '@angular/router';
+import { QUICK_LOG_REPS_MAX, QUICK_LOG_REPS_MIN } from '@pu-stats/models';
+
+import { registerDashboardDeepLinks } from './stats-dashboard.deep-links';
+
+function setup(params: Params) {
+  const openCreateDialog = vitest.fn();
+  const quickLog = vitest.fn();
+  const navigate = vitest.fn().mockResolvedValue(true);
+  const route = {
+    snapshot: { queryParamMap: convertToParamMap(params) },
+  } as unknown as ActivatedRoute;
+  const router = { navigate } as unknown as Router;
+
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({});
+  TestBed.runInInjectionContext(() =>
+    registerDashboardDeepLinks({ route, router, openCreateDialog, quickLog })
+  );
+  TestBed.tick();
+  return { openCreateDialog, quickLog, navigate };
+}
+
+/** The `queryParams` patch of the last `router.navigate` call. */
+function clearedParams(navigate: ReturnType<typeof vitest.fn>): unknown {
+  return navigate.mock.calls.at(-1)?.[1]?.queryParams;
+}
+
+describe('registerDashboardDeepLinks', () => {
+  it('should log an in-range quickLog and clear the param', () => {
+    // given / when
+    const { quickLog, navigate } = setup({ quickLog: '20' });
+
+    // then
+    expect(quickLog).toHaveBeenCalledWith(20);
+    expect(clearedParams(navigate)).toEqual({ quickLog: null });
+  });
+
+  it('should clamp a quickLog above the maximum', () => {
+    // given a tampered deep-link
+    const { quickLog } = setup({ quickLog: '99999' });
+
+    // then the entry stays inside the configured range
+    expect(quickLog).toHaveBeenCalledWith(QUICK_LOG_REPS_MAX);
+  });
+
+  it('should floor a fractional quickLog', () => {
+    // given / when
+    const { quickLog } = setup({ quickLog: '20.9' });
+
+    // then
+    expect(quickLog).toHaveBeenCalledWith(20);
+  });
+
+  it('should ignore a quickLog below the minimum', () => {
+    // given a value under the configured floor
+    const { quickLog, navigate } = setup({
+      quickLog: String(QUICK_LOG_REPS_MIN - 1),
+    });
+
+    // then nothing is logged and the URL is left alone
+    expect(quickLog).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('should ignore a non-numeric quickLog', () => {
+    // given / when
+    const { quickLog, navigate } = setup({ quickLog: 'drop-table' });
+
+    // then
+    expect(quickLog).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('should open the entry dialog for ?log=1 and clear the param', () => {
+    // given / when
+    const { openCreateDialog, navigate } = setup({ log: '1' });
+
+    // then
+    expect(openCreateDialog).toHaveBeenCalledTimes(1);
+    expect(clearedParams(navigate)).toEqual({ log: null });
+  });
+
+  it('should let a snooze deep-link suppress both actions', () => {
+    // given a combined URL — the user snoozed, they did not ask to log
+    const { quickLog, openCreateDialog, navigate } = setup({
+      snooze: '30',
+      quickLog: '20',
+      log: '1',
+    });
+
+    // then
+    expect(quickLog).not.toHaveBeenCalled();
+    expect(openCreateDialog).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app/stats/shell/stats-dashboard.deep-links.ts
+++ b/web/src/app/stats/shell/stats-dashboard.deep-links.ts
@@ -1,0 +1,55 @@
+import { afterNextRender } from '@angular/core';
+import type { ActivatedRoute, Router } from '@angular/router';
+import { QUICK_LOG_REPS_MAX, QUICK_LOG_REPS_MIN } from '@pu-stats/models';
+
+/**
+ * Handles the dashboard's two notification deep-links. Must be called
+ * from an injection context (the component constructor).
+ *
+ *   - `?log=1`      → open the create-entry dialog
+ *   - `?quickLog=N` → silently log N pushups (notification button click
+ *                     when no app tab was open — see sw-push handlers)
+ *
+ * `quickLog` arrives via URL and is therefore untrusted: clamp into the
+ * configured `[QUICK_LOG_REPS_MIN, QUICK_LOG_REPS_MAX]` range so a tampered
+ * link can't persist absurd entries (CodeRabbit/Copilot/Codex P1, PR #249).
+ *
+ * Snooze always wins: if `?snooze=N` is also present, the user explicitly
+ * snoozed and did NOT want to log push-ups in this navigation. Skip both
+ * deep-links so a combined or stale URL can never silently create an entry
+ * alongside the snooze — App.ts consumes the snooze param separately.
+ */
+export function registerDashboardDeepLinks(deps: {
+  route: ActivatedRoute;
+  router: Router;
+  openCreateDialog: () => void;
+  quickLog: (reps: number) => void;
+}): void {
+  afterNextRender(() => {
+    const params = deps.route.snapshot.queryParamMap;
+    if (params.has('snooze')) return;
+    const raw = params.get('quickLog');
+    const quickReps = raw != null ? Number(raw) : NaN;
+    if (Number.isFinite(quickReps) && quickReps >= QUICK_LOG_REPS_MIN) {
+      clearParam(deps, 'quickLog');
+      deps.quickLog(Math.min(Math.floor(quickReps), QUICK_LOG_REPS_MAX));
+      return;
+    }
+    if (params.get('log') === '1') {
+      clearParam(deps, 'log');
+      deps.openCreateDialog();
+    }
+  });
+}
+
+function clearParam(
+  deps: { route: ActivatedRoute; router: Router },
+  key: string
+): void {
+  void deps.router.navigate([], {
+    relativeTo: deps.route,
+    queryParams: { [key]: null },
+    queryParamsHandling: 'merge',
+    replaceUrl: true,
+  });
+}

--- a/web/src/app/training-plans/plan-day-exercises.component.html
+++ b/web/src/app/training-plans/plan-day-exercises.component.html
@@ -55,6 +55,19 @@
           </button>
         }
 
+        @if (interactive() && ex.done) {
+          <button
+            mat-icon-button
+            class="exercise-reset"
+            data-testid="plan-exercise-reset"
+            (click)="resetExercise.emit(ex.itemIndex)"
+            [matTooltip]="resetTooltip"
+            [attr.aria-label]="resetTooltip + ': ' + ex.name"
+          >
+            <mat-icon>restart_alt</mat-icon>
+          </button>
+        }
+
         @if (ex.quantified) {
           <mat-progress-bar
             class="exercise-bar"

--- a/web/src/app/training-plans/plan-day-exercises.component.spec.ts
+++ b/web/src/app/training-plans/plan-day-exercises.component.spec.ts
@@ -21,11 +21,12 @@ function row(overrides: Partial<DayExerciseRow> = {}): DayExerciseRow {
 async function setup(exercises: DayExerciseRow[], interactive = true) {
   const logExercise = vitest.fn();
   const toggleExercise = vitest.fn();
+  const resetExercise = vitest.fn();
   await render(PlanDayExercisesComponent, {
     inputs: { exercises, interactive },
-    on: { logExercise, toggleExercise },
+    on: { logExercise, toggleExercise, resetExercise },
   });
-  return { logExercise, toggleExercise };
+  return { logExercise, toggleExercise, resetExercise };
 }
 
 describe('PlanDayExercisesComponent', () => {
@@ -84,11 +85,37 @@ describe('PlanDayExercisesComponent', () => {
     expect(screen.queryByRole('button')).toBeNull();
   });
 
-  it('should hide the log action for an exercise that is already done', async () => {
+  it('should replace the log action of a done exercise with a reset action', async () => {
     // given / when
     await setup([row({ done: true })]);
     // then
-    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByLabelText(/Vorgabe eintragen/)).toBeNull();
+    expect(screen.getByTestId('plan-exercise-reset')).toBeTruthy();
+  });
+
+  it('should emit a reset for the clicked exercise', async () => {
+    // given a done exercise
+    const { resetExercise } = await setup([row({ itemIndex: 3, done: true })]);
+    // when the reset action is used
+    await userEvent.click(screen.getByTestId('plan-exercise-reset'));
+    // then
+    expect(resetExercise).toHaveBeenCalledWith(3);
+  });
+
+  it('should offer a reset for an exercise fulfilled by logged entries', async () => {
+    // given an auto-fulfilled exercise whose checkbox is locked
+    const { resetExercise } = await setup([row({ done: true, auto: true })]);
+    // when
+    await userEvent.click(screen.getByTestId('plan-exercise-reset'));
+    // then the only way back is the reset, and it works
+    expect(resetExercise).toHaveBeenCalledWith(0);
+  });
+
+  it('should offer no reset on a read-only day', async () => {
+    // given / when
+    await setup([row({ done: true })], false);
+    // then
+    expect(screen.queryByTestId('plan-exercise-reset')).toBeNull();
   });
 
   it('should show a placeholder instead of numbers for an unquantified exercise', async () => {

--- a/web/src/app/training-plans/plan-day-exercises.component.ts
+++ b/web/src/app/training-plans/plan-day-exercises.component.ts
@@ -25,7 +25,8 @@ export interface ExerciseToggle {
  * amount as a real entry (so it counts towards stats and streaks), or
  * ticking it off. Exercises already covered by logged entries render as
  * done and lock their checkbox — un-ticking them would be a lie the
- * next mirror update would immediately undo.
+ * next mirror update would immediately undo. Reopening those goes
+ * through `resetExercise`, which also drops the entries the plan wrote.
  */
 @Component({
   selector: 'app-plan-day-exercises',
@@ -47,9 +48,11 @@ export class PlanDayExercisesComponent {
 
   readonly logExercise = output<number>();
   readonly toggleExercise = output<ExerciseToggle>();
+  readonly resetExercise = output<number>();
 
   protected readonly autoTooltip = $localize`:@@trainingPlans.exercise.auto:Automatisch erfüllt — durch deine Einträge an diesem Tag.`;
   protected readonly checkTooltip = $localize`:@@trainingPlans.exercise.check:Übung abhaken (ohne Eintrag)`;
   protected readonly undoTooltip = $localize`:@@trainingPlans.exercise.undo:Haken entfernen`;
   protected readonly logTooltip = $localize`:@@trainingPlans.exercise.log:Vorgabe eintragen`;
+  protected readonly resetTooltip = $localize`:@@trainingPlans.exercise.reset:Übung zurücksetzen`;
 }

--- a/web/src/app/training-plans/training-plan-detail.component.html
+++ b/web/src/app/training-plans/training-plan-detail.component.html
@@ -237,6 +237,7 @@
                   [interactive]="isThisPlanActive() && !row.isFuture"
                   (logExercise)="logExercise(row.day.dayIndex, $event)"
                   (toggleExercise)="toggleExercise(row.day.dayIndex, $event)"
+                  (resetExercise)="resetExercise(row.day.dayIndex, $event)"
                 />
                 @if (row.pushupTypes.length > 0) {
                   <div class="pushup-types">

--- a/web/src/app/training-plans/training-plan-detail.component.ts
+++ b/web/src/app/training-plans/training-plan-detail.component.ts
@@ -36,6 +36,7 @@ import {
   buildWeeks,
   formatSets,
   messageForLogResult,
+  messageForResetResult,
 } from './training-plan-detail.helpers';
 
 @Component({
@@ -232,6 +233,15 @@ export class TrainingPlanDetailComponent {
 
   async toggleExercise(dayIndex: number, event: ExerciseToggle): Promise<void> {
     await this.store.setItemDone(dayIndex, event.itemIndex, event.done);
+  }
+
+  async resetExercise(dayIndex: number, itemIndex: number): Promise<void> {
+    const message = messageForResetResult(
+      await this.store.resetPlanExercise(dayIndex, itemIndex)
+    );
+    if (message) {
+      this.snackbar.open(message, undefined, { duration: 3000 });
+    }
   }
 
   private reportLogResult(result: LogPlanDayResult): void {

--- a/web/src/app/training-plans/training-plan-detail.helpers.ts
+++ b/web/src/app/training-plans/training-plan-detail.helpers.ts
@@ -116,6 +116,8 @@ export function messageForResetResult(
       return $localize`:@@trainingPlans.exercise.resetDone:Übung zurückgesetzt.`;
     case 'kept-entries':
       return $localize`:@@trainingPlans.exercise.resetKept:Haken entfernt — deine eigenen Einträge bleiben bestehen.`;
+    case 'not-ready':
+      return $localize`:@@trainingPlans.notReady:Daten werden noch geladen, bitte gleich noch einmal versuchen.`;
     case 'in-flight':
     case 'noop':
       return null;

--- a/web/src/app/training-plans/training-plan-detail.helpers.ts
+++ b/web/src/app/training-plans/training-plan-detail.helpers.ts
@@ -8,7 +8,10 @@ import {
   TrainingPlan,
   TrainingPlanDay,
 } from '@pu-stats/models';
-import { LogPlanDayResult } from './training-plan.store';
+import type {
+  LogPlanDayResult,
+  ResetExerciseResult,
+} from './training-plan.store';
 import {
   asCompletedRows,
   buildExerciseRows,
@@ -98,6 +101,21 @@ export function messageForLogResult(result: LogPlanDayResult): string | null {
       return $localize`:@@trainingPlans.alreadyLogged:Tag war schon eingetragen — als erledigt markiert.`;
     case 'not-ready':
       return $localize`:@@trainingPlans.notReady:Daten werden noch geladen, bitte gleich noch einmal versuchen.`;
+    case 'in-flight':
+    case 'noop':
+      return null;
+  }
+}
+
+/** Maps a reset outcome to a user-facing snackbar message (or none). */
+export function messageForResetResult(
+  result: ResetExerciseResult
+): string | null {
+  switch (result) {
+    case 'reset':
+      return $localize`:@@trainingPlans.exercise.resetDone:Übung zurückgesetzt.`;
+    case 'kept-entries':
+      return $localize`:@@trainingPlans.exercise.resetKept:Haken entfernt — deine eigenen Einträge bleiben bestehen.`;
     case 'in-flight':
     case 'noop':
       return null;

--- a/web/src/app/training-plans/training-plan-store.internals.ts
+++ b/web/src/app/training-plans/training-plan-store.internals.ts
@@ -71,6 +71,18 @@ export function planDayDateFor(store: Store, dayIndex: number): string {
   return planDayDate(store.activePlan()?.startDate, dayIndex);
 }
 
+/** Whether a day index can be written to at all (active plan, real
+ *  non-rest day, not in the future, live mirror synced). */
+export function dayIsWritable(store: Store, dayIndex: number): boolean {
+  const plan = store.activePlan();
+  const catalog = store.activeCatalog();
+  if (!plan || !catalog || plan.status !== 'active') return false;
+  const day = planDayByIndex(catalog, dayIndex);
+  if (!day || day.kind === 'rest') return false;
+  const currentIdx = store.currentDayIndex();
+  return currentIdx !== null && dayIndex <= currentIdx;
+}
+
 /** Lazily resolve the Firestore-bound exercise API. Returns null when no
  *  provider is registered (e.g. a test harness without `Firestore`). */
 export function resolveExerciseApi(

--- a/web/src/app/training-plans/training-plan-store.internals.ts
+++ b/web/src/app/training-plans/training-plan-store.internals.ts
@@ -71,8 +71,9 @@ export function planDayDateFor(store: Store, dayIndex: number): string {
   return planDayDate(store.activePlan()?.startDate, dayIndex);
 }
 
-/** Whether a day index can be written to at all (active plan, real
- *  non-rest day, not in the future, live mirror synced). */
+/** Whether a day index can be written to at all: active plan, real
+ *  non-rest day, not in the future. Callers that read the live entry
+ *  mirror must check `_live.exerciseEntriesLoaded()` themselves. */
 export function dayIsWritable(store: Store, dayIndex: number): boolean {
   const plan = store.activePlan();
   const catalog = store.activeCatalog();

--- a/web/src/app/training-plans/training-plan-store.items.ts
+++ b/web/src/app/training-plans/training-plan-store.items.ts
@@ -1,7 +1,6 @@
 import { firstValueFrom } from 'rxjs';
 import {
   isPlanDayFulfilled,
-  planDayByIndex,
   planDayItemId,
   planExerciseEntryPayload,
   PlanExerciseProgress,
@@ -11,6 +10,7 @@ import { appendLocalOffset } from '@pu-stats/date';
 import { ExerciseFirestoreService } from '@pu-stats/data-access';
 import {
   acquireWriteLock,
+  dayIsWritable,
   dayProgress,
   LogPlanDayResult,
   planDayDateFor,
@@ -20,18 +20,6 @@ import {
 } from './training-plan-store.internals';
 
 type Store = TrainingPlanActionsStore;
-
-/** Whether a day index can be written to at all (active plan, real
- *  non-rest day, not in the future, live mirror synced). */
-function dayIsWritable(store: Store, dayIndex: number): boolean {
-  const plan = store.activePlan();
-  const catalog = store.activeCatalog();
-  if (!plan || !catalog || plan.status !== 'active') return false;
-  const day = planDayByIndex(catalog, dayIndex);
-  if (!day || day.kind === 'rest') return false;
-  const currentIdx = store.currentDayIndex();
-  return currentIdx !== null && dayIndex <= currentIdx;
-}
 
 /** Everything an entry write needs, resolved once up front. */
 interface EntryWriter {

--- a/web/src/app/training-plans/training-plan-store.reset.ts
+++ b/web/src/app/training-plans/training-plan-store.reset.ts
@@ -24,10 +24,11 @@ type Store = TrainingPlanActionsStore;
  *  - `reset` — the exercise is open again
  *  - `kept-entries` — tick and plan entries are gone, but entries the user
  *    logged themselves still cover the target, so it stays fulfilled
+ *  - `not-ready` — the entry mirror hasn't synced yet
  *  - `noop` / `in-flight` — nothing was written
  */
 export type ResetExerciseResult =
-  'reset' | 'kept-entries' | 'noop' | 'in-flight';
+  'reset' | 'kept-entries' | 'noop' | 'in-flight' | 'not-ready';
 
 /**
  * The plan's own entries for one exercise on one day, newest first. Only
@@ -70,9 +71,13 @@ async function deletePlanEntries(
   let removed = 0;
   for (const entry of planWrittenEntries(store, dateIso, exercise)) {
     if (removed >= budget) break;
+    // An entry that contributes nothing to this measurement would never
+    // advance the budget, so deleting it would drain the whole day's pool.
+    const value = entry[field] ?? 0;
+    if (value <= 0) continue;
     await firstValueFrom(api.deleteEntry(entry._id));
     deleted.add(entry._id);
-    removed += entry[field] ?? 0;
+    removed += value;
   }
   return deleted;
 }
@@ -92,6 +97,12 @@ export async function resetPlanExercise(
   itemIndex: number
 ): Promise<ResetExerciseResult> {
   if (!dayIsWritable(store, dayIndex)) return 'noop';
+  // The `exerciseEntries` mirror is empty until its Firestore listener has
+  // emitted. Resetting off pre-sync data would drop the tick and leave the
+  // plan's entries in place, so the exercise would re-fulfil itself.
+  if (store._isBrowser && !store._live.exerciseEntriesLoaded()) {
+    return 'not-ready';
+  }
   if (!acquireWriteLock(store, dayIndex)) return 'in-flight';
   try {
     const item = dayProgress(store, dayIndex)[itemIndex];

--- a/web/src/app/training-plans/training-plan-store.reset.ts
+++ b/web/src/app/training-plans/training-plan-store.reset.ts
@@ -1,0 +1,131 @@
+import { firstValueFrom } from 'rxjs';
+import {
+  type ExerciseEntry,
+  measurementValueField,
+  planDayItemId,
+  planExerciseLoggedTotal,
+  planExerciseMeasurement,
+  type TrainingPlanExercise,
+} from '@pu-stats/models';
+import {
+  acquireWriteLock,
+  dayIsWritable,
+  dayProgress,
+  planDayDateFor,
+  releaseWriteLock,
+  resolveExerciseApi,
+  TrainingPlanActionsStore,
+} from './training-plan-store.internals';
+
+type Store = TrainingPlanActionsStore;
+
+/**
+ * Outcome of {@link resetPlanExercise}:
+ *  - `reset` — the exercise is open again
+ *  - `kept-entries` — tick and plan entries are gone, but entries the user
+ *    logged themselves still cover the target, so it stays fulfilled
+ *  - `noop` / `in-flight` — nothing was written
+ */
+export type ResetExerciseResult =
+  'reset' | 'kept-entries' | 'noop' | 'in-flight';
+
+/**
+ * The plan's own entries for one exercise on one day, newest first. Only
+ * `source: 'plan'` docs qualify: a reset undoes what the plan wrote, it
+ * never touches a workout the user logged by hand.
+ */
+function planWrittenEntries(
+  store: Store,
+  dateIso: string,
+  exercise: TrainingPlanExercise
+): ExerciseEntry[] {
+  return store._live
+    .exerciseEntries()
+    .filter(
+      (e) =>
+        e.source === 'plan' &&
+        e.exerciseId === exercise.exerciseId &&
+        e.timestamp.slice(0, 10) === dateIso
+    )
+    .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+}
+
+/**
+ * Delete plan entries until `budget` (the amount credited to this item)
+ * is covered, and return their ids. A day may name the same exercise
+ * twice, so the entries are drawn down rather than wiped: resetting the
+ * first Plank item must leave the second one's seconds alone.
+ */
+async function deletePlanEntries(
+  store: Store,
+  dateIso: string,
+  exercise: TrainingPlanExercise,
+  budget: number
+): Promise<ReadonlySet<string>> {
+  const api = resolveExerciseApi(store);
+  const measurement = planExerciseMeasurement(exercise);
+  const deleted = new Set<string>();
+  if (!api || !measurement || budget <= 0) return deleted;
+  const field = measurementValueField(measurement);
+  let removed = 0;
+  for (const entry of planWrittenEntries(store, dateIso, exercise)) {
+    if (removed >= budget) break;
+    await firstValueFrom(api.deleteEntry(entry._id));
+    deleted.add(entry._id);
+    removed += entry[field] ?? 0;
+  }
+  return deleted;
+}
+
+/**
+ * Re-open a single exercise of a plan day: drop its manual tick, delete
+ * the entries the plan wrote for it, and un-finish the day so the list
+ * doesn't sit under a "done" header with an open exercise in it.
+ *
+ * Entries the user logged themselves survive — the reset reports
+ * `kept-entries` when those alone still cover the target, so the caller
+ * can explain why the row stays ticked.
+ */
+export async function resetPlanExercise(
+  store: Store,
+  dayIndex: number,
+  itemIndex: number
+): Promise<ResetExerciseResult> {
+  if (!dayIsWritable(store, dayIndex)) return 'noop';
+  if (!acquireWriteLock(store, dayIndex)) return 'in-flight';
+  try {
+    const item = dayProgress(store, dayIndex)[itemIndex];
+    if (!item) return 'noop';
+    const userId = store._user.userIdSafe();
+    const dateIso = planDayDateFor(store, dayIndex);
+
+    if (item.checkedOff) {
+      await firstValueFrom(
+        store._api.removeCompletedItems(userId, [
+          planDayItemId(dayIndex, itemIndex),
+        ])
+      );
+    }
+    const deleted = await deletePlanEntries(
+      store,
+      dateIso,
+      item.exercise,
+      item.logged
+    );
+    if (store.activePlan()?.completedDays.includes(dayIndex)) {
+      await firstValueFrom(store._api.removeCompletedDay(userId, dayIndex));
+    }
+    store.activeResource.reload();
+
+    const target = item.exercise.target;
+    if (target <= 0) return 'reset';
+    const stillLogged = planExerciseLoggedTotal(
+      store._live.exerciseEntries().filter((e) => !deleted.has(e._id)),
+      dateIso,
+      item.exercise
+    );
+    return stillLogged >= target ? 'kept-entries' : 'reset';
+  } finally {
+    releaseWriteLock(store, dayIndex);
+  }
+}

--- a/web/src/app/training-plans/training-plan.store.spec.ts
+++ b/web/src/app/training-plans/training-plan.store.spec.ts
@@ -238,6 +238,7 @@ interface Mocks {
   };
   exerciseApiMock: {
     createEntry: ReturnType<typeof vitest.fn>;
+    deleteEntry: ReturnType<typeof vitest.fn>;
   };
   liveMock: {
     exerciseEntries: Signal<ExerciseEntry[]>;
@@ -426,6 +427,14 @@ describe('TrainingPlanStore', () => {
             source: payload.source ?? 'plan',
           } satisfies ExerciseEntry)
         ),
+        // Mirrors the Firestore listener: a deleted doc disappears from
+        // the live mirror the store reads its progress from.
+        deleteEntry: vitest.fn((id: string) => {
+          liveExerciseEntries.update((list) =>
+            list.filter((e) => e._id !== id)
+          );
+          return of({ ok: true as const });
+        }),
       },
       liveMock: {
         // Post-cutover pushups are exerciseEntries (`exerciseId:'pushup'`);
@@ -1750,6 +1759,137 @@ describe('TrainingPlanStore', () => {
 
       // then
       expect(mocks.apiMock.addCompletedItems).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetPlanExercise', () => {
+    /** Entry mirror helper for one exercise on the current plan day. */
+    function planEntry(
+      id: string,
+      exerciseId: string,
+      values: Partial<ExerciseEntry>
+    ): ExerciseEntry {
+      return {
+        _id: id,
+        userId: 'u1',
+        exerciseId,
+        timestamp: `${toBerlinIsoDate(new Date())}T12:00:00.000+02:00`,
+        source: 'plan',
+        ...values,
+      } as ExerciseEntry;
+    }
+
+    it('should delete the entries the plan wrote and re-open the exercise', async () => {
+      // given the squats item of today's circuit was logged from the plan
+      const { store, mocks } = setup(
+        planStartedYesterday('circuit-plan'),
+        [],
+        [planEntry('sq-1', 'legs.squats', { reps: 45 })],
+        circuitLookup
+      );
+      await flush();
+      expect(store.dayProgress(2)[1].done).toBe(true);
+
+      // when the user resets it
+      const result = await store.resetPlanExercise(2, 1);
+      await flush();
+
+      // then the entry is gone and the exercise is open again
+      expect(result).toBe('reset');
+      expect(mocks.exerciseApiMock.deleteEntry).toHaveBeenCalledWith('sq-1');
+      expect(store.dayProgress(2)[1].done).toBe(false);
+    });
+
+    it('should keep entries the user logged themselves and say so', async () => {
+      // given the target is covered by the user's own workout, not the plan
+      const { store, mocks } = setup(
+        planStartedYesterday('circuit-plan'),
+        [],
+        [planEntry('sq-own', 'legs.squats', { reps: 45, source: 'web' })],
+        circuitLookup
+      );
+      await flush();
+
+      // when
+      const result = await store.resetPlanExercise(2, 1);
+      await flush();
+
+      // then nothing is deleted and the caller can explain why
+      expect(result).toBe('kept-entries');
+      expect(mocks.exerciseApiMock.deleteEntry).not.toHaveBeenCalled();
+      expect(store.dayProgress(2)[1].done).toBe(true);
+    });
+
+    it('should drop a manual tick and re-open the completed day', async () => {
+      // given a day closed by ticking every exercise off
+      const { store, mocks } = setup(
+        planStartedYesterday('hiit-plan'),
+        [],
+        [],
+        hiitLookup
+      );
+      await flush();
+      await store.setItemDone(2, 0, true);
+      await store.setItemDone(2, 1, true);
+      await flush();
+      expect(store.activePlan()?.completedDays).toContain(2);
+
+      // when one of them is reset
+      const result = await store.resetPlanExercise(2, 1);
+      await flush();
+
+      // then the tick and the day completion are both undone
+      expect(result).toBe('reset');
+      expect(mocks.apiMock.removeCompletedItems).toHaveBeenCalledWith('u1', [
+        '2:1',
+      ]);
+      expect(mocks.apiMock.removeCompletedDay).toHaveBeenCalledWith('u1', 2);
+      expect(store.activePlan()?.completedDays).not.toContain(2);
+    });
+
+    it('should delete only as much as the reset exercise was credited', async () => {
+      // given two plan entries covering pushups twice over
+      const { store, mocks } = setup(
+        planStartedYesterday('circuit-plan'),
+        [],
+        [
+          planEntry('pu-1', 'pushup', { reps: 30 }),
+          planEntry('pu-2', 'pushup', {
+            reps: 30,
+            timestamp: `${toBerlinIsoDate(new Date())}T18:00:00.000+02:00`,
+          }),
+        ],
+        circuitLookup
+      );
+      await flush();
+
+      // when the single pushup item (target 30) is reset
+      await store.resetPlanExercise(2, 0);
+      await flush();
+
+      // then only the newest entry is removed — the rest stays the user's
+      expect(mocks.exerciseApiMock.deleteEntry).toHaveBeenCalledTimes(1);
+      expect(mocks.exerciseApiMock.deleteEntry).toHaveBeenCalledWith('pu-2');
+    });
+
+    it('should refuse a reset for a future day', async () => {
+      // given day 4 is still ahead of today
+      const { store, mocks } = setup(
+        planStartedYesterday('circuit-plan'),
+        [],
+        [],
+        circuitLookup
+      );
+      await flush();
+
+      // when
+      const result = await store.resetPlanExercise(4, 0);
+      await flush();
+
+      // then
+      expect(result).toBe('noop');
+      expect(mocks.exerciseApiMock.deleteEntry).not.toHaveBeenCalled();
+      expect(mocks.apiMock.removeCompletedItems).not.toHaveBeenCalled();
     });
   });
 });

--- a/web/src/app/training-plans/training-plan.store.spec.ts
+++ b/web/src/app/training-plans/training-plan.store.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { computed, PLATFORM_ID, signal, type Signal } from '@angular/core';
-import { BehaviorSubject, from, map, of } from 'rxjs';
+import { BehaviorSubject, from, map, of, Subject } from 'rxjs';
 import { UserContextService } from '@pu-auth/auth';
 import {
   ExerciseFirestoreService,
@@ -1870,6 +1870,87 @@ describe('TrainingPlanStore', () => {
       // then only the newest entry is removed — the rest stays the user's
       expect(mocks.exerciseApiMock.deleteEntry).toHaveBeenCalledTimes(1);
       expect(mocks.exerciseApiMock.deleteEntry).toHaveBeenCalledWith('pu-2');
+    });
+
+    it("should return 'not-ready' before the entry mirror has synced", async () => {
+      // given a browser context whose exerciseEntries listener hasn't
+      // emitted yet — deleting off pre-sync data would drop the tick and
+      // leave the plan's entries behind
+      const stream = new BehaviorSubject<UserTrainingPlan | null>(
+        planStartedYesterday('circuit-plan')
+      );
+      const apiMock = {
+        getActivePlan: vitest.fn(() => stream.asObservable()),
+        setPlan: vitest.fn(),
+        updatePlan: vitest.fn(),
+        addCompletedDay: vitest.fn(() => of(void 0)),
+        removeCompletedDay: vitest.fn(() => of(void 0)),
+        addCompletedItems: vitest.fn(() => of(void 0)),
+        removeCompletedItems: vitest.fn(() => of(void 0)),
+      };
+      const exerciseApiMock = {
+        createEntry: vitest.fn(),
+        deleteEntry: vitest.fn(),
+      };
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: PLATFORM_ID, useValue: 'browser' },
+          { provide: UserTrainingPlanApiService, useValue: apiMock },
+          { provide: StatsApiService, useValue: { createPushup: vitest.fn() } },
+          { provide: ExerciseFirestoreService, useValue: exerciseApiMock },
+          {
+            provide: LiveDataStore,
+            useValue: {
+              exerciseEntries: signal<ExerciseEntry[]>([]),
+              connected: signal(true),
+              exerciseEntriesLoaded: signal(false),
+              updateTick: signal(0),
+            },
+          },
+          { provide: UserContextService, useValue: { userIdSafe: () => 'u1' } },
+          { provide: TRAINING_PLAN_LOOKUP, useValue: circuitLookup },
+        ],
+      });
+      const store = TestBed.inject(TrainingPlanStore);
+      await flush();
+
+      // when
+      const result = await store.resetPlanExercise(2, 1);
+      await flush();
+
+      // then
+      expect(result).toBe('not-ready');
+      expect(exerciseApiMock.deleteEntry).not.toHaveBeenCalled();
+      expect(apiMock.removeCompletedItems).not.toHaveBeenCalled();
+      TestBed.resetTestingModule();
+    });
+
+    it("should return 'in-flight' while a reset for the same day runs", async () => {
+      // given a first reset whose delete never settles
+      const { store, mocks } = setup(
+        planStartedYesterday('circuit-plan'),
+        [],
+        [planEntry('sq-1', 'legs.squats', { reps: 45 })],
+        circuitLookup
+      );
+      await flush();
+      const blocked = new Subject<{ ok: true }>();
+      mocks.exerciseApiMock.deleteEntry.mockReturnValueOnce(
+        blocked.asObservable()
+      );
+
+      // when a second reset for the same day starts before it finishes
+      const first = store.resetPlanExercise(2, 1);
+      const second = await store.resetPlanExercise(2, 1);
+
+      // then the day lock rejects it, so nothing is deleted twice
+      expect(second).toBe('in-flight');
+      blocked.next({ ok: true });
+      blocked.complete();
+      await first;
+      await flush();
+      expect(mocks.exerciseApiMock.deleteEntry).toHaveBeenCalledTimes(1);
     });
 
     it('should refuse a reset for a future day', async () => {

--- a/web/src/app/training-plans/training-plan.store.ts
+++ b/web/src/app/training-plans/training-plan.store.ts
@@ -39,10 +39,12 @@ import {
 import * as actions from './training-plan-store.actions';
 import * as items from './training-plan-store.items';
 import * as lifecycle from './training-plan-store.lifecycle';
+import { resetPlanExercise } from './training-plan-store.reset';
 import { dayProgress } from './training-plan-store.internals';
 import { registerTrainingPlanHooks } from './training-plan-store.hooks';
 
 export type { LogPlanDayResult } from './training-plan-store.internals';
+export type { ResetExerciseResult } from './training-plan-store.reset';
 
 /**
  * Seam for resolving a curated plan by id so tests can drive a plan the
@@ -222,6 +224,9 @@ export const TrainingPlanStore = signalStore(
       items.logPlanExercise(store, dayIndex, itemIndex),
     setItemDone: (dayIndex: number, itemIndex: number, done: boolean) =>
       items.setItemDone(store, dayIndex, itemIndex, done),
+    /** Re-open one exercise: drop its tick and the entries the plan wrote. */
+    resetPlanExercise: (dayIndex: number, itemIndex: number) =>
+      resetPlanExercise(store, dayIndex, itemIndex),
     unmarkDayDone: (dayIndex: number) =>
       lifecycle.unmarkDayDone(store, dayIndex),
     skipDay: (dayIndex: number) => lifecycle.skipDay(store, dayIndex),

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10570,5 +10570,77 @@
         <target>Alle Übungen eintragen &amp; abhaken</target>
       </segment>
     </unit>
+    <unit id="quickAdd.fab.goals">
+      <segment state="initial">
+        <source>Tagesziele</source>
+        <target>Tagesziele</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalsAria">
+      <segment state="initial">
+        <source>Tagesziele zum Abhaken anzeigen</source>
+        <target>Tagesziele zum Abhaken anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="toolbarDailyGoal.checkHint">
+      <segment state="initial">
+        <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
+        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.reached">
+      <segment state="initial">
+        <source>Ziel erreicht</source>
+        <target>Ziel erreicht</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.manual">
+      <segment state="initial">
+        <source>Dieses Ziel braucht einen manuellen Eintrag</source>
+        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.fill">
+      <segment state="initial">
+        <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
+        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.aria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemReachedAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
+        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.reset">
+      <segment state="initial">
+        <source>Übung zurücksetzen</source>
+        <target>Übung zurücksetzen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetDone">
+      <segment state="initial">
+        <source>Übung zurückgesetzt.</source>
+        <target>Übung zurückgesetzt.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetKept">
+      <segment state="initial">
+        <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
+        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10769,5 +10769,77 @@ Deine Position: # ·  Reps        </source>
         <target>Alle Übungen eintragen &amp; abhaken</target>
       </segment>
     </unit>
+    <unit id="quickAdd.fab.goals">
+      <segment state="initial">
+        <source>Tagesziele</source>
+        <target>Tagesziele</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalsAria">
+      <segment state="initial">
+        <source>Tagesziele zum Abhaken anzeigen</source>
+        <target>Tagesziele zum Abhaken anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="toolbarDailyGoal.checkHint">
+      <segment state="initial">
+        <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
+        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.reached">
+      <segment state="initial">
+        <source>Ziel erreicht</source>
+        <target>Ziel erreicht</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.manual">
+      <segment state="initial">
+        <source>Dieses Ziel braucht einen manuellen Eintrag</source>
+        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.fill">
+      <segment state="initial">
+        <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
+        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.aria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemReachedAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
+        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.reset">
+      <segment state="initial">
+        <source>Übung zurücksetzen</source>
+        <target>Übung zurücksetzen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetDone">
+      <segment state="initial">
+        <source>Übung zurückgesetzt.</source>
+        <target>Übung zurückgesetzt.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetKept">
+      <segment state="initial">
+        <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
+        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10566,5 +10566,77 @@
         <target>Alle Übungen eintragen &amp; abhaken</target>
       </segment>
     </unit>
+    <unit id="quickAdd.fab.goals">
+      <segment state="initial">
+        <source>Tagesziele</source>
+        <target>Tagesziele</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalsAria">
+      <segment state="initial">
+        <source>Tagesziele zum Abhaken anzeigen</source>
+        <target>Tagesziele zum Abhaken anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="toolbarDailyGoal.checkHint">
+      <segment state="initial">
+        <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
+        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.reached">
+      <segment state="initial">
+        <source>Ziel erreicht</source>
+        <target>Ziel erreicht</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.manual">
+      <segment state="initial">
+        <source>Dieses Ziel braucht einen manuellen Eintrag</source>
+        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.fill">
+      <segment state="initial">
+        <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
+        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.aria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemReachedAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
+        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.reset">
+      <segment state="initial">
+        <source>Übung zurücksetzen</source>
+        <target>Übung zurücksetzen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetDone">
+      <segment state="initial">
+        <source>Übung zurückgesetzt.</source>
+        <target>Übung zurückgesetzt.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetKept">
+      <segment state="initial">
+        <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
+        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10442,5 +10442,77 @@
         <target>Alle Übungen eintragen &amp; abhaken</target>
       </segment>
     </unit>
+    <unit id="quickAdd.fab.goals">
+      <segment state="initial">
+        <source>Tagesziele</source>
+        <target>Tagesziele</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalsAria">
+      <segment state="initial">
+        <source>Tagesziele zum Abhaken anzeigen</source>
+        <target>Tagesziele zum Abhaken anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="toolbarDailyGoal.checkHint">
+      <segment state="initial">
+        <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
+        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.reached">
+      <segment state="initial">
+        <source>Ziel erreicht</source>
+        <target>Ziel erreicht</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.manual">
+      <segment state="initial">
+        <source>Dieses Ziel braucht einen manuellen Eintrag</source>
+        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.fill">
+      <segment state="initial">
+        <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
+        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.aria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemReachedAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
+        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.reset">
+      <segment state="initial">
+        <source>Übung zurücksetzen</source>
+        <target>Übung zurücksetzen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetDone">
+      <segment state="initial">
+        <source>Übung zurückgesetzt.</source>
+        <target>Übung zurückgesetzt.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetKept">
+      <segment state="initial">
+        <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
+        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10570,5 +10570,77 @@
         <target>Alle Übungen eintragen &amp; abhaken</target>
       </segment>
     </unit>
+    <unit id="quickAdd.fab.goals">
+      <segment state="initial">
+        <source>Tagesziele</source>
+        <target>Tagesziele</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalsAria">
+      <segment state="initial">
+        <source>Tagesziele zum Abhaken anzeigen</source>
+        <target>Tagesziele zum Abhaken anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="toolbarDailyGoal.checkHint">
+      <segment state="initial">
+        <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
+        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.reached">
+      <segment state="initial">
+        <source>Ziel erreicht</source>
+        <target>Ziel erreicht</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.manual">
+      <segment state="initial">
+        <source>Dieses Ziel braucht einen manuellen Eintrag</source>
+        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.fill">
+      <segment state="initial">
+        <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
+        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.aria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemReachedAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
+        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.reset">
+      <segment state="initial">
+        <source>Übung zurücksetzen</source>
+        <target>Übung zurücksetzen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetDone">
+      <segment state="initial">
+        <source>Übung zurückgesetzt.</source>
+        <target>Übung zurückgesetzt.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetKept">
+      <segment state="initial">
+        <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
+        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10570,5 +10570,77 @@
         <target>Alle Übungen eintragen &amp; abhaken</target>
       </segment>
     </unit>
+    <unit id="quickAdd.fab.goals">
+      <segment state="initial">
+        <source>Tagesziele</source>
+        <target>Tagesziele</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalsAria">
+      <segment state="initial">
+        <source>Tagesziele zum Abhaken anzeigen</source>
+        <target>Tagesziele zum Abhaken anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="toolbarDailyGoal.checkHint">
+      <segment state="initial">
+        <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
+        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.reached">
+      <segment state="initial">
+        <source>Ziel erreicht</source>
+        <target>Ziel erreicht</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.manual">
+      <segment state="initial">
+        <source>Dieses Ziel braucht einen manuellen Eintrag</source>
+        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.fill">
+      <segment state="initial">
+        <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
+        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.aria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemReachedAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
+        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.reset">
+      <segment state="initial">
+        <source>Übung zurücksetzen</source>
+        <target>Übung zurücksetzen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetDone">
+      <segment state="initial">
+        <source>Übung zurückgesetzt.</source>
+        <target>Übung zurückgesetzt.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetKept">
+      <segment state="initial">
+        <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
+        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9863,5 +9863,77 @@ Deine Position: # ·  Reps        </source>
         <target>Alle Übungen eintragen &amp; abhaken</target>
       </segment>
     </unit>
+    <unit id="quickAdd.fab.goals">
+      <segment state="initial">
+        <source>Tagesziele</source>
+        <target>Tagesziele</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalsAria">
+      <segment state="initial">
+        <source>Tagesziele zum Abhaken anzeigen</source>
+        <target>Tagesziele zum Abhaken anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="toolbarDailyGoal.checkHint">
+      <segment state="initial">
+        <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
+        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.reached">
+      <segment state="initial">
+        <source>Ziel erreicht</source>
+        <target>Ziel erreicht</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.manual">
+      <segment state="initial">
+        <source>Dieses Ziel braucht einen manuellen Eintrag</source>
+        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.fill">
+      <segment state="initial">
+        <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
+        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.aria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemReachedAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
+        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.reset">
+      <segment state="initial">
+        <source>Übung zurücksetzen</source>
+        <target>Übung zurücksetzen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetDone">
+      <segment state="initial">
+        <source>Übung zurückgesetzt.</source>
+        <target>Übung zurückgesetzt.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetKept">
+      <segment state="initial">
+        <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
+        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -759,7 +759,7 @@
     </unit>
     <unit id="quickAdd.fab.fillToGoal">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:69,70</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:104,105</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> bis zum Ziel</source>
@@ -767,7 +767,7 @@
     </unit>
     <unit id="quickAdd.fab.open">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:104</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:132</note>
       </notes>
       <segment>
         <source>Schnellerfassung öffnen</source>
@@ -775,7 +775,7 @@
     </unit>
     <unit id="quickAdd.fab.close">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:105</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:133</note>
       </notes>
       <segment>
         <source>Schnellerfassung schließen</source>
@@ -783,7 +783,7 @@
     </unit>
     <unit id="quickAdd.fab.goalReached">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:106</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:134</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -791,7 +791,7 @@
     </unit>
     <unit id="quickAdd.fab.goalReachedAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:107</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:135</note>
       </notes>
       <segment>
         <source>Tagesziel bereits erreicht</source>
@@ -799,10 +799,26 @@
     </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:110</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:138</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="GAP" disp="gap"/> Liegestütze bis zum Tagesziel hinzufügen</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goals">
+      <notes>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:145</note>
+      </notes>
+      <segment>
+        <source>Tagesziele</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalsAria">
+      <notes>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:146</note>
+      </notes>
+      <segment>
+        <source>Tagesziele zum Abhaken anzeigen</source>
       </segment>
     </unit>
     <unit id="plan.day.rest">
@@ -3557,8 +3573,8 @@
     <unit id="nav.dashboard">
       <notes>
         <note category="location">web/src/app/app.html:23,26</note>
-        <note category="location">web/src/app/app.html:258,260</note>
-        <note category="location">web/src/app/app.html:321,323</note>
+        <note category="location">web/src/app/app.html:249,251</note>
+        <note category="location">web/src/app/app.html:312,314</note>
       </notes>
       <segment>
         <source>Dashboard</source>
@@ -3567,8 +3583,8 @@
     <unit id="nav.analysis">
       <notes>
         <note category="location">web/src/app/app.html:33,36</note>
-        <note category="location">web/src/app/app.html:262,264</note>
-        <note category="location">web/src/app/app.html:325,327</note>
+        <note category="location">web/src/app/app.html:253,255</note>
+        <note category="location">web/src/app/app.html:316,318</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -3577,8 +3593,8 @@
     <unit id="nav.leaderboard">
       <notes>
         <note category="location">web/src/app/app.html:43,47</note>
-        <note category="location">web/src/app/app.html:266,268</note>
-        <note category="location">web/src/app/app.html:329,331</note>
+        <note category="location">web/src/app/app.html:257,259</note>
+        <note category="location">web/src/app/app.html:320,322</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3587,8 +3603,8 @@
     <unit id="nav.blog">
       <notes>
         <note category="location">web/src/app/app.html:53,56</note>
-        <note category="location">web/src/app/app.html:274,276</note>
-        <note category="location">web/src/app/app.html:337,339</note>
+        <note category="location">web/src/app/app.html:265,267</note>
+        <note category="location">web/src/app/app.html:328,330</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3597,8 +3613,8 @@
     <unit id="nav.trainingPlans">
       <notes>
         <note category="location">web/src/app/app.html:63,67</note>
-        <note category="location">web/src/app/app.html:270,272</note>
-        <note category="location">web/src/app/app.html:333,335</note>
+        <note category="location">web/src/app/app.html:261,263</note>
+        <note category="location">web/src/app/app.html:324,326</note>
       </notes>
       <segment>
         <source>Trainingspläne</source>
@@ -3670,15 +3686,23 @@
     </unit>
     <unit id="toolbarDailyGoal">
       <notes>
-        <note category="location">web/src/app/app.html:184,185</note>
+        <note category="location">web/src/app/app.html:186,187</note>
       </notes>
       <segment>
         <source>Tagesziel</source>
       </segment>
     </unit>
+    <unit id="toolbarDailyGoal.checkHint">
+      <notes>
+        <note category="location">web/src/app/app.html:219,221</note>
+      </notes>
+      <segment>
+        <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
+      </segment>
+    </unit>
     <unit id="nav.admin">
       <notes>
-        <note category="location">web/src/app/app.html:238,239</note>
+        <note category="location">web/src/app/app.html:229,230</note>
       </notes>
       <segment>
         <source>Admin-Bereich</source>
@@ -3686,7 +3710,7 @@
     </unit>
     <unit id="nav.desktop.aria">
       <notes>
-        <note category="location">web/src/app/app.html:249,250</note>
+        <note category="location">web/src/app/app.html:240,241</note>
       </notes>
       <segment>
         <source>Hauptnavigation</source>
@@ -3694,7 +3718,7 @@
     </unit>
     <unit id="footer.aria">
       <notes>
-        <note category="location">web/src/app/app.html:283</note>
+        <note category="location">web/src/app/app.html:274</note>
       </notes>
       <segment>
         <source>Rechtliches</source>
@@ -3702,7 +3726,7 @@
     </unit>
     <unit id="footer.pushupTypes">
       <notes>
-        <note category="location">web/src/app/app.html:288,290</note>
+        <note category="location">web/src/app/app.html:279,281</note>
       </notes>
       <segment>
         <source>Liegestütztypen</source>
@@ -3710,7 +3734,7 @@
     </unit>
     <unit id="footer.exercises">
       <notes>
-        <note category="location">web/src/app/app.html:291,293</note>
+        <note category="location">web/src/app/app.html:282,284</note>
       </notes>
       <segment>
         <source>Übungen</source>
@@ -3718,7 +3742,7 @@
     </unit>
     <unit id="footer.about">
       <notes>
-        <note category="location">web/src/app/app.html:293,294</note>
+        <note category="location">web/src/app/app.html:284,285</note>
       </notes>
       <segment>
         <source>Über uns</source>
@@ -3726,7 +3750,7 @@
     </unit>
     <unit id="footer.impressum">
       <notes>
-        <note category="location">web/src/app/app.html:295,297</note>
+        <note category="location">web/src/app/app.html:286,288</note>
       </notes>
       <segment>
         <source>Impressum</source>
@@ -3734,7 +3758,7 @@
     </unit>
     <unit id="footer.datenschutz">
       <notes>
-        <note category="location">web/src/app/app.html:298,301</note>
+        <note category="location">web/src/app/app.html:289,292</note>
       </notes>
       <segment>
         <source>Datenschutz</source>
@@ -3742,7 +3766,7 @@
     </unit>
     <unit id="footer.cookies">
       <notes>
-        <note category="location">web/src/app/app.html:305,307</note>
+        <note category="location">web/src/app/app.html:296,298</note>
       </notes>
       <segment>
         <source> Cookie-Einstellungen </source>
@@ -3750,7 +3774,7 @@
     </unit>
     <unit id="nav.bottom.aria">
       <notes>
-        <note category="location">web/src/app/app.html:312,313</note>
+        <note category="location">web/src/app/app.html:303,304</note>
       </notes>
       <segment>
         <source>Mobile-Navigation</source>
@@ -4046,7 +4070,7 @@
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
       <notes>
-        <note category="location">web/src/app/app.ts:279</note>
+        <note category="location">web/src/app/app.ts:282</note>
       </notes>
       <segment>
         <source>Tagesziel-Einzelpositionen anzeigen</source>
@@ -4054,7 +4078,7 @@
     </unit>
     <unit id="seo.default.title">
       <notes>
-        <note category="location">web/src/app/app.ts:389</note>
+        <note category="location">web/src/app/app.ts:371</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -4062,7 +4086,7 @@
     </unit>
     <unit id="seo.default.description">
       <notes>
-        <note category="location">web/src/app/app.ts:392</note>
+        <note category="location">web/src/app/app.ts:374</note>
       </notes>
       <segment>
         <source>Tracke Reps, Trends und Streaks mit Pushup Tracker.</source>
@@ -4070,7 +4094,7 @@
     </unit>
     <unit id="sw.update.available">
       <notes>
-        <note category="location">web/src/app/app.ts:413</note>
+        <note category="location">web/src/app/app.ts:395</note>
       </notes>
       <segment>
         <source>Neue Version verfügbar</source>
@@ -4078,7 +4102,7 @@
     </unit>
     <unit id="sw.update.reload">
       <notes>
-        <note category="location">web/src/app/app.ts:414</note>
+        <note category="location">web/src/app/app.ts:396</note>
       </notes>
       <segment>
         <source>Neu laden</source>
@@ -4086,7 +4110,7 @@
     </unit>
     <unit id="toolbarDailyGoal.replayAria">
       <notes>
-        <note category="location">web/src/app/app.ts:490</note>
+        <note category="location">web/src/app/app.ts:477</note>
       </notes>
       <segment>
         <source>Tagesziel-Animation erneut abspielen</source>
@@ -4094,7 +4118,7 @@
     </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:519</note>
+        <note category="location">web/src/app/app.ts:506</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -4102,7 +4126,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:526</note>
+        <note category="location">web/src/app/app.ts:513</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>
@@ -4504,7 +4528,7 @@
     </unit>
     <unit id="quickAdd.fab.exerciseRepAria">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:46</note>
+        <note category="location">web/src/app/core/app-data.facade.ts:37</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="REPS" disp="cfg.reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
@@ -4512,7 +4536,7 @@
     </unit>
     <unit id="exercise.category.pushup">
       <notes>
-        <note category="location">web/src/app/core/app-data.facade.ts:320</note>
+        <note category="location">web/src/app/core/daily-goal.helpers.ts:59</note>
         <note category="location">web/src/app/leaderboard/shell/leaderboard-page.component.ts:49</note>
         <note category="location">web/src/app/stats/components/analysis-teaser-card/analysis-teaser-card.component.ts:49</note>
         <note category="location">web/src/app/stats/components/quick-add-config-dialog/quick-add-config-dialog.component.ts:385</note>
@@ -4525,6 +4549,54 @@
       </notes>
       <segment>
         <source>Liegestütze</source>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.reached">
+      <notes>
+        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:53</note>
+      </notes>
+      <segment>
+        <source>Ziel erreicht</source>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.manual">
+      <notes>
+        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:56</note>
+      </notes>
+      <segment>
+        <source>Dieses Ziel braucht einen manuellen Eintrag</source>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.fill">
+      <notes>
+        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:58</note>
+      </notes>
+      <segment>
+        <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.aria">
+      <notes>
+        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:62</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemReachedAria">
+      <notes>
+        <note category="location">web/src/app/core/daily-goal/goal-dial-items.ts:21</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemAria">
+      <notes>
+        <note category="location">web/src/app/core/daily-goal/goal-dial-items.ts:22</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
       </segment>
     </unit>
     <unit id="feedback.dialog.title">
@@ -9969,7 +10041,7 @@
       <notes>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:254,256</note>
         <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:281</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:300,301</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:290,291</note>
       </notes>
       <segment>
         <source>Tag</source>
@@ -9985,7 +10057,7 @@
     </unit>
     <unit id="dashboard.weeklyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:310,311</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:300,301</note>
       </notes>
       <segment>
         <source>Woche</source>
@@ -9993,7 +10065,7 @@
     </unit>
     <unit id="dashboard.monthlyGoalLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:319,320</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:309,310</note>
       </notes>
       <segment>
         <source>Monat</source>
@@ -10001,7 +10073,7 @@
     </unit>
     <unit id="dashboard.lastEntryLinkAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:344,345</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:334,335</note>
       </notes>
       <segment>
         <source>Letzten Eintrag in der Historie öffnen</source>
@@ -10009,7 +10081,7 @@
     </unit>
     <unit id="lastEntryTitle">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:348,349</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:338,339</note>
       </notes>
       <segment>
         <source>Letzter Eintrag</source>
@@ -10017,8 +10089,8 @@
     </unit>
     <unit id="dashboard.noEntryYet">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:358,360</note>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:421,424</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:348,350</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:411,414</note>
       </notes>
       <segment>
         <source>Noch kein Eintrag.</source>
@@ -10026,7 +10098,7 @@
     </unit>
     <unit id="loadingStats">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:379,383</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:369,373</note>
       </notes>
       <segment>
         <source> Lade Statistikdaten… </source>
@@ -10034,7 +10106,7 @@
     </unit>
     <unit id="dashboard.latestExercises">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:384,385</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:374,375</note>
       </notes>
       <segment>
         <source>Letzte Übungen</source>
@@ -10042,7 +10114,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCtaAriaLabel">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:428,429</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:418,419</note>
       </notes>
       <segment>
         <source>Zur Historie navigieren</source>
@@ -10050,7 +10122,7 @@
     </unit>
     <unit id="dashboard.latestEntriesCta">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:433,436</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:423,426</note>
       </notes>
       <segment>
         <source>Zur Historie</source>
@@ -10058,7 +10130,7 @@
     </unit>
     <unit id="ads.dashboard.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:439</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.html:429</note>
       </notes>
       <segment>
         <source>Werbung</source>
@@ -10066,7 +10138,7 @@
     </unit>
     <unit id="dashboard.tile.openInHistoryAria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:95</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:98</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="label" disp="label"/> in der Historie öffnen</source>
@@ -10074,7 +10146,7 @@
     </unit>
     <unit id="dashboard.share.aria">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:98</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:101</note>
       </notes>
       <segment>
         <source>Tagesleistung teilen</source>
@@ -10082,7 +10154,7 @@
     </unit>
     <unit id="dashboard.share">
       <notes>
-        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:99</note>
+        <note category="location">web/src/app/stats/shell/stats-dashboard.component.ts:102</note>
       </notes>
       <segment>
         <source>Teilen</source>
@@ -10098,7 +10170,7 @@
     </unit>
     <unit id="trainingPlans.exercise.auto">
       <notes>
-        <note category="location">web/src/app/training-plans/plan-day-exercises.component.ts:51</note>
+        <note category="location">web/src/app/training-plans/plan-day-exercises.component.ts:53</note>
       </notes>
       <segment>
         <source>Automatisch erfüllt — durch deine Einträge an diesem Tag.</source>
@@ -10106,7 +10178,7 @@
     </unit>
     <unit id="trainingPlans.exercise.check">
       <notes>
-        <note category="location">web/src/app/training-plans/plan-day-exercises.component.ts:52</note>
+        <note category="location">web/src/app/training-plans/plan-day-exercises.component.ts:54</note>
       </notes>
       <segment>
         <source>Übung abhaken (ohne Eintrag)</source>
@@ -10114,7 +10186,7 @@
     </unit>
     <unit id="trainingPlans.exercise.undo">
       <notes>
-        <note category="location">web/src/app/training-plans/plan-day-exercises.component.ts:53</note>
+        <note category="location">web/src/app/training-plans/plan-day-exercises.component.ts:55</note>
       </notes>
       <segment>
         <source>Haken entfernen</source>
@@ -10122,10 +10194,18 @@
     </unit>
     <unit id="trainingPlans.exercise.log">
       <notes>
-        <note category="location">web/src/app/training-plans/plan-day-exercises.component.ts:54</note>
+        <note category="location">web/src/app/training-plans/plan-day-exercises.component.ts:56</note>
       </notes>
       <segment>
         <source>Vorgabe eintragen</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.reset">
+      <notes>
+        <note category="location">web/src/app/training-plans/plan-day-exercises.component.ts:57</note>
+      </notes>
+      <segment>
+        <source>Übung zurücksetzen</source>
       </segment>
     </unit>
     <unit id="trainingPlans.photoCreditPrefix">
@@ -10147,7 +10227,7 @@
     <unit id="trainingPlans.back">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.component.html:43</note>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:351,355</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:352,356</note>
       </notes>
       <segment>
         <source>Zurück</source>
@@ -10320,7 +10400,7 @@
     </unit>
     <unit id="trainingPlans.menu.triggerAria">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:267,268</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:268,269</note>
       </notes>
       <segment>
         <source>Tagesaktionen öffnen</source>
@@ -10328,7 +10408,7 @@
     </unit>
     <unit id="trainingPlans.menu.undoDone">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:287,289</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:288,290</note>
       </notes>
       <segment>
         <source>Erledigt rückgängig machen</source>
@@ -10336,7 +10416,7 @@
     </unit>
     <unit id="trainingPlans.menu.undoSkip">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:297,299</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:298,300</note>
       </notes>
       <segment>
         <source>Überspringen rückgängig machen</source>
@@ -10344,7 +10424,7 @@
     </unit>
     <unit id="trainingPlans.menu.logAllDone">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:308,310</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:309,311</note>
       </notes>
       <segment>
         <source>Alle Übungen eintragen &amp; abhaken</source>
@@ -10352,7 +10432,7 @@
     </unit>
     <unit id="trainingPlans.menu.markDone">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:315,317</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:316,318</note>
       </notes>
       <segment>
         <source>Nur abhaken (ohne Eintrag)</source>
@@ -10360,7 +10440,7 @@
     </unit>
     <unit id="trainingPlans.menu.skip">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:321,323</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:322,324</note>
       </notes>
       <segment>
         <source>Tag überspringen</source>
@@ -10368,7 +10448,7 @@
     </unit>
     <unit id="trainingPlans.menu.jump">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:333,335</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:334,336</note>
       </notes>
       <segment>
         <source>Zu diesem Tag springen</source>
@@ -10376,7 +10456,7 @@
     </unit>
     <unit id="trainingPlans.notFound">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:348,349</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.html:349,350</note>
       </notes>
       <segment>
         <source>Plan nicht gefunden.</source>
@@ -10384,7 +10464,7 @@
     </unit>
     <unit id="trainingPlans.started">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:165</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:172</note>
       </notes>
       <segment>
         <source>Plan gestartet — viel Erfolg!</source>
@@ -10392,7 +10472,7 @@
     </unit>
     <unit id="trainingPlans.abandoned">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:182</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:189</note>
       </notes>
       <segment>
         <source>Plan beendet.</source>
@@ -10400,7 +10480,7 @@
     </unit>
     <unit id="trainingPlans.skipped">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:200</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:207</note>
       </notes>
       <segment>
         <source>Tag übersprungen.</source>
@@ -10408,7 +10488,7 @@
     </unit>
     <unit id="trainingPlans.jumped">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:213</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.component.ts:220</note>
       </notes>
       <segment>
         <source>Auf Tag <ph id="0" equiv="INTERPOLATION" disp="dayIndex"/> gesprungen.</source>
@@ -10424,7 +10504,7 @@
     </unit>
     <unit id="trainingPlans.logged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.helpers.ts:96</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.helpers.ts:99</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:390</note>
       </notes>
       <segment>
@@ -10433,7 +10513,7 @@
     </unit>
     <unit id="trainingPlans.alreadyLogged">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.helpers.ts:98</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.helpers.ts:101</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:392</note>
       </notes>
       <segment>
@@ -10442,11 +10522,27 @@
     </unit>
     <unit id="trainingPlans.notReady">
       <notes>
-        <note category="location">web/src/app/training-plans/training-plan-detail.helpers.ts:100</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.helpers.ts:103</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:394</note>
       </notes>
       <segment>
         <source>Daten werden noch geladen, bitte gleich noch einmal versuchen.</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetDone">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.helpers.ts:116</note>
+      </notes>
+      <segment>
+        <source>Übung zurückgesetzt.</source>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetKept">
+      <notes>
+        <note category="location">web/src/app/training-plans/training-plan-detail.helpers.ts:118</note>
+      </notes>
+      <segment>
+        <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
       </segment>
     </unit>
     <unit id="trainingPlans.title">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -759,7 +759,7 @@
     </unit>
     <unit id="quickAdd.fab.fillToGoal">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:104,105</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.html:118,119</note>
       </notes>
       <segment>
         <source>+<ph id="0" equiv="INTERPOLATION" disp="{{ item.value }}"/> bis zum Ziel</source>
@@ -767,7 +767,7 @@
     </unit>
     <unit id="quickAdd.fab.open">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:132</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:135</note>
       </notes>
       <segment>
         <source>Schnellerfassung öffnen</source>
@@ -775,7 +775,7 @@
     </unit>
     <unit id="quickAdd.fab.close">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:133</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:136</note>
       </notes>
       <segment>
         <source>Schnellerfassung schließen</source>
@@ -783,7 +783,7 @@
     </unit>
     <unit id="quickAdd.fab.goalReached">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:134</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:137</note>
       </notes>
       <segment>
         <source>Ziel erreicht ✓</source>
@@ -791,7 +791,7 @@
     </unit>
     <unit id="quickAdd.fab.goalReachedAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:135</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:138</note>
       </notes>
       <segment>
         <source>Tagesziel bereits erreicht</source>
@@ -799,7 +799,7 @@
     </unit>
     <unit id="quickAdd.fab.fillToGoalAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:138</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:141</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="GAP" disp="gap"/> Liegestütze bis zum Tagesziel hinzufügen</source>
@@ -807,7 +807,7 @@
     </unit>
     <unit id="quickAdd.fab.goals">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:145</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:148</note>
       </notes>
       <segment>
         <source>Tagesziele</source>
@@ -815,7 +815,7 @@
     </unit>
     <unit id="quickAdd.fab.goalsAria">
       <notes>
-        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:146</note>
+        <note category="location">libs/quick-add/src/lib/quick-add-fab.component.ts:149</note>
       </notes>
       <segment>
         <source>Tagesziele zum Abhaken anzeigen</source>
@@ -4534,6 +4534,15 @@
         <source><ph id="0" equiv="REPS" disp="cfg.reps"/> <ph id="1" equiv="EXERCISE" disp="exerciseLabel"/> hinzufügen</source>
       </segment>
     </unit>
+    <unit id="dailyGoal.check.manual">
+      <notes>
+        <note category="location">web/src/app/core/daily-goal-actions.service.ts:56</note>
+        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:59</note>
+      </notes>
+      <segment>
+        <source>Dieses Ziel braucht einen manuellen Eintrag</source>
+      </segment>
+    </unit>
     <unit id="exercise.category.pushup">
       <notes>
         <note category="location">web/src/app/core/daily-goal.helpers.ts:59</note>
@@ -4553,23 +4562,15 @@
     </unit>
     <unit id="dailyGoal.check.reached">
       <notes>
-        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:53</note>
+        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:56</note>
       </notes>
       <segment>
         <source>Ziel erreicht</source>
       </segment>
     </unit>
-    <unit id="dailyGoal.check.manual">
-      <notes>
-        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:56</note>
-      </notes>
-      <segment>
-        <source>Dieses Ziel braucht einen manuellen Eintrag</source>
-      </segment>
-    </unit>
     <unit id="dailyGoal.check.fill">
       <notes>
-        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:58</note>
+        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:61</note>
       </notes>
       <segment>
         <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
@@ -4577,7 +4578,7 @@
     </unit>
     <unit id="dailyGoal.check.aria">
       <notes>
-        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:62</note>
+        <note category="location">web/src/app/core/daily-goal/daily-goal-checklist.component.ts:65</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
@@ -4585,7 +4586,7 @@
     </unit>
     <unit id="quickAdd.fab.goalItemReachedAria">
       <notes>
-        <note category="location">web/src/app/core/daily-goal/goal-dial-items.ts:21</note>
+        <note category="location">web/src/app/core/daily-goal/goal-dial-items.ts:24</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
@@ -4593,7 +4594,7 @@
     </unit>
     <unit id="quickAdd.fab.goalItemAria">
       <notes>
-        <note category="location">web/src/app/core/daily-goal/goal-dial-items.ts:22</note>
+        <note category="location">web/src/app/core/daily-goal/goal-dial-items.ts:25</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
@@ -10523,6 +10524,7 @@
     <unit id="trainingPlans.notReady">
       <notes>
         <note category="location">web/src/app/training-plans/training-plan-detail.helpers.ts:103</note>
+        <note category="location">web/src/app/training-plans/training-plan-detail.helpers.ts:120</note>
         <note category="location">web/src/app/training-plans/training-plans-page.component.ts:394</note>
       </notes>
       <segment>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -10076,5 +10076,77 @@
         <target>Alle Übungen eintragen &amp; abhaken</target>
       </segment>
     </unit>
+    <unit id="quickAdd.fab.goals">
+      <segment state="initial">
+        <source>Tagesziele</source>
+        <target>Tagesziele</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalsAria">
+      <segment state="initial">
+        <source>Tagesziele zum Abhaken anzeigen</source>
+        <target>Tagesziele zum Abhaken anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="toolbarDailyGoal.checkHint">
+      <segment state="initial">
+        <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
+        <target> Teilziele abhaken kannst du auf dem Dashboard. </target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.reached">
+      <segment state="initial">
+        <source>Ziel erreicht</source>
+        <target>Ziel erreicht</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.manual">
+      <segment state="initial">
+        <source>Dieses Ziel braucht einen manuellen Eintrag</source>
+        <target>Dieses Ziel braucht einen manuellen Eintrag</target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.fill">
+      <segment state="initial">
+        <source>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></source>
+        <target>Rest eintragen und abhaken: +<ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/></target>
+      </segment>
+    </unit>
+    <unit id="dailyGoal.check.aria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> abhaken</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemReachedAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</source>
+        <target><ph id="0" equiv="EXERCISE" disp="item.exerciseName"/> bereits erreicht</target>
+      </segment>
+    </unit>
+    <unit id="quickAdd.fab.goalItemAria">
+      <segment state="initial">
+        <source><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</source>
+        <target><ph id="0" equiv="REMAINING" disp="item.remainingDisplay"/> <ph id="1" equiv="EXERCISE" disp="item.exerciseName"/> bis zum Tagesziel hinzufügen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.reset">
+      <segment state="initial">
+        <source>Übung zurücksetzen</source>
+        <target>Übung zurücksetzen</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetDone">
+      <segment state="initial">
+        <source>Übung zurückgesetzt.</source>
+        <target>Übung zurückgesetzt.</target>
+      </segment>
+    </unit>
+    <unit id="trainingPlans.exercise.resetKept">
+      <segment state="initial">
+        <source>Haken entfernt — deine eigenen Einträge bleiben bestehen.</source>
+        <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -272,23 +272,10 @@ mat-card-header + mat-card-footer {
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
   color: var(--mat-sys-on-surface, rgba(255, 255, 255, 0.92));
 
-  .goal-dropdown-line {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 4px;
-    font-size: 0.82rem;
-  }
-
-  .goal-dropdown-name {
-    font-weight: 600;
-  }
-
-  .goal-dropdown-val {
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-    opacity: 0.85;
+  .goal-dropdown-hint {
+    margin: 0;
+    font-size: 0.72rem;
+    opacity: 0.7;
   }
 }
 


### PR DESCRIPTION
Tagesziele bestehen aus mehreren Teilzielen, ließen sich bisher aber nur ablesen. Diese Änderung macht sie überall detailliert sichtbar und einzeln erledigbar.

## Änderungen

**Gemeinsame Teilziel-Liste**
- Neue Komponente `app-daily-goal-checklist` rendert eine Zeile pro Teilziel (Übung, Fortschritt/Ziel in der eigenen Einheit, Anteil, Balken) — genutzt von der Dashboard-Zielkarte und vom Tagesziel-Dropdown der Topleiste, damit beide Oberflächen dieselben Zahlen zeigen.

**Dashboard — Teilziele abhaken**
- Jedes Teilziel hat eine Checkbox. Abhaken schreibt den fehlenden Rest als Eintrag in der jeweiligen Messgröße (Wdh. → `reps`, Halteübung → `durationSec`, Distanz → `distanceM`). Ziele werden aus Einträgen berechnet, deshalb ist „abhaken" = „Rest eintragen"; ein erreichtes Ziel bleibt gesetzt und gesperrt.
- Ziele, deren Eintrag einen Begleitwert braucht (`weight` → Gewicht, `distance-time` → Dauer), sind bewusst nicht per Klick erfüllbar und zeigen einen Tooltip.
- Der geschriebene Wert wird in die Katalog-Grenzen der Übung geklemmt, damit eine große Lücke nicht an der Validierung scheitert.

**Topleiste**
- Die Pill öffnet die Details jetzt auch per Tap (Touch-Geräte lösen kein Hover aus) und trägt `role="button"`/`aria-expanded`; bei erreichtem Ziel bleibt der Klick die Snap-Wiederholung.
- Erreichte Teilziele werden mit Häkchen markiert.

**Quick-Add-FAB**
- Bei mehr als einem Tagesziel wird der Ziel-Button zu einem Untermenü mit einem Eintrag pro Teilziel (`Übung +Rest`), aus dem sich ein einzelnes Ziel abhaken lässt. Bei genau einem Ziel bleibt der bisherige „+X bis zum Ziel"-Button.

**Plan-Detailseite — zurücksetzen**
- Jede erledigte Übung eines Plantags hat eine Reset-Aktion: sie entfernt den Haken, löscht die vom Plan geschriebenen Einträge (`source: 'plan'`) für diese Übung an diesem Tag und öffnet den Tag wieder.
- Gelöscht wird nur so viel, wie der Übung gutgeschrieben war — ein Tag, der dieselbe Übung zweimal nennt, verliert nicht beide Portionen. Selbst geloggte Einträge bleiben erhalten; decken sie das Ziel weiterhin ab, sagt das eine Snackbar.

**Aufteilungen (LOC-Grenze)**
- Ziel-Berechnungen aus `AppDataFacade` → `core/daily-goal.helpers.ts`
- Deep-Link-Handling aus der Dashboard-Komponente → `stats-dashboard.deep-links.ts`
- Overlay-Steuerung der Pill aus `App` → `core/daily-goal/goal-pill-overlay.ts`
- Reset-Aktion → `training-plan-store.reset.ts`; `dayIsWritable` nach `training-plan-store.internals.ts`

## Tests
- Neu: `daily-goal.helpers.spec.ts`, `daily-goal-actions.service.spec.ts`, `daily-goal-checklist.component.spec.ts`, `goal-dial-items.spec.ts`
- Erweitert: Dashboard (Abhaken schreibt den Rest, erreichtes Ziel gesperrt), `app.spec` (Pill-Tap öffnet die Details), Quick-Add-FAB (Untermenü), `plan-day-exercises` (Reset-Aktion), `training-plan.store` (Reset: löschen, Fremdeinträge behalten, Tag wieder öffnen, Draw-down, Zukunftstag)
- `pnpm nx run-many --target=test` (1636 Tests), `--target=lint` und `web:build -c production` lokal grün.

## i18n
Neue deutsche Strings extrahiert (`web:extract-i18n`) und Platzhalter über `tools/src/sync-xliff-locales.mjs` in alle Ziel-Locales gesetzt — die Übersetzungs-Routine ersetzt sie.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjmFnirXHEac5J9j6nzZ6Z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an expandable daily-goal checklist with progress, completion states, and one-click goal actions.
  * Added accessible goal controls with keyboard support, contextual labels, and pending/disabled states.
  * Added the ability to reset completed training-plan exercises while preserving personal entries.
  * Added guidance directing users to the dashboard for goals requiring manual entry.

* **Bug Fixes**
  * Improved goal progress handling, completion feedback, and dashboard refresh behavior.
  * Prevented invalid, duplicate, future-day, or unavailable actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->