### PR TITLE
fix(sw): Update-Hinweis überlebt konkurrierende Snackbars

### DIFF
--- a/docs/gotchas/push-and-service-workers.md
+++ b/docs/gotchas/push-and-service-workers.md
@@ -4,25 +4,53 @@
 
 In-app reminders use `ReminderService` with `setInterval`. Server-side reminders come from the `dispatchPushReminders` Cloud Function (runs every 5 min via Web Push).
 
+## The update prompt must not live in a snackbar alone
+
+`MatSnackBar` is a singleton: every `open()` dismisses whatever is currently
+displayed. The app opens routine toasts from ~a dozen call sites (quick-add,
+training plans, feedback, reminders), and `VERSION_READY` fires **exactly once**
+per downloaded version — so the sticky reload prompt was regularly wiped by the
+next "Eintrag gespeichert" toast and never came back. Users reported never
+seeing an update notice at all.
+
+`SwUpdateService` (`web/src/app/core/sw-update.service.ts`) latches the event
+into an `updateAvailable` signal that stays set until the user reloads. The
+toolbar renders it as a persistent button; the snackbar is only the loud,
+transient half of the notice. Anything that has to survive a competing toast
+belongs in that signal, not in the snackbar.
+
+The service also re-opens the prompt (and skips the manifest check) on
+`visibilitychange → visible`, which is what actually reaches a PWA the user
+resumes hours after a deploy — background tabs get their `interval` timers
+throttled, so the 10-minute poll alone is not enough.
+
 ## ngsw update prompt: `activateUpdate()` before `reload()`
 
 `SwUpdate.versionUpdates` fires `VERSION_READY` when ngsw has downloaded a new version, but the new worker stays in `installed/waiting` until the **last** client of the old worker is gone. A plain `window.location.reload()` does not qualify — it just opens another navigation against the still-active old worker, so the user taps "Neu laden", the page reloads, and they keep seeing the old build until every tab is closed.
 
-Always call `await swUpdate.activateUpdate()` first, then `reload()` (`web/src/app/app.ts`):
+Always call `await swUpdate.activateUpdate()` first, then `reload()`
+(`SwUpdateService.applyUpdate()`):
 
 ```ts
-ref.onAction().subscribe(async () => {
+try {
   await swUpdate.activateUpdate();
-  window.location.reload();
-});
+} catch {
+  // no waiting worker (UNRECOVERABLE_STATE) — reload anyway
+}
+window.location.reload();
 ```
+
+`SwUpdate.unrecoverable` needs the same treatment: ngsw has lost the version it
+was serving and cannot self-heal, so the page keeps running on stale in-memory
+code until someone reloads it. Left unhandled it looks exactly like "the app
+stopped updating".
 
 ## ngsw doesn't poll — long-lived PWA/TWA sessions miss updates
 
-`SwUpdate` only checks the manifest once on app stabilisation (`registerWhenStable:2000` in `app.config.ts`). PWA / TWA users who never close the tab consequently **never** receive `VERSION_READY` after a deploy. Poll explicitly:
+`SwUpdate` only checks the manifest once on app stabilisation (`registerWhenStable:2000` in `app.config.ts`). PWA / TWA users who never close the tab consequently **never** receive `VERSION_READY` after a deploy. Poll explicitly, and pair the timer with a visibility hook:
 
 ```ts
-interval(10 * 60 * 1000)
+merge(interval(10 * 60 * 1000), fromEvent(document, 'visibilitychange').pipe(filter(() => document.visibilityState === 'visible')))
   .pipe(takeUntilDestroyed(this.destroyRef))
   .subscribe(() => void swUpdate.checkForUpdate());
 ```

--- a/web/src/app/app.html
+++ b/web/src/app/app.html
@@ -225,8 +225,9 @@
         mat-icon-button
         class="sw-update-button"
         data-testid="sw-update-button"
-        aria-label="Neue Version verfügbar – jetzt neu laden"
-        i18n-aria-label="@@sw.update.buttonAria"
+        [attr.aria-label]="
+          swUpdateUnrecoverable() ? swUpdateRecoverAriaLabel : swUpdateAriaLabel
+        "
         (click)="applyServiceWorkerUpdate()"
       >
         <mat-icon>system_update_alt</mat-icon>

--- a/web/src/app/app.html
+++ b/web/src/app/app.html
@@ -220,6 +220,18 @@
           </p>
         </div>
       </ng-template>
+      @if (swUpdateAvailable()) {
+      <button
+        mat-icon-button
+        class="sw-update-button"
+        data-testid="sw-update-button"
+        aria-label="Neue Version verfügbar – jetzt neu laden"
+        i18n-aria-label="@@sw.update.buttonAria"
+        (click)="applyServiceWorkerUpdate()"
+      >
+        <mat-icon>system_update_alt</mat-icon>
+      </button>
+      }
       <app-theme-toggle />
       <app-ai-assistant-nav-button />
       @if (isAdmin()) {

--- a/web/src/app/app.scss
+++ b/web/src/app/app.scss
@@ -104,6 +104,19 @@ mat-sidenav-content {
     flex: 1 1 auto;
   }
 
+  // The reload prompt's snackbar half can be pushed aside by any other
+  // toast, so this button is the notice that has to survive on its own.
+  // The pulse is what makes it register as new rather than as one more
+  // permanent toolbar icon.
+  .sw-update-button {
+    color: var(--mat-sys-primary, #7aa0ff);
+    animation: sw-update-pulse 2.4s ease-in-out infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+  }
+
   .brand-link {
     display: inline-flex;
     align-items: center;
@@ -384,5 +397,17 @@ html.light-theme {
     a.active {
       color: #1d4ed8;
     }
+  }
+}
+
+@keyframes sw-update-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.55;
+    transform: scale(0.88);
   }
 }

--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -4,9 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { signal, WritableSignal, PLATFORM_ID } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { Title } from '@angular/platform-browser';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { SwUpdate } from '@angular/service-worker';
-import { NEVER, of, Subject } from 'rxjs';
+import { of } from 'rxjs';
 import {
   ExerciseFirestoreService,
   StatsApiService,
@@ -25,6 +23,7 @@ import { VAPID_PUBLIC_KEY } from '@pu-push/push';
 import { App } from './app';
 import { GoalReachedNotificationService } from './core/goal-reached-notification.service';
 import { QuickAddOrchestrationService } from './core/quick-add-orchestration.service';
+import { SwUpdateService } from './core/sw-update.service';
 
 describe('App (testing-library)', () => {
   let userNameSignal: WritableSignal<string>;
@@ -1174,315 +1173,84 @@ describe('App (testing-library)', () => {
     });
   });
 
-  describe('service worker update notifications', () => {
-    function makeSwUpdateMock() {
-      const versionUpdates = new Subject<{ type: string }>();
-      return {
-        versionUpdates: versionUpdates.asObservable(),
-        isEnabled: true,
-        activateUpdate: vitest.fn().mockResolvedValue(true),
-        checkForUpdate: vitest.fn().mockResolvedValue(true),
-        emit: (event: { type: string }) => versionUpdates.next(event),
-      };
+  // The reload prompt used to live only in a MatSnackBar, which any other
+  // toast dismisses for good — VERSION_READY never fires twice. The toolbar
+  // button is the durable half of the notice; SwUpdateService owns the
+  // snackbar half and is covered in core/sw-update.service.spec.ts.
+  describe('service worker update indicator', () => {
+    function renderWithSwUpdate(swUpdateService: {
+      updateAvailable: () => boolean;
+      applyUpdate: () => Promise<void>;
+    }) {
+      return render(App, {
+        providers: [
+          provideRouter([]),
+          { provide: PLATFORM_ID, useValue: 'browser' },
+          {
+            provide: UserContextService,
+            useValue: {
+              userNameSafe: userNameSignal.asReadonly(),
+              userIdSafe: () => 'u1',
+              isAdmin: () => false,
+              isGuest: () => false,
+            },
+          },
+          { provide: AuthStore, useValue: authMock },
+          { provide: AuthService, useValue: authServiceMock },
+          { provide: Auth, useValue: firebaseAuthMock },
+          { provide: UserConfigApiService, useValue: userConfigApiMock },
+          { provide: StatsApiService, useValue: statsApiMock },
+          { provide: AdsStore, useValue: adsStoreMock },
+          { provide: VAPID_PUBLIC_KEY, useValue: 'test-vapid-key' },
+          {
+            provide: ExerciseFirestoreService,
+            useValue: exerciseFirestoreMock,
+          },
+          {
+            provide: LiveDataStore,
+            useValue: {
+              connected: liveConnectedSignal,
+              exerciseEntries: liveEntriesSignal,
+              exerciseEntriesLoaded: liveConnectedSignal,
+              updateTick: signal(0),
+            },
+          },
+          { provide: SwUpdateService, useValue: swUpdateService },
+        ],
+      });
     }
 
-    it('shows the actionable reload snackbar on VERSION_READY', async () => {
-      const swUpdate = makeSwUpdateMock();
-      const onActionSubject = new Subject<void>();
-      const openSpy = vitest
-        .spyOn(MatSnackBar.prototype, 'open')
-        .mockReturnValue({
-          onAction: () => onActionSubject.asObservable(),
-          afterDismissed: () => of({ dismissedByAction: false }),
-        } as unknown as ReturnType<MatSnackBar['open']>);
-
-      await render(App, {
-        providers: [
-          provideRouter([]),
-          { provide: PLATFORM_ID, useValue: 'browser' },
-          {
-            provide: UserContextService,
-            useValue: {
-              userNameSafe: userNameSignal.asReadonly(),
-              userIdSafe: () => 'u1',
-              isAdmin: () => false,
-              isGuest: () => false,
-            },
-          },
-          { provide: AuthStore, useValue: authMock },
-          { provide: AuthService, useValue: authServiceMock },
-          { provide: Auth, useValue: firebaseAuthMock },
-          { provide: UserConfigApiService, useValue: userConfigApiMock },
-          { provide: StatsApiService, useValue: statsApiMock },
-          { provide: AdsStore, useValue: adsStoreMock },
-          { provide: VAPID_PUBLIC_KEY, useValue: 'test-vapid-key' },
-          {
-            provide: ExerciseFirestoreService,
-            useValue: exerciseFirestoreMock,
-          },
-          {
-            provide: LiveDataStore,
-            useValue: {
-              connected: liveConnectedSignal,
-              exerciseEntries: liveEntriesSignal,
-              exerciseEntriesLoaded: liveConnectedSignal,
-              updateTick: signal(0),
-            },
-          },
-          { provide: SwUpdate, useValue: swUpdate },
-        ],
+    it('should hide the reload button while no update is pending', async () => {
+      // given / when
+      await renderWithSwUpdate({
+        updateAvailable: () => false,
+        applyUpdate: vitest.fn().mockResolvedValue(undefined),
       });
 
-      swUpdate.emit({ type: 'VERSION_READY' });
+      // then
+      expect(
+        screen.queryByRole('button', {
+          name: /Neue Version verf\u00fcgbar/i,
+        })
+      ).toBeNull();
+    });
 
-      const reloadCall = openSpy.mock.calls.find(
-        ([, action]) => action === 'Neu laden'
+    it('should apply the update when the toolbar reload button is clicked', async () => {
+      // given
+      const applyUpdate = vitest.fn().mockResolvedValue(undefined);
+      const pending = signal(true);
+      await renderWithSwUpdate({
+        updateAvailable: pending,
+        applyUpdate,
+      });
+
+      // when
+      await userEvent.click(
+        screen.getByRole('button', { name: /Neue Version verf\u00fcgbar/i })
       );
-      expect(reloadCall).toBeTruthy();
-      expect(reloadCall?.[0]).toBe('Neue Version verfügbar');
-    });
 
-    // Regression: a 20s auto-dismiss + bottom anchor meant the prompt was
-    // easy to miss (mobile bottom-nav clipped it; tabbing away wiped it).
-    // The update toast must now be sticky and top-anchored so the user can
-    // always act on it, with a distinct panelClass for styling.
-    it('opens the update snackbar sticky at top-center with the sw-update panelClass', async () => {
-      const swUpdate = makeSwUpdateMock();
-      // `NEVER` (not `of(undefined)`) so the action observable never emits —
-      // an immediate emission would synchronously fire the VERSION_READY
-      // handler's `activateUpdate()` + `window.location.reload()` side
-      // effects during this config-only assertion (jsdom can't navigate).
-      const openSpy = vitest
-        .spyOn(MatSnackBar.prototype, 'open')
-        .mockReturnValue({
-          onAction: () => NEVER,
-          afterDismissed: () => of({ dismissedByAction: false }),
-        } as unknown as ReturnType<MatSnackBar['open']>);
-
-      await render(App, {
-        providers: [
-          provideRouter([]),
-          { provide: PLATFORM_ID, useValue: 'browser' },
-          {
-            provide: UserContextService,
-            useValue: {
-              userNameSafe: userNameSignal.asReadonly(),
-              userIdSafe: () => 'u1',
-              isAdmin: () => false,
-              isGuest: () => false,
-            },
-          },
-          { provide: AuthStore, useValue: authMock },
-          { provide: AuthService, useValue: authServiceMock },
-          { provide: Auth, useValue: firebaseAuthMock },
-          { provide: UserConfigApiService, useValue: userConfigApiMock },
-          { provide: StatsApiService, useValue: statsApiMock },
-          { provide: AdsStore, useValue: adsStoreMock },
-          { provide: VAPID_PUBLIC_KEY, useValue: 'test-vapid-key' },
-          {
-            provide: ExerciseFirestoreService,
-            useValue: exerciseFirestoreMock,
-          },
-          {
-            provide: LiveDataStore,
-            useValue: {
-              connected: liveConnectedSignal,
-              exerciseEntries: liveEntriesSignal,
-              exerciseEntriesLoaded: liveConnectedSignal,
-              updateTick: signal(0),
-            },
-          },
-          { provide: SwUpdate, useValue: swUpdate },
-        ],
-      });
-
-      swUpdate.emit({ type: 'VERSION_READY' });
-
-      const reloadCall = openSpy.mock.calls.find(
-        ([, action]) => action === 'Neu laden'
-      );
-      expect(reloadCall).toBeTruthy();
-      const config = reloadCall?.[2];
-      expect(config?.duration).toBeUndefined();
-      expect(config?.horizontalPosition).toBe('center');
-      expect(config?.verticalPosition).toBe('top');
-      expect(config?.panelClass).toBe('sw-update-snackbar');
-    });
-
-    // Regression: a non-actionable "downloading in background" toast used to
-    // fire on VERSION_DETECTED, visually replacing the actionable reload toast
-    // and leaving users with no way to apply the update.
-    it('does not show a snackbar on VERSION_DETECTED', async () => {
-      const swUpdate = makeSwUpdateMock();
-      const openSpy = vitest
-        .spyOn(MatSnackBar.prototype, 'open')
-        .mockReturnValue({
-          onAction: () => of(undefined),
-          afterDismissed: () => of({ dismissedByAction: false }),
-        } as unknown as ReturnType<MatSnackBar['open']>);
-
-      await render(App, {
-        providers: [
-          provideRouter([]),
-          { provide: PLATFORM_ID, useValue: 'browser' },
-          {
-            provide: UserContextService,
-            useValue: {
-              userNameSafe: userNameSignal.asReadonly(),
-              userIdSafe: () => 'u1',
-              isAdmin: () => false,
-              isGuest: () => false,
-            },
-          },
-          { provide: AuthStore, useValue: authMock },
-          { provide: AuthService, useValue: authServiceMock },
-          { provide: Auth, useValue: firebaseAuthMock },
-          { provide: UserConfigApiService, useValue: userConfigApiMock },
-          { provide: StatsApiService, useValue: statsApiMock },
-          { provide: AdsStore, useValue: adsStoreMock },
-          { provide: VAPID_PUBLIC_KEY, useValue: 'test-vapid-key' },
-          {
-            provide: ExerciseFirestoreService,
-            useValue: exerciseFirestoreMock,
-          },
-          {
-            provide: LiveDataStore,
-            useValue: {
-              connected: liveConnectedSignal,
-              exerciseEntries: liveEntriesSignal,
-              exerciseEntriesLoaded: liveConnectedSignal,
-              updateTick: signal(0),
-            },
-          },
-          { provide: SwUpdate, useValue: swUpdate },
-        ],
-      });
-
-      const callsBefore = openSpy.mock.calls.length;
-      swUpdate.emit({ type: 'VERSION_DETECTED' });
-      expect(openSpy.mock.calls.length).toBe(callsBefore);
-    });
-
-    // Regression: a plain `location.reload()` does not skip the waiting
-    // ngsw, so users would tap "Neu laden" and still get the old build.
-    // The handler must call `activateUpdate()` before the reload.
-    it('activates the waiting worker before reloading on Neu laden click', async () => {
-      const swUpdate = makeSwUpdateMock();
-      const onActionSubject = new Subject<void>();
-      vitest.spyOn(MatSnackBar.prototype, 'open').mockReturnValue({
-        onAction: () => onActionSubject.asObservable(),
-        afterDismissed: () => of({ dismissedByAction: false }),
-      } as unknown as ReturnType<MatSnackBar['open']>);
-
-      const reloadSpy = vitest.fn();
-      vitest.spyOn(window, 'location', 'get').mockReturnValue({
-        reload: reloadSpy,
-      } as unknown as Location);
-
-      await render(App, {
-        providers: [
-          provideRouter([]),
-          { provide: PLATFORM_ID, useValue: 'browser' },
-          {
-            provide: UserContextService,
-            useValue: {
-              userNameSafe: userNameSignal.asReadonly(),
-              userIdSafe: () => 'u1',
-              isAdmin: () => false,
-              isGuest: () => false,
-            },
-          },
-          { provide: AuthStore, useValue: authMock },
-          { provide: AuthService, useValue: authServiceMock },
-          { provide: Auth, useValue: firebaseAuthMock },
-          { provide: UserConfigApiService, useValue: userConfigApiMock },
-          { provide: StatsApiService, useValue: statsApiMock },
-          { provide: AdsStore, useValue: adsStoreMock },
-          { provide: VAPID_PUBLIC_KEY, useValue: 'test-vapid-key' },
-          {
-            provide: ExerciseFirestoreService,
-            useValue: exerciseFirestoreMock,
-          },
-          {
-            provide: LiveDataStore,
-            useValue: {
-              connected: liveConnectedSignal,
-              exerciseEntries: liveEntriesSignal,
-              exerciseEntriesLoaded: liveConnectedSignal,
-              updateTick: signal(0),
-            },
-          },
-          { provide: SwUpdate, useValue: swUpdate },
-        ],
-      });
-
-      swUpdate.emit({ type: 'VERSION_READY' });
-      onActionSubject.next();
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(swUpdate.activateUpdate).toHaveBeenCalledTimes(1);
-      expect(reloadSpy).toHaveBeenCalledTimes(1);
-      expect(swUpdate.activateUpdate.mock.invocationCallOrder[0]).toBeLessThan(
-        reloadSpy.mock.invocationCallOrder[0]
-      );
-    });
-
-    // Regression: long-lived PWA/TWA sessions never received the reload
-    // toast because ngsw only checked the manifest once at app start.
-    // Polling every 10 minutes ensures new deploys eventually surface.
-    it('polls swUpdate.checkForUpdate every 10 minutes', async () => {
-      vitest.useFakeTimers();
-      try {
-        const swUpdate = makeSwUpdateMock();
-
-        await render(App, {
-          providers: [
-            provideRouter([]),
-            { provide: PLATFORM_ID, useValue: 'browser' },
-            {
-              provide: UserContextService,
-              useValue: {
-                userNameSafe: userNameSignal.asReadonly(),
-                userIdSafe: () => 'u1',
-                isAdmin: () => false,
-                isGuest: () => false,
-              },
-            },
-            { provide: AuthStore, useValue: authMock },
-            { provide: AuthService, useValue: authServiceMock },
-            { provide: Auth, useValue: firebaseAuthMock },
-            { provide: UserConfigApiService, useValue: userConfigApiMock },
-            { provide: StatsApiService, useValue: statsApiMock },
-            { provide: AdsStore, useValue: adsStoreMock },
-            { provide: VAPID_PUBLIC_KEY, useValue: 'test-vapid-key' },
-            {
-              provide: ExerciseFirestoreService,
-              useValue: exerciseFirestoreMock,
-            },
-            {
-              provide: LiveDataStore,
-              useValue: {
-                connected: liveConnectedSignal,
-                exerciseEntries: liveEntriesSignal,
-                exerciseEntriesLoaded: liveConnectedSignal,
-                updateTick: signal(0),
-              },
-            },
-            { provide: SwUpdate, useValue: swUpdate },
-          ],
-        });
-
-        expect(swUpdate.checkForUpdate).not.toHaveBeenCalled();
-
-        vitest.advanceTimersByTime(10 * 60 * 1000);
-        expect(swUpdate.checkForUpdate).toHaveBeenCalledTimes(1);
-
-        vitest.advanceTimersByTime(20 * 60 * 1000);
-        expect(swUpdate.checkForUpdate).toHaveBeenCalledTimes(3);
-      } finally {
-        vitest.useRealTimers();
-      }
+      // then
+      expect(applyUpdate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -1180,8 +1180,13 @@ describe('App (testing-library)', () => {
   describe('service worker update indicator', () => {
     function renderWithSwUpdate(swUpdateService: {
       updateAvailable: () => boolean;
+      unrecoverable?: () => boolean;
       applyUpdate: () => Promise<void>;
     }) {
+      const service = {
+        unrecoverable: () => false,
+        ...swUpdateService,
+      };
       return render(App, {
         providers: [
           provideRouter([]),
@@ -1215,7 +1220,7 @@ describe('App (testing-library)', () => {
               updateTick: signal(0),
             },
           },
-          { provide: SwUpdateService, useValue: swUpdateService },
+          { provide: SwUpdateService, useValue: service },
         ],
       });
     }
@@ -1251,6 +1256,25 @@ describe('App (testing-library)', () => {
 
       // then
       expect(applyUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    // A corrupted ngsw cache is not "a new version is ready" — screen readers
+    // must not announce it as one.
+    it('should announce the corrupted-cache state instead of a new version', async () => {
+      // given / when
+      await renderWithSwUpdate({
+        updateAvailable: () => true,
+        unrecoverable: () => true,
+        applyUpdate: vitest.fn().mockResolvedValue(undefined),
+      });
+
+      // then
+      expect(
+        screen.getByRole('button', { name: /App-Daten besch\u00e4digt/i })
+      ).toBeTruthy();
+      expect(
+        screen.queryByRole('button', { name: /Neue Version verf\u00fcgbar/i })
+      ).toBeNull();
     });
   });
 

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -142,6 +142,9 @@ export class App {
   private readonly swUpdate = inject(SwUpdateService);
   /** Drives the persistent "new version" button in the toolbar. */
   readonly swUpdateAvailable = this.swUpdate.updateAvailable;
+  readonly swUpdateUnrecoverable = this.swUpdate.unrecoverable;
+  protected readonly swUpdateAriaLabel = $localize`:@@sw.update.buttonAria:Neue Version verfügbar – jetzt neu laden`;
+  protected readonly swUpdateRecoverAriaLabel = $localize`:@@sw.update.recoverButtonAria:App-Daten beschädigt – jetzt neu laden`;
   private readonly snackBar = inject(MatSnackBar);
   private readonly dialog = inject(MatDialog);
   private readonly firebaseAuth = inject(Auth, { optional: true });

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -34,9 +34,8 @@ import {
   RouterLinkActive,
   RouterOutlet,
 } from '@angular/router';
-import { SwUpdate } from '@angular/service-worker';
 import { AuthService, AuthStore, UserMenuComponent } from '@pu-auth/auth';
-import { filter, interval } from 'rxjs';
+import { filter } from 'rxjs';
 import { AiAssistantNavButtonComponent } from './ai/ai-assistant-nav-button.component';
 import { SeoService } from './core/seo.service';
 import { FeatureFlagsService, UserContextService } from '@pu-auth/auth';
@@ -58,6 +57,7 @@ import { toGoalDialItems } from './core/daily-goal/goal-dial-items';
 import { createGoalPillOverlay } from './core/daily-goal/goal-pill-overlay';
 import { ThemeToggleComponent } from './core/theme';
 import { ReminderOrchestrationService } from './core/reminder-orchestration.service';
+import { SwUpdateService } from './core/sw-update.service';
 import { AppDataFacade } from './core/app-data.facade';
 import { QuickAddOrchestrationService } from './core/quick-add-orchestration.service';
 import { GoalReachedNotificationService } from './core/goal-reached-notification.service';
@@ -139,7 +139,9 @@ function resolveCurrentLocale(localeId: string): SupportedLocale {
   styleUrl: './app.scss',
 })
 export class App {
-  private readonly swUpdate = inject(SwUpdate, { optional: true });
+  private readonly swUpdate = inject(SwUpdateService);
+  /** Drives the persistent "new version" button in the toolbar. */
+  readonly swUpdateAvailable = this.swUpdate.updateAvailable;
   private readonly snackBar = inject(MatSnackBar);
   private readonly dialog = inject(MatDialog);
   private readonly firebaseAuth = inject(Auth, { optional: true });
@@ -377,49 +379,10 @@ export class App {
         this.seo.update(title, description, path, { noindex: data.noindex });
         this.trackAnalytics('page_view', { page_path: path });
       });
+  }
 
-    if (this.swUpdate?.isEnabled) {
-      const swUpdate = this.swUpdate;
-      swUpdate.versionUpdates
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe((event) => {
-          if (event.type !== 'VERSION_READY') return;
-
-          // Sticky (no `duration`) + top-center: the prompt sits at eye level
-          // and stays put until the user clicks "Neu laden". An auto-dismiss
-          // timer made the toast easy to miss (especially when the mobile
-          // bottom-nav cropped the bottom-anchored variant). Distinct
-          // panelClass lets `styles.scss` give it its own surface colour so
-          // it doesn't get mistaken for a routine info toast.
-          const ref = this.snackBar.open(
-            $localize`:@@sw.update.available:Neue Version verfügbar`,
-            $localize`:@@sw.update.reload:Neu laden`,
-            {
-              horizontalPosition: 'center',
-              verticalPosition: 'top',
-              panelClass: 'sw-update-snackbar',
-            }
-          );
-
-          ref.onAction().subscribe(async () => {
-            // `reload()` alone keeps the old waiting worker in place; call
-            // `activateUpdate()` first so the new ngsw takes over before the
-            // browser fetches the next navigation.
-            await swUpdate.activateUpdate();
-            window.location.reload();
-          });
-        });
-
-      // Long-lived sessions (PWA / TWA users who never close the tab) only
-      // see VERSION_READY when ngsw re-checks the manifest. Default check is
-      // once on app stabilisation, so without a poll a deploy never reaches
-      // them. Ten minutes mirrors the cadence used in the SW reminder system.
-      interval(10 * 60 * 1000)
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe(() => {
-          void swUpdate.checkForUpdate();
-        });
-    }
+  applyServiceWorkerUpdate(): void {
+    void this.swUpdate.applyUpdate();
   }
 
   handleQuickAdd(suggestion: QuickAddSuggestion): void {

--- a/web/src/app/core/sw-update.service.spec.ts
+++ b/web/src/app/core/sw-update.service.spec.ts
@@ -1,0 +1,315 @@
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { SwUpdate } from '@angular/service-worker';
+import { NEVER, Subject, of } from 'rxjs';
+import {
+  SW_UPDATE_POLL_INTERVAL_MS,
+  SwUpdateService,
+} from './sw-update.service';
+
+interface SnackBarStub {
+  onAction: () => unknown;
+  afterDismissed: () => unknown;
+}
+
+describe('SwUpdateService', () => {
+  let versionUpdates: Subject<{ type: string }>;
+  let unrecoverable: Subject<{ type: string; reason: string }>;
+  let swUpdateMock: {
+    versionUpdates: ReturnType<Subject<{ type: string }>['asObservable']>;
+    unrecoverable: ReturnType<
+      Subject<{ type: string; reason: string }>['asObservable']
+    >;
+    isEnabled: boolean;
+    activateUpdate: ReturnType<typeof vitest.fn>;
+    checkForUpdate: ReturnType<typeof vitest.fn>;
+  };
+  let openSpy: ReturnType<typeof stubSnackBar>;
+  let onActionSubject: Subject<void>;
+  let afterDismissedSubject: Subject<{ dismissedByAction: boolean }>;
+  let reloadSpy: ReturnType<typeof vitest.fn>;
+
+  function stubSnackBar(overrides: Partial<SnackBarStub> = {}) {
+    return vitest.spyOn(MatSnackBar.prototype, 'open').mockReturnValue({
+      onAction: () => onActionSubject.asObservable(),
+      afterDismissed: () => afterDismissedSubject.asObservable(),
+      ...overrides,
+    } as unknown as ReturnType<MatSnackBar['open']>);
+  }
+
+  function createService(platform: 'browser' | 'server' = 'browser') {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: PLATFORM_ID, useValue: platform },
+        { provide: SwUpdate, useValue: swUpdateMock },
+      ],
+    });
+    return TestBed.inject(SwUpdateService);
+  }
+
+  function updateCalls() {
+    return openSpy.mock.calls.filter(([, action]) => action === 'Neu laden');
+  }
+
+  beforeEach(() => {
+    versionUpdates = new Subject();
+    unrecoverable = new Subject();
+    onActionSubject = new Subject();
+    afterDismissedSubject = new Subject();
+    swUpdateMock = {
+      versionUpdates: versionUpdates.asObservable(),
+      unrecoverable: unrecoverable.asObservable(),
+      isEnabled: true,
+      activateUpdate: vitest.fn().mockResolvedValue(true),
+      checkForUpdate: vitest.fn().mockResolvedValue(true),
+    };
+    reloadSpy = vitest.fn();
+    vitest
+      .spyOn(window, 'location', 'get')
+      .mockReturnValue({ reload: reloadSpy } as unknown as Location);
+    openSpy = stubSnackBar();
+  });
+
+  afterEach(() => {
+    vitest.restoreAllMocks();
+  });
+
+  it('should show the actionable reload snackbar on VERSION_READY', () => {
+    // given
+    const service = createService();
+
+    // when
+    versionUpdates.next({ type: 'VERSION_READY' });
+
+    // then
+    expect(updateCalls()).toHaveLength(1);
+    expect(updateCalls()[0][0]).toBe('Neue Version verfügbar');
+    expect(service.updateAvailable()).toBe(true);
+  });
+
+  // Regression: a 20s auto-dismiss + bottom anchor meant the prompt was easy
+  // to miss (mobile bottom-nav clipped it; tabbing away wiped it).
+  it('should open the prompt sticky at top-center with the sw-update panelClass', () => {
+    // given
+    createService();
+
+    // when
+    versionUpdates.next({ type: 'VERSION_READY' });
+
+    // then
+    const config = updateCalls()[0][2];
+    expect(config?.duration).toBeUndefined();
+    expect(config?.horizontalPosition).toBe('center');
+    expect(config?.verticalPosition).toBe('top');
+    expect(config?.panelClass).toBe('sw-update-snackbar');
+  });
+
+  // Regression: a non-actionable "downloading in background" toast used to
+  // fire on VERSION_DETECTED, visually replacing the actionable reload toast
+  // and leaving users with no way to apply the update.
+  it('should not prompt on VERSION_DETECTED', () => {
+    // given
+    const service = createService();
+
+    // when
+    versionUpdates.next({ type: 'VERSION_DETECTED' });
+
+    // then
+    expect(updateCalls()).toHaveLength(0);
+    expect(service.updateAvailable()).toBe(false);
+  });
+
+  // Regression: a plain `location.reload()` does not skip the waiting ngsw,
+  // so users would tap "Neu laden" and still get the old build.
+  it('should activate the waiting worker before reloading on Neu laden', async () => {
+    // given
+    createService();
+    versionUpdates.next({ type: 'VERSION_READY' });
+
+    // when
+    onActionSubject.next();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // then
+    expect(swUpdateMock.activateUpdate).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(
+      swUpdateMock.activateUpdate.mock.invocationCallOrder[0]
+    ).toBeLessThan(reloadSpy.mock.invocationCallOrder[0]);
+  });
+
+  // Regression: the whole point of the fix — `MatSnackBar` is a singleton, so
+  // any routine toast dismisses the sticky reload prompt, and VERSION_READY
+  // never fires twice. The latched signal is what keeps the notice reachable.
+  it('should keep updateAvailable set after the snackbar is dismissed by another toast', () => {
+    // given
+    const service = createService();
+    versionUpdates.next({ type: 'VERSION_READY' });
+
+    // when
+    afterDismissedSubject.next({ dismissedByAction: false });
+
+    // then
+    expect(service.updateAvailable()).toBe(true);
+  });
+
+  it('should re-open the prompt when the user returns to a backgrounded tab', () => {
+    // given
+    createService();
+    versionUpdates.next({ type: 'VERSION_READY' });
+    afterDismissedSubject.next({ dismissedByAction: false });
+    vitest
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('visible' as DocumentVisibilityState);
+
+    // when
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // then
+    expect(updateCalls()).toHaveLength(2);
+    expect(swUpdateMock.checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should not stack a second prompt while one is still on screen', () => {
+    // given
+    createService();
+    versionUpdates.next({ type: 'VERSION_READY' });
+    vitest
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('visible' as DocumentVisibilityState);
+
+    // when
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // then
+    expect(updateCalls()).toHaveLength(1);
+  });
+
+  it('should check for an update when a hidden tab becomes visible again', () => {
+    // given
+    createService();
+    vitest
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('visible' as DocumentVisibilityState);
+
+    // when
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // then
+    expect(swUpdateMock.checkForUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore a visibilitychange that hides the tab', () => {
+    // given
+    createService();
+    vitest
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('hidden' as DocumentVisibilityState);
+
+    // when
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // then
+    expect(swUpdateMock.checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  // Regression: long-lived PWA/TWA sessions never received the reload toast
+  // because ngsw only checked the manifest once at app start.
+  it('should poll checkForUpdate every 10 minutes', () => {
+    // given
+    vitest.useFakeTimers();
+    try {
+      createService();
+      expect(swUpdateMock.checkForUpdate).not.toHaveBeenCalled();
+
+      // when
+      vitest.advanceTimersByTime(SW_UPDATE_POLL_INTERVAL_MS);
+
+      // then
+      expect(swUpdateMock.checkForUpdate).toHaveBeenCalledTimes(1);
+
+      vitest.advanceTimersByTime(2 * SW_UPDATE_POLL_INTERVAL_MS);
+      expect(swUpdateMock.checkForUpdate).toHaveBeenCalledTimes(3);
+    } finally {
+      vitest.useRealTimers();
+    }
+  });
+
+  it('should survive a rejected checkForUpdate', () => {
+    // given
+    vitest.useFakeTimers();
+    swUpdateMock.checkForUpdate = vitest
+      .fn()
+      .mockRejectedValue(new Error('offline'));
+    try {
+      createService();
+
+      // when
+      vitest.advanceTimersByTime(2 * SW_UPDATE_POLL_INTERVAL_MS);
+
+      // then
+      expect(swUpdateMock.checkForUpdate).toHaveBeenCalledTimes(2);
+    } finally {
+      vitest.useRealTimers();
+    }
+  });
+
+  it('should prompt with the corrupted-cache message on UNRECOVERABLE_STATE', () => {
+    // given
+    const service = createService();
+
+    // when
+    unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'gone' });
+
+    // then
+    expect(updateCalls()).toHaveLength(1);
+    expect(updateCalls()[0][0]).toBe('App-Daten beschädigt – bitte neu laden');
+    expect(service.unrecoverable()).toBe(true);
+    expect(service.updateAvailable()).toBe(true);
+  });
+
+  it('should still reload when activateUpdate rejects', async () => {
+    // given
+    swUpdateMock.activateUpdate = vitest
+      .fn()
+      .mockRejectedValue(new Error('no waiting worker'));
+    const service = createService();
+
+    // when
+    await service.applyUpdate();
+
+    // then
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should stay inert during SSR', () => {
+    // given
+    openSpy = stubSnackBar({
+      onAction: () => NEVER,
+      afterDismissed: () => of({}),
+    });
+
+    // when
+    const service = createService('server');
+    versionUpdates.next({ type: 'VERSION_READY' });
+
+    // then
+    expect(service.updateAvailable()).toBe(false);
+    expect(updateCalls()).toHaveLength(0);
+  });
+
+  it('should stay inert when the service worker is disabled', () => {
+    // given
+    swUpdateMock.isEnabled = false;
+
+    // when
+    const service = createService();
+    versionUpdates.next({ type: 'VERSION_READY' });
+
+    // then
+    expect(service.updateAvailable()).toBe(false);
+    expect(updateCalls()).toHaveLength(0);
+  });
+});

--- a/web/src/app/core/sw-update.service.spec.ts
+++ b/web/src/app/core/sw-update.service.spec.ts
@@ -8,9 +8,20 @@ import {
   SwUpdateService,
 } from './sw-update.service';
 
-interface SnackBarStub {
-  onAction: () => unknown;
-  afterDismissed: () => unknown;
+interface SnackBarOverrides {
+  onAction?: () => unknown;
+  afterDismissed?: () => unknown;
+}
+
+/**
+ * One entry per `MatSnackBar.open()` call. Each opened ref needs its own
+ * `afterDismissed` stream — the service distinguishes "my prompt was
+ * dismissed" from "a prompt I already replaced finished dismissing" by ref
+ * identity, which a single shared subject would paper over.
+ */
+interface RefStub {
+  dismiss: ReturnType<typeof vitest.fn>;
+  afterDismissed$: Subject<{ dismissedByAction: boolean }>;
 }
 
 describe('SwUpdateService', () => {
@@ -26,16 +37,26 @@ describe('SwUpdateService', () => {
     checkForUpdate: ReturnType<typeof vitest.fn>;
   };
   let openSpy: ReturnType<typeof stubSnackBar>;
+  let refs: RefStub[];
   let onActionSubject: Subject<void>;
-  let afterDismissedSubject: Subject<{ dismissedByAction: boolean }>;
   let reloadSpy: ReturnType<typeof vitest.fn>;
 
-  function stubSnackBar(overrides: Partial<SnackBarStub> = {}) {
-    return vitest.spyOn(MatSnackBar.prototype, 'open').mockReturnValue({
-      onAction: () => onActionSubject.asObservable(),
-      afterDismissed: () => afterDismissedSubject.asObservable(),
-      ...overrides,
-    } as unknown as ReturnType<MatSnackBar['open']>);
+  function stubSnackBar(overrides: SnackBarOverrides = {}) {
+    return vitest
+      .spyOn(MatSnackBar.prototype, 'open')
+      .mockImplementation(() => {
+        const stub: RefStub = {
+          dismiss: vitest.fn(),
+          afterDismissed$: new Subject(),
+        };
+        refs.push(stub);
+        return {
+          onAction: () => onActionSubject.asObservable(),
+          afterDismissed: () => stub.afterDismissed$.asObservable(),
+          dismiss: stub.dismiss,
+          ...overrides,
+        } as unknown as ReturnType<MatSnackBar['open']>;
+      });
   }
 
   function createService(platform: 'browser' | 'server' = 'browser') {
@@ -52,11 +73,23 @@ describe('SwUpdateService', () => {
     return openSpy.mock.calls.filter(([, action]) => action === 'Neu laden');
   }
 
+  /** Complete the dismiss animation of the nth opened prompt (default: last). */
+  function finishDismiss(index = refs.length - 1): void {
+    refs[index].afterDismissed$.next({ dismissedByAction: false });
+  }
+
+  function becomeVisible(): void {
+    vitest
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('visible' as DocumentVisibilityState);
+    document.dispatchEvent(new Event('visibilitychange'));
+  }
+
   beforeEach(() => {
     versionUpdates = new Subject();
     unrecoverable = new Subject();
     onActionSubject = new Subject();
-    afterDismissedSubject = new Subject();
+    refs = [];
     swUpdateMock = {
       versionUpdates: versionUpdates.asObservable(),
       unrecoverable: unrecoverable.asObservable(),
@@ -149,7 +182,7 @@ describe('SwUpdateService', () => {
     versionUpdates.next({ type: 'VERSION_READY' });
 
     // when
-    afterDismissedSubject.next({ dismissedByAction: false });
+    finishDismiss();
 
     // then
     expect(service.updateAvailable()).toBe(true);
@@ -159,13 +192,10 @@ describe('SwUpdateService', () => {
     // given
     createService();
     versionUpdates.next({ type: 'VERSION_READY' });
-    afterDismissedSubject.next({ dismissedByAction: false });
-    vitest
-      .spyOn(document, 'visibilityState', 'get')
-      .mockReturnValue('visible' as DocumentVisibilityState);
+    finishDismiss();
 
     // when
-    document.dispatchEvent(new Event('visibilitychange'));
+    becomeVisible();
 
     // then
     expect(updateCalls()).toHaveLength(2);
@@ -176,12 +206,9 @@ describe('SwUpdateService', () => {
     // given
     createService();
     versionUpdates.next({ type: 'VERSION_READY' });
-    vitest
-      .spyOn(document, 'visibilityState', 'get')
-      .mockReturnValue('visible' as DocumentVisibilityState);
 
     // when
-    document.dispatchEvent(new Event('visibilitychange'));
+    becomeVisible();
 
     // then
     expect(updateCalls()).toHaveLength(1);
@@ -190,12 +217,9 @@ describe('SwUpdateService', () => {
   it('should check for an update when a hidden tab becomes visible again', () => {
     // given
     createService();
-    vitest
-      .spyOn(document, 'visibilityState', 'get')
-      .mockReturnValue('visible' as DocumentVisibilityState);
 
     // when
-    document.dispatchEvent(new Event('visibilitychange'));
+    becomeVisible();
 
     // then
     expect(swUpdateMock.checkForUpdate).toHaveBeenCalledTimes(1);
@@ -268,6 +292,37 @@ describe('SwUpdateService', () => {
     expect(updateCalls()[0][0]).toBe('App-Daten beschädigt – bitte neu laden');
     expect(service.unrecoverable()).toBe(true);
     expect(service.updateAvailable()).toBe(true);
+  });
+
+  // Regression: the reopen guard used to check only whether a prompt was open,
+  // so an UNRECOVERABLE_STATE arriving behind an open "Neue Version verfügbar"
+  // left the wrong message on screen.
+  it('should replace an open update prompt when the state escalates to unrecoverable', () => {
+    // given
+    createService();
+    versionUpdates.next({ type: 'VERSION_READY' });
+
+    // when
+    unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'gone' });
+
+    // then
+    expect(refs[0].dismiss).toHaveBeenCalledTimes(1);
+    expect(updateCalls()).toHaveLength(2);
+    expect(updateCalls()[1][0]).toBe('App-Daten beschädigt – bitte neu laden');
+  });
+
+  it('should keep tracking the replacement prompt when the replaced one finishes dismissing', () => {
+    // given
+    createService();
+    versionUpdates.next({ type: 'VERSION_READY' });
+    unrecoverable.next({ type: 'UNRECOVERABLE_STATE', reason: 'gone' });
+
+    // when
+    finishDismiss(0);
+    becomeVisible();
+
+    // then
+    expect(updateCalls()).toHaveLength(2);
   });
 
   it('should still reload when activateUpdate rejects', async () => {

--- a/web/src/app/core/sw-update.service.ts
+++ b/web/src/app/core/sw-update.service.ts
@@ -56,6 +56,7 @@ export class SwUpdateService {
   readonly unrecoverable = computed(() => this.pending() === 'unrecoverable');
 
   private promptRef: MatSnackBarRef<TextOnlySnackBar> | null = null;
+  private promptKind: PendingKind | null = null;
 
   constructor() {
     const swUpdate = this.swUpdate;
@@ -122,12 +123,20 @@ export class SwUpdateService {
   }
 
   private showPrompt(): void {
-    if (this.promptRef) return;
+    const kind = this.pending();
+    if (!kind) return;
+    if (this.promptRef) {
+      // An open prompt for the same state is already saying the right thing.
+      if (this.promptKind === kind) return;
+      // Escalating from 'update' to 'unrecoverable' changes the message, so
+      // the stale one has to go.
+      this.promptRef.dismiss();
+    }
 
-    const unrecoverable = this.unrecoverable();
-    const message = unrecoverable
-      ? $localize`:@@sw.update.unrecoverable:App-Daten beschädigt – bitte neu laden`
-      : $localize`:@@sw.update.available:Neue Version verfügbar`;
+    const message =
+      kind === 'unrecoverable'
+        ? $localize`:@@sw.update.unrecoverable:App-Daten beschädigt – bitte neu laden`
+        : $localize`:@@sw.update.available:Neue Version verfügbar`;
 
     // Sticky (no `duration`) + top-center: the prompt sits at eye level and
     // stays put until the user acts. An auto-dismiss timer made the toast easy
@@ -144,6 +153,7 @@ export class SwUpdateService {
       }
     );
     this.promptRef = ref;
+    this.promptKind = kind;
 
     ref
       .onAction()
@@ -153,7 +163,11 @@ export class SwUpdateService {
       .afterDismissed()
       .pipe(take(1))
       .subscribe(() => {
+        // `dismiss()` above resolves asynchronously, so the replaced ref's
+        // event can land after the replacement is already tracked.
+        if (this.promptRef !== ref) return;
         this.promptRef = null;
+        this.promptKind = null;
       });
   }
 }

--- a/web/src/app/core/sw-update.service.ts
+++ b/web/src/app/core/sw-update.service.ts
@@ -1,0 +1,159 @@
+import { isPlatformBrowser, DOCUMENT } from '@angular/common';
+import {
+  computed,
+  DestroyRef,
+  inject,
+  Injectable,
+  PLATFORM_ID,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  MatSnackBar,
+  type MatSnackBarRef,
+  type TextOnlySnackBar,
+} from '@angular/material/snack-bar';
+import { SwUpdate } from '@angular/service-worker';
+import { filter, fromEvent, interval, merge, take } from 'rxjs';
+
+/** How often a long-lived session asks ngsw for a fresh manifest. */
+export const SW_UPDATE_POLL_INTERVAL_MS = 10 * 60 * 1000;
+
+type PendingKind = 'update' | 'unrecoverable';
+
+/**
+ * Surfaces ngsw version changes to the user.
+ *
+ * `VERSION_READY` fires exactly once per downloaded version, so a prompt
+ * that only lives in a snackbar is lost for good the moment anything else
+ * calls `MatSnackBar.open()` — the snackbar is a singleton and every open
+ * dismisses the current one. Roughly a dozen call sites (quick-add,
+ * training plans, feedback, reminders) do exactly that, which is why the
+ * reload prompt kept vanishing before users could act on it.
+ *
+ * The fix is to latch the event into `updateAvailable`, which the toolbar
+ * renders as a persistent button. The snackbar becomes the loud-but-
+ * transient half of the notice, the toolbar button the durable half.
+ */
+@Injectable({ providedIn: 'root' })
+export class SwUpdateService {
+  private readonly swUpdate = inject(SwUpdate, { optional: true });
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly document = inject(DOCUMENT);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
+  private readonly pending = signal<PendingKind | null>(null);
+
+  /** True from the moment a new version is ready until the user reloads. */
+  readonly updateAvailable = computed(() => this.pending() !== null);
+
+  /**
+   * ngsw lost the cached version it was serving and cannot self-heal — the
+   * page keeps running on whatever is already in memory, so a reload is the
+   * only way back to a consistent build.
+   */
+  readonly unrecoverable = computed(() => this.pending() === 'unrecoverable');
+
+  private promptRef: MatSnackBarRef<TextOnlySnackBar> | null = null;
+
+  constructor() {
+    const swUpdate = this.swUpdate;
+    if (!this.isBrowser || !swUpdate?.isEnabled) return;
+
+    swUpdate.versionUpdates
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((event) => {
+        // VERSION_DETECTED only means "download started" — prompting there
+        // would offer a reload into a version that isn't cached yet.
+        if (event.type !== 'VERSION_READY') return;
+        this.pending.set('update');
+        this.showPrompt();
+      });
+
+    swUpdate.unrecoverable
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.pending.set('unrecoverable');
+        this.showPrompt();
+      });
+
+    // Long-lived sessions (PWA / TWA users who never close the tab) only see
+    // VERSION_READY when ngsw re-checks the manifest, and it only does that
+    // once on app stabilisation. Background tabs also get their timers
+    // throttled, so the visibility hook is what actually catches an app the
+    // user resumes hours after a deploy.
+    merge(
+      interval(SW_UPDATE_POLL_INTERVAL_MS),
+      fromEvent(this.document, 'visibilitychange').pipe(
+        filter(() => this.document.visibilityState === 'visible')
+      )
+    )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.poll());
+  }
+
+  /**
+   * Activate the waiting worker, then reload. `reload()` alone keeps the old
+   * worker in place — it just opens another navigation against the still-
+   * active one, so the user would reload into the same stale build.
+   */
+  async applyUpdate(): Promise<void> {
+    try {
+      await this.swUpdate?.activateUpdate();
+    } catch {
+      // Activation can fail when the cached version is already gone (the
+      // unrecoverable path). Reloading is still the right move: without a
+      // waiting worker the browser fetches the current build from the network.
+    }
+    window.location.reload();
+  }
+
+  private poll(): void {
+    if (this.pending()) {
+      // A prompt is already owed. Re-surfacing it is more useful than asking
+      // ngsw for a manifest we have already acted on.
+      this.showPrompt();
+      return;
+    }
+    this.swUpdate?.checkForUpdate().catch(() => {
+      // Offline or ngsw in safe mode — the next tick retries.
+    });
+  }
+
+  private showPrompt(): void {
+    if (this.promptRef) return;
+
+    const unrecoverable = this.unrecoverable();
+    const message = unrecoverable
+      ? $localize`:@@sw.update.unrecoverable:App-Daten beschädigt – bitte neu laden`
+      : $localize`:@@sw.update.available:Neue Version verfügbar`;
+
+    // Sticky (no `duration`) + top-center: the prompt sits at eye level and
+    // stays put until the user acts. An auto-dismiss timer made the toast easy
+    // to miss (especially when the mobile bottom-nav cropped the bottom-
+    // anchored variant). Distinct panelClass lets `styles.scss` give it its own
+    // surface colour so it doesn't get mistaken for a routine info toast.
+    const ref = this.snackBar.open(
+      message,
+      $localize`:@@sw.update.reload:Neu laden`,
+      {
+        horizontalPosition: 'center',
+        verticalPosition: 'top',
+        panelClass: 'sw-update-snackbar',
+      }
+    );
+    this.promptRef = ref;
+
+    ref
+      .onAction()
+      .pipe(take(1))
+      .subscribe(() => void this.applyUpdate());
+    ref
+      .afterDismissed()
+      .pipe(take(1))
+      .subscribe(() => {
+        this.promptRef = null;
+      });
+  }
+}

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10642,5 +10642,17 @@
         <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
       </segment>
     </unit>
+    <unit id="sw.update.buttonAria">
+      <segment state="initial">
+        <source>Neue Version verfügbar – jetzt neu laden</source>
+        <target>Neue Version verfügbar – jetzt neu laden</target>
+      </segment>
+    </unit>
+    <unit id="sw.update.unrecoverable">
+      <segment state="initial">
+        <source>App-Daten beschädigt – bitte neu laden</source>
+        <target>App-Daten beschädigt – bitte neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10654,5 +10654,11 @@
         <target>App-Daten beschädigt – bitte neu laden</target>
       </segment>
     </unit>
+    <unit id="sw.update.recoverButtonAria">
+      <segment state="initial">
+        <source>App-Daten beschädigt – jetzt neu laden</source>
+        <target>App-Daten beschädigt – jetzt neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10841,5 +10841,17 @@ Deine Position: # ·  Reps        </source>
         <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
       </segment>
     </unit>
+    <unit id="sw.update.buttonAria">
+      <segment state="initial">
+        <source>Neue Version verfügbar – jetzt neu laden</source>
+        <target>Neue Version verfügbar – jetzt neu laden</target>
+      </segment>
+    </unit>
+    <unit id="sw.update.unrecoverable">
+      <segment state="initial">
+        <source>App-Daten beschädigt – bitte neu laden</source>
+        <target>App-Daten beschädigt – bitte neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10853,5 +10853,11 @@ Deine Position: # ·  Reps        </source>
         <target>App-Daten beschädigt – bitte neu laden</target>
       </segment>
     </unit>
+    <unit id="sw.update.recoverButtonAria">
+      <segment state="initial">
+        <source>App-Daten beschädigt – jetzt neu laden</source>
+        <target>App-Daten beschädigt – jetzt neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10650,5 +10650,11 @@
         <target>App-Daten beschädigt – bitte neu laden</target>
       </segment>
     </unit>
+    <unit id="sw.update.recoverButtonAria">
+      <segment state="initial">
+        <source>App-Daten beschädigt – jetzt neu laden</source>
+        <target>App-Daten beschädigt – jetzt neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10638,5 +10638,17 @@
         <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
       </segment>
     </unit>
+    <unit id="sw.update.buttonAria">
+      <segment state="initial">
+        <source>Neue Version verfügbar – jetzt neu laden</source>
+        <target>Neue Version verfügbar – jetzt neu laden</target>
+      </segment>
+    </unit>
+    <unit id="sw.update.unrecoverable">
+      <segment state="initial">
+        <source>App-Daten beschädigt – bitte neu laden</source>
+        <target>App-Daten beschädigt – bitte neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10514,5 +10514,17 @@
         <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
       </segment>
     </unit>
+    <unit id="sw.update.buttonAria">
+      <segment state="initial">
+        <source>Neue Version verfügbar – jetzt neu laden</source>
+        <target>Neue Version verfügbar – jetzt neu laden</target>
+      </segment>
+    </unit>
+    <unit id="sw.update.unrecoverable">
+      <segment state="initial">
+        <source>App-Daten beschädigt – bitte neu laden</source>
+        <target>App-Daten beschädigt – bitte neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10526,5 +10526,11 @@
         <target>App-Daten beschädigt – bitte neu laden</target>
       </segment>
     </unit>
+    <unit id="sw.update.recoverButtonAria">
+      <segment state="initial">
+        <source>App-Daten beschädigt – jetzt neu laden</source>
+        <target>App-Daten beschädigt – jetzt neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10642,5 +10642,17 @@
         <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
       </segment>
     </unit>
+    <unit id="sw.update.buttonAria">
+      <segment state="initial">
+        <source>Neue Version verfügbar – jetzt neu laden</source>
+        <target>Neue Version verfügbar – jetzt neu laden</target>
+      </segment>
+    </unit>
+    <unit id="sw.update.unrecoverable">
+      <segment state="initial">
+        <source>App-Daten beschädigt – bitte neu laden</source>
+        <target>App-Daten beschädigt – bitte neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10654,5 +10654,11 @@
         <target>App-Daten beschädigt – bitte neu laden</target>
       </segment>
     </unit>
+    <unit id="sw.update.recoverButtonAria">
+      <segment state="initial">
+        <source>App-Daten beschädigt – jetzt neu laden</source>
+        <target>App-Daten beschädigt – jetzt neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10642,5 +10642,17 @@
         <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
       </segment>
     </unit>
+    <unit id="sw.update.buttonAria">
+      <segment state="initial">
+        <source>Neue Version verfügbar – jetzt neu laden</source>
+        <target>Neue Version verfügbar – jetzt neu laden</target>
+      </segment>
+    </unit>
+    <unit id="sw.update.unrecoverable">
+      <segment state="initial">
+        <source>App-Daten beschädigt – bitte neu laden</source>
+        <target>App-Daten beschädigt – bitte neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10654,5 +10654,11 @@
         <target>App-Daten beschädigt – bitte neu laden</target>
       </segment>
     </unit>
+    <unit id="sw.update.recoverButtonAria">
+      <segment state="initial">
+        <source>App-Daten beschädigt – jetzt neu laden</source>
+        <target>App-Daten beschädigt – jetzt neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9935,5 +9935,17 @@ Deine Position: # ·  Reps        </source>
         <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
       </segment>
     </unit>
+    <unit id="sw.update.buttonAria">
+      <segment state="initial">
+        <source>Neue Version verfügbar – jetzt neu laden</source>
+        <target>Neue Version verfügbar – jetzt neu laden</target>
+      </segment>
+    </unit>
+    <unit id="sw.update.unrecoverable">
+      <segment state="initial">
+        <source>App-Daten beschädigt – bitte neu laden</source>
+        <target>App-Daten beschädigt – bitte neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9947,5 +9947,11 @@ Deine Position: # ·  Reps        </source>
         <target>App-Daten beschädigt – bitte neu laden</target>
       </segment>
     </unit>
+    <unit id="sw.update.recoverButtonAria">
+      <segment state="initial">
+        <source>App-Daten beschädigt – jetzt neu laden</source>
+        <target>App-Daten beschädigt – jetzt neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -3573,8 +3573,8 @@
     <unit id="nav.dashboard">
       <notes>
         <note category="location">web/src/app/app.html:23,26</note>
-        <note category="location">web/src/app/app.html:249,251</note>
-        <note category="location">web/src/app/app.html:312,314</note>
+        <note category="location">web/src/app/app.html:261,263</note>
+        <note category="location">web/src/app/app.html:324,326</note>
       </notes>
       <segment>
         <source>Dashboard</source>
@@ -3583,8 +3583,8 @@
     <unit id="nav.analysis">
       <notes>
         <note category="location">web/src/app/app.html:33,36</note>
-        <note category="location">web/src/app/app.html:253,255</note>
-        <note category="location">web/src/app/app.html:316,318</note>
+        <note category="location">web/src/app/app.html:265,267</note>
+        <note category="location">web/src/app/app.html:328,330</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -3593,8 +3593,8 @@
     <unit id="nav.leaderboard">
       <notes>
         <note category="location">web/src/app/app.html:43,47</note>
-        <note category="location">web/src/app/app.html:257,259</note>
-        <note category="location">web/src/app/app.html:320,322</note>
+        <note category="location">web/src/app/app.html:269,271</note>
+        <note category="location">web/src/app/app.html:332,334</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3603,8 +3603,8 @@
     <unit id="nav.blog">
       <notes>
         <note category="location">web/src/app/app.html:53,56</note>
-        <note category="location">web/src/app/app.html:265,267</note>
-        <note category="location">web/src/app/app.html:328,330</note>
+        <note category="location">web/src/app/app.html:277,279</note>
+        <note category="location">web/src/app/app.html:340,342</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3613,8 +3613,8 @@
     <unit id="nav.trainingPlans">
       <notes>
         <note category="location">web/src/app/app.html:63,67</note>
-        <note category="location">web/src/app/app.html:261,263</note>
-        <note category="location">web/src/app/app.html:324,326</note>
+        <note category="location">web/src/app/app.html:273,275</note>
+        <note category="location">web/src/app/app.html:336,338</note>
       </notes>
       <segment>
         <source>Trainingspläne</source>
@@ -3700,9 +3700,17 @@
         <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
       </segment>
     </unit>
+    <unit id="sw.update.buttonAria">
+      <notes>
+        <note category="location">web/src/app/app.html:228,229</note>
+      </notes>
+      <segment>
+        <source>Neue Version verfügbar – jetzt neu laden</source>
+      </segment>
+    </unit>
     <unit id="nav.admin">
       <notes>
-        <note category="location">web/src/app/app.html:229,230</note>
+        <note category="location">web/src/app/app.html:241,242</note>
       </notes>
       <segment>
         <source>Admin-Bereich</source>
@@ -3710,7 +3718,7 @@
     </unit>
     <unit id="nav.desktop.aria">
       <notes>
-        <note category="location">web/src/app/app.html:240,241</note>
+        <note category="location">web/src/app/app.html:252,253</note>
       </notes>
       <segment>
         <source>Hauptnavigation</source>
@@ -3718,7 +3726,7 @@
     </unit>
     <unit id="footer.aria">
       <notes>
-        <note category="location">web/src/app/app.html:274</note>
+        <note category="location">web/src/app/app.html:286</note>
       </notes>
       <segment>
         <source>Rechtliches</source>
@@ -3726,7 +3734,7 @@
     </unit>
     <unit id="footer.pushupTypes">
       <notes>
-        <note category="location">web/src/app/app.html:279,281</note>
+        <note category="location">web/src/app/app.html:291,293</note>
       </notes>
       <segment>
         <source>Liegestütztypen</source>
@@ -3734,7 +3742,7 @@
     </unit>
     <unit id="footer.exercises">
       <notes>
-        <note category="location">web/src/app/app.html:282,284</note>
+        <note category="location">web/src/app/app.html:294,296</note>
       </notes>
       <segment>
         <source>Übungen</source>
@@ -3742,7 +3750,7 @@
     </unit>
     <unit id="footer.about">
       <notes>
-        <note category="location">web/src/app/app.html:284,285</note>
+        <note category="location">web/src/app/app.html:296,297</note>
       </notes>
       <segment>
         <source>Über uns</source>
@@ -3750,7 +3758,7 @@
     </unit>
     <unit id="footer.impressum">
       <notes>
-        <note category="location">web/src/app/app.html:286,288</note>
+        <note category="location">web/src/app/app.html:298,300</note>
       </notes>
       <segment>
         <source>Impressum</source>
@@ -3758,7 +3766,7 @@
     </unit>
     <unit id="footer.datenschutz">
       <notes>
-        <note category="location">web/src/app/app.html:289,292</note>
+        <note category="location">web/src/app/app.html:301,304</note>
       </notes>
       <segment>
         <source>Datenschutz</source>
@@ -3766,7 +3774,7 @@
     </unit>
     <unit id="footer.cookies">
       <notes>
-        <note category="location">web/src/app/app.html:296,298</note>
+        <note category="location">web/src/app/app.html:308,310</note>
       </notes>
       <segment>
         <source> Cookie-Einstellungen </source>
@@ -3774,7 +3782,7 @@
     </unit>
     <unit id="nav.bottom.aria">
       <notes>
-        <note category="location">web/src/app/app.html:303,304</note>
+        <note category="location">web/src/app/app.html:315,316</note>
       </notes>
       <segment>
         <source>Mobile-Navigation</source>
@@ -4070,7 +4078,7 @@
     </unit>
     <unit id="toolbarDailyGoal.detailsAria">
       <notes>
-        <note category="location">web/src/app/app.ts:282</note>
+        <note category="location">web/src/app/app.ts:284</note>
       </notes>
       <segment>
         <source>Tagesziel-Einzelpositionen anzeigen</source>
@@ -4078,7 +4086,7 @@
     </unit>
     <unit id="seo.default.title">
       <notes>
-        <note category="location">web/src/app/app.ts:371</note>
+        <note category="location">web/src/app/app.ts:373</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -4086,31 +4094,15 @@
     </unit>
     <unit id="seo.default.description">
       <notes>
-        <note category="location">web/src/app/app.ts:374</note>
+        <note category="location">web/src/app/app.ts:376</note>
       </notes>
       <segment>
         <source>Tracke Reps, Trends und Streaks mit Pushup Tracker.</source>
       </segment>
     </unit>
-    <unit id="sw.update.available">
-      <notes>
-        <note category="location">web/src/app/app.ts:395</note>
-      </notes>
-      <segment>
-        <source>Neue Version verfügbar</source>
-      </segment>
-    </unit>
-    <unit id="sw.update.reload">
-      <notes>
-        <note category="location">web/src/app/app.ts:396</note>
-      </notes>
-      <segment>
-        <source>Neu laden</source>
-      </segment>
-    </unit>
     <unit id="toolbarDailyGoal.replayAria">
       <notes>
-        <note category="location">web/src/app/app.ts:477</note>
+        <note category="location">web/src/app/app.ts:441</note>
       </notes>
       <segment>
         <source>Tagesziel-Animation erneut abspielen</source>
@@ -4118,7 +4110,7 @@
     </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:506</note>
+        <note category="location">web/src/app/app.ts:470</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -4126,7 +4118,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:513</note>
+        <note category="location">web/src/app/app.ts:477</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>
@@ -4688,6 +4680,30 @@
       </notes>
       <segment>
         <source>In die Zwischenablage kopiert. Jetzt einfügen und teilen!</source>
+      </segment>
+    </unit>
+    <unit id="sw.update.unrecoverable">
+      <notes>
+        <note category="location">web/src/app/core/sw-update.service.ts:129</note>
+      </notes>
+      <segment>
+        <source>App-Daten beschädigt – bitte neu laden</source>
+      </segment>
+    </unit>
+    <unit id="sw.update.available">
+      <notes>
+        <note category="location">web/src/app/core/sw-update.service.ts:130</note>
+      </notes>
+      <segment>
+        <source>Neue Version verfügbar</source>
+      </segment>
+    </unit>
+    <unit id="sw.update.reload">
+      <notes>
+        <note category="location">web/src/app/core/sw-update.service.ts:139</note>
+      </notes>
+      <segment>
+        <source>Neu laden</source>
       </segment>
     </unit>
     <unit id="theme.toggle.auto">

--- a/web/src/locale/messages.xlf
+++ b/web/src/locale/messages.xlf
@@ -3573,8 +3573,8 @@
     <unit id="nav.dashboard">
       <notes>
         <note category="location">web/src/app/app.html:23,26</note>
-        <note category="location">web/src/app/app.html:261,263</note>
-        <note category="location">web/src/app/app.html:324,326</note>
+        <note category="location">web/src/app/app.html:262,264</note>
+        <note category="location">web/src/app/app.html:325,327</note>
       </notes>
       <segment>
         <source>Dashboard</source>
@@ -3583,8 +3583,8 @@
     <unit id="nav.analysis">
       <notes>
         <note category="location">web/src/app/app.html:33,36</note>
-        <note category="location">web/src/app/app.html:265,267</note>
-        <note category="location">web/src/app/app.html:328,330</note>
+        <note category="location">web/src/app/app.html:266,268</note>
+        <note category="location">web/src/app/app.html:329,331</note>
       </notes>
       <segment>
         <source>Analyse</source>
@@ -3593,8 +3593,8 @@
     <unit id="nav.leaderboard">
       <notes>
         <note category="location">web/src/app/app.html:43,47</note>
-        <note category="location">web/src/app/app.html:269,271</note>
-        <note category="location">web/src/app/app.html:332,334</note>
+        <note category="location">web/src/app/app.html:270,272</note>
+        <note category="location">web/src/app/app.html:333,335</note>
       </notes>
       <segment>
         <source>Bestenliste</source>
@@ -3603,8 +3603,8 @@
     <unit id="nav.blog">
       <notes>
         <note category="location">web/src/app/app.html:53,56</note>
-        <note category="location">web/src/app/app.html:277,279</note>
-        <note category="location">web/src/app/app.html:340,342</note>
+        <note category="location">web/src/app/app.html:278,280</note>
+        <note category="location">web/src/app/app.html:341,343</note>
       </notes>
       <segment>
         <source>Blog</source>
@@ -3613,8 +3613,8 @@
     <unit id="nav.trainingPlans">
       <notes>
         <note category="location">web/src/app/app.html:63,67</note>
-        <note category="location">web/src/app/app.html:273,275</note>
-        <note category="location">web/src/app/app.html:336,338</note>
+        <note category="location">web/src/app/app.html:274,276</note>
+        <note category="location">web/src/app/app.html:337,339</note>
       </notes>
       <segment>
         <source>Trainingspläne</source>
@@ -3700,17 +3700,9 @@
         <source> Teilziele abhaken kannst du auf dem Dashboard. </source>
       </segment>
     </unit>
-    <unit id="sw.update.buttonAria">
-      <notes>
-        <note category="location">web/src/app/app.html:228,229</note>
-      </notes>
-      <segment>
-        <source>Neue Version verfügbar – jetzt neu laden</source>
-      </segment>
-    </unit>
     <unit id="nav.admin">
       <notes>
-        <note category="location">web/src/app/app.html:241,242</note>
+        <note category="location">web/src/app/app.html:242,243</note>
       </notes>
       <segment>
         <source>Admin-Bereich</source>
@@ -3718,7 +3710,7 @@
     </unit>
     <unit id="nav.desktop.aria">
       <notes>
-        <note category="location">web/src/app/app.html:252,253</note>
+        <note category="location">web/src/app/app.html:253,254</note>
       </notes>
       <segment>
         <source>Hauptnavigation</source>
@@ -3726,7 +3718,7 @@
     </unit>
     <unit id="footer.aria">
       <notes>
-        <note category="location">web/src/app/app.html:286</note>
+        <note category="location">web/src/app/app.html:287</note>
       </notes>
       <segment>
         <source>Rechtliches</source>
@@ -3734,7 +3726,7 @@
     </unit>
     <unit id="footer.pushupTypes">
       <notes>
-        <note category="location">web/src/app/app.html:291,293</note>
+        <note category="location">web/src/app/app.html:292,294</note>
       </notes>
       <segment>
         <source>Liegestütztypen</source>
@@ -3742,7 +3734,7 @@
     </unit>
     <unit id="footer.exercises">
       <notes>
-        <note category="location">web/src/app/app.html:294,296</note>
+        <note category="location">web/src/app/app.html:295,297</note>
       </notes>
       <segment>
         <source>Übungen</source>
@@ -3750,7 +3742,7 @@
     </unit>
     <unit id="footer.about">
       <notes>
-        <note category="location">web/src/app/app.html:296,297</note>
+        <note category="location">web/src/app/app.html:297,298</note>
       </notes>
       <segment>
         <source>Über uns</source>
@@ -3758,7 +3750,7 @@
     </unit>
     <unit id="footer.impressum">
       <notes>
-        <note category="location">web/src/app/app.html:298,300</note>
+        <note category="location">web/src/app/app.html:299,301</note>
       </notes>
       <segment>
         <source>Impressum</source>
@@ -3766,7 +3758,7 @@
     </unit>
     <unit id="footer.datenschutz">
       <notes>
-        <note category="location">web/src/app/app.html:301,304</note>
+        <note category="location">web/src/app/app.html:302,305</note>
       </notes>
       <segment>
         <source>Datenschutz</source>
@@ -3774,7 +3766,7 @@
     </unit>
     <unit id="footer.cookies">
       <notes>
-        <note category="location">web/src/app/app.html:308,310</note>
+        <note category="location">web/src/app/app.html:309,311</note>
       </notes>
       <segment>
         <source> Cookie-Einstellungen </source>
@@ -3782,7 +3774,7 @@
     </unit>
     <unit id="nav.bottom.aria">
       <notes>
-        <note category="location">web/src/app/app.html:315,316</note>
+        <note category="location">web/src/app/app.html:316,317</note>
       </notes>
       <segment>
         <source>Mobile-Navigation</source>
@@ -4076,9 +4068,25 @@
         <source>Datenschutzerklärung von Pushup Tracker – Informationen zu Datenverarbeitung, Cookies und Ihren Rechten.</source>
       </segment>
     </unit>
+    <unit id="sw.update.buttonAria">
+      <notes>
+        <note category="location">web/src/app/app.ts:146</note>
+      </notes>
+      <segment>
+        <source>Neue Version verfügbar – jetzt neu laden</source>
+      </segment>
+    </unit>
+    <unit id="sw.update.recoverButtonAria">
+      <notes>
+        <note category="location">web/src/app/app.ts:147</note>
+      </notes>
+      <segment>
+        <source>App-Daten beschädigt – jetzt neu laden</source>
+      </segment>
+    </unit>
     <unit id="toolbarDailyGoal.detailsAria">
       <notes>
-        <note category="location">web/src/app/app.ts:284</note>
+        <note category="location">web/src/app/app.ts:287</note>
       </notes>
       <segment>
         <source>Tagesziel-Einzelpositionen anzeigen</source>
@@ -4086,7 +4094,7 @@
     </unit>
     <unit id="seo.default.title">
       <notes>
-        <note category="location">web/src/app/app.ts:373</note>
+        <note category="location">web/src/app/app.ts:376</note>
       </notes>
       <segment>
         <source>Pushup Tracker</source>
@@ -4094,7 +4102,7 @@
     </unit>
     <unit id="seo.default.description">
       <notes>
-        <note category="location">web/src/app/app.ts:376</note>
+        <note category="location">web/src/app/app.ts:379</note>
       </notes>
       <segment>
         <source>Tracke Reps, Trends und Streaks mit Pushup Tracker.</source>
@@ -4102,7 +4110,7 @@
     </unit>
     <unit id="toolbarDailyGoal.replayAria">
       <notes>
-        <note category="location">web/src/app/app.ts:441</note>
+        <note category="location">web/src/app/app.ts:443</note>
       </notes>
       <segment>
         <source>Tagesziel-Animation erneut abspielen</source>
@@ -4110,7 +4118,7 @@
     </unit>
     <unit id="feedback.success">
       <notes>
-        <note category="location">web/src/app/app.ts:470</note>
+        <note category="location">web/src/app/app.ts:472</note>
       </notes>
       <segment>
         <source>Danke für dein Feedback!</source>
@@ -4118,7 +4126,7 @@
     </unit>
     <unit id="feedback.error">
       <notes>
-        <note category="location">web/src/app/app.ts:477</note>
+        <note category="location">web/src/app/app.ts:479</note>
       </notes>
       <segment>
         <source>Feedback konnte nicht gesendet werden.</source>
@@ -4684,7 +4692,7 @@
     </unit>
     <unit id="sw.update.unrecoverable">
       <notes>
-        <note category="location">web/src/app/core/sw-update.service.ts:129</note>
+        <note category="location">web/src/app/core/sw-update.service.ts:138</note>
       </notes>
       <segment>
         <source>App-Daten beschädigt – bitte neu laden</source>
@@ -4692,7 +4700,7 @@
     </unit>
     <unit id="sw.update.available">
       <notes>
-        <note category="location">web/src/app/core/sw-update.service.ts:130</note>
+        <note category="location">web/src/app/core/sw-update.service.ts:139</note>
       </notes>
       <segment>
         <source>Neue Version verfügbar</source>
@@ -4700,7 +4708,7 @@
     </unit>
     <unit id="sw.update.reload">
       <notes>
-        <note category="location">web/src/app/core/sw-update.service.ts:139</note>
+        <note category="location">web/src/app/core/sw-update.service.ts:148</note>
       </notes>
       <segment>
         <source>Neu laden</source>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -10160,5 +10160,11 @@
         <target>App-Daten beschädigt – bitte neu laden</target>
       </segment>
     </unit>
+    <unit id="sw.update.recoverButtonAria">
+      <segment state="initial">
+        <source>App-Daten beschädigt – jetzt neu laden</source>
+        <target>App-Daten beschädigt – jetzt neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -10148,5 +10148,17 @@
         <target>Haken entfernt — deine eigenen Einträge bleiben bestehen.</target>
       </segment>
     </unit>
+    <unit id="sw.update.buttonAria">
+      <segment state="initial">
+        <source>Neue Version verfügbar – jetzt neu laden</source>
+        <target>Neue Version verfügbar – jetzt neu laden</target>
+      </segment>
+    </unit>
+    <unit id="sw.update.unrecoverable">
+      <segment state="initial">
+        <source>App-Daten beschädigt – bitte neu laden</source>
+        <target>App-Daten beschädigt – bitte neu laden</target>
+      </segment>
+    </unit>
 </file>
 </xliff>


### PR DESCRIPTION
## Problem

In der App war kein Hinweis zu sehen, wenn sich der Service Worker aktualisiert — auch keine „Neu laden"-Toast-Message.

**Ursache:** `MatSnackBar` ist ein Singleton — jedes `open()` schließt die aktuell sichtbare Nachricht. Der Reload-Prompt lebte ausschließlich in einer Snackbar, und `VERSION_READY` feuert **genau einmal** pro heruntergeladener Version. Da rund ein Dutzend Stellen (Quick-Add, Trainingspläne, Feedback, Erinnerungen) Routine-Toasts öffnen, wurde der sticky Prompt regelmäßig weggedrückt, bevor Nutzer reagieren konnten — und es gab keine zweite Anlaufstelle in der UI.

## Änderungen

- **`web/src/app/core/sw-update.service.ts` (neu)** — bündelt den kompletten ngsw-Update-Flow und rastet `VERSION_READY` in ein persistentes `updateAvailable`-Signal ein, statt sich auf die Snackbar zu verlassen.
- **`web/src/app/app.html`** — dauerhafter, pulsierender Toolbar-Button (`system_update_alt`), solange ein Update aussteht. Das ist der fehlende „Hinweis in der App"; er bleibt bis zum Reload sichtbar. Die Snackbar ist nur noch die laute, flüchtige Hälfte.
- **`SwUpdate.unrecoverable`** wurde bisher gar nicht behandelt — ein verlorener ngsw-Cache sah exakt wie „die App aktualisiert nicht mehr" aus. Jetzt eigener Prompt.
- **Fehlgeschlagenes `activateUpdate()`** blockierte bisher den Reload. Jetzt wird trotzdem neu geladen (ohne wartenden Worker holt der Browser den aktuellen Build ohnehin vom Netz).
- **Update-Check zusätzlich bei `visibilitychange → visible`.** Hintergrund-Tabs drosseln ihre Timer, der 10-Minuten-Poll allein erreicht eine PWA nicht, die Stunden nach einem Deploy wieder aufgenommen wird.
- **`web/src/app/app.ts`** — 45 Zeilen leichter, SW-Logik ausgelagert (Richtung ≤ 250 LOC).

## Tests

- Neue `sw-update.service.spec.ts` (15 Fälle), u. a. Regression für den Singleton-Snackbar-Fall, `UNRECOVERABLE_STATE`, visibility-Poll, SSR-/disabled-Inertheit sowie die bestehenden `activateUpdate()`-vor-`reload()`- und Poll-Regressionen (aus `app.spec.ts` hierher gezogen).
- `app.spec.ts` behält zwei Tests auf Komponentenebene für den Toolbar-Button.
- `nx test web` und `nx lint web` grün.

## Doku & i18n

- `docs/gotchas/push-and-service-workers.md` um den Snackbar-Singleton-Fallstrick, `unrecoverable` und den visibility-Hook ergänzt.
- Neue i18n-IDs `@@sw.update.unrecoverable` und `@@sw.update.buttonAria`; `extract-i18n` + `sync-xliff-locales.mjs` gelaufen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCGgdBwb94gHYUop1gdkyM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toolbar indicator when a new app version is available.
  * Users can reload to apply updates, with prompts reopening when they return to the app.
  * Added recovery messaging and reload handling for unrecoverable app data.
  * Added accessible update controls and localized messages across supported languages.

* **Bug Fixes**
  * Improved update detection through periodic and visibility-triggered checks.
  * Ensured updates are activated before reloading and handled activation failures safely.

* **Documentation**
  * Updated service-worker guidance for persistent prompts, activation, polling, and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->