### PR TITLE
feat(store): add the English Play Store listing

### DIFF
--- a/docs/play-store-publishing.md
+++ b/docs/play-store-publishing.md
@@ -109,6 +109,34 @@ Aktuelles Mapping:
 Ein Test pinnt diese Tabelle an die `localize`-Liste in `web/project.json`:
 eine neue App-Sprache ohne Play-Mapping bricht CI.
 
+Gepflegt sind aktuell **`de-DE`** (Quelle) und **`en-US`**. Die übrigen
+Codes stehen im Mapping bereit, haben aber noch kein Listing — Play fällt
+für sie auf die Default-Sprache des Store-Eintrags zurück.
+
+### Welche Sprachen sich lohnen
+
+Store-Texte laufen **nicht** über die tägliche Übersetzungs-Routine (die
+arbeitet auf XLIFF und `content/`). Jede zusätzliche Sprache ist damit
+dauerhafte Handarbeit bei jeder Textänderung — die Frage ist also nicht
+„welche können wir", sondern „welche verdienen die Pflege".
+
+- **`en-US` ist Pflicht**, weil Play für jede Sprache ohne eigenes Listing
+  auf die Default-Sprache zurückfällt. Ohne sie sieht die halbe Welt
+  deutschen Fließtext.
+- **`fr-FR`, `es-ES`, `it-IT`** sind die nächsten sinnvollen Kandidaten:
+  große Märkte, in denen ein englisches Fallback-Listing spürbar Installs
+  kostet.
+- **`nl-NL`, `no-NO`** haben sehr hohe Englisch-Kompetenz und lesen das
+  englische Listing reibungslos; `el-GR` ist ein kleiner Markt. Alle drei
+  eher nachrangig.
+- **`zh-CN` ist praktisch wertlos**: Google Play gibt es in Festlandchina
+  nicht. Wer chinesische Nutzer erreichen will, braucht `zh-TW` oder
+  `zh-HK` — die stehen bewusst nicht im Mapping, weil die App-Locale `zh`
+  nicht sagt, welche Region gemeint ist.
+
+Belastbar entscheidet das aber nur die Play Console unter **Statistiken →
+Nutzer nach Land/Sprache**, nicht diese Liste.
+
 ## Gotchas
 
 - **Review-Queue.** Ein committeter Listing-Text ist nicht sofort live,

--- a/docs/playstore-listing.md
+++ b/docs/playstore-listing.md
@@ -9,14 +9,15 @@ analog zu `web/src/locale/messages.xlf`.
 > direkt in die Play Console — siehe
 > [`docs/play-store-publishing.md`](play-store-publishing.md).
 >
-> | Feld                      | Datei                                    | Limit |
-> | ------------------------- | ---------------------------------------- | ----- |
-> | Titel                     | `store/play/de-DE/title.txt`             | 30    |
-> | Kurzbeschreibung          | `store/play/de-DE/short-description.txt` | 80    |
-> | Vollständige Beschreibung | `store/play/de-DE/full-description.txt`  | 4000  |
+> | Feld                      | Datei                                       | Limit |
+> | ------------------------- | ------------------------------------------- | ----- |
+> | Titel                     | `store/play/<locale>/title.txt`             | 30    |
+> | Kurzbeschreibung          | `store/play/<locale>/short-description.txt` | 80    |
+> | Vollständige Beschreibung | `store/play/<locale>/full-description.txt`  | 4000  |
 >
-> Die Limits prüft `pnpm nx test tools` — zu langer Text scheitert in CI,
-> nicht erst beim Veröffentlichen.
+> Gepflegt: `de-DE` (Quelle) und `en-US`. Die Limits prüft
+> `pnpm nx test tools` — zu langer Text scheitert in CI, nicht erst beim
+> Veröffentlichen.
 
 Diese Datei bleibt als **Beleg-Sammlung**: Der Store-Text behauptet konkrete
 Zahlen und Eigenschaften, und die veralten still, wenn sie niemand an den Code
@@ -57,9 +58,17 @@ Liegestütz-Varianten (`PUSHUP_TYPES`) oder die Locale-Liste in
 
 ## Was noch fehlt
 
-- **Übersetzungen.** Nur `de-DE` ist gepflegt. Die Store-Texte laufen bewusst
-  **nicht** über die tägliche Übersetzungs-Routine (die arbeitet auf XLIFF und
-  `content/`), also müssen weitere Sprachen von Hand ergänzt werden.
+- **Weitere Sprachen.** `de-DE` und `en-US` sind gepflegt. Die Store-Texte
+  laufen bewusst **nicht** über die tägliche Übersetzungs-Routine (die
+  arbeitet auf XLIFF und `content/`), jede weitere Sprache ist also
+  dauerhafte Handarbeit. Welche sich lohnen:
+  [`docs/play-store-publishing.md`](play-store-publishing.md#welche-sprachen-sich-lohnen).
+- **`en-US` ist kein Übersetzungs-Klon.** Titel, Kurzbeschreibung und der
+  Einstieg sind eigenständig getextet, weil englisches ASO auf andere
+  Suchbegriffe zielt („push-up counter", „workout tracker") als das
+  deutsche Original. Eine Änderung am deutschen Text ist deshalb **nicht**
+  automatisch eine am englischen — beide Dateien wollen einzeln gepflegt
+  werden, und die Beleg-Liste unten gilt für beide.
 - **KI-Coach.** Nicht im Listing erwähnt: `aiAssistantConfig.runtimeUrl` ist
   leer, im ausgelieferten Build ist der Assistent also nicht nutzbar.
 - **Grafiken.** Screenshots, Feature-Grafik und Icon pflegt weiterhin die

--- a/docs/playstore-listing.md
+++ b/docs/playstore-listing.md
@@ -65,7 +65,7 @@ Liegestütz-Varianten (`PUSHUP_TYPES`) oder die Locale-Liste in
   [`docs/play-store-publishing.md`](play-store-publishing.md#welche-sprachen-sich-lohnen).
 - **`en-US` ist kein Übersetzungs-Klon.** Titel, Kurzbeschreibung und der
   Einstieg sind eigenständig getextet, weil englisches ASO auf andere
-  Suchbegriffe zielt („push-up counter", „workout tracker") als das
+  Suchbegriffe zielt („push-up counter“, „workout tracker“) als das
   deutsche Original. Eine Änderung am deutschen Text ist deshalb **nicht**
   automatisch eine am englischen — beide Dateien wollen einzeln gepflegt
   werden, und die Beleg-Liste unten gilt für beide.

--- a/store/play/en-US/full-description.txt
+++ b/store/play/en-US/full-description.txt
@@ -3,14 +3,14 @@ A push-up counter and workout tracker that turns push-ups and 40 more exercises 
 Whether you are starting from zero or already past your first hundred, this app keeps you going. Your camera counts reps automatically, curated training plans tell you exactly what to do today, and the leaderboard pushes you without nagging.
 
 📷 AUTOMATIC REP COUNTING
-Prop up your phone, open the auto counter, start moving: the AI recognises push-ups, squats, pull-ups and sit-ups in real time and counts every clean rep. Planks and hollow holds get an automatic hold timer instead. Detection runs entirely on your device — no video ever leaves your phone.
+Prop up your phone, open the auto counter, start moving: the AI recognizes push-ups, squats, pull-ups and sit-ups in real time and counts every clean rep. Planks and hollow holds get an automatic hold timer instead. Detection runs entirely on your device — no video ever leaves your phone.
 
 🏋️ MORE THAN PUSH-UPS
 • 13 push-up variations: standard, knee, incline, decline, wide, diamond, pike, archer, all the way to one-arm — each with technique instructions
 • 41 exercises across 9 categories: push-ups, push, pull, squat, hinge, lunge, core, cardio, mobility
 • Pull-ups, dips, squats, lunges, planks, hollow holds, burpees, jump rope, yoga, stretching and more
 • Distance and time cardio: running, walking, cycling, rowing, swimming — pace included
-• Every exercise in its own unit — reps, seconds or metres
+• Every exercise in its own unit — reps, seconds or meters
 
 ⚡ LOGGING IN TWO SECONDS
 • One tap on the quick button: entry done, no dialog at all
@@ -44,7 +44,7 @@ Push notifications with a configurable interval, quiet hours, weekdays and time 
 An exercise wiki with clean form, technique cues and the mistakes everyone makes. Plus a blog with training tips from beginner to advanced.
 
 🔒 YOUR DATA
-Try it as a guest, no account needed. Private mode whenever you want it. GDPR compliant with adjustable cookie consent. Delete your account any time — training data is kept only in anonymised form afterwards. Database hosted in Frankfurt, Germany.
+Try it as a guest, no account needed. Private mode whenever you want it. Adjustable cookie consent — personalized ads only with your OK. Delete your account any time — training data is kept only in anonymized form afterward. Database hosted in Frankfurt, Germany.
 
 📱 ANDROID + WEB
 The same data on your phone and in the browser, synced live across every device. Sign in with Google or email. Works offline too — entries sync as soon as you are back online. Light and dark themes.

--- a/store/play/en-US/full-description.txt
+++ b/store/play/en-US/full-description.txt
@@ -1,0 +1,58 @@
+A push-up counter and workout tracker that turns push-ups and 40 more exercises into a game you want to win.
+
+Whether you are starting from zero or already past your first hundred, this app keeps you going. Your camera counts reps automatically, curated training plans tell you exactly what to do today, and the leaderboard pushes you without nagging.
+
+📷 AUTOMATIC REP COUNTING
+Prop up your phone, open the auto counter, start moving: the AI recognises push-ups, squats, pull-ups and sit-ups in real time and counts every clean rep. Planks and hollow holds get an automatic hold timer instead. Detection runs entirely on your device — no video ever leaves your phone.
+
+🏋️ MORE THAN PUSH-UPS
+• 13 push-up variations: standard, knee, incline, decline, wide, diamond, pike, archer, all the way to one-arm — each with technique instructions
+• 41 exercises across 9 categories: push-ups, push, pull, squat, hinge, lunge, core, cardio, mobility
+• Pull-ups, dips, squats, lunges, planks, hollow holds, burpees, jump rope, yoga, stretching and more
+• Distance and time cardio: running, walking, cycling, rowing, swimming — pace included
+• Every exercise in its own unit — reps, seconds or metres
+
+⚡ LOGGING IN TWO SECONDS
+• One tap on the quick button: entry done, no dialog at all
+• Adaptive suggestions learn from your history, plus six quick actions you assign yourself
+• Log sets individually (12 + 10 + 8) — the app adds them up
+• Intervals with pace for running and endurance workouts
+
+📈 TRAIN WITH A PLAN — 10 TRAINING PLANS
+• Zero to 100 — 6-week build for beginners
+• 30-Day Challenge with a max test on day 1 and day 30
+• Push-ups Over 40 — gentler 4-week plan
+• Daily 100 — 30 days to the 100 mark
+• One-Arm Push-Up — 12-week progression
+• Push & Pull Balance, Full Body Strong, Core Foundations, HIIT Burner, Mobility & Recovery
+Every day gives you the target that actually moves you forward — with rest days, light days and test days. Completed days tick themselves off the moment you hit your daily goal.
+
+🎯 GOALS, STREAKS & STATS
+• Daily, weekly and monthly goals — per exercise, with a weekday filter
+• Triple progress bar, confetti when you hit your goal, streak counter for showing up
+• Heatmap calendar across weeks and months
+• Analysis with trend charts, KPI cards and category comparison over any period
+• Personal bests: best day, best set, best single session
+
+🏆 LEADERBOARD & PROFILE
+Measure yourself against other athletes or stay private — your call. Rankings for today, the last 7 days and the last 30 days. Share your public profile with total reps, streak and personal bests by link. Plus a fresh piece of motivation every day.
+
+🔔 SMART REMINDERS
+Push notifications with a configurable interval, quiet hours, weekdays and time zone — even when the app is closed. And the fastest way to log: one tap on "Log 50" right in the notification.
+
+📚 KNOW-HOW, NOT GUESSWORK
+An exercise wiki with clean form, technique cues and the mistakes everyone makes. Plus a blog with training tips from beginner to advanced.
+
+🔒 YOUR DATA
+Try it as a guest, no account needed. Private mode whenever you want it. GDPR compliant with adjustable cookie consent. Delete your account any time — training data is kept only in anonymised form afterwards. Database hosted in Frankfurt, Germany.
+
+📱 ANDROID + WEB
+The same data on your phone and in the browser, synced live across every device. Sign in with Google or email. Works offline too — entries sync as soon as you are back online. Light and dark themes.
+
+🌍 NINE LANGUAGES
+English, German, French, Spanish, Italian, Dutch, Greek, Norwegian, Chinese.
+
+Free. No subscription. No credit card.
+
+Pushup Stats is an honest app for people who actually train — not for sticker collectors.
+Download it and knock out your first one.

--- a/store/play/en-US/short-description.txt
+++ b/store/play/en-US/short-description.txt
@@ -1,0 +1,1 @@
+Count reps with your camera, follow training plans, climb the leaderboard.

--- a/store/play/en-US/title.txt
+++ b/store/play/en-US/title.txt
@@ -1,0 +1,1 @@
+Pushup Stats: Rep Counter


### PR DESCRIPTION
## Warum genau diese eine Sprache

Play fällt für jedes Locale ohne eigenes Listing auf die Default-Sprache des Store-Eintrags zurück — aktuell Deutsch. Jeder Brite, Amerikaner, Inder oder Schwede liest also gerade deutschen Fließtext. Das macht `en-US` zur mit Abstand wertvollsten Ergänzung und zur einzigen, die sich vor echten Install-Daten rechtfertigen lässt.

## Kein Übersetzungs-Klon

Titel, Kurzbeschreibung und Einstieg sind eigenständig getextet, weil englisches ASO auf andere Suchbegriffe zielt:

| Feld | Deutsch | Englisch |
| --- | --- | --- |
| Titel | `Pushup Stats` | `Pushup Stats: Rep Counter` |
| Kurz | „Reps per Kamera zählen…" | „Count reps with your camera…" |
| Einstieg | „macht aus Liegestützen… ein Spiel" | „A push-up counter and workout tracker that…" |

Die Feature-Abschnitte behalten die deutsche Struktur — das ist Inhalt, nicht Positionierung.

## Zeichen

| Feld | de-DE | en-US | Limit |
| --- | --- | --- | --- |
| Titel | 12 | 25 | 30 |
| Kurzbeschreibung | 77 | 74 | 80 |
| Vollständige Beschreibung | 3990 | 3781 | 4000 |

## Tests

Keine neuen nötig — der Guard aus #567 deckt das automatisch ab: der Test über die eingecheckten Quellen validiert jetzt beide Locales, und der Mehrsprachen-Pfad des Publishers hängt an denselben Transaktions-Tests. `pnpm nx test tools` grün (159 Tests).

Zusätzlich gegen die simulierte Console geprüft: `en-US` wird korrekt als Neuanlage erkannt (alle drei Felder `(empty)` → Text), beide Locales in einem Edit, danach keine offenen Edits.

## Sprachenwahl dokumentiert

`docs/play-store-publishing.md` hält jetzt fest, welche weiteren Sprachen sich lohnen — Store-Texte laufen bewusst nicht über die tägliche Übersetzungs-Routine, jede Sprache ist also dauerhafte Handarbeit bei jeder Textänderung.

Ein Fund dabei: **`zh-CN` ist praktisch wertlos, weil es Google Play in Festlandchina nicht gibt.** Chinesische Reichweite bräuchte `zh-TW` oder `zh-HK` — und die App-Locale `zh` sagt nicht, welche Region gemeint ist. Mein Mapping aus #567 hatte das zu mechanisch aus der App-Locale-Liste abgeleitet.

## Nächster Schritt für dich

Nach dem Merge derselbe Workflow wie gehabt: *Actions → Play Store Listing*, erst ohne Häkchen (Dry-Run zeigt beide Locales im Diff), dann mit. Setup-Schritte weiterhin in [`docs/play-store-publishing.md`](https://github.com/WolfSoko/pushup-stats-service/blob/main/docs/play-store-publishing.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyNwMqPcnxzPHkdCJZejKR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an English Google Play Store title and short description highlighting camera-based rep counting, training plans, and leaderboard progress.
  * Added a complete English store listing covering tracking, goals, statistics, reminders, privacy, synchronization, languages, and pricing.

* **Documentation**
  * Updated Play Store publishing guidance to clarify supported locales, fallback mappings, maintenance expectations, and language prioritization.
  * Documented locale-specific listing files and independently maintained English content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->