### PR TITLE
chore(i18n): fill missing translations (8 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10661,9 +10661,9 @@
       </segment>
     </unit>
     <unit id="dashboard.goalFill.fillPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen</source>
-        <target>Alle Übungen eintragen</target>
+        <target>Καταχώρηση όλων των ασκήσεων</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10860,9 +10860,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.fillPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen</source>
-        <target>Alle Übungen eintragen</target>
+        <target>Log all exercises</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10657,9 +10657,9 @@
       </segment>
     </unit>
     <unit id="dashboard.goalFill.fillPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen</source>
-        <target>Alle Übungen eintragen</target>
+        <target>Registrar todos los ejercicios</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10533,9 +10533,9 @@
       </segment>
     </unit>
     <unit id="dashboard.goalFill.fillPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen</source>
-        <target>Alle Übungen eintragen</target>
+        <target>Saisir tous les exercices</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10661,9 +10661,9 @@
       </segment>
     </unit>
     <unit id="dashboard.goalFill.fillPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen</source>
-        <target>Alle Übungen eintragen</target>
+        <target>Registra tutti gli esercizi</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10661,9 +10661,9 @@
       </segment>
     </unit>
     <unit id="dashboard.goalFill.fillPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen</source>
-        <target>Alle Übungen eintragen</target>
+        <target>Alle oefeningen invoeren</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9954,9 +9954,9 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="dashboard.goalFill.fillPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen</source>
-        <target>Alle Übungen eintragen</target>
+        <target>Registrer alle øvelser</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -10167,9 +10167,9 @@
       </segment>
     </unit>
     <unit id="dashboard.goalFill.fillPlan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle Übungen eintragen</source>
-        <target>Alle Übungen eintragen</target>
+        <target>记录所有动作</target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
Fills XLIFF translation gaps detected by `tools/src/detect-translation-gaps.mjs`.

## Touched locales

- en: 1 unit(s), 0 blog post(s), 0 wiki entry/entries
- fr: 1 unit(s), 0 blog post(s), 0 wiki entry/entries
- es: 1 unit(s), 0 blog post(s), 0 wiki entry/entries
- it: 1 unit(s), 0 blog post(s), 0 wiki entry/entries
- nl: 1 unit(s), 0 blog post(s), 0 wiki entry/entries
- no: 1 unit(s), 0 blog post(s), 0 wiki entry/entries
- zh: 1 unit(s), 0 blog post(s), 0 wiki entry/entries
- el: 1 unit(s), 0 blog post(s), 0 wiki entry/entries

The single translated unit is `dashboard.goalFill.fillPlan` ("Alle Übungen eintragen"), the label on the dashboard's "fill all exercises to reach today's plan goal" quick-action button. Translations were chosen to match the verb already used for "eintragen" in the sibling string `trainingPlans.menu.logAllDone` in each locale (Log/Saisir/Registrar/Registra/invoeren/Registrer/记录/Καταχώρηση).

## Skipped

None — all 8 detected gaps were translated.

## Detector summary

```
Detected 8 gap(s) — xliff:8 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYHg6Z26E5QT146TUL3yFz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Completed translations for the “Log all exercises” dashboard prompt in Greek, English, Spanish, French, Italian, Dutch, Norwegian, and Chinese.
  * The prompt now displays in the appropriate language instead of showing untranslated German text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->