### PR TITLE
chore(i18n): fill missing translations (248 items)

### DIFF
--- a/web/src/app/admin/android-test-page.component.spec.ts
+++ b/web/src/app/admin/android-test-page.component.spec.ts
@@ -116,7 +116,10 @@ describe('AndroidTestPageComponent', () => {
   it('should copy opted-in emails to the clipboard', async () => {
     // given
     const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText } });
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
     await createComponent([
       user({
         uid: 'o1',

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10681,7 +10681,7 @@
     <unit id="admin.androidTest.backToAdmin">
       <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Πίσω στη διαχείριση</target>
+        <target>Επιστροφή στη διαχείριση</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10667,189 +10667,189 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Android-App-Test</source>
-        <target>Android-App-Test</target>
+        <target>Δοκιμή εφαρμογής Android</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tester für den geschlossenen Android-App-Test verwalten. </source>
-        <target> Tester für den geschlossenen Android-App-Test verwalten. </target>
+        <target> Διαχείριση δοκιμαστών για την κλειστή δοκιμή της εφαρμογής Android. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Πίσω στη διαχείριση</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kandidaten ermitteln</source>
-        <target>Kandidaten ermitteln</target>
+        <target>Εύρεση υποψηφίων</target>
       </segment>
     </unit>
         <unit id="admin.androidTest.scanResult">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> νέοι υποψήφιοι βρέθηκαν.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.candidatesTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </source>
-        <target> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
+        <target> Υποψήφιοι (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noCandidates">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Kandidaten.</source>
-        <target>Keine offenen Kandidaten.</target>
+        <target>Δεν υπάρχουν εκκρεμείς υποψήφιοι.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirm">
-      <segment state="initial">
+      <segment state="translated">
         <source> Bestätigen </source>
-        <target> Bestätigen </target>
+        <target> Επιβεβαίωση </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ablehnen </source>
-        <target> Ablehnen </target>
+        <target> Απόρριψη </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.optedInTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </source>
-        <target> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
+        <target> Εγγεγραμμένοι (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noOptedIn">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch niemand hat sich angemeldet. </source>
-        <target> Noch niemand hat sich angemeldet. </target>
+        <target> Κανείς δεν έχει εγγραφεί ακόμα. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.emailsCopied">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert!</source>
-        <target>Kopiert!</target>
+        <target>Αντιγράφηκε!</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.copyEmails">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle E-Mails kopieren</source>
-        <target>Alle E-Mails kopieren</target>
+        <target>Αντιγραφή όλων των email</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.markAdded">
-      <segment state="initial">
+      <segment state="translated">
         <source> Als Tester hinzugefügt (benachrichtigen) </source>
-        <target> Als Tester hinzugefügt (benachrichtigen) </target>
+        <target> Προστέθηκε ως δοκιμαστής (ειδοποίηση) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.notifiedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </source>
-        <target> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
+        <target> Ειδοποιήθηκαν (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noPush">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</source>
-        <target>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</target>
+        <target>Δεν υπάρχει ενεργή συνδρομή push — παρακαλούμε ενημερώστε τον χρήστη χειροκίνητα.</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Werde Android-App-Tester </source>
-        <target> Werde Android-App-Tester </target>
+        <target> Γίνε δοκιμαστής της εφαρμογής Android </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </source>
-        <target> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </target>
+        <target> Αναπτύσσουμε αυτή τη στιγμή την εφαρμογή Android του PushUp Stats και αναζητούμε δοκιμαστές. Θέλεις να τη δοκιμάσεις πριν από όλους τους άλλους; </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.notNow">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nicht jetzt </source>
-        <target> Nicht jetzt </target>
+        <target> Όχι τώρα </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.join">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></source>
-        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></target>
+        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Μέσα είμαι </pc></target>
       </segment>
     </unit>
         <unit id="androidTest.invite.thanksTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Danke!</source>
-        <target>Danke!</target>
+        <target>Ευχαριστούμε!</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.thanksBody">
-      <segment state="initial">
+      <segment state="translated">
         <source> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </source>
-        <target> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </target>
+        <target> Θα ειδοποιηθείς μέσω push notification μόλις εγκριθείς ως δοκιμαστής. </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Κλείσιμο </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Das hat leider nicht geklappt. Bitte versuch es später erneut.</source>
-        <target>Das hat leider nicht geklappt. Bitte versuch es später erneut.</target>
+        <target>Δυστυχώς κάτι πήγε στραβά. Δοκίμασε ξανά αργότερα.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Manuell hinzufügen</source>
-        <target>Manuell hinzufügen</target>
+        <target>Χειροκίνητη προσθήκη</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </source>
-        <target> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </target>
+        <target> Αναζήτησε έναν χρήστη και προσκάλεσέ τον απευθείας — ανεξάρτητα από τα κριτήρια δραστηριότητας. Ανώνυμοι λογαριασμοί και όσοι δεν έχουν email δεν εμφανίζονται· δεν μπορούν να προστεθούν ως δοκιμαστές. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddSearch">
-      <segment state="initial">
+      <segment state="translated">
         <source>Name oder E-Mail</source>
-        <target>Name oder E-Mail</target>
+        <target>Όνομα ή email</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAdd">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einladen </source>
-        <target> Einladen </target>
+        <target> Πρόσκληση </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirmedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </source>
-        <target> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
+        <target> Προσκεκλημένοι, αναμονή επιβεβαίωσης (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noConfirmed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Einladungen.</source>
-        <target>Keine offenen Einladungen.</target>
+        <target>Δεν υπάρχουν εκκρεμείς προσκλήσεις.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.withdraw">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurückziehen </source>
-        <target> Zurückziehen </target>
+        <target> Απόσυρση </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -10866,189 +10866,189 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.androidTest.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Android-App-Test</source>
-        <target>Android-App-Test</target>
+        <target>Android App Test</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tester für den geschlossenen Android-App-Test verwalten. </source>
-        <target> Tester für den geschlossenen Android-App-Test verwalten. </target>
+        <target> Manage testers for the closed Android app test. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Back to admin area</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kandidaten ermitteln</source>
-        <target>Kandidaten ermitteln</target>
+        <target>Find candidates</target>
       </segment>
     </unit>
         <unit id="admin.androidTest.scanResult">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> new candidates found.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.candidatesTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </source>
-        <target> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
+        <target> Candidates (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noCandidates">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Kandidaten.</source>
-        <target>Keine offenen Kandidaten.</target>
+        <target>No open candidates.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirm">
-      <segment state="initial">
+      <segment state="translated">
         <source> Bestätigen </source>
-        <target> Bestätigen </target>
+        <target> Confirm </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ablehnen </source>
-        <target> Ablehnen </target>
+        <target> Decline </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.optedInTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </source>
-        <target> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
+        <target> Opted in (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noOptedIn">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch niemand hat sich angemeldet. </source>
-        <target> Noch niemand hat sich angemeldet. </target>
+        <target> No one has signed up yet. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.emailsCopied">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert!</source>
-        <target>Kopiert!</target>
+        <target>Copied!</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.copyEmails">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle E-Mails kopieren</source>
-        <target>Alle E-Mails kopieren</target>
+        <target>Copy all emails</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.markAdded">
-      <segment state="initial">
+      <segment state="translated">
         <source> Als Tester hinzugefügt (benachrichtigen) </source>
-        <target> Als Tester hinzugefügt (benachrichtigen) </target>
+        <target> Marked as tester (notify) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.notifiedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </source>
-        <target> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
+        <target> Notified (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noPush">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</source>
-        <target>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</target>
+        <target>No active push subscription — please inform the user manually.</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Werde Android-App-Tester </source>
-        <target> Werde Android-App-Tester </target>
+        <target> Become an Android app tester </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </source>
-        <target> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </target>
+        <target> We're currently building the PushUp Stats Android app and are looking for testers. Want to try it before everyone else? </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.notNow">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nicht jetzt </source>
-        <target> Nicht jetzt </target>
+        <target> Not now </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.join">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></source>
-        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></target>
+        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Count me in </pc></target>
       </segment>
     </unit>
         <unit id="androidTest.invite.thanksTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Danke!</source>
-        <target>Danke!</target>
+        <target>Thanks!</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.thanksBody">
-      <segment state="initial">
+      <segment state="translated">
         <source> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </source>
-        <target> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </target>
+        <target> You'll be notified via push notification once you're approved as a tester. </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Close </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Das hat leider nicht geklappt. Bitte versuch es später erneut.</source>
-        <target>Das hat leider nicht geklappt. Bitte versuch es später erneut.</target>
+        <target>Unfortunately that didn't work. Please try again later.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Manuell hinzufügen</source>
-        <target>Manuell hinzufügen</target>
+        <target>Add manually</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </source>
-        <target> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </target>
+        <target> Search for a user and invite them directly — independent of the activity criteria. Anonymous accounts and those without an email don't appear; they can't be added as testers. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddSearch">
-      <segment state="initial">
+      <segment state="translated">
         <source>Name oder E-Mail</source>
-        <target>Name oder E-Mail</target>
+        <target>Name or email</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAdd">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einladen </source>
-        <target> Einladen </target>
+        <target> Invite </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirmedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </source>
-        <target> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
+        <target> Invited, awaiting confirmation (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noConfirmed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Einladungen.</source>
-        <target>Keine offenen Einladungen.</target>
+        <target>No open invitations.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.withdraw">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurückziehen </source>
-        <target> Zurückziehen </target>
+        <target> Withdraw </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10663,189 +10663,189 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Android-App-Test</source>
-        <target>Android-App-Test</target>
+        <target>Prueba de la app de Android</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tester für den geschlossenen Android-App-Test verwalten. </source>
-        <target> Tester für den geschlossenen Android-App-Test verwalten. </target>
+        <target> Gestionar testers de la prueba cerrada de la app Android. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Volver al área de administración</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kandidaten ermitteln</source>
-        <target>Kandidaten ermitteln</target>
+        <target>Buscar candidatos</target>
       </segment>
     </unit>
         <unit id="admin.androidTest.scanResult">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> candidatos nuevos encontrados.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.candidatesTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </source>
-        <target> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
+        <target> Candidatos (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noCandidates">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Kandidaten.</source>
-        <target>Keine offenen Kandidaten.</target>
+        <target>No hay candidatos pendientes.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirm">
-      <segment state="initial">
+      <segment state="translated">
         <source> Bestätigen </source>
-        <target> Bestätigen </target>
+        <target> Confirmar </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ablehnen </source>
-        <target> Ablehnen </target>
+        <target> Rechazar </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.optedInTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </source>
-        <target> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
+        <target> Inscritos (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noOptedIn">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch niemand hat sich angemeldet. </source>
-        <target> Noch niemand hat sich angemeldet. </target>
+        <target> Todavía nadie se ha inscrito. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.emailsCopied">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert!</source>
-        <target>Kopiert!</target>
+        <target>¡Copiado!</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.copyEmails">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle E-Mails kopieren</source>
-        <target>Alle E-Mails kopieren</target>
+        <target>Copiar todos los correos</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.markAdded">
-      <segment state="initial">
+      <segment state="translated">
         <source> Als Tester hinzugefügt (benachrichtigen) </source>
-        <target> Als Tester hinzugefügt (benachrichtigen) </target>
+        <target> Marcado como tester (notificar) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.notifiedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </source>
-        <target> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
+        <target> Notificados (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noPush">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</source>
-        <target>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</target>
+        <target>No hay suscripción push activa — por favor informa al usuario manualmente.</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Werde Android-App-Tester </source>
-        <target> Werde Android-App-Tester </target>
+        <target> Conviértete en tester de la app Android </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </source>
-        <target> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </target>
+        <target> Estamos desarrollando la app Android de PushUp Stats y buscamos testers. ¿Te apetece probarla antes que nadie? </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.notNow">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nicht jetzt </source>
-        <target> Nicht jetzt </target>
+        <target> Ahora no </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.join">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></source>
-        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></target>
+        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Cuenta conmigo </pc></target>
       </segment>
     </unit>
         <unit id="androidTest.invite.thanksTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Danke!</source>
-        <target>Danke!</target>
+        <target>¡Gracias!</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.thanksBody">
-      <segment state="initial">
+      <segment state="translated">
         <source> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </source>
-        <target> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </target>
+        <target> Recibirás una notificación push en cuanto seas aceptado/a como tester. </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Cerrar </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Das hat leider nicht geklappt. Bitte versuch es später erneut.</source>
-        <target>Das hat leider nicht geklappt. Bitte versuch es später erneut.</target>
+        <target>Lamentablemente no ha funcionado. Inténtalo de nuevo más tarde.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Manuell hinzufügen</source>
-        <target>Manuell hinzufügen</target>
+        <target>Añadir manualmente</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </source>
-        <target> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </target>
+        <target> Busca un usuario e invítalo directamente — independientemente de los criterios de actividad. Las cuentas anónimas y las que no tienen correo no aparecen; no se pueden añadir como testers. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddSearch">
-      <segment state="initial">
+      <segment state="translated">
         <source>Name oder E-Mail</source>
-        <target>Name oder E-Mail</target>
+        <target>Nombre o correo</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAdd">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einladen </source>
-        <target> Einladen </target>
+        <target> Invitar </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirmedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </source>
-        <target> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
+        <target> Invitados, esperando confirmación (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noConfirmed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Einladungen.</source>
-        <target>Keine offenen Einladungen.</target>
+        <target>No hay invitaciones pendientes.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.withdraw">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurückziehen </source>
-        <target> Zurückziehen </target>
+        <target> Retirar </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10553,7 +10553,7 @@
     <unit id="admin.androidTest.backToAdmin">
       <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Retour à l'administration</target>
+        <target>Retour à l'espace admin</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10539,189 +10539,189 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Android-App-Test</source>
-        <target>Android-App-Test</target>
+        <target>Test de l'app Android</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tester für den geschlossenen Android-App-Test verwalten. </source>
-        <target> Tester für den geschlossenen Android-App-Test verwalten. </target>
+        <target> Gérer les testeurs du test fermé de l'app Android. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Retour à l'administration</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kandidaten ermitteln</source>
-        <target>Kandidaten ermitteln</target>
+        <target>Rechercher des candidats</target>
       </segment>
     </unit>
         <unit id="admin.androidTest.scanResult">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> nouveaux candidats trouvés.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.candidatesTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </source>
-        <target> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
+        <target> Candidats (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noCandidates">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Kandidaten.</source>
-        <target>Keine offenen Kandidaten.</target>
+        <target>Aucun candidat en attente.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirm">
-      <segment state="initial">
+      <segment state="translated">
         <source> Bestätigen </source>
-        <target> Bestätigen </target>
+        <target> Confirmer </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ablehnen </source>
-        <target> Ablehnen </target>
+        <target> Refuser </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.optedInTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </source>
-        <target> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
+        <target> Inscrits (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noOptedIn">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch niemand hat sich angemeldet. </source>
-        <target> Noch niemand hat sich angemeldet. </target>
+        <target> Personne ne s'est encore inscrit. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.emailsCopied">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert!</source>
-        <target>Kopiert!</target>
+        <target>Copié !</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.copyEmails">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle E-Mails kopieren</source>
-        <target>Alle E-Mails kopieren</target>
+        <target>Copier tous les e-mails</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.markAdded">
-      <segment state="initial">
+      <segment state="translated">
         <source> Als Tester hinzugefügt (benachrichtigen) </source>
-        <target> Als Tester hinzugefügt (benachrichtigen) </target>
+        <target> Ajouté comme testeur (notifier) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.notifiedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </source>
-        <target> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
+        <target> Notifiés (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noPush">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</source>
-        <target>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</target>
+        <target>Aucun abonnement push actif — merci d'informer l'utilisateur manuellement.</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Werde Android-App-Tester </source>
-        <target> Werde Android-App-Tester </target>
+        <target> Deviens testeur de l'app Android </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </source>
-        <target> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </target>
+        <target> Nous développons actuellement l'app Android PushUp Stats et recherchons des testeurs. Envie de l'essayer avant tout le monde ? </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.notNow">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nicht jetzt </source>
-        <target> Nicht jetzt </target>
+        <target> Pas maintenant </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.join">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></source>
-        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></target>
+        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Je participe </pc></target>
       </segment>
     </unit>
         <unit id="androidTest.invite.thanksTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Danke!</source>
-        <target>Danke!</target>
+        <target>Merci !</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.thanksBody">
-      <segment state="initial">
+      <segment state="translated">
         <source> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </source>
-        <target> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </target>
+        <target> Tu seras informé(e) par notification push dès que tu seras validé(e) comme testeur. </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Fermer </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Das hat leider nicht geklappt. Bitte versuch es später erneut.</source>
-        <target>Das hat leider nicht geklappt. Bitte versuch es später erneut.</target>
+        <target>Cela n'a malheureusement pas fonctionné. Merci de réessayer plus tard.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Manuell hinzufügen</source>
-        <target>Manuell hinzufügen</target>
+        <target>Ajouter manuellement</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </source>
-        <target> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </target>
+        <target> Rechercher un(e) utilisateur/utilisatrice et l'inviter directement — indépendamment des critères d'activité. Les comptes anonymes et ceux sans e-mail n'apparaissent pas ; ils ne peuvent pas être ajoutés comme testeurs. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddSearch">
-      <segment state="initial">
+      <segment state="translated">
         <source>Name oder E-Mail</source>
-        <target>Name oder E-Mail</target>
+        <target>Nom ou e-mail</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAdd">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einladen </source>
-        <target> Einladen </target>
+        <target> Inviter </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirmedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </source>
-        <target> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
+        <target> Invités, en attente de confirmation (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noConfirmed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Einladungen.</source>
-        <target>Keine offenen Einladungen.</target>
+        <target>Aucune invitation en attente.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.withdraw">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurückziehen </source>
-        <target> Zurückziehen </target>
+        <target> Retirer </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10667,189 +10667,189 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Android-App-Test</source>
-        <target>Android-App-Test</target>
+        <target>Test dell'app Android</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tester für den geschlossenen Android-App-Test verwalten. </source>
-        <target> Tester für den geschlossenen Android-App-Test verwalten. </target>
+        <target> Gestisci i tester per il test chiuso dell'app Android. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Torna all'area amministrativa</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kandidaten ermitteln</source>
-        <target>Kandidaten ermitteln</target>
+        <target>Trova candidati</target>
       </segment>
     </unit>
         <unit id="admin.androidTest.scanResult">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> nuovi candidati trovati.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.candidatesTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </source>
-        <target> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
+        <target> Candidati (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noCandidates">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Kandidaten.</source>
-        <target>Keine offenen Kandidaten.</target>
+        <target>Nessun candidato in sospeso.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirm">
-      <segment state="initial">
+      <segment state="translated">
         <source> Bestätigen </source>
-        <target> Bestätigen </target>
+        <target> Conferma </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ablehnen </source>
-        <target> Ablehnen </target>
+        <target> Rifiuta </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.optedInTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </source>
-        <target> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
+        <target> Iscritti (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noOptedIn">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch niemand hat sich angemeldet. </source>
-        <target> Noch niemand hat sich angemeldet. </target>
+        <target> Nessuno si è ancora iscritto. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.emailsCopied">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert!</source>
-        <target>Kopiert!</target>
+        <target>Copiato!</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.copyEmails">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle E-Mails kopieren</source>
-        <target>Alle E-Mails kopieren</target>
+        <target>Copia tutte le email</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.markAdded">
-      <segment state="initial">
+      <segment state="translated">
         <source> Als Tester hinzugefügt (benachrichtigen) </source>
-        <target> Als Tester hinzugefügt (benachrichtigen) </target>
+        <target> Aggiunto come tester (notifica) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.notifiedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </source>
-        <target> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
+        <target> Notificati (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noPush">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</source>
-        <target>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</target>
+        <target>Nessun abbonamento push attivo — informa manualmente l'utente.</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Werde Android-App-Tester </source>
-        <target> Werde Android-App-Tester </target>
+        <target> Diventa tester dell'app Android </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </source>
-        <target> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </target>
+        <target> Stiamo sviluppando l'app Android di PushUp Stats e cerchiamo tester. Ti va di provarla prima di tutti gli altri? </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.notNow">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nicht jetzt </source>
-        <target> Nicht jetzt </target>
+        <target> Non ora </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.join">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></source>
-        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></target>
+        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ci sto </pc></target>
       </segment>
     </unit>
         <unit id="androidTest.invite.thanksTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Danke!</source>
-        <target>Danke!</target>
+        <target>Grazie!</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.thanksBody">
-      <segment state="initial">
+      <segment state="translated">
         <source> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </source>
-        <target> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </target>
+        <target> Riceverai una notifica push non appena sarai approvato/a come tester. </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Chiudi </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Das hat leider nicht geklappt. Bitte versuch es später erneut.</source>
-        <target>Das hat leider nicht geklappt. Bitte versuch es später erneut.</target>
+        <target>Purtroppo non ha funzionato. Riprova più tardi.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Manuell hinzufügen</source>
-        <target>Manuell hinzufügen</target>
+        <target>Aggiungi manualmente</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </source>
-        <target> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </target>
+        <target> Cerca un utente e invitalo direttamente — indipendentemente dai criteri di attività. Gli account anonimi e quelli senza email non compaiono; non possono essere aggiunti come tester. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddSearch">
-      <segment state="initial">
+      <segment state="translated">
         <source>Name oder E-Mail</source>
-        <target>Name oder E-Mail</target>
+        <target>Nome o email</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAdd">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einladen </source>
-        <target> Einladen </target>
+        <target> Invita </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirmedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </source>
-        <target> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
+        <target> Invitati, in attesa di conferma (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noConfirmed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Einladungen.</source>
-        <target>Keine offenen Einladungen.</target>
+        <target>Nessun invito in sospeso.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.withdraw">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurückziehen </source>
-        <target> Zurückziehen </target>
+        <target> Ritira </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10681,7 +10681,7 @@
     <unit id="admin.androidTest.backToAdmin">
       <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Terug naar beheer</target>
+        <target>Terug naar beheergebied</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10667,189 +10667,189 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Android-App-Test</source>
-        <target>Android-App-Test</target>
+        <target>Android-app-test</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tester für den geschlossenen Android-App-Test verwalten. </source>
-        <target> Tester für den geschlossenen Android-App-Test verwalten. </target>
+        <target> Testers voor de gesloten Android-app-test beheren. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Terug naar beheer</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kandidaten ermitteln</source>
-        <target>Kandidaten ermitteln</target>
+        <target>Kandidaten zoeken</target>
       </segment>
     </unit>
         <unit id="admin.androidTest.scanResult">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> nieuwe kandidaten gevonden.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.candidatesTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </source>
         <target> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noCandidates">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Kandidaten.</source>
-        <target>Keine offenen Kandidaten.</target>
+        <target>Geen openstaande kandidaten.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirm">
-      <segment state="initial">
+      <segment state="translated">
         <source> Bestätigen </source>
-        <target> Bestätigen </target>
+        <target> Bevestigen </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ablehnen </source>
-        <target> Ablehnen </target>
+        <target> Afwijzen </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.optedInTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </source>
-        <target> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
+        <target> Aangemeld (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noOptedIn">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch niemand hat sich angemeldet. </source>
-        <target> Noch niemand hat sich angemeldet. </target>
+        <target> Nog niemand heeft zich aangemeld. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.emailsCopied">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert!</source>
-        <target>Kopiert!</target>
+        <target>Gekopieerd!</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.copyEmails">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle E-Mails kopieren</source>
-        <target>Alle E-Mails kopieren</target>
+        <target>Alle e-mails kopiëren</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.markAdded">
-      <segment state="initial">
+      <segment state="translated">
         <source> Als Tester hinzugefügt (benachrichtigen) </source>
-        <target> Als Tester hinzugefügt (benachrichtigen) </target>
+        <target> Toegevoegd als tester (informeren) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.notifiedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </source>
-        <target> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
+        <target> Geïnformeerd (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noPush">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</source>
-        <target>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</target>
+        <target>Geen actief push-abonnement — gebruiker handmatig informeren.</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Werde Android-App-Tester </source>
-        <target> Werde Android-App-Tester </target>
+        <target> Word Android-app-tester </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </source>
-        <target> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </target>
+        <target> We bouwen momenteel de PushUp Stats Android-app en zoeken testers. Heb je zin om deze als eerste uit te proberen? </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.notNow">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nicht jetzt </source>
-        <target> Nicht jetzt </target>
+        <target> Niet nu </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.join">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></source>
-        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></target>
+        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ik doe mee </pc></target>
       </segment>
     </unit>
         <unit id="androidTest.invite.thanksTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Danke!</source>
-        <target>Danke!</target>
+        <target>Bedankt!</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.thanksBody">
-      <segment state="initial">
+      <segment state="translated">
         <source> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </source>
-        <target> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </target>
+        <target> Je krijgt een pushmelding zodra je als tester bent goedgekeurd. </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Sluiten </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Das hat leider nicht geklappt. Bitte versuch es später erneut.</source>
-        <target>Das hat leider nicht geklappt. Bitte versuch es später erneut.</target>
+        <target>Dat is helaas niet gelukt. Probeer het later opnieuw.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Manuell hinzufügen</source>
-        <target>Manuell hinzufügen</target>
+        <target>Handmatig toevoegen</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </source>
-        <target> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </target>
+        <target> Gebruiker zoeken en direct uitnodigen — ongeacht de activiteitscriteria. Anonieme accounts en accounts zonder e-mail worden niet weergegeven; ze kunnen niet als tester worden toegevoegd. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddSearch">
-      <segment state="initial">
+      <segment state="translated">
         <source>Name oder E-Mail</source>
-        <target>Name oder E-Mail</target>
+        <target>Naam of e-mail</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAdd">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einladen </source>
-        <target> Einladen </target>
+        <target> Uitnodigen </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirmedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </source>
-        <target> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
+        <target> Uitgenodigd, wacht op bevestiging (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noConfirmed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Einladungen.</source>
-        <target>Keine offenen Einladungen.</target>
+        <target>Geen openstaande uitnodigingen.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.withdraw">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurückziehen </source>
-        <target> Zurückziehen </target>
+        <target> Intrekken </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9974,7 +9974,7 @@ Deine Position: # ·  Reps        </source>
     <unit id="admin.androidTest.backToAdmin">
       <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Tilbake til admin</target>
+        <target>Tilbake til administrasjonsområdet</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -9960,189 +9960,189 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.androidTest.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Android-App-Test</source>
-        <target>Android-App-Test</target>
+        <target>Android-app-test</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tester für den geschlossenen Android-App-Test verwalten. </source>
-        <target> Tester für den geschlossenen Android-App-Test verwalten. </target>
+        <target> Administrer testere for den lukkede Android-app-testen. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>Tilbake til admin</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kandidaten ermitteln</source>
-        <target>Kandidaten ermitteln</target>
+        <target>Finn kandidater</target>
       </segment>
     </unit>
         <unit id="admin.androidTest.scanResult">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> nye kandidater funnet.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.candidatesTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </source>
-        <target> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
+        <target> Kandidater (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noCandidates">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Kandidaten.</source>
-        <target>Keine offenen Kandidaten.</target>
+        <target>Ingen åpne kandidater.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirm">
-      <segment state="initial">
+      <segment state="translated">
         <source> Bestätigen </source>
-        <target> Bestätigen </target>
+        <target> Bekreft </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ablehnen </source>
-        <target> Ablehnen </target>
+        <target> Avslå </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.optedInTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </source>
-        <target> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
+        <target> Påmeldt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noOptedIn">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch niemand hat sich angemeldet. </source>
-        <target> Noch niemand hat sich angemeldet. </target>
+        <target> Ingen har meldt seg på ennå. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.emailsCopied">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert!</source>
         <target>Kopiert!</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.copyEmails">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle E-Mails kopieren</source>
-        <target>Alle E-Mails kopieren</target>
+        <target>Kopier alle e-poster</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.markAdded">
-      <segment state="initial">
+      <segment state="translated">
         <source> Als Tester hinzugefügt (benachrichtigen) </source>
-        <target> Als Tester hinzugefügt (benachrichtigen) </target>
+        <target> Lagt til som tester (varsle) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.notifiedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </source>
-        <target> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
+        <target> Varslet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noPush">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</source>
-        <target>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</target>
+        <target>Ingen aktivt push-abonnement — vennligst informer brukeren manuelt.</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Werde Android-App-Tester </source>
-        <target> Werde Android-App-Tester </target>
+        <target> Bli Android-app-tester </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </source>
-        <target> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </target>
+        <target> Vi bygger for tiden PushUp Stats Android-appen og ser etter testere. Har du lyst til å prøve den før alle andre? </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.notNow">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nicht jetzt </source>
-        <target> Nicht jetzt </target>
+        <target> Ikke nå </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.join">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></source>
-        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></target>
+        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Jeg blir med </pc></target>
       </segment>
     </unit>
         <unit id="androidTest.invite.thanksTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Danke!</source>
-        <target>Danke!</target>
+        <target>Takk!</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.thanksBody">
-      <segment state="initial">
+      <segment state="translated">
         <source> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </source>
-        <target> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </target>
+        <target> Du vil bli varslet via push-varsel så snart du er godkjent som tester. </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> Lukk </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Das hat leider nicht geklappt. Bitte versuch es später erneut.</source>
-        <target>Das hat leider nicht geklappt. Bitte versuch es später erneut.</target>
+        <target>Dette fungerte dessverre ikke. Prøv igjen senere.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Manuell hinzufügen</source>
-        <target>Manuell hinzufügen</target>
+        <target>Legg til manuelt</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </source>
-        <target> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </target>
+        <target> Søk etter en bruker og inviter direkte — uavhengig av aktivitetskriteriene. Anonyme kontoer og de uten e-post vises ikke; de kan ikke legges til som testere. </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddSearch">
-      <segment state="initial">
+      <segment state="translated">
         <source>Name oder E-Mail</source>
-        <target>Name oder E-Mail</target>
+        <target>Navn eller e-post</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAdd">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einladen </source>
-        <target> Einladen </target>
+        <target> Inviter </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirmedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </source>
-        <target> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
+        <target> Invitert, venter på bekreftelse (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noConfirmed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Einladungen.</source>
-        <target>Keine offenen Einladungen.</target>
+        <target>Ingen åpne invitasjoner.</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.withdraw">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurückziehen </source>
-        <target> Zurückziehen </target>
+        <target> Trekk tilbake </target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -10187,7 +10187,7 @@
     <unit id="admin.androidTest.backToAdmin">
       <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>返回管理区</target>
+        <target>返回管理区域</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -10173,189 +10173,189 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.title">
-      <segment state="initial">
+      <segment state="translated">
         <source>Android-App-Test</source>
-        <target>Android-App-Test</target>
+        <target>Android 应用测试</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.subtitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Tester für den geschlossenen Android-App-Test verwalten. </source>
-        <target> Tester für den geschlossenen Android-App-Test verwalten. </target>
+        <target> 管理封闭式 Android 应用测试的测试人员。 </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.backToAdmin">
-      <segment state="initial">
+      <segment state="translated">
         <source>Zurück zum Admin-Bereich</source>
-        <target>Zurück zum Admin-Bereich</target>
+        <target>返回管理区</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.scan">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kandidaten ermitteln</source>
-        <target>Kandidaten ermitteln</target>
+        <target>查找候选人</target>
       </segment>
     </unit>
         <unit id="admin.androidTest.scanResult">
-      <segment state="initial">
+      <segment state="translated">
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> neue Kandidaten gefunden.</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ scanResult() }}"/> 位新候选人。</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.candidatesTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </source>
-        <target> Kandidaten (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
+        <target> 候选人 (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().candidates.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noCandidates">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Kandidaten.</source>
-        <target>Keine offenen Kandidaten.</target>
+        <target>暂无候选人。</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirm">
-      <segment state="initial">
+      <segment state="translated">
         <source> Bestätigen </source>
-        <target> Bestätigen </target>
+        <target> 确认 </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.decline">
-      <segment state="initial">
+      <segment state="translated">
         <source> Ablehnen </source>
-        <target> Ablehnen </target>
+        <target> 拒绝 </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.optedInTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </source>
-        <target> Angemeldet (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
+        <target> 已报名 (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().optedIn.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noOptedIn">
-      <segment state="initial">
+      <segment state="translated">
         <source> Noch niemand hat sich angemeldet. </source>
-        <target> Noch niemand hat sich angemeldet. </target>
+        <target> 还没有人报名。 </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.emailsCopied">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kopiert!</source>
-        <target>Kopiert!</target>
+        <target>已复制！</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.copyEmails">
-      <segment state="initial">
+      <segment state="translated">
         <source>Alle E-Mails kopieren</source>
-        <target>Alle E-Mails kopieren</target>
+        <target>复制所有邮箱</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.markAdded">
-      <segment state="initial">
+      <segment state="translated">
         <source> Als Tester hinzugefügt (benachrichtigen) </source>
-        <target> Als Tester hinzugefügt (benachrichtigen) </target>
+        <target> 已标记为测试人员（通知） </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.notifiedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </source>
-        <target> Benachrichtigt (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
+        <target> 已通知 (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().notified.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noPush">
-      <segment state="initial">
+      <segment state="translated">
         <source>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</source>
-        <target>Kein aktives Push-Abo — Nutzer bitte manuell informieren.</target>
+        <target>没有有效的推送订阅 — 请手动通知用户。</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.title">
-      <segment state="initial">
+      <segment state="translated">
         <source> Werde Android-App-Tester </source>
-        <target> Werde Android-App-Tester </target>
+        <target> 成为 Android 应用测试人员 </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.body">
-      <segment state="initial">
+      <segment state="translated">
         <source> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </source>
-        <target> Wir bauen gerade die PushUp Stats Android-App und suchen Tester. Hast du Lust, sie vor allen anderen auszuprobieren? </target>
+        <target> 我们正在开发 PushUp Stats 的 Android 应用，正在寻找测试人员。想在所有人之前抢先体验吗？ </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.notNow">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nicht jetzt </source>
-        <target> Nicht jetzt </target>
+        <target> 暂不 </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.join">
-      <segment state="initial">
+      <segment state="translated">
         <source><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></source>
-        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> Ich bin dabei </pc></target>
+        <target><pc id="0" equivStart="START_BLOCK_IF" equivEnd="CLOSE_BLOCK_IF" type="other" dispStart="@if (loading()) {" dispEnd="}"><pc id="1" equivStart="START_TAG_MAT_SPINNER" equivEnd="CLOSE_TAG_MAT_SPINNER" type="other" dispStart="&lt;mat-spinner diameter=&quot;18&quot;&gt;" dispEnd="&lt;/mat-spinner&gt;"></pc></pc><pc id="2" equivStart="START_BLOCK_ELSE" equivEnd="CLOSE_BLOCK_ELSE" type="other" dispStart="@else {" dispEnd="}"> 我要参加 </pc></target>
       </segment>
     </unit>
         <unit id="androidTest.invite.thanksTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Danke!</source>
-        <target>Danke!</target>
+        <target>谢谢！</target>
       </segment>
     </unit>
     <unit id="androidTest.invite.thanksBody">
-      <segment state="initial">
+      <segment state="translated">
         <source> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </source>
-        <target> Du wirst per Push-Benachrichtigung informiert, sobald du als Tester freigeschaltet bist. </target>
+        <target> 一旦获批成为测试人员，你将通过推送通知收到提醒。 </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.close">
-      <segment state="initial">
+      <segment state="translated">
         <source> Schließen </source>
-        <target> Schließen </target>
+        <target> 关闭 </target>
       </segment>
     </unit>
     <unit id="androidTest.invite.error">
-      <segment state="initial">
+      <segment state="translated">
         <source>Das hat leider nicht geklappt. Bitte versuch es später erneut.</source>
-        <target>Das hat leider nicht geklappt. Bitte versuch es später erneut.</target>
+        <target>很抱歉，操作未成功。请稍后重试。</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source>Manuell hinzufügen</source>
-        <target>Manuell hinzufügen</target>
+        <target>手动添加</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddHint">
-      <segment state="initial">
+      <segment state="translated">
         <source> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </source>
-        <target> Nutzer:in suchen und direkt einladen — unabhängig von den Aktivitätskriterien. Anonyme Accounts und solche ohne E-Mail erscheinen nicht, sie können nicht als Tester eingetragen werden. </target>
+        <target> 搜索用户并直接邀请 — 与活跃度标准无关。匿名账户和没有邮箱的账户不会显示，无法添加为测试人员。 </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAddSearch">
-      <segment state="initial">
+      <segment state="translated">
         <source>Name oder E-Mail</source>
-        <target>Name oder E-Mail</target>
+        <target>姓名或邮箱</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.manualAdd">
-      <segment state="initial">
+      <segment state="translated">
         <source> Einladen </source>
-        <target> Einladen </target>
+        <target> 邀请 </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.confirmedTitle">
-      <segment state="initial">
+      <segment state="translated">
         <source> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </source>
-        <target> Eingeladen, wartet auf Zusage (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
+        <target> 已邀请，等待确认 (<ph id="0" equiv="INTERPOLATION" disp="{{ groups().confirmed.length }}"/>) </target>
       </segment>
     </unit>
     <unit id="admin.androidTest.noConfirmed">
-      <segment state="initial">
+      <segment state="translated">
         <source>Keine offenen Einladungen.</source>
-        <target>Keine offenen Einladungen.</target>
+        <target>暂无待处理的邀请。</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.withdraw">
-      <segment state="initial">
+      <segment state="translated">
         <source> Zurückziehen </source>
-        <target> Zurückziehen </target>
+        <target> 撤回 </target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
Fills the translation gaps detected by `tools/src/detect-translation-gaps.mjs` for the newly added Android closed-test admin/invite feature strings.

## Touched locales

- `en`: 31 unit(s), 0 blog post(s), 0 wiki entry/entries
- `fr`: 31 unit(s), 0 blog post(s), 0 wiki entry/entries
- `es`: 31 unit(s), 0 blog post(s), 0 wiki entry/entries
- `it`: 31 unit(s), 0 blog post(s), 0 wiki entry/entries
- `nl`: 31 unit(s), 0 blog post(s), 0 wiki entry/entries
- `el`: 31 unit(s), 0 blog post(s), 0 wiki entry/entries
- `no`: 31 unit(s), 0 blog post(s), 0 wiki entry/entries
- `zh`: 31 unit(s), 0 blog post(s), 0 wiki entry/entries

All 31 units are the `admin.androidTest.*` and `androidTest.invite.*` strings for the Android closed-test admin/invite feature.

## Skipped

None — all 248 detected gaps were translated.

## Detector summary

```
Detected 248 gap(s) — xliff:248 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh
```

## Verification

- `pnpm nx run web:extract-i18n` — clean re-extraction from German source
- `node tools/src/sync-xliff-locales.mjs` — no new seeded fallbacks needed
- `node tools/src/detect-translation-gaps.mjs` — confirms 0 gaps remain after this change
- `pnpm nx run web:build -c production` — production build (includes prerender across all locales) succeeds
- `pnpm nx affected -t=lint,test,build -c=production` — no projects affected by locale-file-only changes (Nx project graph doesn't treat `messages.*.xlf` as build inputs), so the production build above was run directly as an additional check

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7G4nCNk4LXgDSUUFFcDbq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added and updated Android app testing, tester management, invitation, notification, and error messages in Greek, English, Spanish, French, Italian, Dutch, Norwegian, and Chinese.
  * Improved localized coverage for candidate actions, manual invitations, approval and withdrawal flows, and status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->