### PR TITLE
chore(i18n): fill missing translations (56 items)

### DIFF
--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10855,7 +10855,7 @@
     <unit id="admin.androidTest.minEntries">
       <segment state="translated">
         <source>Einträge ab</source>
-        <target>Εγγραφές από</target>
+        <target>Καταχωρήσεις από</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.activeWithinDays">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10865,33 +10865,33 @@
       </segment>
     </unit>
     <unit id="admin.release.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Release</source>
-        <target>Release</target>
+        <target>Έκδοση</target>
       </segment>
     </unit>
     <unit id="admin.release.unknown">
-      <segment state="initial">
+      <segment state="translated">
         <source>unbekannt</source>
-        <target>unbekannt</target>
+        <target>άγνωστο</target>
       </segment>
     </unit>
     <unit id="admin.release.unknownTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</source>
-        <target>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</target>
+        <target>Αυτή η ανάπτυξη δεν περιέχει πληροφορίες build (τοπικό build ή διακομιστής ανάπτυξης).</target>
       </segment>
     </unit>
     <unit id="admin.release.commitTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/></source>
         <target>Commit <ph id="0" equiv="release" disp="release"/></target>
       </segment>
     </unit>
     <unit id="admin.release.builtTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></source>
-        <target>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></target>
+        <target>Commit <ph id="0" equiv="release" disp="release"/> · χτίστηκε στις <ph id="1" equiv="built" disp="built"/></target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10879,7 +10879,7 @@
     <unit id="admin.release.unknownTooltip">
       <segment state="translated">
         <source>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</source>
-        <target>Αυτή η ανάπτυξη δεν περιέχει πληροφορίες build (τοπικό build ή διακομιστής ανάπτυξης).</target>
+        <target>Αυτή η εγκατάσταση δεν περιέχει πληροφορίες build (τοπικό build ή διακομιστής ανάπτυξης).</target>
       </segment>
     </unit>
     <unit id="admin.release.commitTooltip">

--- a/web/src/locale/messages.el.xlf
+++ b/web/src/locale/messages.el.xlf
@@ -10853,15 +10853,15 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.minEntries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge ab</source>
-        <target>Einträge ab</target>
+        <target>Εγγραφές από</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.activeWithinDays">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv in den letzten (Tage)</source>
-        <target>Aktiv in den letzten (Tage)</target>
+        <target>Ενεργός τις τελευταίες (ημέρες)</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -11064,33 +11064,33 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.release.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Release</source>
         <target>Release</target>
       </segment>
     </unit>
     <unit id="admin.release.unknown">
-      <segment state="initial">
+      <segment state="translated">
         <source>unbekannt</source>
-        <target>unbekannt</target>
+        <target>unknown</target>
       </segment>
     </unit>
     <unit id="admin.release.unknownTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</source>
-        <target>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</target>
+        <target>This deployment contains no build information (local build or dev server).</target>
       </segment>
     </unit>
     <unit id="admin.release.commitTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/></source>
         <target>Commit <ph id="0" equiv="release" disp="release"/></target>
       </segment>
     </unit>
     <unit id="admin.release.builtTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></source>
-        <target>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></target>
+        <target>Commit <ph id="0" equiv="release" disp="release"/> · built on <ph id="1" equiv="built" disp="built"/></target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.en.xlf
+++ b/web/src/locale/messages.en.xlf
@@ -11052,15 +11052,15 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.androidTest.minEntries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge ab</source>
-        <target>Einträge ab</target>
+        <target>Entries from</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.activeWithinDays">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv in den letzten (Tage)</source>
-        <target>Aktiv in den letzten (Tage)</target>
+        <target>Active in the last (days)</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10869,7 +10869,7 @@
     <unit id="admin.release.unknown">
       <segment state="translated">
         <source>unbekannt</source>
-        <target>desconocido</target>
+        <target>desconocida</target>
       </segment>
     </unit>
     <unit id="admin.release.unknownTooltip">

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10849,15 +10849,15 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.minEntries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge ab</source>
-        <target>Einträge ab</target>
+        <target>Entradas desde</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.activeWithinDays">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv in den letzten (Tage)</source>
-        <target>Aktiv in den letzten (Tage)</target>
+        <target>Activo en los últimos (días)</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.es.xlf
+++ b/web/src/locale/messages.es.xlf
@@ -10861,33 +10861,33 @@
       </segment>
     </unit>
     <unit id="admin.release.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Release</source>
-        <target>Release</target>
+        <target>Versión</target>
       </segment>
     </unit>
     <unit id="admin.release.unknown">
-      <segment state="initial">
+      <segment state="translated">
         <source>unbekannt</source>
-        <target>unbekannt</target>
+        <target>desconocido</target>
       </segment>
     </unit>
     <unit id="admin.release.unknownTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</source>
-        <target>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</target>
+        <target>Esta implementación no contiene información de compilación (compilación local o servidor de desarrollo).</target>
       </segment>
     </unit>
     <unit id="admin.release.commitTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/></source>
         <target>Commit <ph id="0" equiv="release" disp="release"/></target>
       </segment>
     </unit>
     <unit id="admin.release.builtTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></source>
-        <target>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></target>
+        <target>Commit <ph id="0" equiv="release" disp="release"/> · compilado el <ph id="1" equiv="built" disp="built"/></target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10725,15 +10725,15 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.minEntries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge ab</source>
-        <target>Einträge ab</target>
+        <target>Entrées à partir de</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.activeWithinDays">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv in den letzten (Tage)</source>
-        <target>Aktiv in den letzten (Tage)</target>
+        <target>Actif au cours des derniers (jours)</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10733,7 +10733,7 @@
     <unit id="admin.androidTest.activeWithinDays">
       <segment state="translated">
         <source>Aktiv in den letzten (Tage)</source>
-        <target>Actif au cours des derniers (jours)</target>
+        <target>Actif au cours des derniers jours</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.fr.xlf
+++ b/web/src/locale/messages.fr.xlf
@@ -10737,33 +10737,33 @@
       </segment>
     </unit>
     <unit id="admin.release.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Release</source>
-        <target>Release</target>
+        <target>Version</target>
       </segment>
     </unit>
     <unit id="admin.release.unknown">
-      <segment state="initial">
+      <segment state="translated">
         <source>unbekannt</source>
-        <target>unbekannt</target>
+        <target>inconnu</target>
       </segment>
     </unit>
     <unit id="admin.release.unknownTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</source>
-        <target>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</target>
+        <target>Ce déploiement ne contient aucune information de build (build local ou serveur de développement).</target>
       </segment>
     </unit>
     <unit id="admin.release.commitTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/></source>
         <target>Commit <ph id="0" equiv="release" disp="release"/></target>
       </segment>
     </unit>
     <unit id="admin.release.builtTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></source>
-        <target>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></target>
+        <target>Commit <ph id="0" equiv="release" disp="release"/> · compilé le <ph id="1" equiv="built" disp="built"/></target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10865,33 +10865,33 @@
       </segment>
     </unit>
     <unit id="admin.release.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Release</source>
-        <target>Release</target>
+        <target>Versione</target>
       </segment>
     </unit>
     <unit id="admin.release.unknown">
-      <segment state="initial">
+      <segment state="translated">
         <source>unbekannt</source>
-        <target>unbekannt</target>
+        <target>sconosciuto</target>
       </segment>
     </unit>
     <unit id="admin.release.unknownTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</source>
-        <target>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</target>
+        <target>Questa distribuzione non contiene informazioni di build (build locale o server di sviluppo).</target>
       </segment>
     </unit>
     <unit id="admin.release.commitTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/></source>
         <target>Commit <ph id="0" equiv="release" disp="release"/></target>
       </segment>
     </unit>
     <unit id="admin.release.builtTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></source>
-        <target>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></target>
+        <target>Commit <ph id="0" equiv="release" disp="release"/> · compilato il <ph id="1" equiv="built" disp="built"/></target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10873,13 +10873,13 @@
     <unit id="admin.release.unknown">
       <segment state="translated">
         <source>unbekannt</source>
-        <target>sconosciuto</target>
+        <target>sconosciuta</target>
       </segment>
     </unit>
     <unit id="admin.release.unknownTooltip">
       <segment state="translated">
         <source>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</source>
-        <target>Questa distribuzione non contiene informazioni di build (build locale o server di sviluppo).</target>
+        <target>Questa versione non contiene informazioni di build (build locale o server di sviluppo).</target>
       </segment>
     </unit>
     <unit id="admin.release.commitTooltip">

--- a/web/src/locale/messages.it.xlf
+++ b/web/src/locale/messages.it.xlf
@@ -10853,15 +10853,15 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.minEntries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge ab</source>
-        <target>Einträge ab</target>
+        <target>Voci a partire da</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.activeWithinDays">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv in den letzten (Tage)</source>
-        <target>Aktiv in den letzten (Tage)</target>
+        <target>Attivo negli ultimi (giorni)</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10855,7 +10855,7 @@
     <unit id="admin.androidTest.minEntries">
       <segment state="translated">
         <source>Einträge ab</source>
-        <target>Vermeldingen vanaf</target>
+        <target>Invoer vanaf</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.activeWithinDays">

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10853,15 +10853,15 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.minEntries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge ab</source>
-        <target>Einträge ab</target>
+        <target>Vermeldingen vanaf</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.activeWithinDays">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv in den letzten (Tage)</source>
-        <target>Aktiv in den letzten (Tage)</target>
+        <target>Actief in de afgelopen (dagen)</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.nl.xlf
+++ b/web/src/locale/messages.nl.xlf
@@ -10865,33 +10865,33 @@
       </segment>
     </unit>
     <unit id="admin.release.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Release</source>
         <target>Release</target>
       </segment>
     </unit>
     <unit id="admin.release.unknown">
-      <segment state="initial">
+      <segment state="translated">
         <source>unbekannt</source>
-        <target>unbekannt</target>
+        <target>onbekend</target>
       </segment>
     </unit>
     <unit id="admin.release.unknownTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</source>
-        <target>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</target>
+        <target>Deze uitrol bevat geen buildinformatie (lokale build of ontwikkelserver).</target>
       </segment>
     </unit>
     <unit id="admin.release.commitTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/></source>
         <target>Commit <ph id="0" equiv="release" disp="release"/></target>
       </segment>
     </unit>
     <unit id="admin.release.builtTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></source>
-        <target>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></target>
+        <target>Commit <ph id="0" equiv="release" disp="release"/> · gebouwd op <ph id="1" equiv="built" disp="built"/></target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -10158,33 +10158,33 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.release.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Release</source>
-        <target>Release</target>
+        <target>Utgivelse</target>
       </segment>
     </unit>
     <unit id="admin.release.unknown">
-      <segment state="initial">
+      <segment state="translated">
         <source>unbekannt</source>
-        <target>unbekannt</target>
+        <target>ukjent</target>
       </segment>
     </unit>
     <unit id="admin.release.unknownTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</source>
-        <target>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</target>
+        <target>Denne utrullingen inneholder ingen byggeinformasjon (lokalt bygg eller utviklingsserver).</target>
       </segment>
     </unit>
     <unit id="admin.release.commitTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/></source>
         <target>Commit <ph id="0" equiv="release" disp="release"/></target>
       </segment>
     </unit>
     <unit id="admin.release.builtTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></source>
-        <target>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></target>
+        <target>Commit <ph id="0" equiv="release" disp="release"/> · bygget <ph id="1" equiv="built" disp="built"/></target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -10148,13 +10148,13 @@ Deine Position: # ·  Reps        </source>
     <unit id="admin.androidTest.minEntries">
       <segment state="translated">
         <source>Einträge ab</source>
-        <target>Innlegg fra</target>
+        <target>Oppføringer fra</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.activeWithinDays">
       <segment state="translated">
         <source>Aktiv in den letzten (Tage)</source>
-        <target>Aktiv de siste (dager)</target>
+        <target>Aktiv de siste (dagene)</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.no.xlf
+++ b/web/src/locale/messages.no.xlf
@@ -10146,15 +10146,15 @@ Deine Position: # ·  Reps        </source>
       </segment>
     </unit>
     <unit id="admin.androidTest.minEntries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge ab</source>
-        <target>Einträge ab</target>
+        <target>Innlegg fra</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.activeWithinDays">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv in den letzten (Tage)</source>
-        <target>Aktiv in den letzten (Tage)</target>
+        <target>Aktiv de siste (dager)</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -10359,15 +10359,15 @@
       </segment>
     </unit>
     <unit id="admin.androidTest.minEntries">
-      <segment state="initial">
+      <segment state="translated">
         <source>Einträge ab</source>
-        <target>Einträge ab</target>
+        <target>条目数下限</target>
       </segment>
     </unit>
     <unit id="admin.androidTest.activeWithinDays">
-      <segment state="initial">
+      <segment state="translated">
         <source>Aktiv in den letzten (Tage)</source>
-        <target>Aktiv in den letzten (Tage)</target>
+        <target>最近活跃（天）</target>
       </segment>
     </unit>
 </file>

--- a/web/src/locale/messages.zh.xlf
+++ b/web/src/locale/messages.zh.xlf
@@ -10371,33 +10371,33 @@
       </segment>
     </unit>
     <unit id="admin.release.label">
-      <segment state="initial">
+      <segment state="translated">
         <source>Release</source>
-        <target>Release</target>
+        <target>版本</target>
       </segment>
     </unit>
     <unit id="admin.release.unknown">
-      <segment state="initial">
+      <segment state="translated">
         <source>unbekannt</source>
-        <target>unbekannt</target>
+        <target>未知</target>
       </segment>
     </unit>
     <unit id="admin.release.unknownTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</source>
-        <target>Diese Auslieferung enthält keine Build-Informationen (lokaler Build oder Dev-Server).</target>
+        <target>此部署不包含构建信息（本地构建或开发服务器）。</target>
       </segment>
     </unit>
     <unit id="admin.release.commitTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/></source>
-        <target>Commit <ph id="0" equiv="release" disp="release"/></target>
+        <target>提交 <ph id="0" equiv="release" disp="release"/></target>
       </segment>
     </unit>
     <unit id="admin.release.builtTooltip">
-      <segment state="initial">
+      <segment state="translated">
         <source>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></source>
-        <target>Commit <ph id="0" equiv="release" disp="release"/> · gebaut am <ph id="1" equiv="built" disp="built"/></target>
+        <target>提交 <ph id="0" equiv="release" disp="release"/> · 构建于 <ph id="1" equiv="built" disp="built"/></target>
       </segment>
     </unit>
 </file>


### PR DESCRIPTION
Automated translation run via the `Translate XLIFF / content gaps` routine.

This PR now accumulates two rounds of gaps against `main`:

1. The Android-closed-test admin form labels (`admin.androidTest.minEntries`, `admin.androidTest.activeWithinDays`), seeded with the German fallback across all target locales (16 items).
2. The new release badge (`admin.release.*`) build-info strings — release label, unknown-build state, and commit/build tooltips — seeded when the release badge feature merged into `main` (40 items).

- `el`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `en`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `es`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `fr`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `it`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `nl`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `no`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries
- `zh`: 7 unit(s), 0 blog post(s), 0 wiki entry/entries

## Skipped

None — all 56 detected gaps (across both rounds) were translated.

## Detector summary (this run)

```
Detected 40 gap(s) — xliff:40 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh
```

After translation, a re-run confirms:

```
Detected 0 gap(s) — xliff:0 blog:0 wiki:0 across locales: en, fr, es, it, nl, el, no, zh
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added and corrected translations for Android test administration filters across Greek, English, Spanish, French, Italian, Dutch, Norwegian, and Chinese.
  * Filter labels now display in the selected language for minimum entries and recent activity duration.
  * Added localized release metadata, including release labels, unknown-release messages, build details, commit information, and build dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->