### PR TITLE
fix(quick-add): open goal submenu to the left instead of stacking vertically

### DIFF
--- a/libs/quick-add/src/lib/quick-add-fab.component.html
+++ b/libs/quick-add/src/lib/quick-add-fab.component.html
@@ -51,40 +51,42 @@
             <span i18n="@@quickAdd.fab.customValue">Eigener Wert</span>
           </button>
         } @else if (item.type === 'goal' && hasGoalSubmenu()) {
-          @if (fabState.goalMenu()) {
-            <div class="goal-submenu" data-testid="quick-add-goal-submenu">
-              @for (goal of goalItems(); track goal.id) {
-                <button
-                  mat-fab
-                  extended
-                  class="goal-sub-fab"
-                  [class.reached]="goal.reached"
-                  [disabled]="goal.disabled"
-                  [attr.aria-label]="goal.ariaLabel"
-                  data-testid="quick-add-goal-submenu-item"
-                  (click)="onFillGoalItem(goal)"
-                >
-                  <mat-icon>{{ goal.reached ? 'check' : 'flag' }}</mat-icon>
-                  <span>{{ goal.label }}</span>
-                </button>
-              }
-            </div>
-          }
-          <button
-            mat-fab
-            extended
-            class="goal-fab"
-            [attr.aria-expanded]="fabState.goalMenu()"
-            [attr.aria-label]="goalsAria"
-            data-testid="quick-add-goal-menu-toggle"
-            (click)="toggleGoalMenu()"
-          >
-            <mat-icon>{{ item.icon }}</mat-icon>
-            <span>{{ goalsLabel }} ({{ goalItems().length }})</span>
-            <mat-icon>{{
-              fabState.goalMenu() ? 'expand_more' : 'expand_less'
-            }}</mat-icon>
-          </button>
+          <div class="goal-dial-item">
+            @if (fabState.goalMenu()) {
+              <div class="goal-submenu" data-testid="quick-add-goal-submenu">
+                @for (goal of goalItems(); track goal.id) {
+                  <button
+                    mat-fab
+                    extended
+                    class="goal-sub-fab"
+                    [class.reached]="goal.reached"
+                    [disabled]="goal.disabled"
+                    [attr.aria-label]="goal.ariaLabel"
+                    data-testid="quick-add-goal-submenu-item"
+                    (click)="onFillGoalItem(goal)"
+                  >
+                    <mat-icon>{{ goal.reached ? 'check' : 'flag' }}</mat-icon>
+                    <span>{{ goal.label }}</span>
+                  </button>
+                }
+              </div>
+            }
+            <button
+              mat-fab
+              extended
+              class="goal-fab"
+              [attr.aria-expanded]="fabState.goalMenu()"
+              [attr.aria-label]="goalsAria"
+              data-testid="quick-add-goal-menu-toggle"
+              (click)="toggleGoalMenu()"
+            >
+              <mat-icon>{{ item.icon }}</mat-icon>
+              <span>{{ goalsLabel }} ({{ goalItems().length }})</span>
+              <mat-icon>{{
+                fabState.goalMenu() ? 'expand_more' : 'expand_less'
+              }}</mat-icon>
+            </button>
+          </div>
         } @else if (item.type === 'goal' && singleGoal(); as goal) {
           <button
             mat-fab

--- a/libs/quick-add/src/lib/quick-add-fab.component.scss
+++ b/libs/quick-add/src/lib/quick-add-fab.component.scss
@@ -132,16 +132,27 @@
   }
 }
 
+// Wraps the goal toggle button so the submenu can be positioned relative
+// to it without adding height to `.dial-actions`' vertical stack — the
+// submenu used to render inline above the toggle and push/overlap the
+// quick-add buttons above it.
+.goal-dial-item {
+  position: relative;
+  display: flex;
+}
+
 .goal-submenu {
+  position: absolute;
+  top: 50%;
+  right: calc(100% + 8px);
+  transform: translateY(-50%);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: 6px;
+  white-space: nowrap;
 
-  // Indented so the submenu reads as belonging to the goal button below
-  // it rather than as another top-level dial action.
-  padding-right: 12px;
-  animation: dial-item-in 160ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  animation: dial-item-in-left 160ms cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 
 .goal-sub-fab {
@@ -157,5 +168,16 @@
   &.reached,
   &[disabled] {
     opacity: 0.7;
+  }
+}
+
+@keyframes dial-item-in-left {
+  from {
+    opacity: 0;
+    transform: translateY(-50%) translateX(10px) scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0) scale(1);
   }
 }


### PR DESCRIPTION
## Summary

- Fix: the "Tagesziele" speed-dial submenu (shown when there is more than one open daily goal) rendered inline in the vertical button stack of `lib-quick-add-fab`, so opening it inserted extra buttons *above* the toggle and pushed/overlapped the quick-add buttons already in that column.
- The submenu now unfolds to the **left** of the "Tagesziele" toggle button, positioned absolutely relative to a new `.goal-dial-item` wrapper, instead of adding height to `.dial-actions`'s vertical flow.
- Added a `dial-item-in-left` slide-in animation for the repositioned submenu (previously reused the vertical `dial-item-in` keyframes).

## Test plan

- [x] `pnpm nx test stats-quick-add` — all existing unit tests pass unchanged (submenu structure change is presentation-only, `data-testid`s preserved)
- [x] `pnpm nx affected -t=lint,test --base=origin/main` — lint + tests green for all affected projects
- [x] `pnpm nx affected -t=build -c=production --base=origin/main` — production build succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bvr4whzhG3AHMae7gqExEU)_